### PR TITLE
0.5.1

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -16,6 +16,7 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
+    if: "!contains(github.event.commits[0].message, '[skip ci]')"
     runs-on: ubuntu-latest
     env:
       GRADLE_OPTS: "-Dorg.gradle.daemon=false"
@@ -29,7 +30,7 @@ jobs:
     steps:
 
       - run: export GRADLE_USER_HOME=`pwd`/.gradle
-      - run: echo ::set-output name=RELEASE_TAG::${GITHUB_REF/refs\/tags\//}
+      - run: echo ::set-env name=RELEASE_TAG::${GITHUB_REF#refs/tags/}
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,17 @@
 # 0.5.1
 
 ## Additions
-
+* Added `PartialGuild` in `Invite`
 * Added `GuildBehavior.createEmoji`
 * Added `GuildEmoji.delete` and `GuildEmoji.edit`
+* Added `getInviteOrNull` method to `RestEntitySupplier`
 
 ## Fixes
 
 * `DiscordInvite#targetUser` is now correctly nullable.
-
+* `PermissionOverwriteEntity#getGuildOrNull` uses the correct supplier method.
+## Changes
+* `Invite` now uses a `Channel` instead of `GuildChannel`.
 # 0.5.0
 
 ## Additions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # 0.5.1
 
+## Additions
+
+* Added `GuildBehavior.createEmoji`
+* Added `GuildEmoji.delete` and `GuildEmoji.edit`
+
 ## Fixes
 
 * `DiscordInvite#targetUser` is now correctly nullable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
+# 0.5.1
+
+## Fixes
+
+* `DiscordInvite#targetUser` is now correctly nullable.
+
 # 0.5.0
+
 ## Additions
-`mention` properties for `GuildEmoji` and `ReactionEmoji`
+
+* `mention` properties for `GuildEmoji` and `ReactionEmoji`
 
 # 0.5.0-rc2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.5.0
+## Additions
+`mention` properties for `GuildEmoji` and `ReactionEmoji`
+
 # 0.5.0-rc2
 
 ## Additions

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/GuildBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/GuildBehavior.kt
@@ -14,6 +14,8 @@ import com.gitlab.kordlib.core.supplier.EntitySupplier
 import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy
 import com.gitlab.kordlib.rest.builder.ban.BanCreateBuilder
 import com.gitlab.kordlib.rest.builder.channel.*
+import com.gitlab.kordlib.rest.builder.guild.EmojiCreateBuilder
+import com.gitlab.kordlib.rest.builder.guild.EmojiModifyBuilder
 import com.gitlab.kordlib.rest.builder.guild.GuildModifyBuilder
 import com.gitlab.kordlib.rest.builder.role.RoleCreateBuilder
 import com.gitlab.kordlib.rest.builder.role.RolePositionsModifyBuilder
@@ -328,6 +330,10 @@ suspend inline fun GuildBehavior.edit(builder: GuildModifyBuilder.() -> Unit): G
     val data = GuildData.from(response)
 
     return Guild(data, kord)
+}
+
+suspend inline fun GuildBehavior.createEmoji(builder: EmojiCreateBuilder.() -> Unit) {
+    kord.rest.emoji.createEmoji(guildId = id.value, builder = builder)
 }
 
 /**

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/GuildBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/GuildBehavior.kt
@@ -12,6 +12,7 @@ import com.gitlab.kordlib.core.exception.EntityNotFoundException
 import com.gitlab.kordlib.core.sorted
 import com.gitlab.kordlib.core.supplier.EntitySupplier
 import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy
+import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy.Companion.rest
 import com.gitlab.kordlib.rest.builder.ban.BanCreateBuilder
 import com.gitlab.kordlib.rest.builder.channel.*
 import com.gitlab.kordlib.rest.builder.guild.EmojiCreateBuilder
@@ -198,6 +199,30 @@ interface GuildBehavior : Entity, Strategizable {
     suspend fun getRoleOrNull(roleId: Snowflake): Role? = supplier.getRoleOrNull(guildId = id, roleId = roleId)
 
     /**
+     * Requests to get the [Invite] represented by the [code].
+     *
+     *
+     * This property is not resolvable through cache and will always use the [RestClient] instead.
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     * @throws [EntityNotFoundException] if the [Invite] wasn't present.
+     */
+    suspend fun getInvite(code: String, withCounts: Boolean = true): Invite =
+            kord.with(rest).getInvite(code, withCounts)
+
+    /**
+     * Requests to get the [Invite] represented by the [code],
+     * returns null if the [Invite] isn't present.
+     *
+     * This property is not resolvable through cache and will always use the [RestClient] instead.
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     */
+    suspend fun getInviteOrNull(code: String, withCounts: Boolean = true): Invite? =
+            kord.with(rest).getInviteOrNull(code, withCounts)
+
+
+    /**
      *  Requests to change the nickname of the bot in this guild, passing `null` will remove it.
      *
      * @throws [RestRequestException] if something went wrong during the request.
@@ -251,7 +276,7 @@ interface GuildBehavior : Entity, Strategizable {
      * @throws RequestException if the guild does not exist or is not public.
      * @throws [EntityNotFoundException] if the preview was not found.
      */
-    suspend fun getPreview(): GuildPreview = kord.with(EntitySupplyStrategy.rest).getGuildPreview(id)
+    suspend fun getPreview(): GuildPreview = kord.with(rest).getGuildPreview(id)
 
     /**
      * Returns the preview of this guild. The bot does not need to present in this guild
@@ -261,7 +286,7 @@ interface GuildBehavior : Entity, Strategizable {
      *
      * @throws RequestException if the guild does not exist or is not public.
      */
-    suspend fun getPreviewOrNull(): GuildPreview? = kord.with(EntitySupplyStrategy.rest).getGuildPreviewOrNull(id)
+    suspend fun getPreviewOrNull(): GuildPreview? = kord.with(rest).getGuildPreviewOrNull(id)
 
     /**
      * Requests to get the amount of users that would be pruned in this guild.
@@ -311,6 +336,7 @@ interface GuildBehavior : Entity, Strategizable {
 
             override fun equals(other: Any?): Boolean = when (other) {
                 is GuildBehavior -> other.id == id
+                is PartialGuild -> other.id == id
                 else -> false
             }
         }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/MessageBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/MessageBehavior.kt
@@ -70,7 +70,7 @@ interface MessageBehavior : Entity, Strategizable {
                 kord.rest.channel.getReactions(
                         channelId = channelId.value,
                         messageId = id.value,
-                        emoji = emoji.formatted,
+                        emoji = emoji.urlFormat,
                         limit = 100,
                         position = position
                 )
@@ -82,7 +82,7 @@ interface MessageBehavior : Entity, Strategizable {
      * @throws [RestRequestException] if something went wrong during the request.
      */
     suspend fun addReaction(emoji: ReactionEmoji) {
-        kord.rest.channel.createReaction(channelId = channelId.value, messageId = id.value, emoji = emoji.formatted)
+        kord.rest.channel.createReaction(channelId = channelId.value, messageId = id.value, emoji = emoji.urlFormat)
     }
 
     /**
@@ -100,7 +100,7 @@ interface MessageBehavior : Entity, Strategizable {
      * @throws [RestRequestException] if something went wrong during the request.
      */
     suspend fun deleteReaction(userId: Snowflake, emoji: ReactionEmoji) {
-        kord.rest.channel.deleteReaction(channelId = channelId.value, messageId = id.value, userId = userId.value, emoji = emoji.formatted)
+        kord.rest.channel.deleteReaction(channelId = channelId.value, messageId = id.value, userId = userId.value, emoji = emoji.urlFormat)
     }
 
     /**
@@ -109,7 +109,7 @@ interface MessageBehavior : Entity, Strategizable {
      * @throws [RestRequestException] if something went wrong during the request.
      */
     suspend fun deleteOwnReaction(emoji: ReactionEmoji) {
-        kord.rest.channel.deleteOwnReaction(channelId = channelId.value, messageId = id.value, emoji = emoji.formatted)
+        kord.rest.channel.deleteOwnReaction(channelId = channelId.value, messageId = id.value, emoji = emoji.urlFormat)
     }
 
     /**
@@ -127,7 +127,7 @@ interface MessageBehavior : Entity, Strategizable {
      * @throws [RestRequestException] if something went wrong during the request.
      */
     suspend fun deleteReaction(emoji: ReactionEmoji) {
-        kord.rest.channel.deleteAllReactionsForEmoji(channelId = channelId.value, messageId = id.value, emoji = emoji.formatted)
+        kord.rest.channel.deleteAllReactionsForEmoji(channelId = channelId.value, messageId = id.value, emoji = emoji.urlFormat)
     }
 
     /**

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/MessageBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/MessageBehavior.kt
@@ -65,16 +65,9 @@ interface MessageBehavior : Entity, Strategizable {
      * The returned flow is lazily executed, any [RequestException] will be thrown on
      * [terminal operators](https://kotlinlang.org/docs/reference/coroutines/flow.html#terminal-flow-operators) instead.
      */
+
     fun getReactors(emoji: ReactionEmoji): Flow<User> =
-            paginateForwards(batchSize = 100, idSelector = { it.id }) { position ->
-                kord.rest.channel.getReactions(
-                        channelId = channelId.value,
-                        messageId = id.value,
-                        emoji = emoji.urlFormat,
-                        limit = 100,
-                        position = position
-                )
-            }.map { UserData.from(it) }.map { User(it, kord) }
+            kord.with(EntitySupplyStrategy.rest).getReactors(channelId, id, emoji)
 
     /**
      * Requests to add an [emoji] to this message.
@@ -153,7 +146,7 @@ interface MessageBehavior : Entity, Strategizable {
      */
     override fun withStrategy(
             strategy: EntitySupplyStrategy<*>
-    ) : MessageBehavior = MessageBehavior(channelId, id, kord, strategy)
+    ): MessageBehavior = MessageBehavior(channelId, id, kord, strategy)
 
     companion object {
         internal operator fun invoke(
@@ -169,7 +162,7 @@ interface MessageBehavior : Entity, Strategizable {
 
             override fun hashCode(): Int = Objects.hash(id)
 
-            override fun equals(other: Any?): Boolean = when(other) {
+            override fun equals(other: Any?): Boolean = when (other) {
                 is MessageBehavior -> other.id == id && other.channelId == channelId
                 else -> false
             }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/cache/DataCacheExtensions.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/cache/DataCacheExtensions.kt
@@ -41,4 +41,4 @@ internal suspend fun DataCache.removeKordData() {
  * Creates a [DataCacheView] for this view, only removing elements that were added
  * directly to this instance.
  */
-suspend fun DataCache.createView() : DataCacheView = DataCacheView(this)
+suspend fun DataCache.createView(): DataCacheView = DataCacheView(this)

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/InviteData.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/InviteData.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.cache.data
 
+import com.gitlab.kordlib.cache.api.data.description
 import com.gitlab.kordlib.common.entity.TargetUserType
 import com.gitlab.kordlib.rest.json.response.InviteResponse
 import kotlinx.serialization.Serializable
@@ -7,7 +8,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class InviteData(
         val code: String,
-        val guildId: Long?,
+        val guild: PartialGuildData?,
         val channelId: Long,
         val targetUserId: Long?,
         val inviterId: Long?,
@@ -15,12 +16,14 @@ data class InviteData(
         val approximateMemberCount: Int?,
         val targetUserType: TargetUserType?
 ) {
+
     companion object {
+
         fun from(entity: InviteResponse) = with(entity) {
             InviteData(
-                    code!!,
-                    guild!!.id.toLong(),
-                    channel!!.id.toLong(),
+                    code,
+                    guild?.let { PartialGuildData.from(it) },
+                    channel.id.toLong(),
                     targetUser?.id?.toLong(),
                     inviter?.id?.toLong(),
                     approximatePresenceCount,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/PartialGuildData.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/PartialGuildData.kt
@@ -22,5 +22,3 @@ class PartialGuildData(
 
 
 }
-
-val InviteData.guildId get() = guild?.id

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/PartialGuildData.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/PartialGuildData.kt
@@ -1,0 +1,26 @@
+package com.gitlab.kordlib.core.cache.data
+
+import com.gitlab.kordlib.cache.api.data.description
+import com.gitlab.kordlib.common.entity.DiscordPartialGuild
+import com.gitlab.kordlib.common.entity.Permissions
+import kotlinx.serialization.Serializable
+
+@Serializable
+class PartialGuildData(
+        val id: Long,
+        val name: String,
+        val icon: String? = null,
+        val owner: Boolean? = null,
+        val permissions: Permissions? = null
+) {
+    companion object {
+
+        fun from(partialGuild: DiscordPartialGuild) = with(partialGuild) {
+            PartialGuildData(id.toLong(), name, icon, owner, permissions)
+        }
+    }
+
+
+}
+
+val InviteData.guildId get() = guild?.id

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/GuildEmoji.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/GuildEmoji.kt
@@ -30,6 +30,9 @@ class GuildEmoji(
     val guildId: Snowflake
         get() = Snowflake(data.guildId)
 
+    val mention: String
+        get() = if (isAnimated) "<a:$name:${id.value}>" else "<:$name:${id.value}>"
+
     /**
      * Whether this emoji can be used, may be false due to loss of Server Boosts.
      */
@@ -118,7 +121,7 @@ class GuildEmoji(
 
     override fun hashCode(): Int = Objects.hash(id, guildId)
 
-    override fun equals(other: Any?): Boolean = when(other) {
+    override fun equals(other: Any?): Boolean = when (other) {
         is GuildEmoji -> other.id == id && other.guildId == guildId
         else -> super.equals(other)
     }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/GuildEmoji.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/GuildEmoji.kt
@@ -10,6 +10,8 @@ import com.gitlab.kordlib.core.cache.data.EmojiData
 import com.gitlab.kordlib.core.supplier.EntitySupplier
 import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy
 import com.gitlab.kordlib.core.toSnowflakeOrNull
+import com.gitlab.kordlib.rest.builder.guild.EmojiModifyBuilder
+import io.ktor.utils.io.bits.withMemory
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filter
@@ -97,6 +99,24 @@ class GuildEmoji(
      * The [User] who created the emote, if present.
      */
     val user: UserBehavior? get() = userId?.let { UserBehavior(it, kord) }
+
+    /**
+     * Requests to delete this emoji, with the given [reason].
+     *
+     * @throws RequestException if anything went wrong during the request.
+     */
+    suspend fun delete(reason: String? = null) {
+        kord.rest.emoji.deleteEmoji(guildId = guildId.value, emojiId = id.value, reason = reason)
+    }
+
+    /**
+     *  Requests to edit the emoji.
+     *
+     *  @throws [RequestException] if anything went wrong during the request.
+     */
+    suspend inline fun edit(builder: EmojiModifyBuilder.() -> Unit) {
+        kord.rest.emoji.modifyEmoji(guildId = guildId.value, emojiId = id.value, builder = builder)
+    }
 
     /**
      * Requests to get the creator of the emoji as a [Member],

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Invite.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Invite.kt
@@ -5,11 +5,10 @@ import com.gitlab.kordlib.common.entity.TargetUserType
 import com.gitlab.kordlib.common.exception.RequestException
 import com.gitlab.kordlib.core.Kord
 import com.gitlab.kordlib.core.KordObject
-import com.gitlab.kordlib.core.behavior.GuildBehavior
 import com.gitlab.kordlib.core.behavior.UserBehavior
-import com.gitlab.kordlib.core.behavior.channel.GuildChannelBehavior
+import com.gitlab.kordlib.core.behavior.channel.ChannelBehavior
 import com.gitlab.kordlib.core.cache.data.InviteData
-import com.gitlab.kordlib.core.entity.channel.GuildChannel
+import com.gitlab.kordlib.core.entity.channel.Channel
 import com.gitlab.kordlib.core.exception.EntityNotFoundException
 import com.gitlab.kordlib.core.supplier.EntitySupplier
 import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy
@@ -37,9 +36,9 @@ data class Invite(
     val channelId: Snowflake get() = Snowflake(data.channelId)
 
     /**
-     * The id of the guild this invite is associated to.
+     * Returns [PartialGuild] if the invite was made in a guild, or null if not.
      */
-    val guildId: Snowflake get() = Snowflake(data.guildId!!)
+    val partialGuild: PartialGuild? get() = data.guild?.let { PartialGuild(it, kord) }
 
     /**
      * The id of the user who created this invite, if present.
@@ -54,12 +53,8 @@ data class Invite(
     /**
      * The behavior of the channel this invite is associated to.
      */
-    val channel: GuildChannelBehavior get() = GuildChannelBehavior(guildId, channelId, kord)
+    val channel: ChannelBehavior get() = ChannelBehavior(channelId, kord)
 
-    /**
-     * The behavior of the guild this invite is associated to.
-     */
-    val guild: GuildBehavior get() = GuildBehavior(guildId, kord)
 
     /**
      * The user behavior of the user who created this invite, if present.
@@ -90,40 +85,25 @@ data class Invite(
      * Requests to get the channel this invite is for.
      *
      * @throws [RequestException] if anything went wrong during the request.
-     * @throws [EntityNotFoundException] if the [GuildChannel] wasn't present.
+     * @throws [EntityNotFoundException] if the [Channel] wasn't present.
      */
-    suspend fun getChannel(): GuildChannel = supplier.getChannelOf(channelId)
+    suspend fun getChannel(): Channel = supplier.getChannelOf(channelId)
 
     /**
      * Requests to get the channel this invite is for,
-     * returns null if the [GuildChannel] isn't present.
+     * returns null if the [Channel] isn't present.
      *
      * @throws [RequestException] if anything went wrong during the request.
      */
-    suspend fun getChannelOrNull(): GuildChannel? = supplier.getChannelOfOrNull(channelId)
-
-    /**
-     * Requests to get the [Guild] for this invite.
-     *
-     * @throws [RequestException] if anything went wrong during the request.
-     * @throws [EntityNotFoundException] if the [Guild] wasn't present.
-     */
-    suspend fun getGuild(): Guild = supplier.getGuild(guildId)
-
-    /**
-     * Requests to get the [Guild] for this invite,
-     * returns null if the [Guild] isn't present.
-     *
-     * @throws [RequestException] if anything went wrong during the request.
-     */
-    suspend fun getGuildOrNull(): Guild? = supplier.getGuildOrNull(guildId)
+    suspend fun getChannelOrNull(): Channel? = supplier.getChannelOfOrNull(channelId)
 
     /**
      * Requests to get the creator of the invite for,
      * returns null if the [User] isn't present or [inviterId] is null.
      *
      * @throws [RequestException] if anything went wrong during the request.
-     */    suspend fun getInviter(): User? = inviterId?.let { supplier.getUserOrNull(it) }
+     */
+    suspend fun getInviter(): User? = inviterId?.let { supplier.getUserOrNull(it) }
 
     /**
      * Requests to get the user this invite was created for,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/PartialGuild.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/PartialGuild.kt
@@ -1,0 +1,92 @@
+package com.gitlab.kordlib.core.entity
+
+import com.gitlab.kordlib.common.entity.Permissions
+import com.gitlab.kordlib.common.entity.Snowflake
+import com.gitlab.kordlib.common.exception.RequestException
+import com.gitlab.kordlib.core.Kord
+import com.gitlab.kordlib.core.behavior.GuildBehavior
+import com.gitlab.kordlib.core.cache.data.PartialGuildData
+import com.gitlab.kordlib.core.entity.channel.Channel
+import com.gitlab.kordlib.core.exception.EntityNotFoundException
+import com.gitlab.kordlib.core.supplier.EntitySupplier
+import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy
+import com.gitlab.kordlib.core.supplier.getChannelOf
+import com.gitlab.kordlib.core.supplier.getChannelOfOrNull
+import com.gitlab.kordlib.rest.Image
+import java.util.*
+
+class PartialGuild(
+        val data: PartialGuildData,
+        override val kord: Kord,
+        override val supplier: EntitySupplier = kord.defaultSupplier
+) : Entity, Strategizable {
+
+    /**
+     * The name of this guild.
+     */
+    val name: String get() = data.name
+
+
+    override val id: Snowflake get() = Snowflake(data.id)
+
+    /**
+     * The icon hash, if present.
+     */
+    val iconHash: String? get() = data.icon
+
+    /**
+     * wither who created the invite is the owner or not.
+     */
+
+    val owner: Boolean? get() = data.owner
+
+    /**
+     * permissions that the invite creator has, if present.
+     */
+
+    val permissions: Permissions? get() = data.permissions
+
+    /**
+     * Gets the icon url, if present.
+     */
+    fun getIconUrl(format: Image.Format): String? = data.icon?.let { "https://cdn.discordapp.com/icons/${id.value}/$it.${format.extension}" }
+
+    /**
+     * Requests to get the icon image in the specified [format], if present.
+     */
+    suspend fun getIcon(format: Image.Format): Image? {
+        val url = getIconUrl(format) ?: return null
+
+        return Image.fromUrl(kord.resources.httpClient, url)
+    }
+
+    /**
+     * Requests to get the full [Guild] entity  for this [PartialGuild].
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     * @throws [EntityNotFoundException] if the [Guild] wasn't present, or the bot is not a part of this [Guild].
+     */
+    suspend fun getGuild(): Guild = supplier.getGuild(id)
+
+    /**
+     * Requests to get the [Guild] for this invite,
+     * returns null if the [Guild] isn't present.
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     */
+    suspend fun getGuildOrNull(): Guild? = supplier.getGuildOrNull(id)
+
+
+    override fun hashCode(): Int = Objects.hash(id)
+
+    override fun equals(other: Any?): Boolean = when (other) {
+        is GuildBehavior -> other.id == id
+        is PartialGuild -> other.id == id
+        else -> false
+    }
+
+
+    override fun withStrategy(strategy: EntitySupplyStrategy<*>): PartialGuild =
+            PartialGuild(data, kord, strategy.supply(kord))
+
+}

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/PermissionOverwriteEntity.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/PermissionOverwriteEntity.kt
@@ -57,7 +57,7 @@ class PermissionOverwriteEntity(
      *
      * @throws [RequestException] if anything went wrong during the request.
      */
-    suspend fun getGuildOrNull(): Guild? = supplier.getGuild(guildId)
+    suspend fun getGuildOrNull(): Guild? = supplier.getGuildOrNull(guildId)
 
     /**
      * Requests to delete this overwrite.

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/ReactionEmoji.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/ReactionEmoji.kt
@@ -4,19 +4,27 @@ import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.core.cache.data.RemovedReactionData
 
 sealed class ReactionEmoji {
-    abstract val formatted: String
+    abstract val urlFormat: String
     abstract val name: String
 
     data class Custom(val id: Snowflake, override val name: String, val isAnimated: Boolean) : ReactionEmoji() {
-        override val formatted: String
+        /**
+         *
+         * Format used in HTTP queries.
+         *
+         */
+        override val urlFormat: String
             get() = "$name:${id.value}"
+
+        val mention: String
+            get() = if (isAnimated) "<a:$name:${id.value}>" else "<:$name:${id.value}>"
 
 
         override fun toString() = "Custom(id=$id, name=$name, isAnimated=$isAnimated)"
     }
 
     class Unicode(override val name: String) : ReactionEmoji() {
-        override val formatted: String get() = name
+        override val urlFormat: String get() = name
     }
 
     companion object {

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/exception/EntityNotFoundException.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/exception/EntityNotFoundException.kt
@@ -50,6 +50,9 @@ class EntityNotFoundException : Exception {
         fun webhookNotFound(webhookId: Snowflake): Nothing =
                 entityNotFound("Webhook", webhookId)
 
+        fun inviteNotFound(code: String): Nothing =
+                throw EntityNotFoundException("Invite with code $code was not found.")
+
     }
 
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/supplier/CacheEntitySupplier.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/supplier/CacheEntitySupplier.kt
@@ -238,4 +238,6 @@ class CacheEntitySupplier(private val kord: Kord) : EntitySupplier {
 
         return User(data, kord)
     }
+
+
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/supplier/EntitySupplier.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/supplier/EntitySupplier.kt
@@ -343,7 +343,6 @@ interface EntitySupplier {
      */
     suspend fun getWebhookWithToken(id: Snowflake, token: String): Webhook =
             getWebhookWithTokenOrNull(id, token) ?: EntityNotFoundException.webhookNotFound(id)
-
 }
 
 

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/supplier/FallbackEntitySupplier.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/supplier/FallbackEntitySupplier.kt
@@ -23,8 +23,6 @@ private class FallbackEntitySupplier(val first: EntitySupplier, val second: Enti
     override suspend fun getChannelOrNull(id: Snowflake): Channel? =
             first.getChannelOrNull(id) ?: second.getChannelOrNull(id)
 
-    override suspend fun getChannel(id: Snowflake): Channel = getChannelOrNull(id)!!
-
     override fun getGuildChannels(guildId: Snowflake): Flow<GuildChannel> =
             first.getGuildChannels(guildId).switchIfEmpty(second.getGuildChannels(guildId))
 
@@ -37,13 +35,8 @@ private class FallbackEntitySupplier(val first: EntitySupplier, val second: Enti
     override suspend fun getMessageOrNull(channelId: Snowflake, messageId: Snowflake): Message? =
             first.getMessageOrNull(channelId, messageId) ?: second.getMessageOrNull(channelId, messageId)
 
-    override suspend fun getGuild(id: Snowflake): Guild = getGuildOrNull(id)!!
-
     override suspend fun getMember(guildId: Snowflake, userId: Snowflake): Member =
             getMemberOrNull(guildId, userId)!!
-
-    override suspend fun getMessage(channelId: Snowflake, messageId: Snowflake): Message =
-            getMessageOrNull(channelId, messageId)!!
 
     override fun getMessagesAfter(messageId: Snowflake, channelId: Snowflake, limit: Int): Flow<Message> =
             first.getMessagesAfter(messageId, channelId, limit).switchIfEmpty(second.getMessagesAfter(messageId, channelId, limit))
@@ -60,24 +53,15 @@ private class FallbackEntitySupplier(val first: EntitySupplier, val second: Enti
     override suspend fun getUserOrNull(id: Snowflake): User? =
             first.getUserOrNull(id) ?: second.getUserOrNull(id)
 
-    override suspend fun getSelf(): User = getSelfOrNull()!!
-
-    override suspend fun getUser(id: Snowflake): User = getUserOrNull(id)!!
-
     override suspend fun getRoleOrNull(guildId: Snowflake, roleId: Snowflake): Role? =
             first.getRoleOrNull(guildId, roleId) ?: second.getRoleOrNull(guildId, roleId)
 
-    override suspend fun getRole(guildId: Snowflake, roleId: Snowflake): Role =
-            getRoleOrNull(guildId, roleId)!!
 
     override fun getGuildRoles(guildId: Snowflake): Flow<Role> =
             first.getGuildRoles(guildId).switchIfEmpty(second.getGuildRoles(guildId))
 
     override suspend fun getGuildBanOrNull(guildId: Snowflake, userId: Snowflake): Ban? =
             first.getGuildBanOrNull(guildId, userId) ?: second.getGuildBanOrNull(guildId, userId)
-
-    override suspend fun getGuildBan(guildId: Snowflake, userId: Snowflake): Ban =
-            getGuildBanOrNull(guildId, userId)!!
 
     override fun getGuildBans(guildId: Snowflake): Flow<Ban> =
             first.getGuildBans(guildId).switchIfEmpty(second.getGuildBans(guildId))
@@ -90,9 +74,6 @@ private class FallbackEntitySupplier(val first: EntitySupplier, val second: Enti
 
     override suspend fun getEmojiOrNull(guildId: Snowflake, emojiId: Snowflake): GuildEmoji? =
             first.getEmojiOrNull(guildId, emojiId) ?: second.getEmojiOrNull(guildId, emojiId)
-
-    override suspend fun getEmoji(guildId: Snowflake, emojiId: Snowflake): GuildEmoji =
-            getEmojiOrNull(guildId, emojiId)!!
 
     override fun getEmojis(guildId: Snowflake): Flow<GuildEmoji> =
             first.getEmojis(guildId).switchIfEmpty(second.getEmojis(guildId))
@@ -111,12 +92,6 @@ private class FallbackEntitySupplier(val first: EntitySupplier, val second: Enti
 
     override suspend fun getWebhookWithTokenOrNull(id: Snowflake, token: String): Webhook? =
             first.getWebhookWithTokenOrNull(id, token) ?: second.getWebhookWithTokenOrNull(id, token)
-
-    override suspend fun getWebhook(id: Snowflake): Webhook =
-            getWebhookOrNull(id)!!
-
-    override suspend fun getWebhookWithToken(id: Snowflake, token: String): Webhook =
-            getWebhookWithTokenOrNull(id, token)!!
 
 }
 

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/supplier/RestEntitySupplier.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/supplier/RestEntitySupplier.kt
@@ -73,8 +73,8 @@ class RestEntitySupplier(val kord: Kord) : EntitySupplier {
      * @throws [RestRequestException] if something went wrong during the request.
      * @throws [EntityNotFoundException] if the preview was not found.
      */
-     suspend fun getGuildPreview(id: Snowflake): GuildPreview = getGuildPreviewOrNull(id)
-             ?: EntityNotFoundException.entityNotFound("Guild preview", id)
+    suspend fun getGuildPreview(id: Snowflake): GuildPreview = getGuildPreviewOrNull(id)
+            ?: EntityNotFoundException.entityNotFound("Guild preview", id)
 
     /**
      * Returns the preview of the guild matching the [id]. The bot does not need to present in this guild
@@ -228,6 +228,14 @@ class RestEntitySupplier(val kord: Kord) : EntitySupplier {
         val data = WebhookData.from(webhook.getWebhookWithToken(id.value, token))
         return Webhook(data, kord)
     }
+
+    suspend fun getInviteOrNull(code: String, withCounts: Boolean): Invite? = catchNotFound {
+        val response = invite.getInvite(code, withCounts)
+        return Invite(InviteData.from(response), kord)
+    }
+
+    suspend fun getInvite(code: String, withCounts: Boolean = true): Invite =
+            getInviteOrNull(code, withCounts) ?: EntityNotFoundException.inviteNotFound(code)
 
     /**
      * Requests to get the information of the current application.

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/supplier/RestEntitySupplier.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/supplier/RestEntitySupplier.kt
@@ -175,7 +175,7 @@ class RestEntitySupplier(val kord: Kord) : EntitySupplier {
                 kord.rest.channel.getReactions(
                         channelId = channelId.value,
                         messageId = messageId.value,
-                        emoji = emoji.formatted,
+                        emoji = emoji.urlFormat,
                         limit = 100,
                         position = position
                 )

--- a/core/src/test/kotlin/InviteTests.kt
+++ b/core/src/test/kotlin/InviteTests.kt
@@ -1,0 +1,22 @@
+import com.gitlab.kordlib.cache.api.put
+import com.gitlab.kordlib.core.Kord
+import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
+import kotlin.test.assertEquals
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@EnabledIfEnvironmentVariable(named = "TARGET_BRANCH", matches = "master")
+class InviteTests {
+
+    @Test
+    fun `get invite from rest and cache`() = runBlocking {
+        val kord = Kord(System.getenv("KORD_TEST_TOKEN"))
+        val invite = kord.with(EntitySupplyStrategy.rest).getInvite("mpDQm5N")
+        assertEquals("mpDQm5N", invite.code)
+    }
+}

--- a/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/Event.kt
+++ b/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/Event.kt
@@ -346,7 +346,7 @@ data class DiscordCreatedInvite(
          * The target user for this invite.
          */
         @SerialName("target_user")
-        val targetUser: DiscordInviteUser,
+        val targetUser: DiscordInviteUser? = null,
 
         /**
          * The type of user target for this invite.

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/guild/EmojiCreateBuilder.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/guild/EmojiCreateBuilder.kt
@@ -1,0 +1,22 @@
+package com.gitlab.kordlib.rest.builder.guild
+
+import com.gitlab.kordlib.common.annotation.KordDsl
+import com.gitlab.kordlib.common.entity.Snowflake
+import com.gitlab.kordlib.rest.Image
+import com.gitlab.kordlib.rest.builder.AuditRequestBuilder
+import com.gitlab.kordlib.rest.json.request.EmojiCreateRequest
+import com.gitlab.kordlib.rest.json.request.EmojiModifyRequest
+
+@KordDsl
+class EmojiCreateBuilder : AuditRequestBuilder<EmojiCreateRequest> {
+    override var reason: String? = null
+    lateinit var name: String
+    lateinit var image: Image
+    var roles: Set<Snowflake> = emptySet()
+
+    override fun toRequest(): EmojiCreateRequest = EmojiCreateRequest(
+            name = name,
+            image = image.dataUri,
+            roles = roles.map { it.value }
+    )
+}

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/response/Invite.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/response/Invite.kt
@@ -9,9 +9,9 @@ import kotlinx.serialization.internal.IntDescriptor
 
 @Serializable
 data class InviteResponse(
-        val code: String? = null,
+        val code: String,
         val guild: DiscordPartialGuild? = null,
-        val channel: DiscordChannel? = null,
+        val channel: DiscordChannel,
         val inviter: DiscordUser? = null,
         @SerialName("target_user")
         val targetUser: DiscordUser? = null,

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/service/EmojiService.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/service/EmojiService.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.rest.service
 
+import com.gitlab.kordlib.rest.builder.guild.EmojiCreateBuilder
 import com.gitlab.kordlib.rest.builder.guild.EmojiModifyBuilder
 import com.gitlab.kordlib.rest.json.request.EmojiCreateRequest
 import com.gitlab.kordlib.rest.json.request.EmojiModifyRequest
@@ -8,6 +9,16 @@ import com.gitlab.kordlib.rest.route.Route
 
 class EmojiService(requestHandler: RequestHandler) : RestService(requestHandler) {
 
+
+    suspend inline fun createEmoji(guildId: String, builder: EmojiCreateBuilder.() -> Unit) = call(Route.GuildEmojiPost) {
+        keys[Route.GuildId] = guildId
+        val emoji = EmojiCreateBuilder().apply(builder)
+
+        body(EmojiCreateRequest.serializer(), emoji.toRequest())
+        emoji.reason?.let { header("X-Audit-Log-Reason", it) }
+    }
+
+    @Deprecated("use the inline builder instead",  ReplaceWith("createEmoji(guildId) {  }") ,level = DeprecationLevel.WARNING)
     suspend fun createEmoji(guildId: String, emoji: EmojiCreateRequest, reason: String? = null) = call(Route.GuildEmojiPost) {
         keys[Route.GuildId] = guildId
         body(EmojiCreateRequest.serializer(), emoji)


### PR DESCRIPTION
# 0.5.1

## Additions
* Added `PartialGuild` in `Invite`
* Added `GuildBehavior#createEmoji`
* Added `GuildEmoji#delete` and `GuildEmoji#edit`
* Added `getInviteOrNull` method to `RestEntitySupplier`

## Fixes

* `DiscordInvite#targetUser` is now correctly nullable.
* `PermissionOverwriteEntity#getGuildOrNull` uses the correct supplier method.
## Changes

* `Invite` now uses a `Channel` instead of `GuildChannel`.
