### PR TITLE
0.5.12 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.5.12
+
+## Fixes
+
+* Fixed an issue where Invite events would not fire if the invited user didn't have an avatar.
+
 # 0.5.11
 
 ## Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,23 @@
 
 * `Member#kick` and `Guild#kick` now have an optional reason.
 * `KordBuilder` now throws a (more) useful exception when building a bot with an invalid token.
+* The REST module will now use `discord.com/api` instead of the deprecated `discordapp.com/api`.
+* Kord now uses `Dispatchers.default` as the default dispatcher.
 
 ## Fixes
 
 * Fixed an issue where Invite events would not fire if the invited user didn't have an avatar.
+* Fixed some outdated docs on the `KordBuilder`.
+
+## Additions
+
+* Introduced an experimental REST-only variant of the Kord builder. This will automatically disable gateway and cache
+related APIs and replace them with a no-op implementation.
+* Introduced a no-op `Gateway` implementation.
+
+## Performance
+
+* Removed an unneeded REST call when building Kord.
 
 # 0.5.11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ related APIs and replace them with a no-op implementation.
 
 * Removed an unneeded REST call when building Kord.
 
+## Dependencies
+
+* kotlin 1.3.72 -> 1.4.0
+* ktor 1.3.2 -> 1.4.0
+* kotlinx.serialization 0.2.0 -> 1.0.0-RC
+* kotlinx.coroutines 1.3.7 -> 1.3.9
+
 # 0.5.11
 
 ## Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # 0.5.12
 
+## Changes
+
+* `Member#kick` and `Guild#kick` now have an optional reason.
+* `KordBuilder` now throws a (more) useful exception when building a bot with an invalid token.
+
 ## Fixes
 
 * Fixed an issue where Invite events would not fire if the invited user didn't have an avatar.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Fixed an issue where Invite events would not fire if the invited user didn't have an avatar.
 * Fixed some outdated docs on the `KordBuilder`.
+* Fixed an issue where voice states from guild creates were not getting cached.
 
 ## Additions
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 import com.jfrog.bintray.gradle.BintrayExtension
 import com.jfrog.bintray.gradle.BintrayPlugin
-import org.jetbrains.dokka.gradle.DokkaTask
+//import org.jetbrains.dokka.gradle.DokkaTask
 import org.ajoberstar.gradle.git.publish.GitPublishExtension
 import org.ajoberstar.gradle.git.publish.tasks.GitPublishPush
 
@@ -13,6 +13,7 @@ buildscript {
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.kotlin}")
         classpath("org.jetbrains.kotlin:kotlin-serialization:${Versions.kotlin}")
         classpath("com.jfrog.bintray.gradle:gradle-bintray-plugin:${Versions.bintray}")
+        classpath("org.jetbrains.kotlinx:atomicfu-gradle-plugin:${Versions.atomicFu}")
     }
 }
 
