### PR TITLE
Throw a nice exception when using a bad bot token.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # 0.5.12
 
+## Changes
+
+* `Member#kick` and `Guild#kick` now have an optional reason.
+* `KordBuilder` now throws a (more) useful exception when building a bot with an invalid token.
+
 ## Fixes
 
 * Fixed an issue where Invite events would not fire if the invited user didn't have an avatar.

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/Kord.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/Kord.kt
@@ -7,17 +7,19 @@ import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.common.entity.Status
 import com.gitlab.kordlib.core.builder.kord.KordBuilder
 import com.gitlab.kordlib.core.cache.data.GuildData
-import com.gitlab.kordlib.core.cache.data.GuildPreviewData
-import com.gitlab.kordlib.core.entity.*
+import com.gitlab.kordlib.core.entity.ApplicationInfo
+import com.gitlab.kordlib.core.entity.Guild
+import com.gitlab.kordlib.core.entity.Region
+import com.gitlab.kordlib.core.entity.User
 import com.gitlab.kordlib.core.entity.channel.Channel
 import com.gitlab.kordlib.core.event.Event
+import com.gitlab.kordlib.core.exception.KordInitializationException
 import com.gitlab.kordlib.core.gateway.MasterGateway
 import com.gitlab.kordlib.core.gateway.handler.GatewayEventInterceptor
 import com.gitlab.kordlib.core.supplier.EntitySupplier
 import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy
 import com.gitlab.kordlib.gateway.Gateway
 import com.gitlab.kordlib.gateway.builder.PresenceBuilder
-import com.gitlab.kordlib.gateway.start
 import com.gitlab.kordlib.rest.builder.guild.GuildCreateBuilder
 import com.gitlab.kordlib.rest.service.RestClient
 import kotlinx.coroutines.CoroutineDispatcher
@@ -119,6 +121,10 @@ class Kord(
     }
 
     companion object {
+
+        /**
+         * @throws KordInitializationException if something went wrong while getting the bot's gateway information.
+         */
         suspend inline operator fun invoke(token: String, builder: KordBuilder.() -> Unit = {}) =
                 KordBuilder(token).apply(builder).build()
     }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/exception/KordInitializationException.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/exception/KordInitializationException.kt
@@ -1,0 +1,7 @@
+package com.gitlab.kordlib.core.exception
+
+class KordInitializationException : Exception {
+    constructor(message: String) : super(message)
+    constructor(cause: Throwable) : super(cause)
+    constructor(message: String, cause: Throwable) : super(message, cause)
+}


### PR DESCRIPTION
Made the KordBuilder throw an exception when getting the bot info goes wrong:
`Something went wrong while initializing Kord, make sure the bot token you entered is valid. $json-response`.

The reminder is only added when the response code is a 401, so this shouldn't give people a false lead if something else went wrong.