### PR TITLE
Bits and bobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,23 @@
 
 * `Member#kick` and `Guild#kick` now have an optional reason.
 * `KordBuilder` now throws a (more) useful exception when building a bot with an invalid token.
+* The REST module will now use `discord.com/api` instead of the deprecated `discordapp.com/api`.
+* Kord now uses `Dispatchers.default` as the default dispatcher.
 
 ## Fixes
 
 * Fixed an issue where Invite events would not fire if the invited user didn't have an avatar.
+* Fixed some outdated docs on the `KordBuilder`.
+
+## Additions
+
+* Introduced an experimental REST-only variant of the Kord builder. This will automatically disable gateway and cache
+related APIs and replace them with a no-op implementation.
+* Introduced a no-op `Gateway` implementation.
+
+## Performance
+
+* Removed an unneeded REST call when building Kord.
 
 # 0.5.11
 

--- a/common/src/main/kotlin/com/gitlab/kordlib/common/entity/DiscordShard.kt
+++ b/common/src/main/kotlin/com/gitlab/kordlib/common/entity/DiscordShard.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.json.JsonLiteral
 import kotlinx.serialization.json.jsonArray
 
 /**
- * An instance of a [Discord shard](https://discordapp.com/developers/docs/topics/gateway#sharding).
+ * An instance of a [Discord shard](https://discord.com/developers/docs/topics/gateway#sharding).
  */
 @Serializable
 data class DiscordShard(val index: Int, val count: Int) {

--- a/common/src/main/kotlin/com/gitlab/kordlib/common/entity/Snowflake.kt
+++ b/common/src/main/kotlin/com/gitlab/kordlib/common/entity/Snowflake.kt
@@ -7,7 +7,7 @@ import kotlin.time.toKotlinDuration
 
 
 /**
- * A unique identifier for entities [used by discord](https://discordapp.com/developers/docs/reference#snowflakes).
+ * A unique identifier for entities [used by discord](https://discord.com/developers/docs/reference#snowflakes).
  */
 inline class Snowflake(val longValue: Long) : Comparable<Snowflake> {
     constructor(value: String) : this(value.toLong())

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/Kord.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/Kord.kt
@@ -1,12 +1,17 @@
 package com.gitlab.kordlib.core
 
 import com.gitlab.kordlib.cache.api.DataCache
+import com.gitlab.kordlib.cache.api.query
+import com.gitlab.kordlib.common.annotation.KordExperimental
+import com.gitlab.kordlib.common.annotation.KordPreview
 import com.gitlab.kordlib.common.annotation.KordUnsafe
 import com.gitlab.kordlib.common.entity.DiscordShard
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.common.entity.Status
 import com.gitlab.kordlib.core.builder.kord.KordBuilder
+import com.gitlab.kordlib.core.builder.kord.KordRestOnlyBuilder
 import com.gitlab.kordlib.core.cache.data.GuildData
+import com.gitlab.kordlib.core.cache.data.UserData
 import com.gitlab.kordlib.core.entity.ApplicationInfo
 import com.gitlab.kordlib.core.entity.Guild
 import com.gitlab.kordlib.core.entity.Region
@@ -123,10 +128,25 @@ class Kord(
     companion object {
 
         /**
+         * Builds a [Kord] instance configured by the [builder].
+         *
          * @throws KordInitializationException if something went wrong while getting the bot's gateway information.
          */
-        suspend inline operator fun invoke(token: String, builder: KordBuilder.() -> Unit = {}) =
+        suspend inline operator fun invoke(token: String, builder: KordBuilder.() -> Unit = {}): Kord =
                 KordBuilder(token).apply(builder).build()
+
+        /**
+         * Builds a [Kord] instance configured by the [builder].
+         *
+         * The instance only allows for configuration of REST related APIs,
+         * interacting with the [gateway][Kord.gateway] or its [events][Kord.events] will result in no-ops.
+         *
+         * Similarly, [cache][Kord.cache] related functionality has been disabled and
+         * replaced with a no-op implementation.
+         */
+        @KordExperimental
+        inline fun restOnly(token: String, builder: KordRestOnlyBuilder.() -> Unit = {}): Kord =
+                KordRestOnlyBuilder(token).apply(builder).build()
     }
 
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/KordObject.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/KordObject.kt
@@ -1,5 +1,12 @@
 package com.gitlab.kordlib.core
 
+/**
+ * An instance than contains a reference to [Kord].
+ */
 interface KordObject {
+
+    /**
+     * The kord instance that created this object.
+     */
     val kord: Kord
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/Util.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/Util.kt
@@ -1,6 +1,5 @@
 package com.gitlab.kordlib.core
 
-
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.core.entity.Entity
 import com.gitlab.kordlib.core.event.Event
@@ -13,7 +12,6 @@ import com.gitlab.kordlib.core.event.message.*
 import com.gitlab.kordlib.core.event.role.RoleCreateEvent
 import com.gitlab.kordlib.core.event.role.RoleDeleteEvent
 import com.gitlab.kordlib.core.event.role.RoleUpdateEvent
-import com.gitlab.kordlib.gateway.Intent
 import com.gitlab.kordlib.gateway.Intent.*
 import com.gitlab.kordlib.gateway.Intents
 import com.gitlab.kordlib.gateway.MessageDelete
@@ -24,7 +22,6 @@ import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.flow.*
 import java.time.Instant
 import java.time.format.DateTimeFormatter
-import kotlin.math.max
 import kotlin.reflect.KClass
 
 internal fun String?.toSnowflakeOrNull(): Snowflake? = when {
@@ -153,14 +150,14 @@ internal fun <T> youngestItem(idSelector: (T) -> String): (Collection<T>) -> T? 
  */
 internal fun <T> oldestItem(idSelector: (T) -> String): (Collection<T>) -> T? = function@{
     if (it.size <= 1) return@function it.firstOrNull()
-        val first = it.first()
-        val last = it.last()
+    val first = it.first()
+    val last = it.last()
 
-        val firstId = idSelector(first).toLong()
-        val lastId = idSelector(last).toLong()
+    val firstId = idSelector(first).toLong()
+    val lastId = idSelector(last).toLong()
 
-        if (firstId < lastId) first
-        else last
+    if (firstId < lastId) first
+    else last
 }
 
 /**

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/Util.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/Util.kt
@@ -54,13 +54,31 @@ fun <T : Entity> Flow<T>.sorted(): Flow<T> = flow {
     }
 }
 
+/**
+ * The terminal operator that returns the first element emitted by the flow that matches the [predicate]
+ * and then cancels flow's collection.
+ * Returns `null` if the flow was empty.
+ */
 suspend inline fun <T : Any> Flow<T>.firstOrNull(crossinline predicate: suspend (T) -> Boolean): T? =
-        filter { predicate(it) }.take(1).singleOrNull()
+        filter { predicate(it) }.firstOrNull()
 
-
+/**
+ * The terminal operator that returns `true` if any of the elements match [predicate].
+ * The flow's collection is cancelled when a match is found.
+ */
 suspend inline fun <T : Any> Flow<T>.any(crossinline predicate: suspend (T) -> Boolean): Boolean =
         firstOrNull(predicate) != null
 
+/**
+ * The non-terminal operator that returns a new flow that will emit values of the second [flow] only after the first
+ * flow finished collecting without values.
+ *
+ * ```kotlin
+ * emptyFlow<String>().switchIfEmpty(flowOf("hello", "world")) //["hello", "world"]
+ *
+ * flowOf("hello", "world").switchIfEmpty(flowOf("goodbye", "world")) //["hello", "world"]
+ * ```
+ */
 internal fun <T> Flow<T>.switchIfEmpty(flow: Flow<T>): Flow<T> = flow {
     var empty = true
     collect {
@@ -75,6 +93,11 @@ internal fun <T> Flow<T>.switchIfEmpty(flow: Flow<T>): Flow<T> = flow {
     }
 }
 
+/**
+ * The terminal operator that returns the index of the first element emitted by the flow that matches the [predicate]
+ * and then cancels flow's collection.
+ * Returns `null` if the flow was empty or no element matched the [predicate].
+ */
 internal suspend inline fun <T> Flow<T>.indexOfFirstOrNull(crossinline predicate: suspend (T) -> Boolean): Int? {
     val counter = atomic(0)
     return map { counter.getAndIncrement() to it }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/GuildBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/GuildBehavior.kt
@@ -35,7 +35,7 @@ import java.util.*
 import com.gitlab.kordlib.rest.service.RestClient
 
 /**
- * The behavior of a [Discord Guild](https://discordapp.com/developers/docs/resources/guild).
+ * The behavior of a [Discord Guild](https://discord.com/developers/docs/resources/guild).
  */
 interface GuildBehavior : Entity, Strategizable {
     /**

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/GuildEmojiBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/GuildEmojiBehavior.kt
@@ -13,7 +13,7 @@ import com.gitlab.kordlib.rest.request.RestRequestException
 import java.util.*
 
 /**
- * The behavior of a [Discord Emoij](https://discordapp.com/developers/docs/resources/emoji).
+ * The behavior of a [Discord Emoij](https://discord.com/developers/docs/resources/emoji).
  */
 interface GuildEmojiBehavior : Entity, Strategizable {
 

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/MemberBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/MemberBehavior.kt
@@ -16,7 +16,7 @@ import com.gitlab.kordlib.rest.request.RestRequestException
 import java.util.*
 
 /**
- * The behavior of a [Discord Member](https://discordapp.com/developers/docs/resources/guild#guild-member-object).
+ * The behavior of a [Discord Member](https://discord.com/developers/docs/resources/guild#guild-member-object).
  */
 interface MemberBehavior : Entity, UserBehavior {
 

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/MessageBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/MessageBehavior.kt
@@ -21,7 +21,7 @@ import com.gitlab.kordlib.rest.request.RestRequestException
 import com.gitlab.kordlib.common.entity.Permission
 
 /**
- * The behavior of a [Discord Message](https://discordapp.com/developers/docs/resources/channel#message-object).
+ * The behavior of a [Discord Message](https://discord.com/developers/docs/resources/channel#message-object).
  */
 interface MessageBehavior : Entity, Strategizable {
     /**

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/RoleBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/RoleBehavior.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.flow.map
 import java.util.*
 
 /**
- * The behavior of a [Discord Role](https://discordapp.com/developers/docs/topics/permissions#role-object) associated to a [guild].
+ * The behavior of a [Discord Role](https://discord.com/developers/docs/topics/permissions#role-object) associated to a [guild].
  */
 interface RoleBehavior : Entity, Strategizable {
     /**

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/UserBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/UserBehavior.kt
@@ -17,7 +17,7 @@ import io.ktor.http.HttpStatusCode
 import java.util.*
 
 /**
- * The behavior of a [Discord User](https://discordapp.com/developers/docs/resources/user)
+ * The behavior of a [Discord User](https://discord.com/developers/docs/resources/user)
  */
 interface UserBehavior : Entity, Strategizable {
 

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/UserBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/UserBehavior.kt
@@ -13,6 +13,7 @@ import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy
 import com.gitlab.kordlib.rest.json.request.DMCreateRequest
 import com.gitlab.kordlib.rest.request.RestRequestException
 import com.gitlab.kordlib.rest.service.RestClient
+import io.ktor.http.HttpStatusCode
 import java.util.*
 
 /**
@@ -60,6 +61,18 @@ interface UserBehavior : Entity, Strategizable {
      * Requests to get or create a [DmChannel] between this bot and the user.
      *
      * This property is not resolvable through cache and will always use the [RestClient] instead.
+     *
+     * If a user does not allow you to send DM's to them, this method will throw a [RestRequestException] with
+     * [code][RestRequestException.code] 403. This can be used to handle the edge case accordingly:
+     * ```kotlin
+     * val channel = try {
+     *     user.getDmChannel()
+     * } catch (exception: RestRequestException) {
+     *     if(exception.code == HttpStatusCode.Forbidden.value) {
+     *         //user doesn't have DMs enabled
+     *         TODO("handle edge case")
+     *     } else throw exception
+     * }
      *
      * @throws [RestRequestException] if something went wrong during the request.
      */

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/WebhookBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/WebhookBehavior.kt
@@ -16,7 +16,7 @@ import com.gitlab.kordlib.rest.request.RestRequestException
 import java.util.*
 
 /**
- * The behavior of a [Discord Webhook](https://discordapp.com/developers/docs/resources/webhook).
+ * The behavior of a [Discord Webhook](https://discord.com/developers/docs/resources/webhook).
  */
 interface WebhookBehavior : Entity, Strategizable {
 

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/CategoryBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/CategoryBehavior.kt
@@ -93,7 +93,6 @@ interface CategoryBehavior : GuildChannelBehavior {
  * @return The edited [Category].
  * @throws [RestRequestException] if something went wrong during the request.
  */
-@Suppress("NAME_SHADOWING")
 suspend fun CategoryBehavior.edit(builder: CategoryModifyBuilder.() -> Unit): Category {
     val response = kord.rest.channel.patchCategory(id.value, builder)
     val data = ChannelData.from(response)

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/ChannelBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/ChannelBehavior.kt
@@ -13,7 +13,7 @@ import com.gitlab.kordlib.rest.request.RestRequestException
 import java.util.*
 
 /**
- * The behavior of a [Discord Channel](https://discordapp.com/developers/docs/resources/channel)
+ * The behavior of a [Discord Channel](https://discord.com/developers/docs/resources/channel)
  */
 interface ChannelBehavior : Entity, Strategizable {
 

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/builder/kord/KordBuilder.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/builder/kord/KordBuilder.kt
@@ -216,7 +216,7 @@ class KordBuilder(val token: String) {
             throw KordInitializationException(message)
         }
 
-        return Json.parse(BotGatewayResponse.serializer(), responseBody)
+        return Json(JsonConfiguration(ignoreUnknownKeys = true)).parse(BotGatewayResponse.serializer(), responseBody)
     }
 
     /**

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/builder/kord/KordBuilder.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/builder/kord/KordBuilder.kt
@@ -158,7 +158,7 @@ class KordBuilder(val token: String) {
      *
      * ```
      * Kord(token) {
-     *     { resources -> ExclusionRequestHandler(resources.httpClient) }
+     *     { resources -> KtorRequestHandler(resources.httpClient, ExclusionRequestRateLimiter()) }
      * }
      * ```
      */

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/builder/kord/KordBuilderUtil.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/builder/kord/KordBuilderUtil.kt
@@ -1,0 +1,59 @@
+package com.gitlab.kordlib.core.builder.kord
+
+import com.gitlab.kordlib.common.entity.Snowflake
+import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.features.defaultRequest
+import io.ktor.client.features.json.JsonFeature
+import io.ktor.client.features.json.serializer.KotlinxSerializer
+import io.ktor.client.features.websocket.WebSockets
+import io.ktor.client.request.header
+import kotlinx.serialization.UnstableDefault
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonConfiguration
+import java.util.*
+
+internal fun HttpClientConfig<*>.defaultConfig(token: String) {
+    expectSuccess = false
+    defaultRequest {
+        header("Authorization", "Bot $token")
+    }
+
+    install(JsonFeature)
+    install(WebSockets)
+}
+
+internal fun HttpClient?.configure(token: String): HttpClient {
+    if (this != null) return this.config {
+        defaultConfig(token)
+    }
+
+    @OptIn(UnstableDefault::class)
+    val jsonConfig = JsonConfiguration(
+            encodeDefaults = false,
+            allowStructuredMapKeys = true,
+            ignoreUnknownKeys = true,
+            isLenient = true
+    )
+
+    val json = Json(jsonConfig)
+
+    return HttpClient(CIO) {
+        defaultConfig(token)
+        install(JsonFeature) {
+            serializer = KotlinxSerializer(json)
+        }
+    }
+}
+
+
+internal fun getBotIdFromToken(token: String): Snowflake {
+    try {
+        val bytes = Base64.getDecoder().decode(token.split(""".""").first())
+        return Snowflake(String(bytes))
+    } catch (exception: IllegalArgumentException) {
+        throw IllegalArgumentException("Malformed bot token: '$token'. Make sure that your token is correct.")
+    }
+}
+

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/builder/kord/KordRestOnlyBuilder.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/builder/kord/KordRestOnlyBuilder.kt
@@ -1,6 +1,7 @@
 package com.gitlab.kordlib.core.builder.kord
 
 import com.gitlab.kordlib.cache.api.DataCache
+import com.gitlab.kordlib.common.annotation.KordExperimental
 import com.gitlab.kordlib.core.ClientResources
 import com.gitlab.kordlib.core.Kord
 import com.gitlab.kordlib.core.event.Event
@@ -14,16 +15,12 @@ import com.gitlab.kordlib.rest.request.KtorRequestHandler
 import com.gitlab.kordlib.rest.request.RequestHandler
 import com.gitlab.kordlib.rest.service.RestClient
 import io.ktor.client.HttpClient
-import io.ktor.client.engine.cio.CIO
-import io.ktor.client.features.json.JsonFeature
-import io.ktor.client.features.json.serializer.KotlinxSerializer
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.BroadcastChannel
 import kotlinx.coroutines.channels.Channel
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonConfiguration
 
+@KordExperimental
 class KordRestOnlyBuilder(val token: String) {
 
     private var handlerBuilder: (resources: ClientResources) -> RequestHandler =

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/builder/kord/KordRestOnlyBuilder.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/builder/kord/KordRestOnlyBuilder.kt
@@ -1,0 +1,79 @@
+package com.gitlab.kordlib.core.builder.kord
+
+import com.gitlab.kordlib.cache.api.DataCache
+import com.gitlab.kordlib.core.ClientResources
+import com.gitlab.kordlib.core.Kord
+import com.gitlab.kordlib.core.event.Event
+import com.gitlab.kordlib.core.exception.KordInitializationException
+import com.gitlab.kordlib.core.gateway.MasterGateway
+import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy
+import com.gitlab.kordlib.gateway.Gateway
+import com.gitlab.kordlib.gateway.Intents
+import com.gitlab.kordlib.rest.ratelimit.ExclusionRequestRateLimiter
+import com.gitlab.kordlib.rest.request.KtorRequestHandler
+import com.gitlab.kordlib.rest.request.RequestHandler
+import com.gitlab.kordlib.rest.service.RestClient
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.features.json.JsonFeature
+import io.ktor.client.features.json.serializer.KotlinxSerializer
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.BroadcastChannel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonConfiguration
+
+class KordRestOnlyBuilder(val token: String) {
+
+    private var handlerBuilder: (resources: ClientResources) -> RequestHandler =
+            { KtorRequestHandler(it.httpClient, ExclusionRequestRateLimiter()) }
+
+    /**
+     * The [CoroutineDispatcher] kord uses to launch suspending tasks. [Dispatchers.Default] by default.
+     */
+    var defaultDispatcher: CoroutineDispatcher = Dispatchers.Default
+
+    /**
+     * The client used for building [Gateways][Gateway] and [RequestHandlers][RequestHandler]. A default implementation
+     * will be used when not set.
+     */
+    var httpClient: HttpClient? = null
+
+    /**
+     * Configures the [RequestHandler] for the [RestClient].
+     *
+     * ```
+     * Kord(token) {
+     *     { resources -> KtorRequestHandler(resources.httpClient, ExclusionRequestRateLimiter()) }
+     * }
+     * ```
+     */
+    fun requestHandler(handlerBuilder: (resources: ClientResources) -> RequestHandler) {
+        this.handlerBuilder = handlerBuilder
+    }
+
+
+    /**
+     * @throws KordInitializationException if something went wrong while getting the bot's gateway information.
+     */
+    fun build(): Kord {
+        val client = httpClient.configure(token)
+
+        val resources = ClientResources(token, 0, client, EntitySupplyStrategy.rest, Intents.none)
+        val rest = RestClient(handlerBuilder(resources))
+        val selfId = getBotIdFromToken(token)
+
+        val eventPublisher = BroadcastChannel<Event>(Channel.CONFLATED)
+
+        return Kord(
+                resources,
+                DataCache.none(),
+                MasterGateway(mapOf(0 to Gateway.none())),
+                rest,
+                selfId,
+                eventPublisher,
+                defaultDispatcher
+        )
+    }
+}

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/cache/CachingGateway.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/cache/CachingGateway.kt
@@ -13,7 +13,6 @@ import kotlin.coroutines.CoroutineContext
  * A bridge between [DataCache] and [Gateway] that automatically empties cache on disconnect.
  */
 @FlowPreview
-
 class CachingGateway(
         private val cache: DataCache,
         private val gateway: Gateway,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Attachment.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Attachment.kt
@@ -6,7 +6,7 @@ import com.gitlab.kordlib.core.cache.data.AttachmentData
 import java.util.*
 
 /**
- * An instance of a [Discord Attachment](https://discordapp.com/developers/docs/resources/channel#attachment-object).
+ * An instance of a [Discord Attachment](https://discord.com/developers/docs/resources/channel#attachment-object).
  *
  * A file attached to a [Message].
  */

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Ban.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Ban.kt
@@ -11,7 +11,7 @@ import com.gitlab.kordlib.core.supplier.EntitySupplier
 import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy
 
 /**
- * An instance of a [Discord Ban](https://discordapp.com/developers/docs/resources/guild#ban-object).
+ * An instance of a [Discord Ban](https://discord.com/developers/docs/resources/guild#ban-object).
  */
 class Ban(
         val data: BanData,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Embed.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Embed.kt
@@ -11,11 +11,11 @@ import java.time.Instant
 internal const val embedDeprecationMessage = """
 Embed types should be considered deprecated and might be removed in a future API version.
 
-https://discordapp.com/developers/docs/resources/channel#embed-object-embed-types
+https://discord.com/developers/docs/resources/channel#embed-object-embed-types
 """
 
 /**
- * An instance of a [Discord Embed](https://discordapp.com/developers/docs/resources/channel#embed-object).
+ * An instance of a [Discord Embed](https://discord.com/developers/docs/resources/channel#embed-object).
  */
 data class Embed(val data: EmbedData, override val kord: Kord) : KordObject {
 

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Guild.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Guild.kt
@@ -28,7 +28,7 @@ import java.time.format.DateTimeFormatter
 import java.util.*
 
 /**
- * An instance of a [Discord Guild](https://discordapp.com/developers/docs/resources/guild).
+ * An instance of a [Discord Guild](https://discord.com/developers/docs/resources/guild).
  */
 class Guild(
         val data: GuildData,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/GuildEmoji.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/GuildEmoji.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.flow.filter
 import java.util.*
 
 /**
- * An instance of a [Discord emoji](https://discordapp.com/developers/docs/resources/emoji#emoji-object) belonging to a specific guild.
+ * An instance of a [Discord emoji](https://discord.com/developers/docs/resources/emoji#emoji-object) belonging to a specific guild.
  */
 class GuildEmoji(
         val data: EmojiData,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Integration.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Integration.kt
@@ -13,6 +13,7 @@ import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy
 import com.gitlab.kordlib.core.toInstant
 import com.gitlab.kordlib.rest.builder.integration.IntegrationModifyBuilder
 import com.gitlab.kordlib.rest.json.response.IntegrationExpireBehavior
+import com.gitlab.kordlib.rest.request.RestRequestException
 import java.time.Duration
 import java.time.Instant
 import java.time.temporal.ChronoUnit
@@ -169,6 +170,13 @@ class Integration(
     }
 }
 
+/**
+ * Requests to edit this integration.
+ *
+ * @return The edited [Integration].
+ *
+ * @throws [RestRequestException] if something went wrong during the request.
+ */
 suspend inline fun Integration.edit(builder: IntegrationModifyBuilder.() -> Unit) {
     kord.rest.guild.modifyGuildIntegration(guildId.value, id.value, builder)
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Integration.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Integration.kt
@@ -20,7 +20,7 @@ import java.time.temporal.ChronoUnit
 import java.util.*
 
 /**
- * A [Discord integration](https://discordapp.com/developers/docs/resources/guild#get-guild-integrations).
+ * A [Discord integration](https://discord.com/developers/docs/resources/guild#get-guild-integrations).
  */
 class Integration(
         val data: IntegrationData,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Invite.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Invite.kt
@@ -17,7 +17,7 @@ import com.gitlab.kordlib.core.supplier.getChannelOfOrNull
 import com.gitlab.kordlib.core.toSnowflakeOrNull
 
 /**
- * An instance of a [Discord Invite](https://discordapp.com/developers/docs/resources/invite).
+ * An instance of a [Discord Invite](https://discord.com/developers/docs/resources/invite).
  */
 data class Invite(
         val data: InviteData,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Member.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Member.kt
@@ -18,7 +18,7 @@ import java.time.format.DateTimeFormatter
 import java.util.*
 
 /**
- * An instance of a [Discord Member](https://discordapp.com/developers/docs/resources/guild#guild-member-object).
+ * An instance of a [Discord Member](https://discord.com/developers/docs/resources/guild#guild-member-object).
  */
 class Member(
         val memberData: MemberData,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Message.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Message.kt
@@ -23,7 +23,7 @@ import java.time.format.DateTimeFormatter
 import java.util.*
 
 /**
- * An instance of a [Discord Message][https://discordapp.com/developers/docs/resources/channel#message-object].
+ * An instance of a [Discord Message][https://discord.com/developers/docs/resources/channel#message-object].
  */
 class Message(
         val data: MessageData,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Reaction.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Reaction.kt
@@ -6,20 +6,38 @@ import com.gitlab.kordlib.core.KordObject
 import com.gitlab.kordlib.core.cache.data.ReactionData
 import com.gitlab.kordlib.core.toSnowflakeOrNull
 
+/**
+ * An instance of a [Discord Reaction](https://discord.com/developers/docs/resources/channel#reaction-object).
+ */
 class Reaction(val data: ReactionData, override val kord: Kord) : KordObject {
 
+    /**
+     *
+     */
     val id: Snowflake? get() = data.emojiId.toSnowflakeOrNull()
 
+    /**
+     * The amount of users that reacted this emoji to the message.
+     */
     val count: Int get() = data.count
 
+    /**
+     * Whether the current user reacted to the message with this emoji.
+     */
     val selfReacted: Boolean get() = data.me
 
+    /**
+     * The emoji of this reaction.
+     */
     val emoji: ReactionEmoji
         get() = when (data.emojiId) {
             null -> ReactionEmoji.Unicode(data.emojiName!!)
             else -> ReactionEmoji.Custom(Snowflake(data.emojiId), data.emojiName ?: "", data.emojiAnimated)
         }
 
+    /**
+     * Whether the emoji is animated.
+     */
     val isAnimated: Boolean get() = data.emojiAnimated
 
 

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/ReactionEmoji.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/ReactionEmoji.kt
@@ -4,16 +4,21 @@ import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.core.cache.data.RemovedReactionData
 
 sealed class ReactionEmoji {
+    /**
+     * Format used in HTTP queries.
+     */
     abstract val urlFormat: String
+
+    /**
+     * Either the unicode representation if it's a [Unicode] emoji or the emoji name if it's a [Custom] emoji.
+     */
     abstract val name: String
+
+
     abstract val mention: String
 
     data class Custom(val id: Snowflake, override val name: String, val isAnimated: Boolean) : ReactionEmoji() {
-        /**
-         *
-         * Format used in HTTP queries.
-         *
-         */
+
         override val urlFormat: String
             get() = "$name:${id.value}"
 

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Strategizable.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Strategizable.kt
@@ -3,10 +3,23 @@ package com.gitlab.kordlib.core.entity
 import com.gitlab.kordlib.core.supplier.EntitySupplier
 import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy
 
+/**
+ * A class that will defer the requesting of [Entities][Entity] to a [supplier].
+ * Copies of this class with a different [supplier] can be made through [withStrategy].
+ *
+ * Unless stated otherwise, all members that fetch [Entities][Entity] will delegate to the [supplier].
+ */
 interface Strategizable {
 
+    /**
+     * The supplier used to request entities.
+     */
     val supplier: EntitySupplier
 
+
+    /**
+     * Returns a copy of this class with a new [supplier] provided by the [strategy].
+     */
     fun withStrategy(strategy: EntitySupplyStrategy<*>) : Strategizable
 
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/User.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/User.kt
@@ -13,7 +13,7 @@ import com.gitlab.kordlib.rest.Image
 import java.util.*
 
 /**
- * An instance of a [Discord User](https://discordapp.com/developers/docs/resources/user#user-object).
+ * An instance of a [Discord User](https://discord.com/developers/docs/resources/user#user-object).
  */
 open class User(
         val data: UserData,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/channel/Channel.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/channel/Channel.kt
@@ -10,7 +10,7 @@ import com.gitlab.kordlib.core.supplier.EntitySupplier
 import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy
 
 /**
- * An instance of a [Discord Channel](https://discordapp.com/developers/docs/resources/channel)
+ * An instance of a [Discord Channel](https://discord.com/developers/docs/resources/channel)
  */
 interface Channel : ChannelBehavior {
     val data: ChannelData

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/supplier/EntitySupplyStrategy.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/supplier/EntitySupplyStrategy.kt
@@ -2,30 +2,52 @@ package com.gitlab.kordlib.core.supplier
 
 import com.gitlab.kordlib.core.Kord
 
+/**
+ *  A supplier that accepts a [Kord] instance and returns an [EntitySupplier] of type [T].
+ */
 interface EntitySupplyStrategy<T : EntitySupplier> {
 
+    /**
+     * Returns an [EntitySupplier] of type [T] that operates on the [kord] instance.
+     */
     fun supply(kord: Kord): T
 
-
     companion object {
+
+        /**
+         * A supplier providing a strategy which exclusively uses REST calls to fetch entities.
+         * See [RestEntitySupplier] for more details.
+         */
         val rest = object : EntitySupplyStrategy<RestEntitySupplier> {
 
             override fun supply(kord: Kord): RestEntitySupplier = RestEntitySupplier(kord)
 
         }
 
+        /**
+         * A supplier providing a strategy which exclusively uses cache to fetch entities.
+         * See [CacheEntitySupplier] for more details.
+         */
         val cache = object : EntitySupplyStrategy<CacheEntitySupplier> {
 
             override fun supply(kord: Kord): CacheEntitySupplier = CacheEntitySupplier(kord)
 
         }
 
+        /**
+         * A supplier providing a strategy which will first operate on the [cache] supplier. When an entity
+         * is not present from cache it will be fetched from [rest] instead. Operations that return flows
+         * will only fall back to rest when the returned flow contained no elements.
+         */
         val cacheWithRestFallback = object : EntitySupplyStrategy<EntitySupplier> {
 
             override fun supply(kord: Kord): EntitySupplier = cache.supply(kord).withFallback(rest.supply(kord))
 
         }
 
+        /**
+         * Create an [EntitySupplyStrategy] from the given [supplier].
+         */
         operator fun <T : EntitySupplier> invoke(
                 supplier: (Kord) -> T
         ): EntitySupplyStrategy<T> = object : EntitySupplyStrategy<T> {

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/supplier/FallbackEntitySupplier.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/supplier/FallbackEntitySupplier.kt
@@ -4,9 +4,16 @@ import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.core.entity.*
 import com.gitlab.kordlib.core.entity.channel.Channel
 import com.gitlab.kordlib.core.entity.channel.GuildChannel
+import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy.Companion.cache
+import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy.Companion.rest
 import com.gitlab.kordlib.core.switchIfEmpty
 import kotlinx.coroutines.flow.Flow
 
+/**
+ * Creates supplier providing a strategy which will first operate on this supplier. When an entity
+ * is not present from the first supplier it will be fetched from [other] instead. Operations that return flows
+ * will only fall back to [other] when the returned flow contained no elements.
+ */
 infix fun EntitySupplier.withFallback(other: EntitySupplier): EntitySupplier = FallbackEntitySupplier(this, other)
 
 private class FallbackEntitySupplier(val first: EntitySupplier, val second: EntitySupplier) : EntitySupplier {

--- a/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/DefaultGateway.kt
+++ b/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/DefaultGateway.kt
@@ -105,7 +105,7 @@ class DefaultGateway(private val data: DefaultGatewayData) : Gateway {
             try {
                 socket = webSocket(data.url)
                 /**
-                 * https://discordapp.com/developers/docs/topics/gateway#transport-compression
+                 * https://discord.com/developers/docs/topics/gateway#transport-compression
                  *
                  * > Every connection to the gateway should use its own unique zlib context.
                  */

--- a/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/Gateway.kt
+++ b/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/Gateway.kt
@@ -8,15 +8,15 @@ import kotlinx.coroutines.flow.Flow
 import kotlin.time.Duration
 
 /**
- * An implementation of the Discord [Gateway](https://discordapp.com/developers/docs/topics/gateway) and its lifecycle.
+ * An implementation of the Discord [Gateway](https://discord.com/developers/docs/topics/gateway) and its lifecycle.
  *
- * Allows consumers to receive [events](https://discordapp.com/developers/docs/topics/gateway#commands-and-events-gateway-events)
- * through [events] and send [commands](https://discordapp.com/developers/docs/topics/gateway#commands-and-events-gateway-commands)
+ * Allows consumers to receive [events](https://discord.com/developers/docs/topics/gateway#commands-and-events-gateway-events)
+ * through [events] and send [commands](https://discord.com/developers/docs/topics/gateway#commands-and-events-gateway-commands)
  * through [send].
  */
 interface Gateway {
     /**
-     * The incoming [events](https://discordapp.com/developers/docs/topics/gateway#commands-and-events-gateway-events)
+     * The incoming [events](https://discord.com/developers/docs/topics/gateway#commands-and-events-gateway-events)
      * of the Gateway. Users should expect these [Flows](Flow) to be hot and remain open for the entire lifecycle of the
      * Gateway.
      */
@@ -89,7 +89,7 @@ suspend inline fun Gateway.start(token: String, config: GatewayConfigurationBuil
 }
 
 /**
- * Enum representation of Discord's [Gateway close event codes](https://discordapp.com/developers/docs/topics/opcodes-and-status-codes#gateway-gateway-close-event-codes).
+ * Enum representation of Discord's [Gateway close event codes](https://discord.com/developers/docs/topics/opcodes-and-status-codes#gateway-gateway-close-event-codes).
  */
 enum class GatewayCloseCode(val code: Int) {
     Unknown(4000),

--- a/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/Intent.kt
+++ b/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/Intent.kt
@@ -182,7 +182,7 @@ data class Intents internal constructor(val code: Int) {
             }
 
         @OptIn(PrivilegedIntent::class)
-        val nonPrivileged
+        val nonPrivileged: Intents
             get() = invoke {
                 Intent.values().forEach { +it }
 
@@ -190,7 +190,9 @@ data class Intents internal constructor(val code: Int) {
                 -Intent.GuildMembers
             }
 
-        inline operator fun invoke(builder: IntentsBuilder.() -> Unit): Intents {
+        val none: Intents = invoke()
+
+        inline operator fun invoke(builder: IntentsBuilder.() -> Unit = {}): Intents {
             return IntentsBuilder().apply(builder).flags()
         }
     }

--- a/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/Intent.kt
+++ b/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/Intent.kt
@@ -7,18 +7,18 @@ import kotlin.RequiresOptIn.*
 /**
  * Some intents are defined as "Privileged" due to the sensitive nature of the data and cannot be used by Kord without enabling them.
  *
- * See [the official documentation](https://discordapp.com/developers/docs/topics/gateway#privileged-intents) for more info on
+ * See [the official documentation](https://discord.com/developers/docs/topics/gateway#privileged-intents) for more info on
  * how to enable these.
  */
 @RequiresOptIn("""
     Some intents are defined as "Privileged" due to the sensitive nature of the data and cannot be used by Kord without enabling them.
     
-    See https://discordapp.com/developers/docs/topics/gateway#privileged-intents for more info on how to enable these.
+    See https://discord.com/developers/docs/topics/gateway#privileged-intents for more info on how to enable these.
 """, Level.ERROR)
 annotation class PrivilegedIntent
 
 /**
- * Values that enable a group of events as [defined by Discord](https://github.com/discordapp/discord-api-docs/blob/feature/gateway-intents/docs/topics/Gateway.md#gateway-intents).
+ * Values that enable a group of events as [defined by Discord](https://github.com/discord/discord-api-docs/blob/feature/gateway-intents/docs/topics/Gateway.md#gateway-intents).
  */
 enum class Intent(val code: Int) {
     /**

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/integration/IntegrationModifyBuilder.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/integration/IntegrationModifyBuilder.kt
@@ -5,7 +5,7 @@ import com.gitlab.kordlib.rest.json.request.GuildIntegrationModifyRequest
 import com.gitlab.kordlib.rest.json.response.IntegrationExpireBehavior
 
 /**
- * Builder for [modifying an integration](https://discordapp.com/developers/docs/resources/guild#modify-guild-integration).
+ * Builder for [modifying an integration](https://discord.com/developers/docs/resources/guild#modify-guild-integration).
  */
 class IntegrationModifyBuilder : RequestBuilder<GuildIntegrationModifyRequest> {
 

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/message/MessageCreateBuilder.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/message/MessageCreateBuilder.kt
@@ -50,7 +50,7 @@ class MessageCreateBuilder : RequestBuilder<MultipartMessageCreateRequest> {
 }
 
 /**
- * The mentions that should trigger a ping. See the [Discord documentation](https://discordapp.com/developers/docs/resources/channel#allowed-mentions-object).
+ * The mentions that should trigger a ping. See the [Discord documentation](https://discord.com/developers/docs/resources/channel#allowed-mentions-object).
  *
  */
 class AllowedMentionsBuilder {

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/ratelimit/RequestRateLimiter.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/ratelimit/RequestRateLimiter.kt
@@ -5,7 +5,7 @@ import java.lang.Exception
 import java.time.Instant
 
 /**
- * A rate limiter that follows [Discord's rate limits](https://discordapp.com/developers/docs/topics/rate-limits) for
+ * A rate limiter that follows [Discord's rate limits](https://discord.com/developers/docs/topics/rate-limits) for
  * the REST api.
  */
 interface RequestRateLimiter {

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/request/Request.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/request/Request.kt
@@ -34,7 +34,7 @@ val Request<*, *>.identifier get() = when { //The major identifier is always the
 }
 
 /**
- * A ['per-route'](https://discordapp.com/developers/docs/topics/rate-limits) identifier for rate limiting purposes.
+ * A ['per-route'](https://discord.com/developers/docs/topics/rate-limits) identifier for rate limiting purposes.
  */
 sealed class RequestIdentifier {
     /**

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/route/Route.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/route/Route.kt
@@ -323,7 +323,7 @@ sealed class Route<T>(
         : Route<ApplicationInfoResponse>(HttpMethod.Get, "/oauth2/applications/@me", ApplicationInfoResponse.serializer())
 
     companion object {
-        val baseUrl = "https://discordapp.com/api/$restVersion"
+        val baseUrl = "https://discord.com/api/$restVersion"
     }
 
     open class Key(val identifier: String, val isMajor: Boolean = false) {


### PR DESCRIPTION
This PR contains some *fairly* small improvements I've worked on the past days:

* Add some more docs, fixed some outdated docs on Kord's builder as well
* Move non-cdn links from discordapp -> discord. The only non-doc change is `Route's` `baseUrl`
* Add some more docs, again
* Fix an issue with the recently introduced error reporting on faulty tokens when building Kord. 
Seems like discord has again introduced some undocumented fields, so I added the flag to ignore those.
* Added a no-op gateway, this one literally does nothing, its eventflow is empty as well.
* Added a shortcut for creating intents without... intents.
* Fix some formatting in the `Util` file.
* Remove the `rest.getSelf` call when building Kord. we can get the ID from the token itself.
* Introduced an experimental REST-only variant of the Kord builder, this one doesn't need to do any API calls when building and
disables gateway and cache related stuff.
* As a result, some code from the builders have been moved towards an internal util file to reduce duplication.
* Change the default dispatcher to `Dispatchers.Default` when building Kord instances.