### PR TITLE
Make unicode reactions implement content equality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * Added `Team` and other properties to ApplicationInfo.
 
+## Changes
+
+* `ReactionEmoji.Unicode` now correctly compares on name for equality.
+
 # 0.6.0
 
 ## Changes

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/ReactionEmoji.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/ReactionEmoji.kt
@@ -29,7 +29,7 @@ sealed class ReactionEmoji {
         override fun toString() = "Custom(id=$id, name=$name, isAnimated=$isAnimated)"
     }
 
-    class Unicode(override val name: String) : ReactionEmoji() {
+    data class Unicode(override val name: String) : ReactionEmoji() {
         override val urlFormat: String get() = name
         override val mention: String get() = name
     }


### PR DESCRIPTION
This PR makes unicode reaction emojis data classes, effectively implementing content equality as a side effect.