@@ -43,6 +44,7 @@ subprojects {
     apply(plugin = "kotlinx-serialization")
     apply(plugin = "com.jfrog.bintray")
     apply(plugin = "maven-publish")
+    apply(plugin = "kotlinx-atomicfu")
 
     repositories {
         mavenCentral()
@@ -56,6 +58,7 @@ subprojects {
         api(Dependencies.jdk8)
         api(Dependencies.`kotlinx-serialization`)
         api(Dependencies.`kotlinx-coroutines`)
+        implementation("org.jetbrains.kotlinx:atomicfu-jvm:${Versions.atomicFu}")
         implementation(Dependencies.`kotlin-logging`)
 
         testImplementation(Dependencies.`kotlin-test`)
@@ -120,37 +123,37 @@ subprojects {
     }
 }
 
-tasks {
-    val dokkaOutputDir = "dokka"
+//tasks {
+//    val dokkaOutputDir = "dokka"
+//
+//    val clean = getByName("clean", Delete::class) {
+//        delete(rootProject.buildDir)
+//        delete(dokkaOutputDir)
+//    }
+//
+//    val dokka by getting(DokkaTask::class) {
+//        dependsOn(clean)
+//        outputDirectory = dokkaOutputDir
+//        outputFormat = "html"
+//        subProjects = listOf("core", "rest", "gateway", "common")
+//    }
+//
+//    val fixIndex by register<DocsTask>("fixIndex") {
+//        dependsOn(dokka)
+//    }
+//
+//    val gitPublishPush by getting(GitPublishPush::class) {
+//        dependsOn(fixIndex)
+//    }
+//}
 
-    val clean = getByName("clean", Delete::class) {
-        delete(rootProject.buildDir)
-        delete(dokkaOutputDir)
-    }
-
-    val dokka by getting(DokkaTask::class) {
-        dependsOn(clean)
-        outputDirectory = dokkaOutputDir
-        outputFormat = "html"
-        subProjects = listOf("core", "rest", "gateway", "common")
-    }
-
-    val fixIndex by register<DocsTask>("fixIndex") {
-        dependsOn(dokka)
-    }
-
-    val gitPublishPush by getting(GitPublishPush::class) {
-        dependsOn(fixIndex)
-    }
-}
-
-configure<GitPublishExtension> {
-    repoUri.set("https://github.com/kordlib/kord.git")
-    branch.set("gh-pages")
-
-    contents {
-        from("dokka")
-    }
-
-    commitMessage.set("Update Docs")
-}
+//configure<GitPublishExtension> {
+//    repoUri.set("https://github.com/kordlib/kord.git")
+//    branch.set("gh-pages")
+//
+//    contents {
+//        from("dokka")
+//    }
+//
+//    commitMessage.set("Update Docs")
+//}

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -8,7 +8,7 @@ repositories {
 }
 
 dependencies {
-    implementation(kotlin("gradle-plugin-api", version = "1.3.70"))
+    implementation(kotlin("gradle-plugin-api", version = "1.4.0"))
     implementation(gradleApi())
     implementation(localGroovy())
 }

--- a/buildSrc/src/main/kotlin/Compiler.kt
+++ b/buildSrc/src/main/kotlin/Compiler.kt
@@ -2,8 +2,8 @@ object CompilerArguments {
     const val inlineClasses = "-XXLanguage:+InlineClasses"
     const val coroutines = "-Xopt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"
     const val time = "-Xopt-in=kotlin.time.ExperimentalTime"
-    const val unstableDefault = "-Xopt-in=kotlinx.serialization.UnstableDefault"
     const val stdLib = "-Xopt-in=kotlin.ExperimentalStdlibApi"
+    const val optIn = "-Xopt-in=kotlin.RequiresOptIn"
 }
 
 object Jvm {

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,9 +1,10 @@
 object Versions {
-    const val kotlin = "1.3.72"
-    const val kotlinxSerialization = "0.20.0"
-    const val ktor = "1.3.2"
-    const val kotlinxCoroutines = "1.3.7"
+    const val kotlin = "1.4.0"
+    const val kotlinxSerialization = "1.0.0-RC"
+    const val ktor = "1.4.0"
+    const val kotlinxCoroutines = "1.3.9"
     const val kotlinLogging = "1.7.10"
+    const val atomicFu = "0.14.4"
 
     //test deps
     const val kotlinTest = kotlin
@@ -20,8 +21,9 @@ object Versions {
 @Suppress("ObjectPropertyName")
 object Dependencies {
     const val jdk8 = "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
-    const val `kotlinx-serialization` = "org.jetbrains.kotlinx:kotlinx-serialization-runtime:${Versions.kotlinxSerialization}"
+    const val `kotlinx-serialization` = "org.jetbrains.kotlinx:kotlinx-serialization-core:${Versions.kotlinxSerialization}"
     const val `kotlinx-coroutines` = "org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.kotlinxCoroutines}"
+    const val `kotlinx-atomicfu` = ""
 
     const val `kotlin-logging` = "io.github.microutils:kotlin-logging:${Versions.kotlinLogging}"
 

--- a/buildSrc/src/main/kotlin/Publishing.kt
+++ b/buildSrc/src/main/kotlin/Publishing.kt
@@ -2,7 +2,6 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
 import java.nio.file.Files
 import java.nio.file.Paths
-import java.nio.file.StandardOpenOption
 
 open class DocsTask : DefaultTask() {
 
@@ -10,30 +9,10 @@ open class DocsTask : DefaultTask() {
     fun publish() {
         val dokkaRoot = Paths.get(project.projectDir.absolutePath, "dokka")
 
-        val index = Paths.get(dokkaRoot.toAbsolutePath().toString(), "kord", "index.html")
+        val modulesFile = Paths.get(dokkaRoot.toAbsolutePath().toString(), "-modules.html")
         val newIndex = Paths.get(dokkaRoot.toAbsolutePath().toString(), "index.html")
 
-        //We're technically not moving the index.html. Instead, a working copy will be brought over to the root directory.
-        //This is a bit of a MacGyver move, but it's the easiest solution I could think of.
-        Files.createFile(newIndex)
-
-        var reachedPackages = false
-        //the default index.html is nested inside a folder, we'll move all links up by one directory to fix this in the
-        //root index.html copy.
-        Files.lines(index).map { it.replace("""../""", "") }.forEach {
-            var line = it
-            if ( it.contains("packages", true)) {
-                reachedPackages = true
-            }
-
-            if (reachedPackages){
-                //once we reach the packages declaration, we'll have to do a similar thing as above
-                //we'll move all package links down into the kord directory.
-                line = line.replace("""href="""", """href="kord/""")
-            }
-
-            Files.write(newIndex, (line + "\n").toByteArray(Charsets.UTF_8), StandardOpenOption.APPEND)
-        }
+        Files.copy(modulesFile, newIndex)
     }
 
 }

--- a/common/DokkaDescription.md
+++ b/common/DokkaDescription.md
@@ -1,0 +1,1 @@
+Common code shared between the gateway and rest module.

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -6,7 +6,8 @@ tasks.withType<KotlinCompile> {
         freeCompilerArgs = listOf(
                 CompilerArguments.inlineClasses,
                 CompilerArguments.coroutines,
-                CompilerArguments.time
+                CompilerArguments.time,
+                CompilerArguments.optIn
         )
     }
 }

--- a/common/src/main/kotlin/com/gitlab/kordlib/common/entity/DiscordActivity.kt
+++ b/common/src/main/kotlin/com/gitlab/kordlib/common/entity/DiscordActivity.kt
@@ -1,7 +1,11 @@
 package com.gitlab.kordlib.common.entity
 
 import kotlinx.serialization.*
-import kotlinx.serialization.internal.IntDescriptor
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 
 @Serializable
 data class DiscordActivity(
@@ -65,15 +69,15 @@ enum class ActivityType(val code: Int) {
     @Serializer(forClass = ActivityType::class)
     companion object ActivityTypeSerializer : KSerializer<ActivityType> {
         override val descriptor: SerialDescriptor
-            get() = PrimitiveDescriptor("op", PrimitiveKind.INT)
+            get() = PrimitiveSerialDescriptor("op", PrimitiveKind.INT)
 
         override fun deserialize(decoder: Decoder): ActivityType {
             val code = decoder.decodeInt()
             return values().firstOrNull { it.code == code } ?: Unknown
         }
 
-        override fun serialize(encoder: Encoder, obj: ActivityType) {
-            encoder.encodeInt(obj.code)
+        override fun serialize(encoder: Encoder, value: ActivityType) {
+            encoder.encodeInt(value.code)
         }
     }
 

--- a/common/src/main/kotlin/com/gitlab/kordlib/common/entity/DiscordChannel.kt
+++ b/common/src/main/kotlin/com/gitlab/kordlib/common/entity/DiscordChannel.kt
@@ -1,7 +1,11 @@
 package com.gitlab.kordlib.common.entity
 
 import kotlinx.serialization.*
-import kotlinx.serialization.internal.IntDescriptor
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 
 @Serializable
 data class DiscordChannel(
@@ -53,19 +57,19 @@ enum class ChannelType(val code: Int) {
     GuildCategory(4),
     GuildNews(5),
     GuildStore(6);
-
     @Serializer(forClass = ChannelType::class)
     companion object ChannelTypeSerializer : KSerializer<ChannelType> {
         override val descriptor: SerialDescriptor
-            get() = PrimitiveDescriptor("type", PrimitiveKind.INT)
+            get() = PrimitiveSerialDescriptor("type", PrimitiveKind.INT)
 
         override fun deserialize(decoder: Decoder): ChannelType {
             val code = decoder.decodeInt()
             return values().firstOrNull { it.code == code } ?: Unknown
         }
 
-        override fun serialize(encoder: Encoder, obj: ChannelType) {
-            encoder.encodeInt(obj.code)
+        override fun serialize(encoder: Encoder, value: ChannelType) {
+            encoder.encodeInt(value.code)
         }
     }
+
 }

--- a/common/src/main/kotlin/com/gitlab/kordlib/common/entity/DiscordGuild.kt
+++ b/common/src/main/kotlin/com/gitlab/kordlib/common/entity/DiscordGuild.kt
@@ -1,6 +1,11 @@
 package com.gitlab.kordlib.common.entity
 
 import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.internal.IntDescriptor
 import kotlinx.serialization.internal.StringDescriptor
 
@@ -123,7 +128,7 @@ enum class GuildFeature(val value: String) {
     @Serializer(forClass = GuildFeature::class)
     companion object : KSerializer<GuildFeature> {
         override val descriptor: SerialDescriptor
-            get() = PrimitiveDescriptor("feature", PrimitiveKind.STRING)
+            get() = PrimitiveSerialDescriptor("feature", PrimitiveKind.STRING)
 
         override fun deserialize(decoder: Decoder): GuildFeature {
             val name = decoder.decodeString()
@@ -147,7 +152,7 @@ class SystemChannelFlags constructor(val code: Int) {
     companion object : KSerializer<SystemChannelFlags> {
 
         override val descriptor: SerialDescriptor
-            get() = PrimitiveDescriptor("system_channel_flags", PrimitiveKind.INT)
+            get() = PrimitiveSerialDescriptor("system_channel_flags", PrimitiveKind.INT)
 
         override fun deserialize(decoder: Decoder): SystemChannelFlags {
             return SystemChannelFlags(decoder.decodeInt())
@@ -245,7 +250,7 @@ enum class PremiumTier(val level: Int) {
     @Serializer(forClass = PremiumTier::class)
     companion object PremiumTierSerializer : KSerializer<PremiumTier> {
         override val descriptor: SerialDescriptor
-            get() = PrimitiveDescriptor("premium_tier", PrimitiveKind.INT)
+            get() = PrimitiveSerialDescriptor("premium_tier", PrimitiveKind.INT)
 
         override fun deserialize(decoder: Decoder): PremiumTier {
             val level = decoder.decodeInt()
@@ -269,7 +274,7 @@ enum class DefaultMessageNotificationLevel(val code: Int) {
     @Serializer(forClass = DefaultMessageNotificationLevel::class)
     companion object DefaultMessageNotificationLevelSerializer : KSerializer<DefaultMessageNotificationLevel> {
         override val descriptor: SerialDescriptor
-            get() = PrimitiveDescriptor("default_message_notifications", PrimitiveKind.INT)
+            get() = PrimitiveSerialDescriptor("default_message_notifications", PrimitiveKind.INT)
 
         override fun deserialize(decoder: Decoder): DefaultMessageNotificationLevel {
             val code = decoder.decodeInt()
@@ -295,7 +300,7 @@ enum class ExplicitContentFilter(val code: Int) {
     companion object ExplicitContentFilterSerializer : KSerializer<ExplicitContentFilter> {
 
         override val descriptor: SerialDescriptor
-            get() = PrimitiveDescriptor("explicit_content_filter", PrimitiveKind.INT)
+            get() = PrimitiveSerialDescriptor("explicit_content_filter", PrimitiveKind.INT)
 
         override fun deserialize(decoder: Decoder): ExplicitContentFilter {
             val code = decoder.decodeInt()
@@ -320,7 +325,7 @@ enum class MFALevel(val code: Int) {
     object MFALevelSerializer : KSerializer<MFALevel> {
 
         override val descriptor: SerialDescriptor
-            get() = PrimitiveDescriptor("mfa_level", PrimitiveKind.INT)
+            get() = PrimitiveSerialDescriptor("mfa_level", PrimitiveKind.INT)
 
         override fun deserialize(decoder: Decoder): MFALevel {
             val code = decoder.decodeInt()
@@ -348,7 +353,7 @@ enum class VerificationLevel(val code: Int) {
     companion object VerificationLevelSerializer : KSerializer<VerificationLevel> {
 
         override val descriptor: SerialDescriptor
-            get() = PrimitiveDescriptor("verification_level", PrimitiveKind.INT)
+            get() = PrimitiveSerialDescriptor("verification_level", PrimitiveKind.INT)
 
         override fun deserialize(decoder: Decoder): VerificationLevel {
             val code = decoder.decodeInt()

--- a/common/src/main/kotlin/com/gitlab/kordlib/common/entity/DiscordMessage.kt
+++ b/common/src/main/kotlin/com/gitlab/kordlib/common/entity/DiscordMessage.kt
@@ -1,6 +1,11 @@
 package com.gitlab.kordlib.common.entity
 
 import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.internal.IntDescriptor
 
 @Serializable
@@ -130,7 +135,7 @@ data class Flags internal constructor(val code: Int) {
             return FlagsBuilder().apply(builder).flags()
         }
 
-        override val descriptor: SerialDescriptor = IntDescriptor
+        override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("flags", PrimitiveKind.INT)
 
         override fun deserialize(decoder: Decoder): Flags {
             val flags = decoder.decodeInt()
@@ -317,7 +322,7 @@ enum class MessageType(val code: Int) {
     companion object MessageTypeSerializer : KSerializer<MessageType> {
 
         override val descriptor: SerialDescriptor
-            get() = PrimitiveDescriptor("type", PrimitiveKind.INT)
+            get() = PrimitiveSerialDescriptor("type", PrimitiveKind.INT)
 
         override fun deserialize(decoder: Decoder): MessageType {
             val code = decoder.decodeInt()

--- a/common/src/main/kotlin/com/gitlab/kordlib/common/entity/DiscordShard.kt
+++ b/common/src/main/kotlin/com/gitlab/kordlib/common/entity/DiscordShard.kt
@@ -1,9 +1,9 @@
 package com.gitlab.kordlib.common.entity
 
 import kotlinx.serialization.*
-import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.JsonLiteral
-import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.*
 
 /**
  * An instance of a [Discord shard](https://discord.com/developers/docs/topics/gateway#sharding).
@@ -15,18 +15,18 @@ data class DiscordShard(val index: Int, val count: Int) {
     companion object : KSerializer<DiscordShard> {
 
         override fun serialize(encoder: Encoder, obj: DiscordShard) {
-            val array = jsonArray {
-                +JsonLiteral(obj.index)
-                +JsonLiteral(obj.count)
+            val array = buildJsonArray {
+                add(JsonPrimitive(obj.index))
+                add(JsonPrimitive(obj.count))
             }
 
-            encoder.encode(JsonArray.serializer(), array)
+            encoder.encodeSerializableValue(JsonArray.serializer(), array)
         }
 
         override fun deserialize(decoder: Decoder): DiscordShard {
             val array = JsonArray.serializer().deserialize(decoder)
-            val index = array.getPrimitive(0).int
-            val count = array.getPrimitive(1).int
+            val index = array[0].jsonPrimitive.int
+            val count = array[1].jsonPrimitive.int
             return DiscordShard(index, count)
         }
 

--- a/common/src/main/kotlin/com/gitlab/kordlib/common/entity/DiscordShard.kt
+++ b/common/src/main/kotlin/com/gitlab/kordlib/common/entity/DiscordShard.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.json.JsonLiteral
 import kotlinx.serialization.json.jsonArray
 
 /**
- * An instance of a [Discord shard](https://discordapp.com/developers/docs/topics/gateway#sharding).
+ * An instance of a [Discord shard](https://discord.com/developers/docs/topics/gateway#sharding).
  */
 @Serializable
 data class DiscordShard(val index: Int, val count: Int) {

--- a/common/src/main/kotlin/com/gitlab/kordlib/common/entity/DiscordUser.kt
+++ b/common/src/main/kotlin/com/gitlab/kordlib/common/entity/DiscordUser.kt
@@ -1,6 +1,11 @@
 package com.gitlab.kordlib.common.entity
 
 import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.internal.IntDescriptor
 
 @Serializable
@@ -69,7 +74,7 @@ data class UserFlags constructor(val code: Int) {
             return UserFlagsBuilder().apply(builder).flags()
         }
 
-        override val descriptor: SerialDescriptor = IntDescriptor
+        override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("userFlag", PrimitiveKind.INT)
 
         override fun deserialize(decoder: Decoder): UserFlags {
             val flags = decoder.decodeInt()
@@ -122,15 +127,15 @@ enum class Premium(val code: Int) {
     @Serializer(forClass = Premium::class)
     companion object PremiumSerializer : KSerializer<Premium> {
         override val descriptor: SerialDescriptor
-            get() = PrimitiveDescriptor("premium_type", PrimitiveKind.INT)
+            get() = PrimitiveSerialDescriptor("premium_type", PrimitiveKind.INT)
 
         override fun deserialize(decoder: Decoder): Premium {
             val code = decoder.decodeInt()
             return values().firstOrNull { it.code == code } ?: Unknown
         }
 
-        override fun serialize(encoder: Encoder, obj: Premium) {
-            encoder.encodeInt(obj.code)
+        override fun serialize(encoder: Encoder, value: Premium) {
+            encoder.encodeInt(value.code)
         }
     }
 }

--- a/common/src/main/kotlin/com/gitlab/kordlib/common/entity/DiscordWebhook.kt
+++ b/common/src/main/kotlin/com/gitlab/kordlib/common/entity/DiscordWebhook.kt
@@ -1,6 +1,11 @@
 package com.gitlab.kordlib.common.entity
 
 import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.internal.IntDescriptor
 
 @Serializable
@@ -27,7 +32,7 @@ enum class WebhookType(val code: Int) {
     companion object WebhookTypeSerializer : KSerializer<WebhookType> {
 
         override val descriptor: SerialDescriptor
-            get() = PrimitiveDescriptor("type", PrimitiveKind.INT)
+            get() = PrimitiveSerialDescriptor("type", PrimitiveKind.INT)
 
         override fun deserialize(decoder: Decoder): WebhookType {
             val code = decoder.decodeInt()

--- a/common/src/main/kotlin/com/gitlab/kordlib/common/entity/Invite.kt
+++ b/common/src/main/kotlin/com/gitlab/kordlib/common/entity/Invite.kt
@@ -1,6 +1,11 @@
 package com.gitlab.kordlib.common.entity
 
 import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 
 @Serializable(with = TargetUserType.TargetUserTypeSerializer::class)
 enum class TargetUserType(val code: Int) {
@@ -10,7 +15,7 @@ enum class TargetUserType(val code: Int) {
 
     @Serializer(forClass = TargetUserType::class)
     companion object TargetUserTypeSerializer : KSerializer<TargetUserType> {
-        override val descriptor: SerialDescriptor = PrimitiveDescriptor("TargetUserType", PrimitiveKind.INT)
+        override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("TargetUserType", PrimitiveKind.INT)
 
         override fun deserialize(decoder: Decoder): TargetUserType {
             val code = decoder.decodeInt()
@@ -18,8 +23,8 @@ enum class TargetUserType(val code: Int) {
             return values().firstOrNull { it.code == code } ?: Unknown
         }
 
-        override fun serialize(encoder: Encoder, obj: TargetUserType) {
-            encoder.encodeInt(obj.code)
+        override fun serialize(encoder: Encoder, value: TargetUserType) {
+            encoder.encodeInt(value.code)
         }
     }
 

--- a/common/src/main/kotlin/com/gitlab/kordlib/common/entity/Permission.kt
+++ b/common/src/main/kotlin/com/gitlab/kordlib/common/entity/Permission.kt
@@ -1,6 +1,11 @@
 package com.gitlab.kordlib.common.entity
 
 import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 
 @Serializable(with = Permissions.Companion::class)
 class Permissions constructor(val code: Int) {
@@ -31,14 +36,14 @@ class Permissions constructor(val code: Int) {
         }
 
         override val descriptor: SerialDescriptor
-            get() = PrimitiveDescriptor("permission", PrimitiveKind.INT)
+            get() = PrimitiveSerialDescriptor("permission", PrimitiveKind.INT)
 
         override fun deserialize(decoder: Decoder): Permissions {
             return Permissions(decoder.decodeInt())
         }
 
-        override fun serialize(encoder: Encoder, obj: Permissions) {
-            encoder.encodeInt(obj.code)
+        override fun serialize(encoder: Encoder, value: Permissions) {
+            encoder.encodeInt(value.code)
         }
     }
 

--- a/common/src/main/kotlin/com/gitlab/kordlib/common/entity/Presence.kt
+++ b/common/src/main/kotlin/com/gitlab/kordlib/common/entity/Presence.kt
@@ -1,6 +1,11 @@
 package com.gitlab.kordlib.common.entity
 
 import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.JsonElement
 
 @Serializable
@@ -44,15 +49,15 @@ enum class Status {
 
         @Serializer(forClass = Status::class)
         companion object StatusSerializer : KSerializer<Status> {
-                override val descriptor: SerialDescriptor = PrimitiveDescriptor("Status", PrimitiveKind.STRING)
+                override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("Status", PrimitiveKind.STRING)
 
                 override fun deserialize(decoder: Decoder): Status {
                         val name = decoder.decodeString()
                         return values().firstOrNull { it.name.toLowerCase() == name } ?: Unknown
                 }
 
-                override fun serialize(encoder: Encoder, obj: Status) {
-                        encoder.encodeString(obj.name.toLowerCase())
+                override fun serialize(encoder: Encoder, value: Status) {
+                        encoder.encodeString(value.name.toLowerCase())
                 }
         }
 }

--- a/common/src/main/kotlin/com/gitlab/kordlib/common/entity/Snowflake.kt
+++ b/common/src/main/kotlin/com/gitlab/kordlib/common/entity/Snowflake.kt
@@ -1,10 +1,9 @@
 package com.gitlab.kordlib.common.entity
 
 import java.time.Instant
-import kotlin.time.ClockMark
 import kotlin.time.Duration
+import kotlin.time.TimeMark
 import kotlin.time.toKotlinDuration
-
 
 /**
  * A unique identifier for entities [used by discord](https://discord.com/developers/docs/reference#snowflakes).
@@ -16,16 +15,16 @@ inline class Snowflake(val longValue: Long) : Comparable<Snowflake> {
 
     val timeStamp: Instant get() = Instant.ofEpochMilli(discordEpoch + (longValue shr 22))
 
-    val timeMark: ClockMark get() = SnowflakeMark(longValue shr 22)
+    val timeMark: TimeMark get() = SnowflakeMark(longValue shr 22)
 
     override fun compareTo(other: Snowflake): Int = longValue.shr(22).compareTo(other.longValue.shr(22))
 
     companion object {
-        val discordEpoch = 1420070400000L
+        const val discordEpoch = 1420070400000L
     }
 }
 
-private class SnowflakeMark(val epochMilliseconds: Long) : ClockMark() {
+private class SnowflakeMark(val epochMilliseconds: Long) : TimeMark() {
 
     override fun elapsedNow(): Duration =
             java.time.Duration.between(Instant.ofEpochMilli(epochMilliseconds), Instant.now()).toKotlinDuration()

--- a/common/src/main/kotlin/com/gitlab/kordlib/common/entity/Snowflake.kt
+++ b/common/src/main/kotlin/com/gitlab/kordlib/common/entity/Snowflake.kt
@@ -7,7 +7,7 @@ import kotlin.time.toKotlinDuration
 
 
 /**
- * A unique identifier for entities [used by discord](https://discordapp.com/developers/docs/reference#snowflakes).
+ * A unique identifier for entities [used by discord](https://discord.com/developers/docs/reference#snowflakes).
  */
 inline class Snowflake(val longValue: Long) : Comparable<Snowflake> {
     constructor(value: String) : this(value.toLong())

--- a/common/src/test/kotlin/json/ChannelTest.kt
+++ b/common/src/test/kotlin/json/ChannelTest.kt
@@ -4,6 +4,7 @@ package json
 
 import com.gitlab.kordlib.common.entity.DiscordChannel
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.parse
 import org.junit.jupiter.api.Test
 
 private fun file(name: String): String {
@@ -15,7 +16,7 @@ class ChannelTest {
 
     @Test
     fun `DMChannel serialization`() {
-        val channel = Json.parse(DiscordChannel.serializer(), file("dmchannel"))
+        val channel = Json.decodeFromString(DiscordChannel.serializer(), file("dmchannel"))
 
         with(channel) {
             lastMessageId shouldBe "3343820033257021450"
@@ -35,7 +36,7 @@ class ChannelTest {
 
     @Test
     fun `ChannelCategory serialization`() {
-        val channel = Json.parse(DiscordChannel.serializer(), file("channelcategory"))
+        val channel = Json.decodeFromString(DiscordChannel.serializer(), file("channelcategory"))
 
         with(channel) {
             permissionOverwrites shouldBe emptyList()
@@ -51,7 +52,7 @@ class ChannelTest {
 
     @Test
     fun `GroupDMChannel serialization`() {
-        val channel = Json.parse(DiscordChannel.serializer(), file("groupdmchannel"))
+        val channel = Json.decodeFromString(DiscordChannel.serializer(), file("groupdmchannel"))
 
         with(channel) {
             name shouldBe "Some test channel"
@@ -79,7 +80,7 @@ class ChannelTest {
 
     @Test
     fun `GuildNewChannel serialization`() {
-        val channel = Json.parse(DiscordChannel.serializer(), file("guildnewschannel"))
+        val channel = Json.decodeFromString(DiscordChannel.serializer(), file("guildnewschannel"))
 
         with(channel) {
             id shouldBe "41771983423143937"
@@ -98,7 +99,7 @@ class ChannelTest {
 
     @Test
     fun `GuildTextChannel serialization`() {
-        val channel = Json.parse(DiscordChannel.serializer(), file("guildtextchannel"))
+        val channel = Json.decodeFromString(DiscordChannel.serializer(), file("guildtextchannel"))
 
         with(channel) {
             id shouldBe "41771983423143937"
@@ -118,7 +119,7 @@ class ChannelTest {
 
     @Test
     fun `GuildVoiceChannel serialization`() {
-        val channel = Json.parse(DiscordChannel.serializer(), file("guildvoicechannel"))
+        val channel = Json.decodeFromString(DiscordChannel.serializer(), file("guildvoicechannel"))
 
         with(channel) {
             id shouldBe "155101607195836416"
@@ -137,7 +138,7 @@ class ChannelTest {
 
     @Test
     fun `StoreChannel serialization`() {
-        val channel = Json.parse(DiscordChannel.serializer(), file("storechannel"))
+        val channel = Json.decodeFromString(DiscordChannel.serializer(), file("storechannel"))
 
         with(channel) {
             id shouldBe "41771983423143937"

--- a/common/src/test/kotlin/json/EmojiTest.kt
+++ b/common/src/test/kotlin/json/EmojiTest.kt
@@ -16,7 +16,7 @@ class EmojiTest {
 
     @Test
     fun `Emoji serialization`() {
-        val emoji = Json.parse(DiscordEmoji.serializer(), file("customemoji"))
+        val emoji = Json.decodeFromString(DiscordEmoji.serializer(), file("customemoji"))
 
         with(emoji) {
             id shouldBe "41771983429993937"
@@ -28,7 +28,7 @@ class EmojiTest {
 
 @Test
 fun `Standard Emoji serialization`() {
-    val emoji = Json.parse(DiscordEmoji.serializer(), file("standardemoji"))
+    val emoji = Json.decodeFromString(DiscordEmoji.serializer(), file("standardemoji"))
 
     with(emoji) {
         id shouldBe null
@@ -40,7 +40,7 @@ fun `Standard Emoji serialization`() {
 
 @Test
 fun `Emoji serialization`() {
-    val emoji = Json.parse(DiscordEmoji.serializer(), file("emoji"))
+    val emoji = Json.decodeFromString(DiscordEmoji.serializer(), file("emoji"))
 
     with(emoji) {
         id shouldBe "41771983429993937"

--- a/common/src/test/kotlin/json/GuildTest.kt
+++ b/common/src/test/kotlin/json/GuildTest.kt
@@ -16,7 +16,7 @@ class GuildTest {
 
     @Test
     fun `Guild serialization`() {
-        val guild = Json.parse(DiscordGuild.serializer(), file("guild"))
+        val guild = Json.decodeFromString(DiscordGuild.serializer(), file("guild"))
 
         with(guild) {
             id shouldBe "41771983423143937"
@@ -47,7 +47,7 @@ class GuildTest {
 
 @Test
 fun `UnavailableGuild serialization`() {
-    val guild = Json.parse(DiscordUnavailableGuild.serializer(), file("unavailableguild"))
+    val guild = Json.decodeFromString(DiscordUnavailableGuild.serializer(), file("unavailableguild"))
 
     with(guild) {
         id shouldBe "41771983423143937"
@@ -59,7 +59,7 @@ fun `UnavailableGuild serialization`() {
 
 @Test
 fun `GuildMember serialization`() {
-    val member = Json.parse(DiscordGuildMember.serializer(), file("guildmember"))
+    val member = Json.decodeFromString(DiscordGuildMember.serializer(), file("guildmember"))
 
     with(member) {
         nick shouldBe "NOT API SUPPORT"
@@ -73,7 +73,7 @@ fun `GuildMember serialization`() {
 
 @Test
 fun `PartialGuild serialization`() {
-    val guild = Json.parse(DiscordPartialGuild.serializer(), file("partialguild"))
+    val guild = Json.decodeFromString(DiscordPartialGuild.serializer(), file("partialguild"))
 
     with(guild) {
         id shouldBe "80351110224678912"

--- a/common/src/test/kotlin/json/MessageTest.kt
+++ b/common/src/test/kotlin/json/MessageTest.kt
@@ -18,7 +18,7 @@ class MessageTest {
 
     @Test
     fun `Message serialization`() {
-        val message: DiscordMessage = Json.parse(DiscordMessage.serializer(), file("message"))
+        val message: DiscordMessage = Json.decodeFromString(DiscordMessage.serializer(), file("message"))
 
         with(message) {
             reactions!!.size shouldBe 1
@@ -56,7 +56,7 @@ class MessageTest {
 
 @Test
 fun `User serialization`() {
-    val message = Json.parse(DiscordMessage.serializer(), file("crossposted"))
+    val message = Json.decodeFromString(DiscordMessage.serializer(), file("crossposted"))
 
     with(message) {
         reactions!!.size shouldBe 1

--- a/common/src/test/kotlin/json/UserTest.kt
+++ b/common/src/test/kotlin/json/UserTest.kt
@@ -16,7 +16,7 @@ class UserTest {
 
     @Test
     fun `User serialization`() {
-        val user = Json.parse(DiscordUser.serializer(), file("user"))
+        val user = Json.decodeFromString(DiscordUser.serializer(), file("user"))
 
         with(user) {
             id shouldBe "80351110224678912"

--- a/common/src/test/kotlin/json/VoiceStateTest.kt
+++ b/common/src/test/kotlin/json/VoiceStateTest.kt
@@ -15,7 +15,7 @@ class VoiceStateTest {
 
     @Test
     fun `VoiceState serialization`() {
-        val state = Json.parse(DiscordVoiceState.serializer(), file("voicestate"))
+        val state = Json.decodeFromString(DiscordVoiceState.serializer(), file("voicestate"))
 
         with(state) {
             channelId shouldBe "157733188964188161"

--- a/core/DokkaDescription.md
+++ b/core/DokkaDescription.md
@@ -1,0 +1,1 @@
+High level abstraction of the Discord API built on top of the rest and gateway module.

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -33,7 +33,8 @@ tasks.withType<KotlinCompile> {
                 CompilerArguments.inlineClasses,
                 CompilerArguments.coroutines,
                 CompilerArguments.time,
-                CompilerArguments.stdLib
+                CompilerArguments.stdLib,
+                CompilerArguments.optIn
         )
     }
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/Kord.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/Kord.kt
@@ -1,12 +1,17 @@
 package com.gitlab.kordlib.core
 
 import com.gitlab.kordlib.cache.api.DataCache
+import com.gitlab.kordlib.cache.api.query
+import com.gitlab.kordlib.common.annotation.KordExperimental
+import com.gitlab.kordlib.common.annotation.KordPreview
 import com.gitlab.kordlib.common.annotation.KordUnsafe
 import com.gitlab.kordlib.common.entity.DiscordShard
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.common.entity.Status
 import com.gitlab.kordlib.core.builder.kord.KordBuilder
+import com.gitlab.kordlib.core.builder.kord.KordRestOnlyBuilder
 import com.gitlab.kordlib.core.cache.data.GuildData
+import com.gitlab.kordlib.core.cache.data.UserData
 import com.gitlab.kordlib.core.entity.ApplicationInfo
 import com.gitlab.kordlib.core.entity.Guild
 import com.gitlab.kordlib.core.entity.Region
@@ -123,10 +128,25 @@ class Kord(
     companion object {
 
         /**
+         * Builds a [Kord] instance configured by the [builder].
+         *
          * @throws KordInitializationException if something went wrong while getting the bot's gateway information.
          */
-        suspend inline operator fun invoke(token: String, builder: KordBuilder.() -> Unit = {}) =
+        suspend inline operator fun invoke(token: String, builder: KordBuilder.() -> Unit = {}): Kord =
                 KordBuilder(token).apply(builder).build()
+
+        /**
+         * Builds a [Kord] instance configured by the [builder].
+         *
+         * The instance only allows for configuration of REST related APIs,
+         * interacting with the [gateway][Kord.gateway] or its [events][Kord.events] will result in no-ops.
+         *
+         * Similarly, [cache][Kord.cache] related functionality has been disabled and
+         * replaced with a no-op implementation.
+         */
+        @KordExperimental
+        inline fun restOnly(token: String, builder: KordRestOnlyBuilder.() -> Unit = {}): Kord =
+                KordRestOnlyBuilder(token).apply(builder).build()
     }
 
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/Kord.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/Kord.kt
@@ -1,9 +1,7 @@
 package com.gitlab.kordlib.core
 
 import com.gitlab.kordlib.cache.api.DataCache
-import com.gitlab.kordlib.cache.api.query
 import com.gitlab.kordlib.common.annotation.KordExperimental
-import com.gitlab.kordlib.common.annotation.KordPreview
 import com.gitlab.kordlib.common.annotation.KordUnsafe
 import com.gitlab.kordlib.common.entity.DiscordShard
 import com.gitlab.kordlib.common.entity.Snowflake
@@ -11,7 +9,6 @@ import com.gitlab.kordlib.common.entity.Status
 import com.gitlab.kordlib.core.builder.kord.KordBuilder
 import com.gitlab.kordlib.core.builder.kord.KordRestOnlyBuilder
 import com.gitlab.kordlib.core.cache.data.GuildData
-import com.gitlab.kordlib.core.cache.data.UserData
 import com.gitlab.kordlib.core.entity.ApplicationInfo
 import com.gitlab.kordlib.core.entity.Guild
 import com.gitlab.kordlib.core.entity.Region
@@ -46,7 +43,7 @@ class Kord(
         val rest: RestClient,
         val selfId: Snowflake,
         private val eventPublisher: BroadcastChannel<Event>,
-        private val dispatcher: CoroutineDispatcher
+        private val dispatcher: CoroutineDispatcher,
 ) : CoroutineScope {
     private val interceptor = GatewayEventInterceptor(this, gateway, cache, eventPublisher)
 

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/Kord.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/Kord.kt
@@ -7,17 +7,19 @@ import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.common.entity.Status
 import com.gitlab.kordlib.core.builder.kord.KordBuilder
 import com.gitlab.kordlib.core.cache.data.GuildData
-import com.gitlab.kordlib.core.cache.data.GuildPreviewData
-import com.gitlab.kordlib.core.entity.*
+import com.gitlab.kordlib.core.entity.ApplicationInfo
+import com.gitlab.kordlib.core.entity.Guild
+import com.gitlab.kordlib.core.entity.Region
+import com.gitlab.kordlib.core.entity.User
 import com.gitlab.kordlib.core.entity.channel.Channel
 import com.gitlab.kordlib.core.event.Event
+import com.gitlab.kordlib.core.exception.KordInitializationException
 import com.gitlab.kordlib.core.gateway.MasterGateway
 import com.gitlab.kordlib.core.gateway.handler.GatewayEventInterceptor
 import com.gitlab.kordlib.core.supplier.EntitySupplier
 import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy
 import com.gitlab.kordlib.gateway.Gateway
 import com.gitlab.kordlib.gateway.builder.PresenceBuilder
-import com.gitlab.kordlib.gateway.start
 import com.gitlab.kordlib.rest.builder.guild.GuildCreateBuilder
 import com.gitlab.kordlib.rest.service.RestClient
 import kotlinx.coroutines.CoroutineDispatcher
@@ -119,6 +121,10 @@ class Kord(
     }
 
     companion object {
+
+        /**
+         * @throws KordInitializationException if something went wrong while getting the bot's gateway information.
+         */
         suspend inline operator fun invoke(token: String, builder: KordBuilder.() -> Unit = {}) =
                 KordBuilder(token).apply(builder).build()
     }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/KordObject.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/KordObject.kt
@@ -1,5 +1,12 @@
 package com.gitlab.kordlib.core
 
+/**
+ * An instance than contains a reference to [Kord].
+ */
 interface KordObject {
+
+    /**
+     * The kord instance that created this object.
+     */
     val kord: Kord
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/Util.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/Util.kt
@@ -1,6 +1,5 @@
 package com.gitlab.kordlib.core
 
-
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.core.entity.Entity
 import com.gitlab.kordlib.core.event.Event
@@ -13,7 +12,6 @@ import com.gitlab.kordlib.core.event.message.*
 import com.gitlab.kordlib.core.event.role.RoleCreateEvent
 import com.gitlab.kordlib.core.event.role.RoleDeleteEvent
 import com.gitlab.kordlib.core.event.role.RoleUpdateEvent
-import com.gitlab.kordlib.gateway.Intent
 import com.gitlab.kordlib.gateway.Intent.*
 import com.gitlab.kordlib.gateway.Intents
 import com.gitlab.kordlib.gateway.MessageDelete
@@ -24,7 +22,6 @@ import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.flow.*
 import java.time.Instant
 import java.time.format.DateTimeFormatter
-import kotlin.math.max
 import kotlin.reflect.KClass
 
 internal fun String?.toSnowflakeOrNull(): Snowflake? = when {
@@ -153,14 +150,14 @@ internal fun <T> youngestItem(idSelector: (T) -> String): (Collection<T>) -> T? 
  */
 internal fun <T> oldestItem(idSelector: (T) -> String): (Collection<T>) -> T? = function@{
     if (it.size <= 1) return@function it.firstOrNull()
-        val first = it.first()
-        val last = it.last()
+    val first = it.first()
+    val last = it.last()
 
-        val firstId = idSelector(first).toLong()
-        val lastId = idSelector(last).toLong()
+    val firstId = idSelector(first).toLong()
+    val lastId = idSelector(last).toLong()
 
-        if (firstId < lastId) first
-        else last
+    if (firstId < lastId) first
+    else last
 }
 
 /**

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/Util.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/Util.kt
@@ -54,13 +54,31 @@ fun <T : Entity> Flow<T>.sorted(): Flow<T> = flow {
     }
 }
 
+/**
+ * The terminal operator that returns the first element emitted by the flow that matches the [predicate]
+ * and then cancels flow's collection.
+ * Returns `null` if the flow was empty.
+ */
 suspend inline fun <T : Any> Flow<T>.firstOrNull(crossinline predicate: suspend (T) -> Boolean): T? =
-        filter { predicate(it) }.take(1).singleOrNull()
+        filter { predicate(it) }.firstOrNull()
 
-
+/**
+ * The terminal operator that returns `true` if any of the elements match [predicate].
+ * The flow's collection is cancelled when a match is found.
+ */
 suspend inline fun <T : Any> Flow<T>.any(crossinline predicate: suspend (T) -> Boolean): Boolean =
         firstOrNull(predicate) != null
 
+/**
+ * The non-terminal operator that returns a new flow that will emit values of the second [flow] only after the first
+ * flow finished collecting without values.
+ *
+ * ```kotlin
+ * emptyFlow<String>().switchIfEmpty(flowOf("hello", "world")) //["hello", "world"]
+ *
+ * flowOf("hello", "world").switchIfEmpty(flowOf("goodbye", "world")) //["hello", "world"]
+ * ```
+ */
 internal fun <T> Flow<T>.switchIfEmpty(flow: Flow<T>): Flow<T> = flow {
     var empty = true
     collect {
@@ -75,6 +93,11 @@ internal fun <T> Flow<T>.switchIfEmpty(flow: Flow<T>): Flow<T> = flow {
     }
 }
 
+/**
+ * The terminal operator that returns the index of the first element emitted by the flow that matches the [predicate]
+ * and then cancels flow's collection.
+ * Returns `null` if the flow was empty or no element matched the [predicate].
+ */
 internal suspend inline fun <T> Flow<T>.indexOfFirstOrNull(crossinline predicate: suspend (T) -> Boolean): Int? {
     val counter = atomic(0)
     return map { counter.getAndIncrement() to it }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/GuildBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/GuildBehavior.kt
@@ -35,7 +35,7 @@ import java.util.*
 import com.gitlab.kordlib.rest.service.RestClient
 
 /**
- * The behavior of a [Discord Guild](https://discordapp.com/developers/docs/resources/guild).
+ * The behavior of a [Discord Guild](https://discord.com/developers/docs/resources/guild).
  */
 interface GuildBehavior : Entity, Strategizable {
     /**

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/GuildEmojiBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/GuildEmojiBehavior.kt
@@ -13,7 +13,7 @@ import com.gitlab.kordlib.rest.request.RestRequestException
 import java.util.*
 
 /**
- * The behavior of a [Discord Emoij](https://discordapp.com/developers/docs/resources/emoji).
+ * The behavior of a [Discord Emoij](https://discord.com/developers/docs/resources/emoji).
  */
 interface GuildEmojiBehavior : Entity, Strategizable {
 

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/MemberBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/MemberBehavior.kt
@@ -16,7 +16,7 @@ import com.gitlab.kordlib.rest.request.RestRequestException
 import java.util.*
 
 /**
- * The behavior of a [Discord Member](https://discordapp.com/developers/docs/resources/guild#guild-member-object).
+ * The behavior of a [Discord Member](https://discord.com/developers/docs/resources/guild#guild-member-object).
  */
 interface MemberBehavior : Entity, UserBehavior {
 

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/MessageBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/MessageBehavior.kt
@@ -21,7 +21,7 @@ import com.gitlab.kordlib.rest.request.RestRequestException
 import com.gitlab.kordlib.common.entity.Permission
 
 /**
- * The behavior of a [Discord Message](https://discordapp.com/developers/docs/resources/channel#message-object).
+ * The behavior of a [Discord Message](https://discord.com/developers/docs/resources/channel#message-object).
  */
 interface MessageBehavior : Entity, Strategizable {
     /**

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/RoleBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/RoleBehavior.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.flow.map
 import java.util.*
 
 /**
- * The behavior of a [Discord Role](https://discordapp.com/developers/docs/topics/permissions#role-object) associated to a [guild].
+ * The behavior of a [Discord Role](https://discord.com/developers/docs/topics/permissions#role-object) associated to a [guild].
  */
 interface RoleBehavior : Entity, Strategizable {
     /**

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/UserBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/UserBehavior.kt
@@ -17,7 +17,7 @@ import io.ktor.http.HttpStatusCode
 import java.util.*
 
 /**
- * The behavior of a [Discord User](https://discordapp.com/developers/docs/resources/user)
+ * The behavior of a [Discord User](https://discord.com/developers/docs/resources/user)
  */
 interface UserBehavior : Entity, Strategizable {
 

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/UserBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/UserBehavior.kt
@@ -13,6 +13,7 @@ import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy
 import com.gitlab.kordlib.rest.json.request.DMCreateRequest
 import com.gitlab.kordlib.rest.request.RestRequestException
 import com.gitlab.kordlib.rest.service.RestClient
+import io.ktor.http.HttpStatusCode
 import java.util.*
 
 /**
@@ -60,6 +61,18 @@ interface UserBehavior : Entity, Strategizable {
      * Requests to get or create a [DmChannel] between this bot and the user.
      *
      * This property is not resolvable through cache and will always use the [RestClient] instead.
+     *
+     * If a user does not allow you to send DM's to them, this method will throw a [RestRequestException] with
+     * [code][RestRequestException.code] 403. This can be used to handle the edge case accordingly:
+     * ```kotlin
+     * val channel = try {
+     *     user.getDmChannel()
+     * } catch (exception: RestRequestException) {
+     *     if(exception.code == HttpStatusCode.Forbidden.value) {
+     *         //user doesn't have DMs enabled
+     *         TODO("handle edge case")
+     *     } else throw exception
+     * }
      *
      * @throws [RestRequestException] if something went wrong during the request.
      */

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/WebhookBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/WebhookBehavior.kt
@@ -16,7 +16,7 @@ import com.gitlab.kordlib.rest.request.RestRequestException
 import java.util.*
 
 /**
- * The behavior of a [Discord Webhook](https://discordapp.com/developers/docs/resources/webhook).
+ * The behavior of a [Discord Webhook](https://discord.com/developers/docs/resources/webhook).
  */
 interface WebhookBehavior : Entity, Strategizable {
 

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/CategoryBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/CategoryBehavior.kt
@@ -93,7 +93,6 @@ interface CategoryBehavior : GuildChannelBehavior {
  * @return The edited [Category].
  * @throws [RestRequestException] if something went wrong during the request.
  */
-@Suppress("NAME_SHADOWING")
 suspend fun CategoryBehavior.edit(builder: CategoryModifyBuilder.() -> Unit): Category {
     val response = kord.rest.channel.patchCategory(id.value, builder)
     val data = ChannelData.from(response)

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/ChannelBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/ChannelBehavior.kt
@@ -13,7 +13,7 @@ import com.gitlab.kordlib.rest.request.RestRequestException
 import java.util.*
 
 /**
- * The behavior of a [Discord Channel](https://discordapp.com/developers/docs/resources/channel)
+ * The behavior of a [Discord Channel](https://discord.com/developers/docs/resources/channel)
  */
 interface ChannelBehavior : Entity, Strategizable {
 

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/builder/kord/KordBuilder.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/builder/kord/KordBuilder.kt
@@ -39,6 +39,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonConfiguration
+import kotlinx.serialization.parse
 import mu.KotlinLogging
 import kotlin.concurrent.thread
 import kotlin.time.seconds
@@ -199,7 +200,7 @@ class KordBuilder(val token: String) {
             throw KordInitializationException(message)
         }
 
-        return Json(JsonConfiguration(ignoreUnknownKeys = true)).parse(BotGatewayResponse.serializer(), responseBody)
+        return Json { ignoreUnknownKeys = true }.decodeFromString(BotGatewayResponse.serializer(), responseBody)
     }
 
     /**

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/builder/kord/KordBuilder.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/builder/kord/KordBuilder.kt
@@ -216,7 +216,7 @@ class KordBuilder(val token: String) {
             throw KordInitializationException(message)
         }
 
-        return Json.parse(BotGatewayResponse.serializer(), responseBody)
+        return Json(JsonConfiguration(ignoreUnknownKeys = true)).parse(BotGatewayResponse.serializer(), responseBody)
     }
 
     /**

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/builder/kord/KordBuilder.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/builder/kord/KordBuilder.kt
@@ -158,7 +158,7 @@ class KordBuilder(val token: String) {
      *
      * ```
      * Kord(token) {
-     *     { resources -> ExclusionRequestHandler(resources.httpClient) }
+     *     { resources -> KtorRequestHandler(resources.httpClient, ExclusionRequestRateLimiter()) }
      * }
      * ```
      */

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/builder/kord/KordBuilderUtil.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/builder/kord/KordBuilderUtil.kt
@@ -1,0 +1,59 @@
+package com.gitlab.kordlib.core.builder.kord
+
+import com.gitlab.kordlib.common.entity.Snowflake
+import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.features.defaultRequest
+import io.ktor.client.features.json.JsonFeature
+import io.ktor.client.features.json.serializer.KotlinxSerializer
+import io.ktor.client.features.websocket.WebSockets
+import io.ktor.client.request.header
+import kotlinx.serialization.UnstableDefault
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonConfiguration
+import java.util.*
+
+internal fun HttpClientConfig<*>.defaultConfig(token: String) {
+    expectSuccess = false
+    defaultRequest {
+        header("Authorization", "Bot $token")
+    }
+
+    install(JsonFeature)
+    install(WebSockets)
+}
+
+internal fun HttpClient?.configure(token: String): HttpClient {
+    if (this != null) return this.config {
+        defaultConfig(token)
+    }
+
+    @OptIn(UnstableDefault::class)
+    val jsonConfig = JsonConfiguration(
+            encodeDefaults = false,
+            allowStructuredMapKeys = true,
+            ignoreUnknownKeys = true,
+            isLenient = true
+    )
+
+    val json = Json(jsonConfig)
+
+    return HttpClient(CIO) {
+        defaultConfig(token)
+        install(JsonFeature) {
+            serializer = KotlinxSerializer(json)
+        }
+    }
+}
+
+
+internal fun getBotIdFromToken(token: String): Snowflake {
+    try {
+        val bytes = Base64.getDecoder().decode(token.split(""".""").first())
+        return Snowflake(String(bytes))
+    } catch (exception: IllegalArgumentException) {
+        throw IllegalArgumentException("Malformed bot token: '$token'. Make sure that your token is correct.")
+    }
+}
+

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/builder/kord/KordBuilderUtil.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/builder/kord/KordBuilderUtil.kt
@@ -9,7 +9,6 @@ import io.ktor.client.features.json.JsonFeature
 import io.ktor.client.features.json.serializer.KotlinxSerializer
 import io.ktor.client.features.websocket.WebSockets
 import io.ktor.client.request.header
-import kotlinx.serialization.UnstableDefault
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonConfiguration
 import java.util.*
@@ -29,15 +28,12 @@ internal fun HttpClient?.configure(token: String): HttpClient {
         defaultConfig(token)
     }
 
-    @OptIn(UnstableDefault::class)
-    val jsonConfig = JsonConfiguration(
-            encodeDefaults = false,
-            allowStructuredMapKeys = true,
-            ignoreUnknownKeys = true,
-            isLenient = true
-    )
-
-    val json = Json(jsonConfig)
+    val json = Json {
+        encodeDefaults = false
+        allowStructuredMapKeys = true
+        ignoreUnknownKeys = true
+        isLenient = true
+    }
 
     return HttpClient(CIO) {
         defaultConfig(token)

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/builder/kord/KordRestOnlyBuilder.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/builder/kord/KordRestOnlyBuilder.kt
@@ -1,6 +1,7 @@
 package com.gitlab.kordlib.core.builder.kord
 
 import com.gitlab.kordlib.cache.api.DataCache
+import com.gitlab.kordlib.common.annotation.KordExperimental
 import com.gitlab.kordlib.core.ClientResources
 import com.gitlab.kordlib.core.Kord
 import com.gitlab.kordlib.core.event.Event
@@ -14,16 +15,12 @@ import com.gitlab.kordlib.rest.request.KtorRequestHandler
 import com.gitlab.kordlib.rest.request.RequestHandler
 import com.gitlab.kordlib.rest.service.RestClient
 import io.ktor.client.HttpClient
-import io.ktor.client.engine.cio.CIO
-import io.ktor.client.features.json.JsonFeature
-import io.ktor.client.features.json.serializer.KotlinxSerializer
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.BroadcastChannel
 import kotlinx.coroutines.channels.Channel
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonConfiguration
 
+@KordExperimental
 class KordRestOnlyBuilder(val token: String) {
 
     private var handlerBuilder: (resources: ClientResources) -> RequestHandler =

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/builder/kord/KordRestOnlyBuilder.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/builder/kord/KordRestOnlyBuilder.kt
@@ -1,0 +1,79 @@
+package com.gitlab.kordlib.core.builder.kord
+
+import com.gitlab.kordlib.cache.api.DataCache
+import com.gitlab.kordlib.core.ClientResources
+import com.gitlab.kordlib.core.Kord
+import com.gitlab.kordlib.core.event.Event
+import com.gitlab.kordlib.core.exception.KordInitializationException
+import com.gitlab.kordlib.core.gateway.MasterGateway
+import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy
+import com.gitlab.kordlib.gateway.Gateway
+import com.gitlab.kordlib.gateway.Intents
+import com.gitlab.kordlib.rest.ratelimit.ExclusionRequestRateLimiter
+import com.gitlab.kordlib.rest.request.KtorRequestHandler
+import com.gitlab.kordlib.rest.request.RequestHandler
+import com.gitlab.kordlib.rest.service.RestClient
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.features.json.JsonFeature
+import io.ktor.client.features.json.serializer.KotlinxSerializer
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.BroadcastChannel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonConfiguration
+
+class KordRestOnlyBuilder(val token: String) {
+
+    private var handlerBuilder: (resources: ClientResources) -> RequestHandler =
+            { KtorRequestHandler(it.httpClient, ExclusionRequestRateLimiter()) }
+
+    /**
+     * The [CoroutineDispatcher] kord uses to launch suspending tasks. [Dispatchers.Default] by default.
+     */
+    var defaultDispatcher: CoroutineDispatcher = Dispatchers.Default
+
+    /**
+     * The client used for building [Gateways][Gateway] and [RequestHandlers][RequestHandler]. A default implementation
+     * will be used when not set.
+     */
+    var httpClient: HttpClient? = null
+
+    /**
+     * Configures the [RequestHandler] for the [RestClient].
+     *
+     * ```
+     * Kord(token) {
+     *     { resources -> KtorRequestHandler(resources.httpClient, ExclusionRequestRateLimiter()) }
+     * }
+     * ```
+     */
+    fun requestHandler(handlerBuilder: (resources: ClientResources) -> RequestHandler) {
+        this.handlerBuilder = handlerBuilder
+    }
+
+
+    /**
+     * @throws KordInitializationException if something went wrong while getting the bot's gateway information.
+     */
+    fun build(): Kord {
+        val client = httpClient.configure(token)
+
+        val resources = ClientResources(token, 0, client, EntitySupplyStrategy.rest, Intents.none)
+        val rest = RestClient(handlerBuilder(resources))
+        val selfId = getBotIdFromToken(token)
+
+        val eventPublisher = BroadcastChannel<Event>(Channel.CONFLATED)
+
+        return Kord(
+                resources,
+                DataCache.none(),
+                MasterGateway(mapOf(0 to Gateway.none())),
+                rest,
+                selfId,
+                eventPublisher,
+                defaultDispatcher
+        )
+    }
+}

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/cache/CachingGateway.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/cache/CachingGateway.kt
@@ -13,7 +13,6 @@ import kotlin.coroutines.CoroutineContext
  * A bridge between [DataCache] and [Gateway] that automatically empties cache on disconnect.
  */
 @FlowPreview
-
 class CachingGateway(
         private val cache: DataCache,
         private val gateway: Gateway,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/GuildData.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/GuildData.kt
@@ -100,7 +100,7 @@ data class GuildData(
                     joinedAt,
                     large,
                     memberCount,
-                    voiceStates.orEmpty().map { VoiceStateData.from(it) },
+                    voiceStates.orEmpty().map { VoiceStateData.from(id, it) },
                     members.orEmpty().map { MemberData.from(userId = it.user!!.id, guildId = id, entity = it) },
                     channels.orEmpty().map { it.id.toLong() },
                     presences.orEmpty().map { PresenceData.from(id, it) },

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/VoiceStateData.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/VoiceStateData.kt
@@ -23,7 +23,7 @@ data class VoiceStateData(
     companion object {
         val description = description(VoiceStateData::id)
 
-        fun from(entity: DiscordVoiceState) = with(entity) {
+        fun from(guildId: String?, entity: DiscordVoiceState) = with(entity) {
             VoiceStateData(
                     guildId?.toLong(),
                     channelId?.toLong(),

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Attachment.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Attachment.kt
@@ -6,7 +6,7 @@ import com.gitlab.kordlib.core.cache.data.AttachmentData
 import java.util.*
 
 /**
- * An instance of a [Discord Attachment](https://discordapp.com/developers/docs/resources/channel#attachment-object).
+ * An instance of a [Discord Attachment](https://discord.com/developers/docs/resources/channel#attachment-object).
  *
  * A file attached to a [Message].
  */

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Ban.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Ban.kt
@@ -11,7 +11,7 @@ import com.gitlab.kordlib.core.supplier.EntitySupplier
 import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy
 
 /**
- * An instance of a [Discord Ban](https://discordapp.com/developers/docs/resources/guild#ban-object).
+ * An instance of a [Discord Ban](https://discord.com/developers/docs/resources/guild#ban-object).
  */
 class Ban(
         val data: BanData,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Embed.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Embed.kt
@@ -11,11 +11,11 @@ import java.time.Instant
 internal const val embedDeprecationMessage = """
 Embed types should be considered deprecated and might be removed in a future API version.
 
-https://discordapp.com/developers/docs/resources/channel#embed-object-embed-types
+https://discord.com/developers/docs/resources/channel#embed-object-embed-types
 """
 
 /**
- * An instance of a [Discord Embed](https://discordapp.com/developers/docs/resources/channel#embed-object).
+ * An instance of a [Discord Embed](https://discord.com/developers/docs/resources/channel#embed-object).
  */
 data class Embed(val data: EmbedData, override val kord: Kord) : KordObject {
 

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Guild.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Guild.kt
@@ -28,7 +28,7 @@ import java.time.format.DateTimeFormatter
 import java.util.*
 
 /**
- * An instance of a [Discord Guild](https://discordapp.com/developers/docs/resources/guild).
+ * An instance of a [Discord Guild](https://discord.com/developers/docs/resources/guild).
  */
 class Guild(
         val data: GuildData,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/GuildEmoji.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/GuildEmoji.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.flow.filter
 import java.util.*
 
 /**
- * An instance of a [Discord emoji](https://discordapp.com/developers/docs/resources/emoji#emoji-object) belonging to a specific guild.
+ * An instance of a [Discord emoji](https://discord.com/developers/docs/resources/emoji#emoji-object) belonging to a specific guild.
  */
 class GuildEmoji(
         val data: EmojiData,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Integration.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Integration.kt
@@ -13,6 +13,7 @@ import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy
 import com.gitlab.kordlib.core.toInstant
 import com.gitlab.kordlib.rest.builder.integration.IntegrationModifyBuilder
 import com.gitlab.kordlib.rest.json.response.IntegrationExpireBehavior
+import com.gitlab.kordlib.rest.request.RestRequestException
 import java.time.Duration
 import java.time.Instant
 import java.time.temporal.ChronoUnit
@@ -169,6 +170,13 @@ class Integration(
     }
 }
 
+/**
+ * Requests to edit this integration.
+ *
+ * @return The edited [Integration].
+ *
+ * @throws [RestRequestException] if something went wrong during the request.
+ */
 suspend inline fun Integration.edit(builder: IntegrationModifyBuilder.() -> Unit) {
     kord.rest.guild.modifyGuildIntegration(guildId.value, id.value, builder)
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Integration.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Integration.kt
@@ -20,7 +20,7 @@ import java.time.temporal.ChronoUnit
 import java.util.*
 
 /**
- * A [Discord integration](https://discordapp.com/developers/docs/resources/guild#get-guild-integrations).
+ * A [Discord integration](https://discord.com/developers/docs/resources/guild#get-guild-integrations).
  */
 class Integration(
         val data: IntegrationData,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Invite.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Invite.kt
@@ -17,7 +17,7 @@ import com.gitlab.kordlib.core.supplier.getChannelOfOrNull
 import com.gitlab.kordlib.core.toSnowflakeOrNull
 
 /**
- * An instance of a [Discord Invite](https://discordapp.com/developers/docs/resources/invite).
+ * An instance of a [Discord Invite](https://discord.com/developers/docs/resources/invite).
  */
 data class Invite(
         val data: InviteData,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Member.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Member.kt
@@ -18,7 +18,7 @@ import java.time.format.DateTimeFormatter
 import java.util.*
 
 /**
- * An instance of a [Discord Member](https://discordapp.com/developers/docs/resources/guild#guild-member-object).
+ * An instance of a [Discord Member](https://discord.com/developers/docs/resources/guild#guild-member-object).
  */
 class Member(
         val memberData: MemberData,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Message.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Message.kt
@@ -23,7 +23,7 @@ import java.time.format.DateTimeFormatter
 import java.util.*
 
 /**
- * An instance of a [Discord Message][https://discordapp.com/developers/docs/resources/channel#message-object].
+ * An instance of a [Discord Message][https://discord.com/developers/docs/resources/channel#message-object].
  */
 class Message(
         val data: MessageData,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Reaction.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Reaction.kt
@@ -6,20 +6,38 @@ import com.gitlab.kordlib.core.KordObject
 import com.gitlab.kordlib.core.cache.data.ReactionData
 import com.gitlab.kordlib.core.toSnowflakeOrNull
 
+/**
+ * An instance of a [Discord Reaction](https://discord.com/developers/docs/resources/channel#reaction-object).
+ */
 class Reaction(val data: ReactionData, override val kord: Kord) : KordObject {
 
+    /**
+     *
+     */
     val id: Snowflake? get() = data.emojiId.toSnowflakeOrNull()
 
+    /**
+     * The amount of users that reacted this emoji to the message.
+     */
     val count: Int get() = data.count
 
+    /**
+     * Whether the current user reacted to the message with this emoji.
+     */
     val selfReacted: Boolean get() = data.me
 
+    /**
+     * The emoji of this reaction.
+     */
     val emoji: ReactionEmoji
         get() = when (data.emojiId) {
             null -> ReactionEmoji.Unicode(data.emojiName!!)
             else -> ReactionEmoji.Custom(Snowflake(data.emojiId), data.emojiName ?: "", data.emojiAnimated)
         }
 
+    /**
+     * Whether the emoji is animated.
+     */
     val isAnimated: Boolean get() = data.emojiAnimated
 
 

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/ReactionEmoji.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/ReactionEmoji.kt
@@ -4,16 +4,21 @@ import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.core.cache.data.RemovedReactionData
 
 sealed class ReactionEmoji {
+    /**
+     * Format used in HTTP queries.
+     */
     abstract val urlFormat: String
+
+    /**
+     * Either the unicode representation if it's a [Unicode] emoji or the emoji name if it's a [Custom] emoji.
+     */
     abstract val name: String
+
+
     abstract val mention: String
 
     data class Custom(val id: Snowflake, override val name: String, val isAnimated: Boolean) : ReactionEmoji() {
-        /**
-         *
-         * Format used in HTTP queries.
-         *
-         */
+
         override val urlFormat: String
             get() = "$name:${id.value}"
 

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Strategizable.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Strategizable.kt
@@ -3,10 +3,23 @@ package com.gitlab.kordlib.core.entity
 import com.gitlab.kordlib.core.supplier.EntitySupplier
 import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy
 
+/**
+ * A class that will defer the requesting of [Entities][Entity] to a [supplier].
+ * Copies of this class with a different [supplier] can be made through [withStrategy].
+ *
+ * Unless stated otherwise, all members that fetch [Entities][Entity] will delegate to the [supplier].
+ */
 interface Strategizable {
 
+    /**
+     * The supplier used to request entities.
+     */
     val supplier: EntitySupplier
 
+
+    /**
+     * Returns a copy of this class with a new [supplier] provided by the [strategy].
+     */
     fun withStrategy(strategy: EntitySupplyStrategy<*>) : Strategizable
 
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/User.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/User.kt
@@ -13,7 +13,7 @@ import com.gitlab.kordlib.rest.Image
 import java.util.*
 
 /**
- * An instance of a [Discord User](https://discordapp.com/developers/docs/resources/user#user-object).
+ * An instance of a [Discord User](https://discord.com/developers/docs/resources/user#user-object).
  */
 open class User(
         val data: UserData,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/channel/Channel.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/channel/Channel.kt
@@ -10,7 +10,7 @@ import com.gitlab.kordlib.core.supplier.EntitySupplier
 import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy
 
 /**
- * An instance of a [Discord Channel](https://discordapp.com/developers/docs/resources/channel)
+ * An instance of a [Discord Channel](https://discord.com/developers/docs/resources/channel)
  */
 interface Channel : ChannelBehavior {
     val data: ChannelData

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/exception/KordInitializationException.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/exception/KordInitializationException.kt
@@ -1,0 +1,7 @@
+package com.gitlab.kordlib.core.exception
+
+class KordInitializationException : Exception {
+    constructor(message: String) : super(message)
+    constructor(cause: Throwable) : super(cause)
+    constructor(message: String, cause: Throwable) : super(message, cause)
+}

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/gateway/handler/GuildEventHandler.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/gateway/handler/GuildEventHandler.kt
@@ -73,7 +73,7 @@ internal class GuildEventHandler(
         }
 
         for (voiceState in voiceStates.orEmpty()) {
-            cache.put(VoiceStateData.from(voiceState))
+            cache.put(VoiceStateData.from(id, voiceState))
         }
         for (emoji in emojis) {
             cache.put(EmojiData.from(id, emoji.id!!, emoji))

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/gateway/handler/VoiceEventHandler.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/gateway/handler/VoiceEventHandler.kt
@@ -34,7 +34,7 @@ internal class VoiceEventHandler(
     }
 
     private suspend fun handle(event: VoiceStateUpdate, shard: Int) {
-        val data = VoiceStateData.from(event.voiceState)
+        val data = VoiceStateData.from(event.voiceState.guildId, event.voiceState)
 
         val old = cache.query<VoiceStateData> { VoiceStateData::id eq data.id }
                 .asFlow().map { VoiceState(it, kord) }.singleOrNull()

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/supplier/EntitySupplyStrategy.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/supplier/EntitySupplyStrategy.kt
@@ -2,30 +2,52 @@ package com.gitlab.kordlib.core.supplier
 
 import com.gitlab.kordlib.core.Kord
 
+/**
+ *  A supplier that accepts a [Kord] instance and returns an [EntitySupplier] of type [T].
+ */
 interface EntitySupplyStrategy<T : EntitySupplier> {
 
+    /**
+     * Returns an [EntitySupplier] of type [T] that operates on the [kord] instance.
+     */
     fun supply(kord: Kord): T
 
-
     companion object {
+
+        /**
+         * A supplier providing a strategy which exclusively uses REST calls to fetch entities.
+         * See [RestEntitySupplier] for more details.
+         */
         val rest = object : EntitySupplyStrategy<RestEntitySupplier> {
 
             override fun supply(kord: Kord): RestEntitySupplier = RestEntitySupplier(kord)
 
         }
 
+        /**
+         * A supplier providing a strategy which exclusively uses cache to fetch entities.
+         * See [CacheEntitySupplier] for more details.
+         */
         val cache = object : EntitySupplyStrategy<CacheEntitySupplier> {
 
             override fun supply(kord: Kord): CacheEntitySupplier = CacheEntitySupplier(kord)
 
         }
 
+        /**
+         * A supplier providing a strategy which will first operate on the [cache] supplier. When an entity
+         * is not present from cache it will be fetched from [rest] instead. Operations that return flows
+         * will only fall back to rest when the returned flow contained no elements.
+         */
         val cacheWithRestFallback = object : EntitySupplyStrategy<EntitySupplier> {
 
             override fun supply(kord: Kord): EntitySupplier = cache.supply(kord).withFallback(rest.supply(kord))
 
         }
 
+        /**
+         * Create an [EntitySupplyStrategy] from the given [supplier].
+         */
         operator fun <T : EntitySupplier> invoke(
                 supplier: (Kord) -> T
         ): EntitySupplyStrategy<T> = object : EntitySupplyStrategy<T> {

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/supplier/FallbackEntitySupplier.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/supplier/FallbackEntitySupplier.kt
@@ -4,9 +4,16 @@ import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.core.entity.*
 import com.gitlab.kordlib.core.entity.channel.Channel
 import com.gitlab.kordlib.core.entity.channel.GuildChannel
+import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy.Companion.cache
+import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy.Companion.rest
 import com.gitlab.kordlib.core.switchIfEmpty
 import kotlinx.coroutines.flow.Flow
 
+/**
+ * Creates supplier providing a strategy which will first operate on this supplier. When an entity
+ * is not present from the first supplier it will be fetched from [other] instead. Operations that return flows
+ * will only fall back to [other] when the returned flow contained no elements.
+ */
 infix fun EntitySupplier.withFallback(other: EntitySupplier): EntitySupplier = FallbackEntitySupplier(this, other)
 
 private class FallbackEntitySupplier(val first: EntitySupplier, val second: EntitySupplier) : EntitySupplier {

--- a/gateway/DokkaDescription.md
+++ b/gateway/DokkaDescription.md
@@ -1,0 +1,1 @@
+Low level abstraction of the Discord Gateway API.

--- a/gateway/build.gradle.kts
+++ b/gateway/build.gradle.kts
@@ -17,7 +17,7 @@ tasks.withType<KotlinCompile> {
                 CompilerArguments.inlineClasses,
                 CompilerArguments.coroutines,
                 CompilerArguments.time,
-                CompilerArguments.unstableDefault
+                CompilerArguments.optIn
         )
     }
 }

--- a/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/Command.kt
+++ b/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/Command.kt
@@ -3,14 +3,20 @@ package com.gitlab.kordlib.gateway
 import com.gitlab.kordlib.common.entity.*
 import kotlinx.serialization.*
 import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.JsonObject
 
 sealed class Command {
     internal data class Heartbeat(val sequenceNumber: Int? = null) : Command() {
 
         companion object : SerializationStrategy<Heartbeat> {
-            override val descriptor: SerialDescriptor = PrimitiveDescriptor("Heartbeat", PrimitiveKind.INT)
+            override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("Heartbeat", PrimitiveKind.INT)
 
+            @OptIn(ExperimentalSerializationApi::class)
             override fun serialize(encoder: Encoder, obj: Heartbeat) {
                 encoder.encodeNullableSerializableValue(Int.serializer(), obj.sequenceNumber)
             }
@@ -20,7 +26,7 @@ sealed class Command {
 
     companion object : SerializationStrategy<Command> {
 
-        override val descriptor: SerialDescriptor = SerialDescriptor("Command") {
+        override val descriptor: SerialDescriptor = buildClassSerialDescriptor("Command") {
             element("op", OpCode.descriptor)
             element("d", JsonObject.serializer().descriptor)
         }

--- a/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/DefaultGateway.kt
+++ b/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/DefaultGateway.kt
@@ -105,7 +105,7 @@ class DefaultGateway(private val data: DefaultGatewayData) : Gateway {
             try {
                 socket = webSocket(data.url)
                 /**
-                 * https://discordapp.com/developers/docs/topics/gateway#transport-compression
+                 * https://discord.com/developers/docs/topics/gateway#transport-compression
                  *
                  * > Every connection to the gateway should use its own unique zlib context.
                  */

--- a/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/DefaultGatewayBuilder.kt
+++ b/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/DefaultGatewayBuilder.kt
@@ -8,6 +8,8 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.features.json.JsonFeature
 import io.ktor.client.features.websocket.WebSockets
+import io.ktor.util.*
+import kotlinx.coroutines.ObsoleteCoroutinesApi
 import java.time.Duration
 import kotlin.time.seconds
 import kotlin.time.toKotlinDuration
@@ -20,6 +22,7 @@ class DefaultGatewayBuilder {
     var identifyRateLimiter: RateLimiter? = null
 
 
+    @OptIn(KtorExperimentalAPI::class, ObsoleteCoroutinesApi::class)
     fun build(): DefaultGateway {
         val client = client ?: HttpClient(CIO) {
             install(WebSockets)

--- a/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/Event.kt
+++ b/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/Event.kt
@@ -357,7 +357,7 @@ data class DiscordCreatedInvite(
 
 @Serializable
 data class DiscordInviteUser(
-        val avatar: String,
+        val avatar: String? = null,
         val discriminator: String,
         val id: String,
         val username: String

--- a/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/Event.kt
+++ b/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/Event.kt
@@ -68,7 +68,7 @@ sealed class Event {
                                 error("Unknown 'd' field for Op code ${op?.code}: $element")
                             } else {
                                 val element = decodeNullableSerializableElement(descriptor, index, JsonElementSerializer.nullable)
-                                jsonLogger.warn { "Ignored unexpected 'd' field for Op code ${op?.code}: $element" }
+                                // jsonLogger.warn { "Ignored unexpected 'd' field for Op code ${op?.code}: $element" }
                                 data
                             }
                         }

--- a/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/Gateway.kt
+++ b/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/Gateway.kt
@@ -8,15 +8,15 @@ import kotlinx.coroutines.flow.Flow
 import kotlin.time.Duration
 
 /**
- * An implementation of the Discord [Gateway](https://discordapp.com/developers/docs/topics/gateway) and its lifecycle.
+ * An implementation of the Discord [Gateway](https://discord.com/developers/docs/topics/gateway) and its lifecycle.
  *
- * Allows consumers to receive [events](https://discordapp.com/developers/docs/topics/gateway#commands-and-events-gateway-events)
- * through [events] and send [commands](https://discordapp.com/developers/docs/topics/gateway#commands-and-events-gateway-commands)
+ * Allows consumers to receive [events](https://discord.com/developers/docs/topics/gateway#commands-and-events-gateway-events)
+ * through [events] and send [commands](https://discord.com/developers/docs/topics/gateway#commands-and-events-gateway-commands)
  * through [send].
  */
 interface Gateway {
     /**
-     * The incoming [events](https://discordapp.com/developers/docs/topics/gateway#commands-and-events-gateway-events)
+     * The incoming [events](https://discord.com/developers/docs/topics/gateway#commands-and-events-gateway-events)
      * of the Gateway. Users should expect these [Flows](Flow) to be hot and remain open for the entire lifecycle of the
      * Gateway.
      */
@@ -89,7 +89,7 @@ suspend inline fun Gateway.start(token: String, config: GatewayConfigurationBuil
 }
 
 /**
- * Enum representation of Discord's [Gateway close event codes](https://discordapp.com/developers/docs/topics/opcodes-and-status-codes#gateway-gateway-close-event-codes).
+ * Enum representation of Discord's [Gateway close event codes](https://discord.com/developers/docs/topics/opcodes-and-status-codes#gateway-gateway-close-event-codes).
  */
 enum class GatewayCloseCode(val code: Int) {
     Unknown(4000),

--- a/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/Intent.kt
+++ b/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/Intent.kt
@@ -182,7 +182,7 @@ data class Intents internal constructor(val code: Int) {
             }
 
         @OptIn(PrivilegedIntent::class)
-        val nonPrivileged
+        val nonPrivileged: Intents
             get() = invoke {
                 Intent.values().forEach { +it }
 
@@ -190,7 +190,9 @@ data class Intents internal constructor(val code: Int) {
                 -Intent.GuildMembers
             }
 
-        inline operator fun invoke(builder: IntentsBuilder.() -> Unit): Intents {
+        val none: Intents = invoke()
+
+        inline operator fun invoke(builder: IntentsBuilder.() -> Unit = {}): Intents {
             return IntentsBuilder().apply(builder).flags()
         }
     }

--- a/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/Intent.kt
+++ b/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/Intent.kt
@@ -7,18 +7,18 @@ import kotlin.RequiresOptIn.*
 /**
  * Some intents are defined as "Privileged" due to the sensitive nature of the data and cannot be used by Kord without enabling them.
  *
- * See [the official documentation](https://discordapp.com/developers/docs/topics/gateway#privileged-intents) for more info on
+ * See [the official documentation](https://discord.com/developers/docs/topics/gateway#privileged-intents) for more info on
  * how to enable these.
  */
 @RequiresOptIn("""
     Some intents are defined as "Privileged" due to the sensitive nature of the data and cannot be used by Kord without enabling them.
     
-    See https://discordapp.com/developers/docs/topics/gateway#privileged-intents for more info on how to enable these.
+    See https://discord.com/developers/docs/topics/gateway#privileged-intents for more info on how to enable these.
 """, Level.ERROR)
 annotation class PrivilegedIntent
 
 /**
- * Values that enable a group of events as [defined by Discord](https://github.com/discordapp/discord-api-docs/blob/feature/gateway-intents/docs/topics/Gateway.md#gateway-intents).
+ * Values that enable a group of events as [defined by Discord](https://github.com/discord/discord-api-docs/blob/feature/gateway-intents/docs/topics/Gateway.md#gateway-intents).
  */
 enum class Intent(val code: Int) {
     /**

--- a/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/Intent.kt
+++ b/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/Intent.kt
@@ -1,7 +1,11 @@
 package com.gitlab.kordlib.gateway
 
 import kotlinx.serialization.*
-import kotlinx.serialization.internal.IntDescriptor
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 import kotlin.RequiresOptIn.*
 
 /**
@@ -219,7 +223,7 @@ data class Intents internal constructor(val code: Int) {
 
 @Serializer(forClass = Intents::class)
 object IntentsSerializer : KSerializer<Intents> {
-    override val descriptor: SerialDescriptor = IntDescriptor
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("intents", PrimitiveKind.INT)
 
     override fun deserialize(decoder: Decoder): Intents {
         val flags = decoder.decodeInt()

--- a/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/OpCode.kt
+++ b/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/OpCode.kt
@@ -1,6 +1,11 @@
 package com.gitlab.kordlib.gateway
 
 import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.internal.IntDescriptor
 
 @Serializable(with = OpCode.OpCodeSerializer::class)
@@ -22,7 +27,7 @@ enum class OpCode(val code: Int) {
     @Serializer(forClass = OpCode::class)
     companion object OpCodeSerializer : KSerializer<OpCode> {
         override val descriptor: SerialDescriptor
-            get() = PrimitiveDescriptor("op", PrimitiveKind.INT)
+            get() = PrimitiveSerialDescriptor("op", PrimitiveKind.INT)
 
         override fun deserialize(decoder: Decoder): OpCode {
             val code = decoder.decodeInt()

--- a/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/Sequence.kt
+++ b/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/Sequence.kt
@@ -4,7 +4,9 @@ import kotlinx.atomicfu.AtomicRef
 import kotlinx.atomicfu.atomic
 import kotlinx.atomicfu.update
 
-internal class Sequence(private val counter: AtomicRef<Int?> = atomic(null)) {
+internal class Sequence {
+    private val counter: AtomicRef<Int?> = atomic(null)
+
     var value
         get() = counter.value
         set(value) = counter.update { value }

--- a/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/handler/HeartbeatHandler.kt
+++ b/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/handler/HeartbeatHandler.kt
@@ -37,12 +37,12 @@ internal class HeartbeatHandler(
                 }
             }
 
-            timestamp = MonoClock.markNow()
+            timestamp = TimeSource.Monotonic.markNow()
             send(Command.Heartbeat(sequence.value))
         }
 
         on<Heartbeat> {
-            timestamp = MonoClock.markNow()
+            timestamp = TimeSource.Monotonic.markNow()
             send(Command.Heartbeat(sequence.value))
         }
 

--- a/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/retry/LinearRetry.kt
+++ b/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/retry/LinearRetry.kt
@@ -12,8 +12,8 @@ private val linearRetryLogger = KotlinLogging.logger { }
 /**
  * A Retry that linearly increases the delay time between a given minimum and maximum over a given amount of tries.
  *
- * @param firstBackoffMillis the initial delay for a [retry] invocation.
- * @param maxBackoffMillis the maximum delay for a [retry] invocation.
+ * @param firstBackoff the initial delay for a [retry] invocation.
+ * @param maxBackoff the maximum delay for a [retry] invocation.
  * @param maxTries the maximum amount of consecutive retries before [hasNext] returns false.
  */
 class LinearRetry constructor(
@@ -32,7 +32,7 @@ class LinearRetry constructor(
         require(maxTries > 0) { "maxTries needs to be positive but was $maxTries" }
     }
 
-    private var tries = atomic(0)
+    private val tries = atomic(0)
 
     override val hasNext: Boolean
         get() = tries.value < maxTries

--- a/gateway/src/test/kotlin/gateway/DefaultGatewayTest.kt
+++ b/gateway/src/test/kotlin/gateway/DefaultGatewayTest.kt
@@ -6,20 +6,18 @@ import com.gitlab.kordlib.common.entity.Status
 import com.gitlab.kordlib.common.ratelimit.BucketRateLimiter
 import com.gitlab.kordlib.gateway.*
 import com.gitlab.kordlib.gateway.retry.LinearRetry
-import io.ktor.client.HttpClient
-import io.ktor.client.engine.cio.CIO
+import io.ktor.client.*
+import io.ktor.client.engine.cio.*
 import io.ktor.client.features.json.JsonFeature
-import io.ktor.client.features.json.serializer.KotlinxSerializer
-import io.ktor.client.features.websocket.WebSockets
-import io.ktor.util.KtorExperimentalAPI
+import io.ktor.client.features.json.serializer.*
+import io.ktor.client.features.websocket.*
+import io.ktor.util.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import kotlinx.serialization.UnstableDefault
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonConfiguration
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import java.time.Duration
@@ -28,7 +26,6 @@ import kotlin.time.seconds
 import kotlin.time.toKotlinDuration
 
 @FlowPreview
-@UnstableDefault
 @KtorExperimentalAPI
 @ObsoleteCoroutinesApi
 @ExperimentalCoroutinesApi
@@ -43,7 +40,7 @@ class DefaultGatewayTest {
             client = HttpClient(CIO) {
                 install(WebSockets)
                 install(JsonFeature) {
-                    serializer = KotlinxSerializer(Json(JsonConfiguration.Default))
+                    serializer = KotlinxSerializer(Json)
                 }
             }
 
@@ -60,7 +57,7 @@ class DefaultGatewayTest {
                 "!status" -> when (words.getOrNull(1)) {
                     "playing" -> gateway.send(UpdateStatus(status = Status.Online, afk = false, game = DiscordActivity("Kord", ActivityType.Game)))
                 }
-                "!ping" ->  gateway.send(UpdateStatus(status = Status.Online, afk = false, game = DiscordActivity("Ping is ${gateway.ping.toLongMilliseconds()}", ActivityType.Game)))
+                "!ping" -> gateway.send(UpdateStatus(status = Status.Online, afk = false, game = DiscordActivity("Ping is ${gateway.ping.toLongMilliseconds()}", ActivityType.Game)))
             }
         }.launchIn(GlobalScope)
 

--- a/gateway/src/test/kotlin/json/CommandTest.kt
+++ b/gateway/src/test/kotlin/json/CommandTest.kt
@@ -16,15 +16,15 @@ class CommandTest {
         val sessionId = "session"
         val sequence = 1337
 
-        val resume = Json.stringify(Command.Companion, Resume(token, sessionId, sequence))
+        val resume = Json.encodeToString(Command.Companion, Resume(token, sessionId, sequence))
 
-        val json = Json.stringify(JsonObject.serializer(), json {
-            "op" to OpCode.Resume.code
-            "d" to json {
-                "token" to token
-                "session_id" to sessionId
-                "seq" to sequence
-            }
+        val json = Json.encodeToString(JsonObject.serializer(), buildJsonObject {
+            put("op", OpCode.Resume.code)
+            put("d", buildJsonObject {
+                put("token", token)
+                put("session_id", sessionId)
+                put("seq", sequence)
+            })
         })
 
         assertEquals(json, resume)
@@ -35,11 +35,11 @@ class CommandTest {
     fun `Heartbeat command serialization`() {
         val interval = 1337
 
-        val heartbeat = Json.stringify(Command.Companion, Command.Heartbeat(interval))
+        val heartbeat = Json.encodeToString(Command.Companion, Command.Heartbeat(interval))
 
-        val json = Json.stringify(JsonObject.serializer(), json {
-            "op" to OpCode.Heartbeat.code
-            "d" to interval
+        val json = Json.encodeToString(JsonObject.serializer(), buildJsonObject {
+            put("op", OpCode.Heartbeat.code)
+            put("d", interval)
         })
 
         assertEquals(json, heartbeat)
@@ -52,19 +52,19 @@ class CommandTest {
         val query = "test"
         val limit = 1337
 
-        val request = Json.stringify(Command.Companion, RequestGuildMembers(listOf(guildId), query, limit))
+        val request = Json.encodeToString(Command.Companion, RequestGuildMembers(listOf(guildId), query, limit))
 
-        val json = Json.stringify(JsonObject.serializer(), json {
-            "op" to OpCode.RequestGuildMembers.code
-            "d" to json {
-                "guild_id" to jsonArray {
-                    +guildId
-                }
-                "query" to query
-                "limit" to limit
-                "presences" to null as Int?
-                "user_ids" to null as Int?
-            }
+        val json = Json.encodeToString(JsonObject.serializer(), buildJsonObject {
+            put("op", OpCode.RequestGuildMembers.code)
+            put("d", buildJsonObject {
+                put("guild_id", buildJsonArray {
+                    add(guildId)
+                })
+                put("query", query)
+                put("limit", limit)
+                put("presences", null as Int?)
+                put("user_ids", null as Int?)
+            })
         })
 
         assertEquals(json, request)
@@ -78,16 +78,16 @@ class CommandTest {
         val selfMute = true
         val selfDeaf = false
 
-        val status = Json.stringify(Command.Companion, UpdateVoiceStatus(guildId, channelId, selfMute, selfDeaf))
+        val status = Json.encodeToString(Command.Companion, UpdateVoiceStatus(guildId, channelId, selfMute, selfDeaf))
 
-        val json = Json.stringify(JsonObject.serializer(), json {
-            "op" to OpCode.VoiceStateUpdate.code
-            "d" to json {
-                "guild_id" to guildId
-                "channel_id" to channelId
-                "self_mute" to selfMute
-                "self_deaf" to selfDeaf
-            }
+        val json = Json.encodeToString(JsonObject.serializer(), buildJsonObject {
+            put("op", OpCode.VoiceStateUpdate.code)
+            put("d", buildJsonObject {
+                put("guild_id", guildId)
+                put("channel_id", channelId)
+                put("self_mute", selfMute)
+                put("self_deaf", selfDeaf)
+            })
         })
 
         assertEquals(json, status)
@@ -101,16 +101,16 @@ class CommandTest {
         val status = Status.Online
         val afk = false
 
-        val updateStatus = Json.stringify(Command.Companion, UpdateStatus(since, game, status, afk))
+        val updateStatus = Json.encodeToString(Command.Companion, UpdateStatus(since, game, status, afk))
 
-        val json = Json.stringify(JsonObject.serializer(), json {
-            "op" to OpCode.StatusUpdate.code
-            "d" to json {
-                "since" to since
-                "game" to null as String?
-                "status" to status.name.toLowerCase()
-                "afk" to afk
-            }
+        val json = Json.encodeToString(JsonObject.serializer(), buildJsonObject {
+            put("op", OpCode.StatusUpdate.code)
+            put("d", buildJsonObject {
+                put("since", since)
+                put("game", null as String?)
+                put("status", status.name.toLowerCase())
+                put("afk", afk)
+            })
         })
 
         assertEquals(json, updateStatus)
@@ -127,26 +127,26 @@ class CommandTest {
         val shard = DiscordShard(0, 1)
         val presence = null
 
-        val identify = Json.stringify(Command.Companion, Identify(token, properties, compress, largeThreshold, shard, presence, Intents.all))
+        val identify = Json.encodeToString(Command.Companion, Identify(token, properties, compress, largeThreshold, shard, presence, Intents.all))
 
-        val json = Json.stringify(JsonObject.serializer(), json {
-            "op" to OpCode.Identify.code
-            "d" to json {
-                "token" to token
-                "properties" to json {
-                    "\$os" to "os"
-                    "\$browser" to "browser"
-                    "\$device" to "device"
-                }
-                "compress" to compress
-                "large_threshold" to largeThreshold
-                "shard" to jsonArray {
-                    +JsonLiteral(0)
-                    +JsonLiteral(1)
-                }
-                "presence" to null as String?
-                "intents" to Intents.all.code
-            }
+        val json = Json.encodeToString(JsonObject.serializer(), buildJsonObject {
+            put("op", OpCode.Identify.code)
+            put("d", buildJsonObject {
+                put("token", token)
+                put("properties", buildJsonObject {
+                    put("\$os", "os")
+                    put("\$browser", "browser")
+                    put("\$device", "device")
+                })
+                put("compress", compress)
+                put("large_threshold", largeThreshold)
+                put("shard", buildJsonArray {
+                    add(JsonPrimitive(0))
+                    add(JsonPrimitive(1))
+                })
+                put("presence", null as String?)
+                put("intents", Intents.all.code)
+            })
         })
 
         assertEquals(json, identify)

--- a/gateway/src/test/kotlin/json/RegressionTests.kt
+++ b/gateway/src/test/kotlin/json/RegressionTests.kt
@@ -4,6 +4,7 @@ import com.gitlab.kordlib.gateway.Event
 import com.gitlab.kordlib.gateway.HeartbeatACK
 import com.gitlab.kordlib.gateway.Reconnect
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.parse
 import org.junit.jupiter.api.Test
 
 private fun file(name: String): String {
@@ -14,7 +15,7 @@ private fun file(name: String): String {
 class RegressionTests {
     @Test
     fun `Resume command serialization`() {
-        val event = Json.parse(Event.Companion, file("eventWithDataThatShouldNotHaveData"))
+        val event = Json.decodeFromString(Event.Companion, file("eventWithDataThatShouldNotHaveData"))
         event shouldBe Reconnect
     }
 

--- a/gateway/src/test/kotlin/json/SerializationTest.kt
+++ b/gateway/src/test/kotlin/json/SerializationTest.kt
@@ -6,6 +6,7 @@ import com.gitlab.kordlib.common.entity.UserFlag
 import com.gitlab.kordlib.common.entity.UserFlags
 import com.gitlab.kordlib.gateway.*
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.parse
 import org.junit.jupiter.api.Test
 
 private fun file(name: String): String {
@@ -17,14 +18,14 @@ class SerializationTest {
 
     @Test
     fun `HeartbeatACK Event serialization`() {
-        val event = Json.parse(Event.Companion, file("ack"))
+        val event = Json.decodeFromString(Event.Companion, file("ack"))
         event shouldBe HeartbeatACK
     }
 
 
     @Test
     fun `Hello Event serialization`() {
-        val event = Json.parse(Event.Companion, file("hello")) as Hello
+        val event = Json.decodeFromString(Event.Companion, file("hello")) as Hello
         with(event) {
             heartbeatInterval shouldBe 1337
             traces shouldBe listOf("test")
@@ -34,14 +35,14 @@ class SerializationTest {
 
     @Test
     fun `Reconnect Event serialization`() {
-        val event = Json.parse(Event.Companion, file("reconnect"))
+        val event = Json.decodeFromString(Event.Companion, file("reconnect"))
         event shouldBe Reconnect
     }
 
 
     @Test
     fun `Ready Event serialization`() {
-        val event = Json.parse(Event.Companion, file("ready")) as Ready
+        val event = Json.decodeFromString(Event.Companion, file("ready")) as Ready
         with(event.data) {
             with(event.data.guilds) {
                 val guild = get(0)
@@ -71,21 +72,21 @@ class SerializationTest {
 
     @Test
     fun `Resumed Event serialization`() {
-        val event = Json.parse(Event.Companion, file("resumed")) as Resumed
+        val event = Json.decodeFromString(Event.Companion, file("resumed")) as Resumed
         with(event) { data.traces shouldBe listOf("kord", "is", "happy") }
     }
 
 
     @Test
     fun `InvalidSession command serialization`() {
-        val event = Json.parse(Event.Companion, file("invalid")) as InvalidSession
+        val event = Json.decodeFromString(Event.Companion, file("invalid")) as InvalidSession
         with(event) { resumable shouldBe false }
     }
 
 
     @Test
     fun `ChannelPinsUpdate Event serialization`() {
-        val event = Json.parse(Event.Companion, file("channelpinsupdate")) as ChannelPinsUpdate
+        val event = Json.decodeFromString(Event.Companion, file("channelpinsupdate")) as ChannelPinsUpdate
         with(event.pins) {
             guildId shouldBe "41771983423143937"
             channelId shouldBe "399942396007890945"
@@ -97,7 +98,7 @@ class SerializationTest {
 
     @Test
     fun `ChannelCreate Event serialization`() {
-        val event = Json.parse(Event.Companion, file("channelcreate")) as ChannelCreate
+        val event = Json.decodeFromString(Event.Companion, file("channelcreate")) as ChannelCreate
         with(event.channel) {
             id shouldBe "41771983423143937"
             guildId shouldBe "41771983423143937"
@@ -116,7 +117,7 @@ class SerializationTest {
 
     @Test
     fun `ChannelUpdate Event serialization`() {
-        val event = Json.parse(Event.Companion, file("channelupdate")) as ChannelUpdate
+        val event = Json.decodeFromString(Event.Companion, file("channelupdate")) as ChannelUpdate
         with(event.channel) {
             id shouldBe "41771983423143937"
             guildId shouldBe "41771983423143937"
@@ -134,7 +135,7 @@ class SerializationTest {
 
     @Test
     fun `ChannelDelete Event serialization`() {
-        val event = Json.parse(Event.Companion, file("channeldelete")) as ChannelDelete
+        val event = Json.decodeFromString(Event.Companion, file("channeldelete")) as ChannelDelete
         with(event.channel) {
             id shouldBe "41771983423143937"
             guildId shouldBe "41771983423143937"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+#dokka will run out of memory with the default meta space
+org.gradle.jvmargs=-XX:MaxMetaspaceSize=1024m

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Tue Dec 31 15:02:18 CET 2019
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/rest/DokkaDescription.md
+++ b/rest/DokkaDescription.md
@@ -1,0 +1,1 @@
+Low level abstraction of the Discord REST API.

--- a/rest/build.gradle.kts
+++ b/rest/build.gradle.kts
@@ -16,7 +16,8 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
         freeCompilerArgs = listOf(
                 CompilerArguments.inlineClasses,
                 CompilerArguments.coroutines,
-                CompilerArguments.time
+                CompilerArguments.time,
+                CompilerArguments.optIn
         )
     }
 }

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/integration/IntegrationModifyBuilder.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/integration/IntegrationModifyBuilder.kt
@@ -5,7 +5,7 @@ import com.gitlab.kordlib.rest.json.request.GuildIntegrationModifyRequest
 import com.gitlab.kordlib.rest.json.response.IntegrationExpireBehavior
 
 /**
- * Builder for [modifying an integration](https://discordapp.com/developers/docs/resources/guild#modify-guild-integration).
+ * Builder for [modifying an integration](https://discord.com/developers/docs/resources/guild#modify-guild-integration).
  */
 class IntegrationModifyBuilder : RequestBuilder<GuildIntegrationModifyRequest> {
 

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/message/MessageCreateBuilder.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/message/MessageCreateBuilder.kt
@@ -50,7 +50,7 @@ class MessageCreateBuilder : RequestBuilder<MultipartMessageCreateRequest> {
 }
 
 /**
- * The mentions that should trigger a ping. See the [Discord documentation](https://discordapp.com/developers/docs/resources/channel#allowed-mentions-object).
+ * The mentions that should trigger a ping. See the [Discord documentation](https://discord.com/developers/docs/resources/channel#allowed-mentions-object).
  *
  */
 class AllowedMentionsBuilder {

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/webhook/ExecuteWebhookBuilder.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/webhook/ExecuteWebhookBuilder.kt
@@ -8,7 +8,6 @@ import com.gitlab.kordlib.rest.json.request.MultiPartWebhookExecuteRequest
 import com.gitlab.kordlib.rest.json.request.WebhookExecuteRequest
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import kotlinx.io.InputStream
 import java.nio.file.Files
 import java.nio.file.Path
 

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/JsonErrorCode.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/JsonErrorCode.kt
@@ -1,6 +1,10 @@
 package com.gitlab.kordlib.rest.json
 
 import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 
 /**
  * Detailed error codes sent Discord API  in the JSON error response.
@@ -420,7 +424,7 @@ enum class JsonErrorCode(val code: Int) {
 
     @Serializer(forClass = JsonErrorCode::class)
     companion object JsonErrorCodeSerializer : KSerializer<JsonErrorCode>  {
-        override val descriptor = PrimitiveDescriptor("JsonErrorCodeSerializer", PrimitiveKind.INT)
+        override val descriptor = PrimitiveSerialDescriptor("JsonErrorCodeSerializer", PrimitiveKind.INT)
 
 
         override fun deserialize(decoder: Decoder): JsonErrorCode {
@@ -429,7 +433,7 @@ enum class JsonErrorCode(val code: Int) {
         }
 
         override fun serialize(encoder: Encoder, value: JsonErrorCode) {
-            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+            encoder.encodeInt(value.code)
         }
     }
 

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/OptionalSerializer.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/OptionalSerializer.kt
@@ -1,6 +1,9 @@
 package com.gitlab.kordlib.rest.json
 
 import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 
 /**
  * This is a very stupid serializer and you should feel ashamed for calling this.
@@ -12,6 +15,7 @@ import kotlinx.serialization.*
  * swallow any exceptions while doing so, returning null instead. This is incredibly bad because we won't propagate any
  * actual bugs.
  */
+@OptIn(ExperimentalSerializationApi::class)
 internal val <T> KSerializer<T>.optional: KSerializer<T?>
     get() = object: KSerializer<T?> {
 
@@ -19,13 +23,13 @@ internal val <T> KSerializer<T>.optional: KSerializer<T?>
             get() = this@optional.descriptor
 
         override fun deserialize(decoder: Decoder): T? = try {
-            decoder.decode(this@optional)
+            decoder.decodeSerializableValue(this@optional)
         } catch (e :Exception) {
             null
         }
 
         override fun serialize(encoder: Encoder, value: T?) {
             if (value == null) return encoder.encodeNull()
-            else encoder.encode(this@optional, value)
+            else encoder.encodeSerializableValue<T>(this@optional, value)
         }
     }

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/request/GuildRequests.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/request/GuildRequests.kt
@@ -3,6 +3,10 @@ package com.gitlab.kordlib.rest.json.request
 import com.gitlab.kordlib.common.entity.*
 import kotlinx.serialization.*
 import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.StructureKind
+import kotlinx.serialization.descriptors.buildSerialDescriptor
+import kotlinx.serialization.encoding.Encoder
 
 @Serializable
 data class GuildCreateRequest(
@@ -46,11 +50,12 @@ data class GuildCreateChannelRequest(
 data class GuildChannelPositionModifyRequest(val swaps: List<Pair<String, Int>>) {
 
     companion object Serializer : SerializationStrategy<GuildChannelPositionModifyRequest> {
+        @OptIn(InternalSerializationApi::class, ExperimentalSerializationApi::class)
         override val descriptor: SerialDescriptor
-            get() = SerialDescriptor("GuildChannelPosition", StructureKind.LIST)
+            get() = buildSerialDescriptor("GuildChannelPosition", StructureKind.LIST)
 
-        override fun serialize(encoder: Encoder, obj: GuildChannelPositionModifyRequest) {
-            val positions = obj.swaps.map { ChannelPosition(it.first, it.second) }
+        override fun serialize(encoder: Encoder, value: GuildChannelPositionModifyRequest) {
+            val positions = value.swaps.map { ChannelPosition(it.first, it.second) }
             ListSerializer(ChannelPosition.serializer()).serialize(encoder, positions)
         }
 
@@ -101,8 +106,9 @@ data class GuildRoleCreateRequest(
 data class GuildRolePositionModifyRequest(val swaps: List<Pair<String, Int>>) {
 
     companion object Serializer : SerializationStrategy<GuildRolePositionModifyRequest> {
+        @OptIn(ExperimentalSerializationApi::class, InternalSerializationApi::class)
         override val descriptor: SerialDescriptor
-            get() = SerialDescriptor("GuildRolePosition", StructureKind.LIST)
+            get() = buildSerialDescriptor("GuildRolePosition", StructureKind.LIST)
 
         override fun serialize(encoder: Encoder, obj: GuildRolePositionModifyRequest) {
             val positions = obj.swaps.map { RolePosition(it.first, it.second) }

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/request/MessageRequests.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/request/MessageRequests.kt
@@ -1,7 +1,6 @@
 package com.gitlab.kordlib.rest.json.request
 
 import com.gitlab.kordlib.common.entity.Flags
-import kotlinx.io.InputStream
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/request/WebhookRequests.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/request/WebhookRequests.kt
@@ -1,9 +1,7 @@
 package com.gitlab.kordlib.rest.json.request
 
-import com.gitlab.kordlib.rest.Image
-import kotlinx.io.InputStream
 import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
+import kotlinx. serialization.Serializable
 
 @Serializable
 data class WebhookCreateRequest(val name: String, val avatar: String?)

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/response/IntegrationResponse.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/response/IntegrationResponse.kt
@@ -2,6 +2,11 @@ package com.gitlab.kordlib.rest.json.response
 
 import com.gitlab.kordlib.common.entity.DiscordUser
 import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 
 @Serializable
 data class IntegrationResponse(
@@ -31,7 +36,7 @@ enum class IntegrationExpireBehavior(val code: Int) {
 
     companion object Serializer : KSerializer<IntegrationExpireBehavior> {
         override val descriptor: SerialDescriptor
-            get() = PrimitiveDescriptor("expire_behavior", PrimitiveKind.INT)
+            get() = PrimitiveSerialDescriptor("expire_behavior", PrimitiveKind.INT)
 
         override fun deserialize(decoder: Decoder): IntegrationExpireBehavior {
             val code = decoder.decodeInt()

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/ratelimit/RequestRateLimiter.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/ratelimit/RequestRateLimiter.kt
@@ -5,7 +5,7 @@ import java.lang.Exception
 import java.time.Instant
 
 /**
- * A rate limiter that follows [Discord's rate limits](https://discordapp.com/developers/docs/topics/rate-limits) for
+ * A rate limiter that follows [Discord's rate limits](https://discord.com/developers/docs/topics/rate-limits) for
  * the REST api.
  */
 interface RequestRateLimiter {

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/request/Request.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/request/Request.kt
@@ -6,9 +6,7 @@ import io.ktor.client.request.forms.formData
 import io.ktor.http.encodeURLQueryComponent
 import io.ktor.util.StringValues
 import io.ktor.utils.io.streams.outputStream
-import kotlinx.io.InputStream
 import kotlinx.serialization.SerializationStrategy
-import mu.KotlinLogging
 
 sealed class Request<B : Any, R> {
     abstract val route: Route<R>

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/request/Request.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/request/Request.kt
@@ -34,7 +34,7 @@ val Request<*, *>.identifier get() = when { //The major identifier is always the
 }
 
 /**
- * A ['per-route'](https://discordapp.com/developers/docs/topics/rate-limits) identifier for rate limiting purposes.
+ * A ['per-route'](https://discord.com/developers/docs/topics/rate-limits) identifier for rate limiting purposes.
  */
 sealed class RequestIdentifier {
     /**

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/request/RequestBuilder.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/request/RequestBuilder.kt
@@ -3,7 +3,6 @@ package com.gitlab.kordlib.rest.request
 import com.gitlab.kordlib.rest.route.Route
 import io.ktor.http.HeadersBuilder
 import io.ktor.http.ParametersBuilder
-import kotlinx.io.InputStream
 import kotlinx.serialization.SerializationStrategy
 
 class RequestBuilder<T>(private val route: Route<T>, keySize: Int = 2) {

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/route/Route.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/route/Route.kt
@@ -8,6 +8,10 @@ import io.ktor.http.HttpMethod
 import kotlinx.serialization.*
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.StructureKind
+import kotlinx.serialization.descriptors.buildSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
 import com.gitlab.kordlib.common.entity.DiscordEmoji as EmojiEntity
 
 internal const val REST_VERSION_PROPERTY_NAME = "com.gitlab.kordlib.rest.version"
@@ -346,8 +350,9 @@ sealed class Route<T>(
 }
 
 internal object NoStrategy : DeserializationStrategy<Unit> {
+    @OptIn(InternalSerializationApi::class, ExperimentalSerializationApi::class)
     override val descriptor: SerialDescriptor
-        get() = SerialDescriptor("NoStrategy", StructureKind.OBJECT)
+        get() = buildSerialDescriptor("NoStrategy", StructureKind.OBJECT) {}
 
     override fun deserialize(decoder: Decoder) {}
 

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/route/Route.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/route/Route.kt
@@ -323,7 +323,7 @@ sealed class Route<T>(
         : Route<ApplicationInfoResponse>(HttpMethod.Get, "/oauth2/applications/@me", ApplicationInfoResponse.serializer())
 
     companion object {
-        val baseUrl = "https://discordapp.com/api/$restVersion"
+        val baseUrl = "https://discord.com/api/$restVersion"
     }
 
     open class Key(val identifier: String, val isMajor: Boolean = false) {

--- a/rest/src/test/kotlin/com/gitlab/kordlib/rest/json/AuditLogResponseTest.kt
+++ b/rest/src/test/kotlin/com/gitlab/kordlib/rest/json/AuditLogResponseTest.kt
@@ -1,18 +1,17 @@
 package com.gitlab.kordlib.rest.json
 
 import com.gitlab.kordlib.rest.json.response.AuditLogResponse
-import kotlinx.serialization.UnstableDefault
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.parse
 import org.junit.jupiter.api.Test
 
-@UnstableDefault
 object AuditLogResponseTest {
 
     @Test
     fun `AuditLogResponseSerialization serialization`() {
 
         val json = file("auditlog")
-            val log = Json.parse(AuditLogResponse.serializer(), json)
+            val log = Json.decodeFromString(AuditLogResponse.serializer(), json)
 
 
     }

--- a/rest/src/test/kotlin/com/gitlab/kordlib/rest/json/ErrorTest.kt
+++ b/rest/src/test/kotlin/com/gitlab/kordlib/rest/json/ErrorTest.kt
@@ -2,18 +2,24 @@ package com.gitlab.kordlib.rest.json
 
 import com.gitlab.kordlib.rest.json.response.DiscordErrorResponse
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonConfiguration
+import kotlinx.serialization.parse
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 class ErrorTest {
-    private val parser = Json(JsonConfiguration(encodeDefaults = false, allowStructuredMapKeys = true, ignoreUnknownKeys = true, isLenient = true))
+    private val parser = Json {
+        encodeDefaults = false
+        allowStructuredMapKeys = true
+        ignoreUnknownKeys = true
+        isLenient = true
+    }
+
     @Test
     fun `correctly serialize error`() {
         val content = file("error")
-        val parsed  = parser.parse(DiscordErrorResponse.serializer(), content)
-        assertEquals(40001,parsed.code.code)
-        assertEquals("Unauthorized",parsed.message)
+        val parsed = parser.decodeFromString(DiscordErrorResponse.serializer(), content)
+        assertEquals(40001, parsed.code.code)
+        assertEquals("Unauthorized", parsed.message)
 
     }
 }


### PR DESCRIPTION
# 0.5.12

## Changes

* `Member#kick` and `Guild#kick` now have an optional reason.
* `KordBuilder` now throws a (more) useful exception when building a bot with an invalid token.
* The REST module will now use `discord.com/api` instead of the deprecated `discordapp.com/api`.
* Kord now uses `Dispatchers.default` as the default dispatcher.

## Fixes

* Fixed an issue where Invite events would not fire if the invited user didn't have an avatar.
* Fixed some outdated docs on the `KordBuilder`.
* Fixed an issue where voice states from guild creates were not getting cached.

## Additions

* Introduced an experimental REST-only variant of the Kord builder. This will automatically disable gateway and cache
related APIs and replace them with a no-op implementation.
* Introduced a no-op `Gateway` implementation.

## Performance

* Removed an unneeded REST call when building Kord.

## Dependencies

* kotlin 1.3.72 -> 1.4.0
* ktor 1.3.2 -> 1.4.0
* kotlinx.serialization 0.2.0 -> 1.0.0-RC
* kotlinx.coroutines 1.3.7 -> 1.3.9
