### PR TITLE
0.5.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.5.11
+
+## Fixes
+
+* Fixed an issue where multiple voice states could be present per user per guild.
+* Fixed an issue where presences would be incorrectly deserialized in guild member chunk events.
+* Fixes member chunk events not caching presences.
+
 # 0.5.10
 
 ## Fixes

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/VoiceStateData.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/VoiceStateData.kt
@@ -4,7 +4,7 @@ import com.gitlab.kordlib.cache.api.data.description
 import com.gitlab.kordlib.common.entity.DiscordVoiceState
 import kotlinx.serialization.Serializable
 
-val VoiceStateData.id get() = "$userId$channelId$guildId"
+val VoiceStateData.id get() = "$userId$guildId"
 
 @Serializable
 data class VoiceStateData(

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/gateway/handler/GuildEventHandler.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/gateway/handler/GuildEventHandler.kt
@@ -2,6 +2,7 @@ package com.gitlab.kordlib.core.gateway.handler
 
 import com.gitlab.kordlib.cache.api.DataCache
 import com.gitlab.kordlib.cache.api.put
+import com.gitlab.kordlib.cache.api.putAll
 import com.gitlab.kordlib.cache.api.query
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.core.Kord
@@ -213,6 +214,9 @@ internal class GuildEventHandler(
     }
 
     private suspend fun handle(event: GuildMembersChunk, shard: Int) = with(event.data) {
+        val presences = presences.orEmpty().map { PresenceData.from(guildId, it) }
+        cache.putAll(presences)
+
         val members = members.asFlow().map { member ->
             val memberData = MemberData.from(member.user!!.id, guildId, member)
             cache.put(memberData)

--- a/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/Command.kt
+++ b/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/Command.kt
@@ -95,7 +95,7 @@ data class GuildMembersChunkData(
         val members: List<DiscordGuildMember>,
         @SerialName("not_found")
         val notFound: List<String>? = null,
-        val presences: List<Presence>? = null,
+        val presences: List<DiscordPresenceUpdateData>? = null,
         /**
          * The chunk index in the expected chunks for this response.
          */


### PR DESCRIPTION
# 0.5.11

## Fixes

* Fixed an issue where multiple voice states could be present per user per guild.
* Fixed an issue where presences would be incorrectly deserialized in guild member chunk events.
* Fixes member chunk events not caching presences.
