### PR TITLE
Save voice state under proper guild id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Fixed an issue where Invite events would not fire if the invited user didn't have an avatar.
 * Fixed some outdated docs on the `KordBuilder`.
+* Fixed an issue where voice states from guild creates were not getting cached.
 
 ## Additions
 

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/GuildData.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/GuildData.kt
@@ -100,7 +100,7 @@ data class GuildData(
                     joinedAt,
                     large,
                     memberCount,
-                    voiceStates.orEmpty().map { VoiceStateData.from(it) },
+                    voiceStates.orEmpty().map { VoiceStateData.from(id, it) },
                     members.orEmpty().map { MemberData.from(userId = it.user!!.id, guildId = id, entity = it) },
                     channels.orEmpty().map { it.id.toLong() },
                     presences.orEmpty().map { PresenceData.from(id, it) },

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/VoiceStateData.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/VoiceStateData.kt
@@ -23,7 +23,7 @@ data class VoiceStateData(
     companion object {
         val description = description(VoiceStateData::id)
 
-        fun from(entity: DiscordVoiceState) = with(entity) {
+        fun from(guildId: String?, entity: DiscordVoiceState) = with(entity) {
             VoiceStateData(
                     guildId?.toLong(),
                     channelId?.toLong(),

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/gateway/handler/GuildEventHandler.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/gateway/handler/GuildEventHandler.kt
@@ -73,7 +73,7 @@ internal class GuildEventHandler(
         }
 
         for (voiceState in voiceStates.orEmpty()) {
-            cache.put(VoiceStateData.from(voiceState))
+            cache.put(VoiceStateData.from(id, voiceState))
         }
         for (emoji in emojis) {
             cache.put(EmojiData.from(id, emoji.id!!, emoji))

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/gateway/handler/VoiceEventHandler.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/gateway/handler/VoiceEventHandler.kt
@@ -34,7 +34,7 @@ internal class VoiceEventHandler(
     }
 
     private suspend fun handle(event: VoiceStateUpdate, shard: Int) {
-        val data = VoiceStateData.from(event.voiceState)
+        val data = VoiceStateData.from(event.voiceState.guildId, event.voiceState)
 
         val old = cache.query<VoiceStateData> { VoiceStateData::id eq data.id }
                 .asFlow().map { VoiceState(it, kord) }.singleOrNull()


### PR DESCRIPTION
The curse of missing properties has claimed another victim. 

guild create events don't duplicate their guild id to child properties, we were effectively saving the voice state without guild. 
I fixed this by adding an extra argument to the conversion of discord entity -> data entity and changing all related code.