### PR TITLE
Teams prophecy came true!

### DIFF
--- a/common/src/main/kotlin/com/gitlab/kordlib/common/entity/Team.kt
+++ b/common/src/main/kotlin/com/gitlab/kordlib/common/entity/Team.kt
@@ -1,0 +1,98 @@
+package com.gitlab.kordlib.common.entity
+
+import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+/**
+ * The raw developer team data gotten from the API.
+ */
+@Serializable
+data class DiscordTeam(
+        /**
+         * The unique ID of this team.
+         */
+        val id: String,
+        /**
+         * The hash of this team's icon.
+         */
+        val icon: String?,
+        /**
+         * A collection of all members of this team.
+         */
+        val members: List<DiscordTeamMember>,
+        /**
+         * The ID of the user that owns the team.
+         */
+        @SerialName("owner_user_id")
+        val ownerUserId: String
+)
+
+/**
+ * The state of membership on a Discord developer team.
+ */
+@Serializable(with = TeamMembershipState.TeamMembershipStateSerializer::class)
+enum class TeamMembershipState(val value: Int) {
+    /**
+     * Unknown membership state.
+     */
+    Unknown(-1),
+
+    /**
+     * The user has been invited.
+     */
+    Invited(1),
+
+    /**
+     * The user has accepted the invitation.
+     */
+    Accepted(2);
+
+    @OptIn(ExperimentalSerializationApi::class)
+    @Serializer(forClass = TeamMembershipState::class)
+    companion object TeamMembershipStateSerializer : KSerializer<TeamMembershipState> {
+
+        override val descriptor: SerialDescriptor
+            get() = PrimitiveSerialDescriptor("membership_state", PrimitiveKind.INT)
+
+        override fun deserialize(decoder: Decoder): TeamMembershipState {
+            val code = decoder.decodeInt()
+            return values().firstOrNull { it.value == code } ?: Unknown
+        }
+
+        override fun serialize(encoder: Encoder, value: TeamMembershipState) {
+            encoder.encodeInt(value.value)
+        }
+    }
+}
+
+/**
+ * The raw developer team member data gotten from the API.
+ */
+@Serializable
+class DiscordTeamMember(
+        /**
+         * An integer enum representing the state of membership of this user.
+         * `1` means the user has been invited and `2` means the user has accepted the invitation.
+         */
+        @SerialName("membership_state")
+        val membershipState: TeamMembershipState,
+        /**
+         * A collection of permissions granted to this member.
+         * At the moment, this collection will only have one element: `*`, meaning the member has all permissions.
+         * This is because right now there are no other permissions. Read mode [here](https://discord.com/developers/docs/topics/teams#data-models-team-members-object)
+         */
+        val permissions: List<String>,
+        /**
+         * The unique ID that this member belongs to.
+         */
+        @SerialName("team_id")
+        val teamId: String,
+        /**
+         * Partial user data containing only the ID, username, discriminator and avatar.
+         */
+        val user: DiscordUser
+)

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/ApplicationInfoData.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/ApplicationInfoData.kt
@@ -9,12 +9,34 @@ data class ApplicationInfoData(
         val description: String?,
         val botPublic: Boolean,
         val botRequireCodeGrant: Boolean,
-        val ownerId: Long
+        val ownerId: Long,
+        val summary: String,
+        val verifyKey: String,
+        val teamId: Long?,
+        val guildId: Long? = null,
+        val primarySkuId: Long? = null,
+        val slug: String? = null,
+        val coverImage: String? = null
 ) {
     companion object {
 
         fun from(entity: ApplicationInfoResponse) = with(entity) {
-            ApplicationInfoData(id.toLong(), name, icon, description, botPublic, botRequireCodeGrant, owner.id.toLong())
+            ApplicationInfoData(
+                    id.toLong(),
+                    name,
+                    icon,
+                    description,
+                    botPublic,
+                    botRequireCodeGrant,
+                    owner.id.toLong(),
+                    summary,
+                    verifyKey,
+                    team?.id?.toLong(),
+                    guildId?.toLong(),
+                    primarySkuId?.toLong(),
+                    slug,
+                    coverImage
+            )
         }
 
     }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/TeamData.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/TeamData.kt
@@ -1,0 +1,53 @@
+package com.gitlab.kordlib.core.cache.data
+
+
+import com.gitlab.kordlib.common.entity.TeamMembershipState
+import kotlinx.serialization.Serializable
+
+/**
+ * A serializable data representation of a Discord developer team.
+ */
+@Serializable
+data class TeamData(
+        /**
+         * The unique ID of this team.
+         */
+        val id: Long,
+        /**
+         * The hash of this team's icon.
+         */
+        val icon: String?,
+        /**
+         * A collection of all members of this team.
+         */
+        val members: List<TeamMemberData>,
+        /**
+         * The ID of the user that owns the team.
+         */
+        val ownerUserId: Long
+)
+
+/**
+ * A serializable data representation of a Discord developer team member.
+ */
+@Serializable
+class TeamMemberData(
+        /**
+         * An enumeration representing the membership state of this user.
+         */
+        val membershipState: TeamMembershipState,
+        /**
+         * A collection of permissions granted to this member.
+         * At the moment, this collection will only have one element: `*`, meaning the member has all permissions.
+         * This is because right now there are no other permissions. Read mode [here](https://discord.com/developers/docs/topics/teams#data-models-team-members-object)
+         */
+        val permissions: List<String>,
+        /**
+         * The unique ID that this member belongs to.
+         */
+        val teamId: Long,
+        /**
+         * The ID of the user this member represents.
+         */
+        val userId: Long
+)

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/ApplicationInfo.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/ApplicationInfo.kt
@@ -6,8 +6,12 @@ import com.gitlab.kordlib.core.behavior.UserBehavior
 import com.gitlab.kordlib.core.cache.data.ApplicationInfoData
 import com.gitlab.kordlib.core.supplier.EntitySupplier
 import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy
+import com.gitlab.kordlib.rest.Image
 import java.util.*
 
+/**
+ * The details of a [Discord OAuth2](https://discord.com/developers/docs/topics/oauth2) application.
+ */
 class ApplicationInfo(
         val data: ApplicationInfoData,
         override val kord: Kord,
@@ -29,9 +33,25 @@ class ApplicationInfo(
 
     val owner: UserBehavior get() = UserBehavior(ownerId, kord)
 
+    val summary: String get() = data.summary
+
+    val verifyKey: String get() = data.verifyKey
+
+    val teamId: Long? get() = data.teamId
+
+    val guildId: Long? get() = data.guildId
+
+    val primarySkuId: Long? get() = data.primarySkuId
+
+    val slug: String? get() = data.slug
+
+    val coverImage: String? get() = data.coverImage
+
     suspend fun getOwner(): User = supplier.getUser(ownerId)
 
     suspend fun getOwnerOrNull(): User? = supplier.getUserOrNull(ownerId)
+
+    suspend fun getCoverImage(): Image? = coverImage?.let { Image.fromUrl(kord.resources.httpClient, it) }
 
     /**
      * Returns a new [ApplicationInfo] with the given [strategy].
@@ -41,7 +61,7 @@ class ApplicationInfo(
 
     override fun hashCode(): Int = Objects.hash(id)
 
-    override fun equals(other: Any?): Boolean = when(other) {
+    override fun equals(other: Any?): Boolean = when (other) {
         is ApplicationInfo -> other.id == id
         else -> false
     }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Team.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Team.kt
@@ -1,0 +1,72 @@
+package com.gitlab.kordlib.core.entity
+
+import com.gitlab.kordlib.common.entity.Snowflake
+import com.gitlab.kordlib.common.entity.TeamMembershipState
+import com.gitlab.kordlib.core.Kord
+import com.gitlab.kordlib.core.cache.data.TeamData
+import com.gitlab.kordlib.core.cache.data.TeamMemberData
+
+/**
+ * A Discord [developer team](https://discord.com/developers/docs/topics/teams) which can own applications.
+ */
+class Team(val data: TeamData, override val kord: Kord) : Entity {
+    /**
+     * The unique ID of this team.
+     */
+    override val id: Snowflake
+        get() = Snowflake(data.id)
+
+    /**
+     * The hash of this team's icon.
+     */
+    val icon: String? get() = data.icon
+
+    /**
+     * A collection of all members of this team.
+     */
+    val members: List<TeamMember>
+        get() = data.members.map { TeamMember(it, kord) }
+
+    /**
+     * The ID of the user that owns the team.
+     */
+    val ownerUserId: Snowflake
+        get() = Snowflake(data.id)
+
+    /**
+     * Utility method that gets the owner user from Kord.
+     */
+    suspend fun getUser() = kord.getUser(ownerUserId)
+}
+
+/**
+ * A member of a Discord developer team.
+ */
+class TeamMember(val data: TeamMemberData, val kord: Kord) {
+    /**
+     * An enumeration representing the membership state of this user.
+     */
+    val membershipState: TeamMembershipState get() = data.membershipState
+
+    /**
+     * A collection of permissions granted to this member.
+     * At the moment, this collection will only have one element: `*`, meaning the member has all permissions.
+     * This is because right now there are no other permissions. Read mode [here](https://discord.com/developers/docs/topics/teams#data-models-team-members-object)
+     */
+    val permissions: List<String> get() = data.permissions
+
+    /**
+     * The unique ID that this member belongs to.
+     */
+    val teamId: Long get() = data.teamId
+
+    /**
+     * The ID of the user this member represents.
+     */
+    val userId: Snowflake get() = Snowflake(data.userId)
+
+    /**
+     * Utility method that gets the user from Kord.
+     */
+    suspend fun getUser() = kord.getUser(userId)
+}

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/response/ApplicationInfoResponse.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/response/ApplicationInfoResponse.kt
@@ -2,10 +2,14 @@
 
 package com.gitlab.kordlib.rest.json.response
 
+import com.gitlab.kordlib.common.entity.DiscordTeam
 import com.gitlab.kordlib.common.entity.DiscordUser
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+/**
+ * Payload gotten from [GET /oauth2/applications/@me](https://discord.com/developers/docs/topics/oauth2#get-current-application-information)
+ */
 @Serializable
 data class ApplicationInfoResponse(
         val id: String,
@@ -18,5 +22,16 @@ data class ApplicationInfoResponse(
         val botPublic: Boolean,
         @SerialName("bot_require_code_grant")
         val botRequireCodeGrant: Boolean,
-        val owner: DiscordUser
+        val owner: DiscordUser,
+        val summary: String,
+        @SerialName("verify_key")
+        val verifyKey: String,
+        val team: DiscordTeam?,
+        @SerialName("guild_id")
+        val guildId: String? = null,
+        @SerialName("primary_sku_id")
+        val primarySkuId: String? = null,
+        val slug: String? = null,
+        @SerialName("cover_image")
+        val coverImage: String? = null
 )


### PR DESCRIPTION
> *Once upon a time, an aspiring Korder came forward with a proposal, a goal he would set to himself, an extraordinary contribution to Kord, the Cool Project - add [Discord Teams](https://discord.com/developers/docs/topics/teams) support. And so, with the holy blessings of Ser Hope, the Just, and Ser Bart, the Lolz, this epic journey commenced. Hard and valorously this young and naïve apprentice worked, day and night, only stopping to admire the great advices given by his two masters (in the potent form of memes), but alas, the world was cruel and rather extreme, leading this epopee to fade away into a fine thread of sheer legend...*

*that's possibly a really high dosage of shitposting*

Well, it's done now.  Teams have been implemented: models, enum serializers, fields on application info stuff and, of course, all documented :)

Lmk if I made any whoopsie.