### PR TITLE
Annotate unstable API

### DIFF
--- a/common/src/main/kotlin/com/gitlab/kordlib/common/annotation/Annotations.kt
+++ b/common/src/main/kotlin/com/gitlab/kordlib/common/annotation/Annotations.kt
@@ -51,3 +51,20 @@ annotation class KordExperimental
 @Experimental(level = Experimental.Level.WARNING)
 @Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.TYPEALIAS, AnnotationTarget.PROPERTY)
 annotation class KordUnsafe
+
+/**
+ * Marks a Kord-related API as unstable.
+ *
+ * Kord marks targets as unstable if they are subject to changes outside the development process.
+ * They offer no binary compatibility between versions.
+ *
+ * Consumers of this API are advised to lock the Kord dependency to a fixed version as even [patch](https://semver.org/)
+ * versions are allowed to make changes to fields annotated with [KordUnstableApi].
+ *
+ * Compared to [KordExperimental] and [KordPreview], targets annotated with [KordUnstableApi] have no intention
+ * to mature into stable and only serve as a warning to the user.
+ */
+@MustBeDocumented
+@Retention(value = AnnotationRetention.BINARY)
+@RequiresOptIn(level = RequiresOptIn.Level.WARNING)
+annotation class KordUnstableApi

--- a/common/src/main/kotlin/com/gitlab/kordlib/common/entity/Data.kt
+++ b/common/src/main/kotlin/com/gitlab/kordlib/common/entity/Data.kt
@@ -1,9 +1,11 @@
 package com.gitlab.kordlib.common.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
+@KordUnstableApi
 data class DiscordPinsUpdateData(
         @SerialName("guild_id")
         val guildId: String,
@@ -14,6 +16,7 @@ data class DiscordPinsUpdateData(
 )
 
 @Serializable
+@KordUnstableApi
 data class DiscordTyping(
         @SerialName("channel_id")
         val channelId: String,

--- a/common/src/main/kotlin/com/gitlab/kordlib/common/entity/DiscordActivity.kt
+++ b/common/src/main/kotlin/com/gitlab/kordlib/common/entity/DiscordActivity.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.common.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -8,6 +9,7 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
 @Serializable
+@KordUnstableApi
 data class DiscordActivity(
         val name: String,
         val type: ActivityType,
@@ -26,18 +28,21 @@ data class DiscordActivity(
 )
 
 @Serializable
+@KordUnstableApi
 data class DiscordActivityTimeStamps(
         val start: Long? = null,
         val end: Long? = null
 )
 
 @Serializable
+@KordUnstableApi
 data class DiscordActivityParty(
         val id: String? = null,
         val size: List<Int>? = null
 )
 
 @Serializable
+@KordUnstableApi
 data class DiscordActivityAssets(
         @SerialName("large_image")
         val largeImage: String? = null,
@@ -50,6 +55,7 @@ data class DiscordActivityAssets(
 )
 
 @Serializable
+@KordUnstableApi
 data class DiscordActivitySecrets(
         val join: String? = null,
         val spectate: String? = null,

--- a/common/src/main/kotlin/com/gitlab/kordlib/common/entity/DiscordChannel.kt
+++ b/common/src/main/kotlin/com/gitlab/kordlib/common/entity/DiscordChannel.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.common.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -8,6 +9,7 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
 @Serializable
+@KordUnstableApi
 data class DiscordChannel(
         val id: String,
         val type: ChannelType,
@@ -39,6 +41,7 @@ data class DiscordChannel(
 )
 
 @Serializable
+@KordUnstableApi
 data class Overwrite(
         val id: String,
         val type: String,

--- a/common/src/main/kotlin/com/gitlab/kordlib/common/entity/DiscordEmoji.kt
+++ b/common/src/main/kotlin/com/gitlab/kordlib/common/entity/DiscordEmoji.kt
@@ -1,9 +1,11 @@
 package com.gitlab.kordlib.common.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
+@KordUnstableApi
 data class DiscordEmoji(
         val id: String? = null,
         val name: String? = null,
@@ -17,6 +19,7 @@ data class DiscordEmoji(
 )
 
 @Serializable
+@KordUnstableApi
 data class DiscordUpdatedEmojis(
         @SerialName("guild_id")
         val guildId: String,
@@ -24,6 +27,7 @@ data class DiscordUpdatedEmojis(
 )
 
 @Serializable
+@KordUnstableApi
 data class DiscordPartialEmoji(
         val id: String? = null,
         val name: String? = null,

--- a/common/src/main/kotlin/com/gitlab/kordlib/common/entity/DiscordGuild.kt
+++ b/common/src/main/kotlin/com/gitlab/kordlib/common/entity/DiscordGuild.kt
@@ -1,21 +1,22 @@
 package com.gitlab.kordlib.common.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
-import kotlinx.serialization.internal.IntDescriptor
-import kotlinx.serialization.internal.StringDescriptor
 
 @Serializable
+@KordUnstableApi
 data class DiscordUnavailableGuild(
         val id: String,
         val unavailable: Boolean? = null
 )
 
 @Serializable
+@KordUnstableApi
 data class DiscordGuild(
         val id: String,
         val name: String,
@@ -173,6 +174,7 @@ enum class SystemChannelFlag(val code: Int) {
 }
 
 @Serializable
+@KordUnstableApi
 data class DiscordPartialGuild(
         val id: String,
         val name: String,
@@ -182,6 +184,7 @@ data class DiscordPartialGuild(
 )
 
 @Serializable
+@KordUnstableApi
 data class DiscordGuildBan(
         @SerialName("guild_id")
         val guildId: String,
@@ -189,17 +192,20 @@ data class DiscordGuildBan(
 )
 
 @Serializable
+@KordUnstableApi
 data class DiscordGuildIntegrations(
         @SerialName("guild_id")
         val guildId: String
 )
 
 @Serializable
+@KordUnstableApi
 data class DiscordIntegrationAccount(val id: String,
                                      val name: String)
 
 
 @Serializable
+@KordUnstableApi
 data class DiscordVoiceServerUpdateData(
         val token: String,
         @SerialName("guild_id")
@@ -208,6 +214,7 @@ data class DiscordVoiceServerUpdateData(
 )
 
 @Serializable
+@KordUnstableApi
 data class DiscordWebhooksUpdateData(
         @SerialName("guild_id")
         val guildId: String,
@@ -216,6 +223,7 @@ data class DiscordWebhooksUpdateData(
 )
 
 @Serializable
+@KordUnstableApi
 data class DiscordVoiceState(
         @SerialName("guild_id")
         val guildId: String? = null,

--- a/common/src/main/kotlin/com/gitlab/kordlib/common/entity/DiscordGuildPreview.kt
+++ b/common/src/main/kotlin/com/gitlab/kordlib/common/entity/DiscordGuildPreview.kt
@@ -1,9 +1,11 @@
 package com.gitlab.kordlib.common.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
+@KordUnstableApi
 data class DiscordGuildPreview(
         /**
          * Guild id.

--- a/common/src/main/kotlin/com/gitlab/kordlib/common/entity/DiscordMessage.kt
+++ b/common/src/main/kotlin/com/gitlab/kordlib/common/entity/DiscordMessage.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.common.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -9,6 +10,7 @@ import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.internal.IntDescriptor
 
 @Serializable
+@KordUnstableApi
 data class DiscordMessage(
         val id: String,
         @SerialName("channel_id")
@@ -44,6 +46,7 @@ data class DiscordMessage(
         val flags: Flags? = null
 )
 @Serializable
+@KordUnstableApi
 data class DiscordPartialMessage(
         val id: String,
         @SerialName("channel_id")
@@ -80,6 +83,7 @@ data class DiscordPartialMessage(
 )
 
 @Serializable
+@KordUnstableApi
 data class MessageReference(
         @SerialName("message_id")
         val id: String? = null,
@@ -90,6 +94,7 @@ data class MessageReference(
 )
 
 @Serializable
+@KordUnstableApi
 data class MentionedChannel(
         val id: String,
         @SerialName("guild_id")
@@ -161,6 +166,7 @@ data class Flags internal constructor(val code: Int) {
 }
 
 @Serializable
+@KordUnstableApi
 data class Attachment(
         val id: String,
         val filename: String? = null,
@@ -173,6 +179,7 @@ data class Attachment(
 )
 
 @Serializable
+@KordUnstableApi
 data class Embed(
         val title: String? = null,
         val type: String? = null,
@@ -189,6 +196,7 @@ data class Embed(
         val fields: List<Field>? = null
 ) {
     @Serializable
+    @KordUnstableApi
     data class Footer(
             val text: String,
             @SerialName("icon_url")
@@ -198,6 +206,7 @@ data class Embed(
     )
 
     @Serializable
+    @KordUnstableApi
     data class Image(
             val url: String? = null,
             @SerialName("proxy_url")
@@ -207,6 +216,7 @@ data class Embed(
     )
 
     @Serializable
+    @KordUnstableApi
     data class Thumbnail(
             val url: String? = null,
             @SerialName("proxy_url")
@@ -216,12 +226,15 @@ data class Embed(
     )
 
     @Serializable
+    @KordUnstableApi
     data class Video(val url: String? = null, val height: Int? = null, val width: Int? = null)
 
     @Serializable
+    @KordUnstableApi
     data class Provider(val name: String? = null, val url: String? = null)
 
     @Serializable
+    @KordUnstableApi
     data class Author(
             val name: String? = null,
             val url: String? = null,
@@ -232,10 +245,12 @@ data class Embed(
     )
 
     @Serializable
+    @KordUnstableApi
     data class Field(val name: String, val value: String, val inline: Boolean? = null)
 }
 
 @Serializable
+@KordUnstableApi
 data class Reaction(
         val count: Int,
         val me: Boolean,
@@ -243,9 +258,11 @@ data class Reaction(
 )
 
 @Serializable
+@KordUnstableApi
 data class MessageActivity(val type: Int, @SerialName("party_id") val partyId: String? = null)
 
 @Serializable
+@KordUnstableApi
 data class MessageApplication(
         val id: String,
         @SerialName("cover_image")
@@ -256,6 +273,7 @@ data class MessageApplication(
 )
 
 @Serializable
+@KordUnstableApi
 data class DeletedMessage(
         val id: String,
         @SerialName("channel_id")
@@ -265,6 +283,7 @@ data class DeletedMessage(
 )
 
 @Serializable
+@KordUnstableApi
 data class BulkDeleteData(
         val ids: List<String>,
         @SerialName("channel_id")
@@ -274,6 +293,7 @@ data class BulkDeleteData(
 )
 
 @Serializable
+@KordUnstableApi
 data class MessageReaction(
         @SerialName("user_id")
         val userId: String,
@@ -288,6 +308,7 @@ data class MessageReaction(
 )
 
 @Serializable
+@KordUnstableApi
 data class AllRemovedMessageReactions(
         @SerialName("channel_id")
         val channelId: String,

--- a/common/src/main/kotlin/com/gitlab/kordlib/common/entity/DiscordRole.kt
+++ b/common/src/main/kotlin/com/gitlab/kordlib/common/entity/DiscordRole.kt
@@ -1,9 +1,11 @@
 package com.gitlab.kordlib.common.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
+@KordUnstableApi
 data class DiscordRole(
         val id: String,
         val name: String,
@@ -16,6 +18,7 @@ data class DiscordRole(
 )
 
 @Serializable
+@KordUnstableApi
 data class DiscordAuditLogRoleChange(
         val id: String,
         val name: String? = null,
@@ -28,6 +31,7 @@ data class DiscordAuditLogRoleChange(
 )
 
 @Serializable
+@KordUnstableApi
 data class DiscordGuildRole(
         @SerialName("guild_id")
         val guildId: String,
@@ -35,6 +39,7 @@ data class DiscordGuildRole(
 )
 
 @Serializable
+@KordUnstableApi
 data class DiscordDeletedGuildRole(
         @SerialName("guild_id")
         val guildId: String,

--- a/common/src/main/kotlin/com/gitlab/kordlib/common/entity/DiscordShard.kt
+++ b/common/src/main/kotlin/com/gitlab/kordlib/common/entity/DiscordShard.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.common.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import kotlinx.serialization.*
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
@@ -9,6 +10,7 @@ import kotlinx.serialization.json.*
  * An instance of a [Discord shard](https://discord.com/developers/docs/topics/gateway#sharding).
  */
 @Serializable
+@KordUnstableApi
 data class DiscordShard(val index: Int, val count: Int) {
 
     @Serializer(forClass = DiscordShard::class)

--- a/common/src/main/kotlin/com/gitlab/kordlib/common/entity/DiscordUser.kt
+++ b/common/src/main/kotlin/com/gitlab/kordlib/common/entity/DiscordUser.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.common.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -9,6 +10,7 @@ import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.internal.IntDescriptor
 
 @Serializable
+@KordUnstableApi
 data class DiscordUser(
         val id: String,
         val username: String,
@@ -101,6 +103,7 @@ data class UserFlags constructor(val code: Int) {
 
 
 @Serializable
+@KordUnstableApi
 data class DiscordOptionallyMemberUser(
         val id: String,
         val username: String,

--- a/common/src/main/kotlin/com/gitlab/kordlib/common/entity/DiscordWebhook.kt
+++ b/common/src/main/kotlin/com/gitlab/kordlib/common/entity/DiscordWebhook.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.common.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -9,6 +10,7 @@ import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.internal.IntDescriptor
 
 @Serializable
+@KordUnstableApi
 data class DiscordWebhook(
         val id: String,
         val type: WebhookType,

--- a/common/src/main/kotlin/com/gitlab/kordlib/common/entity/Member.kt
+++ b/common/src/main/kotlin/com/gitlab/kordlib/common/entity/Member.kt
@@ -1,9 +1,11 @@
 package com.gitlab.kordlib.common.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
+@KordUnstableApi
 data class DiscordGuildMember(
         val user: DiscordUser? = null,
         val nick: String? = null,
@@ -17,6 +19,7 @@ data class DiscordGuildMember(
 )
 
 @Serializable
+@KordUnstableApi
 data class DiscordAddedGuildMember(
         val user: DiscordUser? = null,
         val nick: String? = null,
@@ -32,6 +35,7 @@ data class DiscordAddedGuildMember(
 )
 
 @Serializable
+@KordUnstableApi
 data class DiscordRemovedGuildMember(
         @SerialName("guild_id")
         val guildId: String,
@@ -39,6 +43,7 @@ data class DiscordRemovedGuildMember(
 )
 
 @Serializable
+@KordUnstableApi
 data class DiscordUpdatedGuildMember(
         @SerialName("guild_id")
         val guildId: String,
@@ -50,6 +55,7 @@ data class DiscordUpdatedGuildMember(
 )
 
 @Serializable
+@KordUnstableApi
 data class DiscordPartialGuildMember(
         val nick: String? = null,
         val roles: List<String>,

--- a/common/src/main/kotlin/com/gitlab/kordlib/common/entity/Presence.kt
+++ b/common/src/main/kotlin/com/gitlab/kordlib/common/entity/Presence.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.common.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -9,6 +10,7 @@ import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.JsonElement
 
 @Serializable
+@KordUnstableApi
 data class DiscordPresenceUpdateData(
         val user: DiscordPresenceUser,
         val roles: List<String>? = null,
@@ -22,6 +24,7 @@ data class DiscordPresenceUpdateData(
 )
 
 @Serializable
+@KordUnstableApi
 data class DiscordPresenceUser(
         val id: String,
         val username: JsonElement? = null,
@@ -39,6 +42,7 @@ data class DiscordPresenceUser(
 )
 
 @Serializable
+@KordUnstableApi
 data class DiscordClientStatus(val desktop: Status? = null, val mobile: Status? = null, val web: Status? = null)
 
 @Serializable(with = Status.StatusSerializer::class)

--- a/common/src/main/kotlin/com/gitlab/kordlib/common/entity/Team.kt
+++ b/common/src/main/kotlin/com/gitlab/kordlib/common/entity/Team.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.common.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -11,6 +12,7 @@ import kotlinx.serialization.encoding.Encoder
  * The raw developer team data gotten from the API.
  */
 @Serializable
+@KordUnstableApi
 data class DiscordTeam(
         /**
          * The unique ID of this team.
@@ -73,6 +75,7 @@ enum class TeamMembershipState(val value: Int) {
  * The raw developer team member data gotten from the API.
  */
 @Serializable
+@KordUnstableApi
 class DiscordTeamMember(
         /**
          * An integer enum representing the state of membership of this user.

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/Kord.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/Kord.kt
@@ -3,6 +3,7 @@ package com.gitlab.kordlib.core
 import com.gitlab.kordlib.cache.api.DataCache
 import com.gitlab.kordlib.common.annotation.KordExperimental
 import com.gitlab.kordlib.common.annotation.KordUnsafe
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.DiscordShard
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.common.entity.Status
@@ -36,6 +37,7 @@ import kotlinx.coroutines.channels.Channel as CoroutineChannel
 
 val kordLogger = KotlinLogging.logger { }
 
+@OptIn(KordUnstableApi::class)
 class Kord(
         val resources: ClientResources,
         val cache: DataCache,
@@ -53,7 +55,7 @@ class Kord(
 
     val defaultSupplier: EntitySupplier = resources.defaultStrategy.supply(this)
 
-    @OptIn(KordUnsafe::class)
+    @OptIn(KordUnsafe::class, KordExperimental::class)
     val unsafe: Unsafe = Unsafe(this)
 
     val events get() = eventPublisher.asFlow()

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/GuildBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/GuildBehavior.kt
@@ -2,6 +2,7 @@ package com.gitlab.kordlib.core.behavior
 
 import com.gitlab.kordlib.cache.api.query
 import com.gitlab.kordlib.common.annotation.KordPreview
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.common.exception.RequestException
 import com.gitlab.kordlib.core.Kord
@@ -37,6 +38,7 @@ import com.gitlab.kordlib.rest.service.RestClient
 /**
  * The behavior of a [Discord Guild](https://discord.com/developers/docs/resources/guild).
  */
+@OptIn(KordUnstableApi::class)
 interface GuildBehavior : Entity, Strategizable {
     /**
      * Requests to get all present bans for this guild.
@@ -389,6 +391,7 @@ interface GuildBehavior : Entity, Strategizable {
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
+@OptIn(KordUnstableApi::class)
 suspend inline fun GuildBehavior.edit(builder: GuildModifyBuilder.() -> Unit): Guild {
     val response = kord.rest.guild.modifyGuild(id.value, builder)
     val data = GuildData.from(response)
@@ -407,6 +410,7 @@ suspend inline fun GuildBehavior.createEmoji(builder: EmojiCreateBuilder.() -> U
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
+@OptIn(KordUnstableApi::class)
 suspend inline fun GuildBehavior.createTextChannel(builder: TextChannelCreateBuilder.() -> Unit): TextChannel {
     val response = kord.rest.guild.createTextChannel(id.value, builder)
     val data = ChannelData.from(response)
@@ -422,6 +426,7 @@ suspend inline fun GuildBehavior.createTextChannel(builder: TextChannelCreateBui
  * @throws [RestRequestException] if something went wrong during the request.
  */
 @Suppress("NAME_SHADOWING")
+@OptIn(KordUnstableApi::class)
 suspend inline fun GuildBehavior.createVoiceChannel(builder: VoiceChannelCreateBuilder.() -> Unit): VoiceChannel {
     val response = kord.rest.guild.createVoiceChannel(id.value, builder)
     val data = ChannelData.from(response)
@@ -437,6 +442,7 @@ suspend inline fun GuildBehavior.createVoiceChannel(builder: VoiceChannelCreateB
  * @throws [RestRequestException] if something went wrong during the request.
  */
 @KordPreview
+@OptIn(KordUnstableApi::class)
 suspend inline fun GuildBehavior.createNewsChannel(builder: NewsChannelCreateBuilder.() -> Unit): NewsChannel {
     val response = kord.rest.guild.createNewsChannel(id.value, builder)
     val data = ChannelData.from(response)
@@ -451,6 +457,7 @@ suspend inline fun GuildBehavior.createNewsChannel(builder: NewsChannelCreateBui
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
+@OptIn(KordUnstableApi::class)
 suspend inline fun GuildBehavior.createCategory(builder: CategoryCreateBuilder.() -> Unit): Category {
     val response = kord.rest.guild.createCategory(id.value, builder)
     val data = ChannelData.from(response)
@@ -476,6 +483,7 @@ suspend inline fun GuildBehavior.swapChannelPositions(builder: GuildChannelPosit
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
+@OptIn(KordUnstableApi::class)
 @Suppress("NAME_SHADOWING")
 suspend inline fun GuildBehavior.swapRolePositions(builder: RolePositionsModifyBuilder.() -> Unit): Flow<Role> {
     val response = kord.rest.guild.modifyGuildRolePosition(id.value, builder)
@@ -491,6 +499,7 @@ suspend inline fun GuildBehavior.swapRolePositions(builder: RolePositionsModifyB
  * @throws [RestRequestException] if something went wrong during the request.
  */
 @Suppress("NAME_SHADOWING")
+@KordUnstableApi
 suspend inline fun GuildBehavior.addRole(builder: RoleCreateBuilder.() -> Unit): Role {
     val response = kord.rest.guild.createGuildRole(id.value, builder)
     val data = RoleData.from(id.value, response)

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/GuildEmojiBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/GuildEmojiBehavior.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.behavior
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.core.Kord
 import com.gitlab.kordlib.core.cache.data.EmojiData
@@ -71,6 +72,7 @@ interface GuildEmojiBehavior : Entity, Strategizable {
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
+@OptIn(KordUnstableApi::class)
 suspend inline fun GuildEmojiBehavior.edit(builder: EmojiModifyBuilder.() -> Unit): GuildEmoji {
     val response = kord.rest.emoji.modifyEmoji(guildId.value, id.value, builder)
     val data = EmojiData.from(guildId = guildId.value, id = id.value, entity = response)

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/MemberBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/MemberBehavior.kt
@@ -1,6 +1,7 @@
 package com.gitlab.kordlib.core.behavior
 
 import com.gitlab.kordlib.cache.api.query
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.common.exception.RequestException
 import com.gitlab.kordlib.core.Kord
@@ -18,6 +19,7 @@ import java.util.*
 /**
  * The behavior of a [Discord Member](https://discord.com/developers/docs/resources/guild#guild-member-object).
  */
+@OptIn(KordUnstableApi::class)
 interface MemberBehavior : Entity, UserBehavior {
 
     /**

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/MessageBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/MessageBehavior.kt
@@ -1,6 +1,7 @@
 package com.gitlab.kordlib.core.behavior
 
 import com.gitlab.kordlib.common.annotation.KordPreview
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.common.exception.RequestException
 import com.gitlab.kordlib.core.Kord
@@ -23,6 +24,7 @@ import com.gitlab.kordlib.common.entity.Permission
 /**
  * The behavior of a [Discord Message](https://discord.com/developers/docs/resources/channel#message-object).
  */
+@OptIn(KordUnstableApi::class)
 interface MessageBehavior : Entity, Strategizable {
     /**
      * The channel id this message belongs to.
@@ -199,6 +201,7 @@ interface MessageBehavior : Entity, Strategizable {
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
+@OptIn(KordUnstableApi::class)
 suspend inline fun MessageBehavior.edit(builder: MessageModifyBuilder.() -> Unit): Message {
     val response = kord.rest.channel.editMessage(channelId = channelId.value, messageId = id.value, builder = builder)
     val data = MessageData.from(response)

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/RoleBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/RoleBehavior.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.behavior
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.core.Kord
 import com.gitlab.kordlib.core.cache.data.RoleData
@@ -20,6 +21,7 @@ import java.util.*
 /**
  * The behavior of a [Discord Role](https://discord.com/developers/docs/topics/permissions#role-object) associated to a [guild].
  */
+@OptIn(KordUnstableApi::class)
 interface RoleBehavior : Entity, Strategizable {
     /**
      * The id of the guild this channel is associated to.
@@ -98,6 +100,7 @@ interface RoleBehavior : Entity, Strategizable {
  * @throws [RestRequestException] if something went wrong during the request.
  */
 @Suppress("NAME_SHADOWING")
+@OptIn(KordUnstableApi::class)
 suspend inline fun RoleBehavior.edit(builder: RoleModifyBuilder.() -> Unit): Role {
     val response = kord.rest.guild.modifyGuildRole(guildId = guildId.value, roleId = id.value, builder = builder)
     val data = RoleData.from(id.value, response)

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/UserBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/UserBehavior.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.behavior
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.common.exception.RequestException
 import com.gitlab.kordlib.core.Kord
@@ -19,6 +20,7 @@ import java.util.*
 /**
  * The behavior of a [Discord User](https://discord.com/developers/docs/resources/user)
  */
+@OptIn(KordUnstableApi::class)
 interface UserBehavior : Entity, Strategizable {
 
     val mention: String get() = "<@${id.value}>"

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/WebhookBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/WebhookBehavior.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.behavior
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.core.Kord
 import com.gitlab.kordlib.core.cache.data.MessageData
@@ -72,6 +73,7 @@ interface WebhookBehavior : Entity, Strategizable {
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
+@OptIn(KordUnstableApi::class)
 @Suppress("NAME_SHADOWING")
 suspend inline fun WebhookBehavior.edit(builder: WebhookModifyBuilder.() -> Unit): Webhook {
     val response = kord.rest.webhook.modifyWebhook(id.value, builder)
@@ -88,6 +90,7 @@ suspend inline fun WebhookBehavior.edit(builder: WebhookModifyBuilder.() -> Unit
  * @throws [RestRequestException] if something went wrong during the request.
  */
 @Suppress("NAME_SHADOWING")
+@OptIn(KordUnstableApi::class)
 suspend inline fun WebhookBehavior.edit(token: String, builder: WebhookModifyBuilder.() -> Unit): Webhook {
     val response = kord.rest.webhook.modifyWebhookWithToken(id.value, token, builder)
     val data = WebhookData.from(response)
@@ -100,6 +103,7 @@ suspend inline fun WebhookBehavior.edit(token: String, builder: WebhookModifyBui
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
+@OptIn(KordUnstableApi::class)
 suspend inline fun WebhookBehavior.execute(token: String, builder: ExecuteWebhookBuilder.() -> Unit): Message {
     val response = kord.rest.webhook.executeWebhook(
             token = token,
@@ -119,6 +123,7 @@ suspend inline fun WebhookBehavior.execute(token: String, builder: ExecuteWebhoo
  * This is a 'fire and forget' variant of [execute]. It will not wait for a response and might not throw an
  * Exception if the request wasn't executed.
  */
+@OptIn(KordUnstableApi::class)
 suspend inline fun WebhookBehavior.executeIgnored(token: String, builder: ExecuteWebhookBuilder.() -> Unit) {
     kord.rest.webhook.executeWebhook(token = token, webhookId = id.value, wait = false, builder = builder)
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/CategoryBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/CategoryBehavior.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.behavior.channel
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.common.exception.RequestException
 import com.gitlab.kordlib.core.Kord
@@ -93,7 +94,8 @@ interface CategoryBehavior : GuildChannelBehavior {
  * @return The edited [Category].
  * @throws [RestRequestException] if something went wrong during the request.
  */
-suspend fun CategoryBehavior.edit(builder: CategoryModifyBuilder.() -> Unit): Category {
+@OptIn(KordUnstableApi::class)
+suspend fun CategoryBehavior.edit(builder: CategoryModifyBuilder.() -> Unit): Category {//TODO, inline this
     val response = kord.rest.channel.patchCategory(id.value, builder)
     val data = ChannelData.from(response)
 

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/GuildChannelBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/GuildChannelBehavior.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.behavior.channel
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.common.exception.RequestException
 import com.gitlab.kordlib.core.Kord
@@ -24,6 +25,7 @@ import java.util.*
 /**
  * The behavior of a Discord channel associated to a [guild].
  */
+@OptIn(KordUnstableApi::class)
 interface GuildChannelBehavior : ChannelBehavior, Strategizable {
 
     /**

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/GuildMessageChannelBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/GuildMessageChannelBehavior.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.behavior.channel
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.common.exception.RequestException
 import com.gitlab.kordlib.core.Kord
@@ -21,6 +22,7 @@ import kotlin.time.days
 /**
  * The behavior of a Discord message channel associated to a [guild].
  */
+@OptIn(KordUnstableApi::class)
 interface GuildMessageChannelBehavior : GuildChannelBehavior, MessageChannelBehavior {
 
     /**
@@ -111,6 +113,7 @@ interface GuildMessageChannelBehavior : GuildChannelBehavior, MessageChannelBeha
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
+@OptIn(KordUnstableApi::class)
 suspend inline fun GuildMessageChannelBehavior.createWebhook(builder: WebhookCreateBuilder.() -> Unit): Webhook {
     val response = kord.rest.webhook.createWebhook(id.value, builder)
     val data = WebhookData.from(response)

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/MessageChannelBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/MessageChannelBehavior.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.behavior.channel
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.common.exception.RequestException
 import com.gitlab.kordlib.core.Kord
@@ -27,6 +28,7 @@ import kotlin.time.seconds
 /**
  * The behavior of a Discord channel that can use messages.
  */
+@OptIn(KordUnstableApi::class)
 interface MessageChannelBehavior : ChannelBehavior, Strategizable {
 
     /**
@@ -241,6 +243,7 @@ interface MessageChannelBehavior : ChannelBehavior, Strategizable {
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
+@OptIn(KordUnstableApi::class)
 suspend inline fun MessageChannelBehavior.createMessage(builder: MessageCreateBuilder.() -> Unit): Message {
     val response = kord.rest.channel.createMessage(id.value, builder)
     val data = MessageData.from(response)

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/NewsChannelBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/NewsChannelBehavior.kt
@@ -1,6 +1,7 @@
 package com.gitlab.kordlib.core.behavior.channel
 
 import com.gitlab.kordlib.common.annotation.KordPreview
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.common.exception.RequestException
 import com.gitlab.kordlib.core.Kord
@@ -20,6 +21,7 @@ import com.gitlab.kordlib.rest.json.request.ChannelFollowRequest
 /**
  * The behavior of a Discord News Channel associated to a guild.
  */
+@OptIn(KordUnstableApi::class)
 interface NewsChannelBehavior : GuildMessageChannelBehavior {
 
     /**
@@ -83,6 +85,8 @@ interface NewsChannelBehavior : GuildMessageChannelBehavior {
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
+
+@OptIn(KordUnstableApi::class)
 suspend inline fun NewsChannelBehavior.edit(builder: NewsChannelModifyBuilder.() -> Unit): NewsChannel {
     val response = kord.rest.channel.patchNewsChannel(id.value, builder)
     val data = ChannelData.from(response)

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/StoreChannelBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/StoreChannelBehavior.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.behavior.channel
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.common.exception.RequestException
 import com.gitlab.kordlib.core.Kord
@@ -69,6 +70,7 @@ interface StoreChannelBehavior : GuildChannelBehavior {
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
+@OptIn(KordUnstableApi::class)
 suspend inline fun StoreChannelBehavior.edit(builder: StoreChannelModifyBuilder.() -> Unit): StoreChannel {
     val response = kord.rest.channel.patchStoreChannel(id.value, builder)
     val data = ChannelData.from(response)

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/TextChannelBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/TextChannelBehavior.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.behavior.channel
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.common.exception.RequestException
 import com.gitlab.kordlib.core.Kord
@@ -70,6 +71,7 @@ interface TextChannelBehavior : GuildMessageChannelBehavior {
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
+@OptIn(KordUnstableApi::class)
 suspend inline fun TextChannelBehavior.edit(builder: TextChannelModifyBuilder.() -> Unit): TextChannel {
     val response = kord.rest.channel.patchTextChannel(id.value, builder)
 

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/VoiceChannelBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/VoiceChannelBehavior.kt
@@ -1,6 +1,7 @@
 package com.gitlab.kordlib.core.behavior.channel
 
 import com.gitlab.kordlib.cache.api.query
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.common.exception.RequestException
 import com.gitlab.kordlib.core.Kord
@@ -22,6 +23,7 @@ import java.util.*
 /**
  * The behavior of a Discord Voice Channel associated to a guild.
  */
+@OptIn(KordUnstableApi::class)
 interface VoiceChannelBehavior : GuildChannelBehavior {
 
     /**
@@ -85,6 +87,7 @@ interface VoiceChannelBehavior : GuildChannelBehavior {
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
+@OptIn(KordUnstableApi::class)
 suspend inline fun VoiceChannelBehavior.edit(builder: VoiceChannelModifyBuilder.() -> Unit): VoiceChannel {
     val response = kord.rest.channel.patchVoiceChannel(id.value, builder)
 

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/builder/kord/KordBuilder.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/builder/kord/KordBuilder.kt
@@ -3,6 +3,7 @@
 package com.gitlab.kordlib.core.builder.kord
 
 import com.gitlab.kordlib.cache.api.DataCache
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.ratelimit.BucketRateLimiter
 import com.gitlab.kordlib.core.ClientResources
 import com.gitlab.kordlib.core.Kord
@@ -49,6 +50,7 @@ operator fun DefaultGateway.Companion.invoke(resources: ClientResources, retry: 
 
 private val logger = KotlinLogging.logger { }
 
+@OptIn(KordUnstableApi::class)
 class KordBuilder(val token: String) {
     private var shardRange: (recommended: Int) -> Iterable<Int> = { 0 until it }
     private var gatewayBuilder: (resources: ClientResources, shards: List<Int>) -> List<Gateway> = { resources, shards ->

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/cache/DataCacheExtensions.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/cache/DataCacheExtensions.kt
@@ -3,11 +3,13 @@ package com.gitlab.kordlib.core.cache
 import com.gitlab.kordlib.cache.api.DataCache
 import com.gitlab.kordlib.cache.api.find
 import com.gitlab.kordlib.cache.api.query
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.core.cache.data.*
 
 /**
  * Registers all Kord data classes for this cache
  */
+@OptIn(KordUnstableApi::class)
 internal suspend fun DataCache.registerKordData() = register(
         RoleData.description,
         ChannelData.description,
@@ -24,6 +26,7 @@ internal suspend fun DataCache.registerKordData() = register(
 /**
  * Removes all cached Kord data instances from this cache
  */
+@OptIn(KordUnstableApi::class)
 internal suspend fun DataCache.removeKordData() {
     query<RoleData>().remove()
     query<ChannelData>().remove()

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/cache/KordCache.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/cache/KordCache.kt
@@ -8,11 +8,13 @@ import com.gitlab.kordlib.cache.api.delegate.EntrySupplier
 import com.gitlab.kordlib.cache.map.MapLikeCollection
 import com.gitlab.kordlib.cache.map.internal.MapEntryCache
 import com.gitlab.kordlib.cache.map.lruLinkedHashMap
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.core.cache.data.*
 import java.util.concurrent.ConcurrentHashMap
 
 typealias Generator<I, T> = (cache: DataCache, description: DataDescription<T, I>) -> DataEntryCache<out T>
 
+@OptIn(KordUnstableApi::class)
 class KordCacheBuilder {
 
     /**

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/ActivityData.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/ActivityData.kt
@@ -1,11 +1,13 @@
 package com.gitlab.kordlib.core.cache.data
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.ActivityType
 import com.gitlab.kordlib.common.entity.DiscordActivity
 import com.gitlab.kordlib.common.entity.DiscordPartialEmoji
 import kotlinx.serialization.Serializable
 
 @Serializable
+@KordUnstableApi
 data class ActivityData(
         val name: String,
         val type: ActivityType,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/ApplicationInfoData.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/ApplicationInfoData.kt
@@ -1,7 +1,9 @@
 package com.gitlab.kordlib.core.cache.data
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.rest.json.response.ApplicationInfoResponse
 
+@KordUnstableApi
 data class ApplicationInfoData(
         val id: Long,
         val name: String,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/AttachmentData.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/AttachmentData.kt
@@ -1,9 +1,11 @@
 package com.gitlab.kordlib.core.cache.data
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Attachment
 import kotlinx.serialization.Serializable
 
 @Serializable
+@KordUnstableApi
 data class AttachmentData(
         val id: Long,
         val filename: String,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/BanData.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/BanData.kt
@@ -1,9 +1,11 @@
 package com.gitlab.kordlib.core.cache.data
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.rest.json.response.BanResponse
 import kotlinx.serialization.Serializable
 
 @Serializable
+@KordUnstableApi
 data class BanData(val reason: String?, val userId: Long, val guildId: Long) {
     companion object {
         fun from(guildId: String, entity: BanResponse) = with(entity) {

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/ChannelData.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/ChannelData.kt
@@ -1,11 +1,13 @@
 package com.gitlab.kordlib.core.cache.data
 
 import com.gitlab.kordlib.cache.api.data.description
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.ChannelType
 import com.gitlab.kordlib.common.entity.DiscordChannel
 import kotlinx.serialization.Serializable
 
 @Serializable
+@KordUnstableApi
 data class ChannelData(
         val id: Long,
         val type: ChannelType,
@@ -57,4 +59,5 @@ data class ChannelData(
 
 }
 
+@OptIn(KordUnstableApi::class)
 fun DiscordChannel.toData() = ChannelData.from(this)

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/ClientStatusData.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/ClientStatusData.kt
@@ -1,10 +1,12 @@
 package com.gitlab.kordlib.core.cache.data
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.DiscordClientStatus
 import com.gitlab.kordlib.common.entity.Status
 import kotlinx.serialization.Serializable
 
 @Serializable
+@KordUnstableApi
 data class ClientStatusData(
         val desktop: Status?,
         val mobile: Status?,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/EmbedData.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/EmbedData.kt
@@ -1,9 +1,11 @@
 package com.gitlab.kordlib.core.cache.data
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Embed
 import kotlinx.serialization.Serializable
 
 @Serializable
+@KordUnstableApi
 data class EmbedData(
         val title: String? = null,
         val type: String? = null,
@@ -41,6 +43,7 @@ data class EmbedData(
 }
 
 @Serializable
+@KordUnstableApi
 data class EmbedFooterData(
         val text: String,
         val iconUrl: String? = null,
@@ -54,6 +57,7 @@ data class EmbedFooterData(
 }
 
 @Serializable
+@KordUnstableApi
 data class EmbedImageData(
         val url: String? = null,
         val proxyUrl: String? = null,
@@ -68,6 +72,7 @@ data class EmbedImageData(
 }
 
 @Serializable
+@KordUnstableApi
 data class EmbedThumbnailData(
         val url: String? = null,
         val proxyUrl: String? = null,
@@ -82,6 +87,7 @@ data class EmbedThumbnailData(
 }
 
 @Serializable
+@KordUnstableApi
 data class EmbedVideoData(
         val url: String? = null,
         val height: Int? = null,
@@ -95,6 +101,7 @@ data class EmbedVideoData(
 }
 
 @Serializable
+@KordUnstableApi
 data class EmbedProviderData(
         val name: String? = null,
         val url: String? = null
@@ -107,6 +114,7 @@ data class EmbedProviderData(
 }
 
 @Serializable
+@KordUnstableApi
 data class EmbedAuthorData(
         val name: String? = null,
         val url: String? = null,
@@ -121,6 +129,7 @@ data class EmbedAuthorData(
 }
 
 @Serializable
+@KordUnstableApi
 data class EmbedFieldData(
         val name: String,
         val value: String,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/EmojiData.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/EmojiData.kt
@@ -1,10 +1,12 @@
 package com.gitlab.kordlib.core.cache.data
 
 import com.gitlab.kordlib.cache.api.data.description
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.DiscordEmoji
 import kotlinx.serialization.Serializable
 
 @Serializable
+@KordUnstableApi
 data class EmojiData(
         val id: Long,
         val guildId: Long,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/GuildData.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/GuildData.kt
@@ -1,10 +1,12 @@
 package com.gitlab.kordlib.core.cache.data
 
 import com.gitlab.kordlib.cache.api.data.description
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.*
 import kotlinx.serialization.Serializable
 
 @Serializable
+@KordUnstableApi
 data class GuildData(
         val id: Long,
         val name: String,
@@ -121,4 +123,5 @@ data class GuildData(
     }
 }
 
+@OptIn(KordUnstableApi::class)
 fun DiscordGuild.toData() = GuildData.from(this)

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/GuildPreviewData.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/GuildPreviewData.kt
@@ -1,10 +1,12 @@
 package com.gitlab.kordlib.core.cache.data
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.DiscordGuildPreview
 import com.gitlab.kordlib.common.entity.GuildFeature
 import kotlinx.serialization.Serializable
 
 @Serializable
+@KordUnstableApi
 class GuildPreviewData(
         /**
          * Guild id.

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/IntegrationData.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/IntegrationData.kt
@@ -1,11 +1,13 @@
 package com.gitlab.kordlib.core.cache.data
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.rest.json.response.DiscordIntegrationsAccount
 import com.gitlab.kordlib.rest.json.response.IntegrationExpireBehavior
 import com.gitlab.kordlib.rest.json.response.IntegrationResponse
 import kotlinx.serialization.Serializable
 
 @Serializable
+@KordUnstableApi
 data class IntegrationData(
         val id: Long,
         val name: String,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/InviteCreateData.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/InviteCreateData.kt
@@ -1,9 +1,11 @@
 package com.gitlab.kordlib.core.cache.data
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.gateway.DiscordCreatedInvite
 import kotlinx.serialization.Serializable
 
 @Serializable
+@KordUnstableApi
 data class InviteCreateData(
         /**
          * The channel the invite is for.

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/InviteData.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/InviteData.kt
@@ -1,11 +1,13 @@
 package com.gitlab.kordlib.core.cache.data
 
 import com.gitlab.kordlib.cache.api.data.description
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.TargetUserType
 import com.gitlab.kordlib.rest.json.response.InviteResponse
 import kotlinx.serialization.Serializable
 
 @Serializable
+@KordUnstableApi
 data class InviteData(
         val code: String,
         val guild: PartialGuildData?,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/InviteDeleteData.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/InviteDeleteData.kt
@@ -1,9 +1,11 @@
 package com.gitlab.kordlib.core.cache.data
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.gateway.DiscordDeletedInvite
 import kotlinx.serialization.Serializable
 
 @Serializable
+@KordUnstableApi
 data class InviteDeleteData(
         /**
          * The channel of the invite.

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/MemberData.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/MemberData.kt
@@ -1,15 +1,18 @@
 package com.gitlab.kordlib.core.cache.data
 
 import com.gitlab.kordlib.cache.api.data.description
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.DiscordAddedGuildMember
 import com.gitlab.kordlib.common.entity.DiscordGuildMember
 import com.gitlab.kordlib.common.entity.DiscordPartialGuildMember
 import com.gitlab.kordlib.common.entity.DiscordUpdatedGuildMember
 import kotlinx.serialization.Serializable
 
+@OptIn(KordUnstableApi::class)
 private val MemberData.id get() = "$userId$guildId"
 
 @Serializable
+@KordUnstableApi
 data class MemberData(
         val userId: Long,
         val guildId: Long,
@@ -36,4 +39,5 @@ data class MemberData(
     }
 }
 
+@OptIn(KordUnstableApi::class)
 fun DiscordGuildMember.toData(userId: String, guildId: String) = MemberData.from(userId, guildId, this)

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/MessageData.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/MessageData.kt
@@ -1,12 +1,15 @@
 package com.gitlab.kordlib.core.cache.data
 
 import com.gitlab.kordlib.cache.api.data.description
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.*
 import kotlinx.serialization.Serializable
 
+@OptIn(KordUnstableApi::class)
 internal val MessageData.authorId get() = author?.id
 
 @Serializable
+@KordUnstableApi
 data class MessageData(
         val id: Long,
         val channelId: Long,
@@ -119,4 +122,5 @@ data class MessageData(
     }
 }
 
+@OptIn(KordUnstableApi::class)
 fun DiscordMessage.toData() = MessageData.from(this)

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/PartialGuildData.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/PartialGuildData.kt
@@ -1,17 +1,18 @@
 package com.gitlab.kordlib.core.cache.data
 
-import com.gitlab.kordlib.cache.api.data.description
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.DiscordPartialGuild
 import com.gitlab.kordlib.common.entity.Permissions
 import kotlinx.serialization.Serializable
 
 @Serializable
+@KordUnstableApi
 class PartialGuildData(
         val id: Long,
         val name: String,
         val icon: String? = null,
         val owner: Boolean? = null,
-        val permissions: Permissions? = null
+        val permissions: Permissions? = null,
 ) {
     companion object {
 

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/PermissionOverwriteData.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/PermissionOverwriteData.kt
@@ -1,9 +1,11 @@
 package com.gitlab.kordlib.core.cache.data
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Overwrite
 import kotlinx.serialization.Serializable
 
 @Serializable
+@KordUnstableApi
 data class PermissionOverwriteData(
         val id: Long,
         val type: String,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/PresenceData.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/PresenceData.kt
@@ -1,13 +1,16 @@
 package com.gitlab.kordlib.core.cache.data
 
 import com.gitlab.kordlib.cache.api.data.description
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.DiscordPresenceUpdateData
 import com.gitlab.kordlib.common.entity.Status
 import kotlinx.serialization.Serializable
 
+@OptIn(KordUnstableApi::class)
 val PresenceData.id get() = "$userId$guildId"
 
 @Serializable
+@KordUnstableApi
 data class PresenceData(
         val userId: Long,
         val roles: List<Long>? = null,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/ReactionData.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/ReactionData.kt
@@ -1,10 +1,12 @@
 package com.gitlab.kordlib.core.cache.data
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.DiscordPartialEmoji
 import com.gitlab.kordlib.common.entity.Reaction
 import kotlinx.serialization.Serializable
 
 @Serializable
+@KordUnstableApi
 data class ReactionData(
         val count: Int,
         val me: Boolean,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/ReactionRemoveEmojiData.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/ReactionRemoveEmojiData.kt
@@ -1,10 +1,12 @@
 package com.gitlab.kordlib.core.cache.data
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.gateway.DiscordRemovedEmoji
 import com.gitlab.kordlib.gateway.DiscordRemovedReactionEmoji
 import kotlinx.serialization.Serializable
 
 @Serializable
+@KordUnstableApi
 data class RemovedReactionData(val id: Long?, val name: String) {
     companion object {
         fun from(entity: DiscordRemovedReactionEmoji): RemovedReactionData = with(entity) {
@@ -14,6 +16,7 @@ data class RemovedReactionData(val id: Long?, val name: String) {
 }
 
 @Serializable
+@KordUnstableApi
 data class ReactionRemoveEmojiData(
         /**
          * The id of the channel.

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/RegionData.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/RegionData.kt
@@ -1,9 +1,11 @@
 package com.gitlab.kordlib.core.cache.data
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.rest.json.response.VoiceRegion
 import kotlinx.serialization.Serializable
 
 @Serializable
+@KordUnstableApi
 data class RegionData(
         val id: Long,
         val guildId: Long?,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/RoleData.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/RoleData.kt
@@ -1,12 +1,14 @@
 package com.gitlab.kordlib.core.cache.data
 
 import com.gitlab.kordlib.cache.api.data.description
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.DiscordGuildRole
 import com.gitlab.kordlib.common.entity.DiscordRole
 import com.gitlab.kordlib.common.entity.Permissions
 import kotlinx.serialization.Serializable
 
 @Serializable
+@KordUnstableApi
 data class RoleData(
         val id: Long,
         val guildId: Long,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/UserData.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/UserData.kt
@@ -1,12 +1,14 @@
 package com.gitlab.kordlib.core.cache.data
 
 import com.gitlab.kordlib.cache.api.data.description
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.DiscordUser
 import com.gitlab.kordlib.common.entity.Premium
 import com.gitlab.kordlib.common.entity.UserFlags
 import kotlinx.serialization.Serializable
 
 @Serializable
+@KordUnstableApi
 data class UserData(
         val id: Long,
         val username: String,
@@ -41,4 +43,5 @@ data class UserData(
     }
 }
 
+@OptIn(KordUnstableApi::class)
 fun DiscordUser.toData() = UserData.from(this)

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/VoiceStateData.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/VoiceStateData.kt
@@ -1,12 +1,15 @@
 package com.gitlab.kordlib.core.cache.data
 
 import com.gitlab.kordlib.cache.api.data.description
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.DiscordVoiceState
 import kotlinx.serialization.Serializable
 
+@OptIn(KordUnstableApi::class)
 val VoiceStateData.id get() = "$userId$guildId"
 
 @Serializable
+@KordUnstableApi
 data class VoiceStateData(
         val guildId: Long?,
         val channelId: Long?,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/WebhookData.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/cache/data/WebhookData.kt
@@ -1,11 +1,13 @@
 package com.gitlab.kordlib.core.cache.data
 
 import com.gitlab.kordlib.cache.api.data.description
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.DiscordWebhook
 import com.gitlab.kordlib.common.entity.WebhookType
 import kotlinx.serialization.Serializable
 
 @Serializable
+@KordUnstableApi
 data class WebhookData(
         val id: Long,
         val type: WebhookType,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Activity.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Activity.kt
@@ -1,11 +1,13 @@
 package com.gitlab.kordlib.core.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.ActivityType
 import com.gitlab.kordlib.common.entity.DiscordPartialEmoji
 import com.gitlab.kordlib.core.cache.data.ActivityData
 import com.gitlab.kordlib.core.toInstant
 import java.time.Instant
 
+@OptIn(KordUnstableApi::class)
 class Activity(val data: ActivityData) {
 
     val name: String get() = data.name

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/ApplicationInfo.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/ApplicationInfo.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.core.Kord
 import com.gitlab.kordlib.core.behavior.UserBehavior
@@ -12,6 +13,7 @@ import java.util.*
 /**
  * The details of a [Discord OAuth2](https://discord.com/developers/docs/topics/oauth2) application.
  */
+@OptIn(KordUnstableApi::class)
 class ApplicationInfo(
         val data: ApplicationInfoData,
         override val kord: Kord,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Attachment.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Attachment.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.core.Kord
 import com.gitlab.kordlib.core.cache.data.AttachmentData
@@ -10,6 +11,7 @@ import java.util.*
  *
  * A file attached to a [Message].
  */
+@OptIn(KordUnstableApi::class)
 data class Attachment(val data: AttachmentData, override val kord: Kord) : Entity {
 
     override val id: Snowflake

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Ban.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Ban.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.common.exception.RequestException
 import com.gitlab.kordlib.core.Kord
@@ -13,6 +14,7 @@ import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy
 /**
  * An instance of a [Discord Ban](https://discord.com/developers/docs/resources/guild#ban-object).
  */
+@OptIn(KordUnstableApi::class)
 class Ban(
         val data: BanData,
         override val kord: Kord,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Embed.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Embed.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.core.Kord
 import com.gitlab.kordlib.core.KordObject
 import com.gitlab.kordlib.core.cache.data.*
@@ -17,6 +18,7 @@ https://discord.com/developers/docs/resources/channel#embed-object-embed-types
 /**
  * An instance of a [Discord Embed](https://discord.com/developers/docs/resources/channel#embed-object).
  */
+@OptIn(KordUnstableApi::class)
 data class Embed(val data: EmbedData, override val kord: Kord) : KordObject {
 
     /**

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Guild.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Guild.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.*
 import com.gitlab.kordlib.common.exception.RequestException
 import com.gitlab.kordlib.core.Kord
@@ -30,6 +31,7 @@ import java.util.*
 /**
  * An instance of a [Discord Guild](https://discord.com/developers/docs/resources/guild).
  */
+@OptIn(KordUnstableApi::class)
 class Guild(
         val data: GuildData,
         override val kord: Kord,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/GuildEmoji.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/GuildEmoji.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.common.exception.RequestException
 import com.gitlab.kordlib.core.Kord
@@ -20,6 +21,7 @@ import java.util.*
 /**
  * An instance of a [Discord emoji](https://discord.com/developers/docs/resources/emoji#emoji-object) belonging to a specific guild.
  */
+@OptIn(KordUnstableApi::class)
 class GuildEmoji(
         val data: EmojiData,
         override val kord: Kord,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/GuildPreview.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/GuildPreview.kt
@@ -1,11 +1,13 @@
 package com.gitlab.kordlib.core.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.GuildFeature
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.core.Kord
 import com.gitlab.kordlib.core.cache.data.GuildPreviewData
 import com.gitlab.kordlib.core.supplier.EntitySupplier
 
+@OptIn(KordUnstableApi::class)
 class GuildPreview(
         val data: GuildPreviewData,
         override val kord: Kord

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Integration.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Integration.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.common.exception.RequestException
 import com.gitlab.kordlib.core.Kord
@@ -22,6 +23,7 @@ import java.util.*
 /**
  * A [Discord integration](https://discord.com/developers/docs/resources/guild#get-guild-integrations).
  */
+@OptIn(KordUnstableApi::class)
 class Integration(
         val data: IntegrationData,
         override val kord: Kord,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Invite.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Invite.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.common.entity.TargetUserType
 import com.gitlab.kordlib.common.exception.RequestException
@@ -19,6 +20,7 @@ import com.gitlab.kordlib.core.toSnowflakeOrNull
 /**
  * An instance of a [Discord Invite](https://discord.com/developers/docs/resources/invite).
  */
+@OptIn(KordUnstableApi::class)
 data class Invite(
         val data: InviteData,
         override val kord: Kord,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Member.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Member.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Permission
 import com.gitlab.kordlib.common.entity.Permissions
 import com.gitlab.kordlib.common.entity.Snowflake
@@ -20,6 +21,7 @@ import java.util.*
 /**
  * An instance of a [Discord Member](https://discord.com/developers/docs/resources/guild#guild-member-object).
  */
+@OptIn(KordUnstableApi::class)
 class Member(
         val memberData: MemberData,
         userData: UserData,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Message.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Message.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.MessageType
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.common.exception.RequestException
@@ -25,6 +26,7 @@ import java.util.*
 /**
  * An instance of a [Discord Message][https://discord.com/developers/docs/resources/channel#message-object].
  */
+@OptIn(KordUnstableApi::class)
 class Message(
         val data: MessageData,
         override val kord: Kord,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/PartialGuild.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/PartialGuild.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Permissions
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.common.exception.RequestException
@@ -15,6 +16,7 @@ import com.gitlab.kordlib.core.supplier.getChannelOfOrNull
 import com.gitlab.kordlib.rest.Image
 import java.util.*
 
+@OptIn(KordUnstableApi::class)
 class PartialGuild(
         val data: PartialGuildData,
         override val kord: Kord,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/PermissionOverwrite.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/PermissionOverwrite.kt
@@ -1,11 +1,13 @@
 package com.gitlab.kordlib.core.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Overwrite
 import com.gitlab.kordlib.common.entity.Permissions
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.core.cache.data.PermissionOverwriteData
 import com.gitlab.kordlib.rest.json.request.ChannelPermissionEditRequest
 
+@OptIn(KordUnstableApi::class)
 open class PermissionOverwrite constructor(
         val data: PermissionOverwriteData
 ) {
@@ -14,8 +16,10 @@ open class PermissionOverwrite constructor(
     val target: Snowflake get() = Snowflake(data.id)
     val type: Type get() = Type.from(data.type)
 
+    @KordUnstableApi
     internal fun asRequest() = ChannelPermissionEditRequest(allowed, denied, type.value)
 
+    @KordUnstableApi
     internal fun toOverwrite() = Overwrite(id = target.value, type = type.value, allow = allowed.code, deny = denied.code)
 
     override fun hashCode(): Int = target.hashCode()

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/PermissionOverwriteEntity.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/PermissionOverwriteEntity.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.common.exception.RequestException
 import com.gitlab.kordlib.core.Kord
@@ -15,6 +16,7 @@ import com.gitlab.kordlib.core.supplier.getChannelOf
 import com.gitlab.kordlib.core.supplier.getChannelOfOrNull
 import com.gitlab.kordlib.rest.request.RestRequestException
 
+@OptIn(KordUnstableApi::class)
 class PermissionOverwriteEntity(
         val guildId: Snowflake,
         val channelId: Snowflake,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Presence.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Presence.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.common.entity.Status
 import com.gitlab.kordlib.common.exception.RequestException
@@ -13,6 +14,7 @@ import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 
+@OptIn(KordUnstableApi::class)
 class Presence(
         val data: PresenceData,
         override val kord: Kord,
@@ -61,6 +63,7 @@ class Presence(
 
 }
 
+@OptIn(KordUnstableApi::class)
 class ClientStatus(val data: ClientStatusData) {
     val desktop: Client.Desktop? get() = data.desktop?.let { Client.Desktop(it) }
     val mobile: Client.Mobile? get() = data.mobile?.let { Client.Mobile(it) }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Reaction.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Reaction.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.core.Kord
 import com.gitlab.kordlib.core.KordObject
@@ -9,6 +10,7 @@ import com.gitlab.kordlib.core.toSnowflakeOrNull
 /**
  * An instance of a [Discord Reaction](https://discord.com/developers/docs/resources/channel#reaction-object).
  */
+@OptIn(KordUnstableApi::class)
 class Reaction(val data: ReactionData, override val kord: Kord) : KordObject {
 
     /**

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/ReactionEmoji.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/ReactionEmoji.kt
@@ -1,8 +1,10 @@
 package com.gitlab.kordlib.core.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.core.cache.data.RemovedReactionData
 
+@OptIn(KordUnstableApi::class)
 sealed class ReactionEmoji {
     /**
      * Format used in HTTP queries.

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Region.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Region.kt
@@ -1,11 +1,13 @@
 package com.gitlab.kordlib.core.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.core.Kord
 import com.gitlab.kordlib.core.behavior.MessageBehavior
 import com.gitlab.kordlib.core.cache.data.RegionData
 import java.util.*
 
+@OptIn(KordUnstableApi::class)
 class Region(val data: RegionData, override val kord: Kord) : Entity {
     override val id: Snowflake
         get() = Snowflake(data.id)

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Role.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Role.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Permissions
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.core.Kord
@@ -10,6 +11,7 @@ import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy
 import java.awt.Color
 import java.util.*
 
+@OptIn(KordUnstableApi::class)
 data class Role(
         val data: RoleData,
         override val kord: Kord,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/User.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/User.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Premium
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.common.entity.UserFlags
@@ -15,6 +16,7 @@ import java.util.*
 /**
  * An instance of a [Discord User](https://discord.com/developers/docs/resources/user#user-object).
  */
+@OptIn(KordUnstableApi::class)
 open class User(
         val data: UserData,
         override val kord: Kord, override val supplier: EntitySupplier = kord.defaultSupplier

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/VoiceState.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/VoiceState.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.core.Kord
 import com.gitlab.kordlib.core.KordObject
@@ -10,6 +11,7 @@ import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy
 import com.gitlab.kordlib.core.supplier.getChannelOfOrNull
 import com.gitlab.kordlib.core.toSnowflakeOrNull
 
+@OptIn(KordUnstableApi::class)
 class VoiceState(
         val data: VoiceStateData,
         override val kord: Kord,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Webhook.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Webhook.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.common.entity.WebhookType
 import com.gitlab.kordlib.common.exception.RequestException
@@ -16,6 +17,7 @@ import com.gitlab.kordlib.core.supplier.getChannelOf
 import com.gitlab.kordlib.core.supplier.getChannelOfOrNull
 import java.util.*
 
+@OptIn(KordUnstableApi::class)
 data class Webhook(
         val data: WebhookData,
         override val kord: Kord,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/channel/CategorizableChannel.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/channel/CategorizableChannel.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.entity.channel
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.core.behavior.channel.CategoryBehavior
 import com.gitlab.kordlib.core.cache.data.InviteData
@@ -11,6 +12,7 @@ import com.gitlab.kordlib.rest.request.RestRequestException
 /**
  * An instance of a Discord channel associated to a [category].
  */
+@OptIn(KordUnstableApi::class)
 interface CategorizableChannel : GuildChannel {
 
     /**

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/channel/Category.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/channel/Category.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.entity.channel
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.core.Kord
 import com.gitlab.kordlib.core.behavior.channel.CategoryBehavior
@@ -14,6 +15,7 @@ import java.util.*
 /**
  * An instance of a Discord category associated to a [guild].
  */
+@OptIn(KordUnstableApi::class)
 class Category(
         override val data: ChannelData,
         override val kord: Kord,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/channel/Channel.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/channel/Channel.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.entity.channel
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.ChannelType
 import com.gitlab.kordlib.common.entity.ChannelType.*
 import com.gitlab.kordlib.common.entity.Snowflake
@@ -12,6 +13,7 @@ import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy
 /**
  * An instance of a [Discord Channel](https://discord.com/developers/docs/resources/channel)
  */
+@OptIn(KordUnstableApi::class)
 interface Channel : ChannelBehavior {
     val data: ChannelData
 

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/channel/DmChannel.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/channel/DmChannel.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.entity.channel
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.common.exception.RequestException
 import com.gitlab.kordlib.core.Kord
@@ -18,6 +19,7 @@ import java.util.*
 /**
  * An instance of a Discord DM channel.
  */
+@OptIn(KordUnstableApi::class)
 data class DmChannel(
         override val data: ChannelData,
         override val kord: Kord,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/channel/GuildChannel.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/channel/GuildChannel.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.entity.channel
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Permission
 import com.gitlab.kordlib.common.entity.Permissions
 import com.gitlab.kordlib.common.entity.Snowflake
@@ -13,6 +14,7 @@ import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy
 /**
  * An instance of a Discord channel associated to a [guild].
  */
+@OptIn(KordUnstableApi::class)
 interface GuildChannel : Channel, GuildChannelBehavior {
 
     override val guildId: Snowflake

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/channel/GuildMessageChannel.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/channel/GuildMessageChannel.kt
@@ -1,11 +1,13 @@
 package com.gitlab.kordlib.core.entity.channel
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.core.behavior.channel.GuildMessageChannelBehavior
 import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy
 
 /**
  * An instance of a Discord message channel associated to a [guild].
  */
+@OptIn(KordUnstableApi::class)
 interface GuildMessageChannel : CategorizableChannel, MessageChannel, GuildMessageChannelBehavior {
 
     /**

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/channel/MessageChannel.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/channel/MessageChannel.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.entity.channel
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.common.exception.RequestException
 import com.gitlab.kordlib.core.behavior.MessageBehavior
@@ -13,6 +14,7 @@ import java.time.Instant
 /**
  * An instance of a Discord channel that can use messages.
  */
+@OptIn(KordUnstableApi::class)
 interface MessageChannel : Channel, MessageChannelBehavior {
 
     /**

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/channel/NewsChannel.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/channel/NewsChannel.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.entity.channel
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.core.Kord
 import com.gitlab.kordlib.core.behavior.channel.ChannelBehavior
 import com.gitlab.kordlib.core.behavior.channel.GuildChannelBehavior
@@ -12,6 +13,7 @@ import java.util.*
 /**
  * An instance of a Discord News Channel associated to a guild.
  */
+@OptIn(KordUnstableApi::class)
 data class NewsChannel(
         override val data: ChannelData,
         override val kord: Kord,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/channel/StoreChannel.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/channel/StoreChannel.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.entity.channel
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.core.Kord
 import com.gitlab.kordlib.core.behavior.channel.ChannelBehavior
 import com.gitlab.kordlib.core.behavior.channel.GuildChannelBehavior
@@ -12,6 +13,7 @@ import java.util.*
 /**
  * An instance of a Discord Store Channel associated to a guild.
  */
+@OptIn(KordUnstableApi::class)
 data class StoreChannel(
         override val data: ChannelData,
         override val kord: Kord,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/channel/TextChannel.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/channel/TextChannel.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.entity.channel
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.core.Kord
 import com.gitlab.kordlib.core.behavior.channel.ChannelBehavior
 import com.gitlab.kordlib.core.behavior.channel.GuildChannelBehavior
@@ -12,6 +13,7 @@ import java.util.*
 /**
  * An instance of a Discord Text Channel associated to a guild.
  */
+@OptIn(KordUnstableApi::class)
 class TextChannel(
         override val data: ChannelData,
         override val kord: Kord,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/channel/VoiceChannel.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/channel/VoiceChannel.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.entity.channel
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.core.Kord
 import com.gitlab.kordlib.core.behavior.channel.ChannelBehavior
 import com.gitlab.kordlib.core.behavior.channel.GuildChannelBehavior
@@ -12,6 +13,7 @@ import java.util.*
 /**
  * An instance of a Discord Voice Channel associated to a guild.
  */
+@OptIn(KordUnstableApi::class)
 class VoiceChannel(
         override val data: ChannelData,
         override val kord: Kord,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/event/PresenceUpdateEvent.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/event/PresenceUpdateEvent.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.event
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.DiscordPresenceUser
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.common.exception.RequestException
@@ -11,6 +12,7 @@ import com.gitlab.kordlib.core.exception.EntityNotFoundException
 import com.gitlab.kordlib.core.supplier.EntitySupplier
 import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy
 
+@OptIn(KordUnstableApi::class)
 class PresenceUpdateEvent(
         val oldUser: User?,
         val user: DiscordPresenceUser,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/event/guild/InviteCreateEvent.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/event/guild/InviteCreateEvent.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.event.guild
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.common.exception.RequestException
 import com.gitlab.kordlib.core.Kord
@@ -27,6 +28,7 @@ import kotlin.time.seconds
 /**
  * Sent when a new invite to a channel is created.
  */
+@OptIn(KordUnstableApi::class)
 class InviteCreateEvent(
         val data: InviteCreateData,
         override val kord: Kord,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/event/guild/InviteDeleteEvent.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/event/guild/InviteDeleteEvent.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.event.guild
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.core.Kord
 import com.gitlab.kordlib.core.behavior.GuildBehavior
@@ -17,6 +18,7 @@ import com.gitlab.kordlib.core.supplier.getChannelOfOrNull
 /**
  * Sent when an invite is deleted.
  */
+@OptIn(KordUnstableApi::class)
 class InviteDeleteEvent(
         val data: InviteDeleteData,
         override val kord: Kord,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/event/message/MessageUpdateEvent.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/event/message/MessageUpdateEvent.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.event.message
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.DiscordPartialMessage
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.core.Kord
@@ -11,6 +12,7 @@ import com.gitlab.kordlib.core.event.Event
 import com.gitlab.kordlib.core.supplier.EntitySupplier
 import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy
 
+@OptIn(KordUnstableApi::class)
 class MessageUpdateEvent (
         val messageId: Snowflake,
         val channelId: Snowflake,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/event/message/ReactionRemoveEmojiEvent.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/event/message/ReactionRemoveEmojiEvent.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.event.message
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.core.Kord
 import com.gitlab.kordlib.core.behavior.GuildBehavior
@@ -17,6 +18,7 @@ import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy
 import com.gitlab.kordlib.core.supplier.getChannelOf
 import com.gitlab.kordlib.core.supplier.getChannelOfOrNull
 
+@OptIn(KordUnstableApi::class)
 class ReactionRemoveEmojiEvent(
         val data: ReactionRemoveEmojiData,
         override val kord: Kord,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/gateway/MasterGateway.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/gateway/MasterGateway.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.gateway
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.gateway.*
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
@@ -9,6 +10,7 @@ import kotlin.time.milliseconds
 
 data class ShardEvent(val event: Event, val gateway: Gateway, val shard: Int)
 
+@OptIn(KordUnstableApi::class)
 class MasterGateway(
         val gateways: Map<Int, Gateway>
 ) {

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/gateway/handler/ChannelEventHandler.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/gateway/handler/ChannelEventHandler.kt
@@ -3,6 +3,7 @@ package com.gitlab.kordlib.core.gateway.handler
 import com.gitlab.kordlib.cache.api.DataCache
 import com.gitlab.kordlib.cache.api.put
 import com.gitlab.kordlib.cache.api.query
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.core.Kord
 import com.gitlab.kordlib.core.cache.data.ChannelData
@@ -15,6 +16,7 @@ import com.gitlab.kordlib.gateway.*
 import kotlinx.coroutines.channels.SendChannel
 import com.gitlab.kordlib.core.event.Event as CoreEvent
 
+@OptIn(KordUnstableApi::class)
 @Suppress("EXPERIMENTAL_API_USAGE")
 internal class ChannelEventHandler(
         kord: Kord,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/gateway/handler/MessageEventHandler.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/gateway/handler/MessageEventHandler.kt
@@ -3,6 +3,7 @@ package com.gitlab.kordlib.core.gateway.handler
 import com.gitlab.kordlib.cache.api.DataCache
 import com.gitlab.kordlib.cache.api.put
 import com.gitlab.kordlib.cache.api.query
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.core.Kord
 import com.gitlab.kordlib.core.cache.data.*
@@ -19,6 +20,7 @@ import kotlinx.coroutines.flow.singleOrNull
 import kotlinx.coroutines.flow.toSet
 import com.gitlab.kordlib.core.event.Event as CoreEvent
 
+@OptIn(KordUnstableApi::class)
 @Suppress("EXPERIMENTAL_API_USAGE")
 internal class MessageEventHandler(
         kord: Kord,

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/live/LiveGuild.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/live/LiveGuild.kt
@@ -1,6 +1,7 @@
 package com.gitlab.kordlib.core.live
 
 import com.gitlab.kordlib.common.annotation.KordPreview
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.core.entity.Entity
 import com.gitlab.kordlib.core.entity.Guild
 import com.gitlab.kordlib.core.event.*
@@ -17,6 +18,7 @@ import com.gitlab.kordlib.core.event.role.RoleUpdateEvent
 fun Guild.live(): LiveGuild = LiveGuild(this)
 
 @KordPreview
+@OptIn(KordUnstableApi::class)
 class LiveGuild(guild: Guild) : AbstractLiveEntity(), Entity by guild {
 
     var guild: Guild = guild

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/live/LiveMember.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/live/LiveMember.kt
@@ -1,6 +1,7 @@
 package com.gitlab.kordlib.core.live
 
 import com.gitlab.kordlib.common.annotation.KordPreview
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.core.entity.Entity
 import com.gitlab.kordlib.core.entity.Member
 import com.gitlab.kordlib.core.event.Event
@@ -13,6 +14,7 @@ import com.gitlab.kordlib.core.event.guild.MemberUpdateEvent
 fun Member.live() = LiveMember(this)
 
 @KordPreview
+@OptIn(KordUnstableApi::class)
 class LiveMember(member: Member) : AbstractLiveEntity(), Entity by member {
     var member = member
         private set

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/live/LiveMessage.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/live/LiveMessage.kt
@@ -1,6 +1,7 @@
 package com.gitlab.kordlib.core.live
 
 import com.gitlab.kordlib.common.annotation.KordPreview
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.core.cache.data.ReactionData
 import com.gitlab.kordlib.core.entity.Entity
@@ -17,6 +18,7 @@ import kotlinx.coroutines.flow.Flow
 suspend fun Message.live() = LiveMessage(this, withStrategy(EntitySupplyStrategy.cacheWithRestFallback).getGuildOrNull()?.id)
 
 @KordPreview
+@OptIn(KordUnstableApi::class)
 class LiveMessage(message: Message, val guildId: Snowflake?) : AbstractLiveEntity(), Entity by message {
 
     var message: Message = message

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/live/channel/LiveChannel.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/live/channel/LiveChannel.kt
@@ -1,6 +1,7 @@
 package com.gitlab.kordlib.core.live.channel
 
 import com.gitlab.kordlib.common.annotation.KordPreview
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.core.entity.channel.*
 import com.gitlab.kordlib.core.event.Event
 import com.gitlab.kordlib.core.event.VoiceStateUpdateEvent
@@ -24,6 +25,7 @@ fun Channel.live() = when (this) {
 }
 
 @KordPreview
+@OptIn(KordUnstableApi::class)
 abstract class LiveChannel : AbstractLiveEntity() {
 
     abstract val channel: Channel

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/supplier/CacheEntitySupplier.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/supplier/CacheEntitySupplier.kt
@@ -2,6 +2,7 @@ package com.gitlab.kordlib.core.supplier
 
 import com.gitlab.kordlib.cache.api.DataCache
 import com.gitlab.kordlib.cache.api.query
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.common.exception.RequestException
 import com.gitlab.kordlib.core.Kord
@@ -28,6 +29,7 @@ import kotlinx.coroutines.flow.*
  * Returned flows without entities will not throw an [EntityNotFoundException]
  * if none are presented like other `getX` functions. Instead, the flow will be empty.
  */
+@OptIn(KordUnstableApi::class)
 class CacheEntitySupplier(private val kord: Kord) : EntitySupplier {
     /**
      *

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/supplier/RestEntitySupplier.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/supplier/RestEntitySupplier.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.supplier
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.DiscordGuildMember
 import com.gitlab.kordlib.common.entity.DiscordPartialGuild
 import com.gitlab.kordlib.common.entity.Snowflake
@@ -30,6 +31,7 @@ import kotlin.math.min
  * This supplier will always be able to resolve entities if they exist according
  * to Discord, entities will always be up to date at the moment of the call.
  */
+@OptIn(KordUnstableApi::class)
 class RestEntitySupplier(val kord: Kord) : EntitySupplier {
 
     private val auditLog: AuditLogService get() = kord.rest.auditLog

--- a/core/src/test/kotlin/com/gitlab/kordlib/core/entity/ApplicationInfoTest.kt
+++ b/core/src/test/kotlin/com/gitlab/kordlib/core/entity/ApplicationInfoTest.kt
@@ -1,11 +1,13 @@
 package com.gitlab.kordlib.core.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.core.cache.data.ApplicationInfoData
 import equality.EntityEqualityTest
 import io.mockk.every
 import io.mockk.mockk
 import mockKord
 
+@KordUnstableApi
 internal class ApplicationInfoTest : EntityEqualityTest<ApplicationInfo> by EntityEqualityTest({
     val kord = mockKord()
     val data = mockk<ApplicationInfoData>()

--- a/core/src/test/kotlin/com/gitlab/kordlib/core/entity/AttachmentTest.kt
+++ b/core/src/test/kotlin/com/gitlab/kordlib/core/entity/AttachmentTest.kt
@@ -1,11 +1,13 @@
 package com.gitlab.kordlib.core.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.core.cache.data.AttachmentData
 import equality.EntityEqualityTest
 import io.mockk.every
 import io.mockk.mockk
 import mockKord
 
+@KordUnstableApi
 internal class AttachmentTest : EntityEqualityTest<Attachment> by EntityEqualityTest({
     val kord = mockKord()
     val data = mockk<AttachmentData>()

--- a/core/src/test/kotlin/com/gitlab/kordlib/core/entity/GuildEmojiTest.kt
+++ b/core/src/test/kotlin/com/gitlab/kordlib/core/entity/GuildEmojiTest.kt
@@ -1,11 +1,13 @@
 package com.gitlab.kordlib.core.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.core.cache.data.EmojiData
 import equality.GuildEntityEqualityTest
 import io.mockk.every
 import io.mockk.mockk
 import mockKord
 
+@OptIn(KordUnstableApi::class)
 internal class GuildEmojiTest : GuildEntityEqualityTest<GuildEmoji> by GuildEntityEqualityTest({ id, guildId ->
     val kord = mockKord()
     val data = mockk<EmojiData>()

--- a/core/src/test/kotlin/com/gitlab/kordlib/core/entity/GuildTest.kt
+++ b/core/src/test/kotlin/com/gitlab/kordlib/core/entity/GuildTest.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.core.behavior.GuildBehavior
 import com.gitlab.kordlib.core.cache.data.GuildData
 import equality.BehaviorEqualityTest
@@ -8,6 +9,7 @@ import io.mockk.every
 import io.mockk.mockk
 import mockKord
 
+@KordUnstableApi
 internal class GuildTest: EntityEqualityTest<Guild> by EntityEqualityTest({
     val kord = mockKord()
     val data = mockk<GuildData>()

--- a/core/src/test/kotlin/com/gitlab/kordlib/core/entity/IntegrationTest.kt
+++ b/core/src/test/kotlin/com/gitlab/kordlib/core/entity/IntegrationTest.kt
@@ -1,11 +1,13 @@
 package com.gitlab.kordlib.core.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.core.cache.data.IntegrationData
 import equality.GuildEntityEqualityTest
 import io.mockk.every
 import io.mockk.mockk
 import mockKord
 
+@KordUnstableApi
 internal class IntegrationTest : GuildEntityEqualityTest<Integration> by GuildEntityEqualityTest ({ id, guildId ->
     val kord = mockKord()
     val data = mockk<IntegrationData>()

--- a/core/src/test/kotlin/com/gitlab/kordlib/core/entity/MemberTest.kt
+++ b/core/src/test/kotlin/com/gitlab/kordlib/core/entity/MemberTest.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.core.behavior.MemberBehavior
 import com.gitlab.kordlib.core.cache.data.MemberData
 import com.gitlab.kordlib.core.cache.data.UserData
@@ -9,6 +10,7 @@ import io.mockk.every
 import io.mockk.mockk
 import mockKord
 
+@OptIn(KordUnstableApi::class)
 internal class MemberTest : GuildEntityEqualityTest<Member> by GuildEntityEqualityTest({ id, guildId ->
     val kord = mockKord()
     val memberData = mockk<MemberData>()

--- a/core/src/test/kotlin/com/gitlab/kordlib/core/entity/MessageTest.kt
+++ b/core/src/test/kotlin/com/gitlab/kordlib/core/entity/MessageTest.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.core.behavior.MessageBehavior
 import com.gitlab.kordlib.core.cache.data.MessageData
 import equality.BehaviorEqualityTest
@@ -8,6 +9,7 @@ import io.mockk.every
 import io.mockk.mockk
 import mockKord
 
+@OptIn(KordUnstableApi::class)
 internal class MessageTest : EntityEqualityTest<Message> by EntityEqualityTest({
     val kord = mockKord()
     val data = mockk<MessageData>()

--- a/core/src/test/kotlin/com/gitlab/kordlib/core/entity/RegionTest.kt
+++ b/core/src/test/kotlin/com/gitlab/kordlib/core/entity/RegionTest.kt
@@ -1,11 +1,13 @@
 package com.gitlab.kordlib.core.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.core.cache.data.RegionData
 import equality.EntityEqualityTest
 import io.mockk.every
 import io.mockk.mockk
 import mockKord
 
+@KordUnstableApi
 internal class RegionTest : EntityEqualityTest<Region> by EntityEqualityTest({
     val kord = mockKord()
     val data = mockk<RegionData>()

--- a/core/src/test/kotlin/com/gitlab/kordlib/core/entity/RoleTest.kt
+++ b/core/src/test/kotlin/com/gitlab/kordlib/core/entity/RoleTest.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.core.behavior.RoleBehavior
 import com.gitlab.kordlib.core.cache.data.RoleData
 import equality.BehaviorEqualityTest
@@ -8,6 +9,7 @@ import io.mockk.every
 import io.mockk.mockk
 import mockKord
 
+@KordUnstableApi
 internal class RoleTest : GuildEntityEqualityTest<Role> by GuildEntityEqualityTest({ id, guildId ->
     val kord = mockKord()
     val data = mockk<RoleData>()

--- a/core/src/test/kotlin/com/gitlab/kordlib/core/entity/UserTest.kt
+++ b/core/src/test/kotlin/com/gitlab/kordlib/core/entity/UserTest.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.core.behavior.UserBehavior
 import com.gitlab.kordlib.core.cache.data.UserData
 import equality.BehaviorEqualityTest
@@ -8,6 +9,7 @@ import io.mockk.every
 import io.mockk.mockk
 import mockKord
 
+@OptIn(KordUnstableApi::class)
 internal class UserTest : EntityEqualityTest<User> by EntityEqualityTest({
     val kord = mockKord()
     val data = mockk<UserData>()

--- a/core/src/test/kotlin/com/gitlab/kordlib/core/entity/WebhookTest.kt
+++ b/core/src/test/kotlin/com/gitlab/kordlib/core/entity/WebhookTest.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.core.entity
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.core.behavior.WebhookBehavior
 import com.gitlab.kordlib.core.cache.data.WebhookData
 import equality.BehaviorEqualityTest
@@ -8,6 +9,7 @@ import io.mockk.every
 import io.mockk.mockk
 import mockKord
 
+@OptIn(KordUnstableApi::class)
 internal class WebhookTest : EntityEqualityTest<Webhook> by EntityEqualityTest({
     val kord = mockKord()
     val data = mockk<WebhookData>()

--- a/core/src/test/kotlin/com/gitlab/kordlib/core/entity/channel/CategoryTest.kt
+++ b/core/src/test/kotlin/com/gitlab/kordlib/core/entity/channel/CategoryTest.kt
@@ -1,10 +1,12 @@
 package com.gitlab.kordlib.core.entity.channel
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.ChannelType
 import com.gitlab.kordlib.core.cache.data.ChannelData
 import equality.GuildChannelEqualityTest
 import mockKord
 
+@OptIn(KordUnstableApi::class)
 @Suppress("DELEGATED_MEMBER_HIDES_SUPERTYPE_OVERRIDE")
 internal class CategoryTest : GuildChannelEqualityTest<Category> by GuildChannelEqualityTest ({ id, guildId ->
     val kord = mockKord()

--- a/core/src/test/kotlin/com/gitlab/kordlib/core/entity/channel/DmChannelTest.kt
+++ b/core/src/test/kotlin/com/gitlab/kordlib/core/entity/channel/DmChannelTest.kt
@@ -1,10 +1,12 @@
 package com.gitlab.kordlib.core.entity.channel
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.ChannelType
 import com.gitlab.kordlib.core.cache.data.ChannelData
 import equality.ChannelEqualityTest
 import mockKord
 
+@OptIn(KordUnstableApi::class)
 internal class DmChannelTest: ChannelEqualityTest<DmChannel> by ChannelEqualityTest ({ id ->
     val kord = mockKord()
     DmChannel(ChannelData(id.longValue, type = ChannelType.DM), kord)

--- a/core/src/test/kotlin/com/gitlab/kordlib/core/entity/channel/NewsChannelTest.kt
+++ b/core/src/test/kotlin/com/gitlab/kordlib/core/entity/channel/NewsChannelTest.kt
@@ -1,10 +1,12 @@
 package com.gitlab.kordlib.core.entity.channel
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.ChannelType
 import com.gitlab.kordlib.core.cache.data.ChannelData
 import equality.GuildChannelEqualityTest
 import mockKord
 
+@OptIn(KordUnstableApi::class)
 @Suppress("DELEGATED_MEMBER_HIDES_SUPERTYPE_OVERRIDE")
 internal class NewsChannelTest : GuildChannelEqualityTest<NewsChannel> by GuildChannelEqualityTest({ id, guildId ->
     val kord = mockKord()

--- a/core/src/test/kotlin/com/gitlab/kordlib/core/entity/channel/StoreChannelTest.kt
+++ b/core/src/test/kotlin/com/gitlab/kordlib/core/entity/channel/StoreChannelTest.kt
@@ -1,10 +1,12 @@
 package com.gitlab.kordlib.core.entity.channel
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.ChannelType
 import com.gitlab.kordlib.core.cache.data.ChannelData
 import equality.GuildChannelEqualityTest
 import mockKord
 
+@OptIn(KordUnstableApi::class)
 @Suppress("DELEGATED_MEMBER_HIDES_SUPERTYPE_OVERRIDE")
 internal class StoreChannelTest : GuildChannelEqualityTest<StoreChannel> by GuildChannelEqualityTest({ id, guildId ->
     val kord = mockKord()

--- a/core/src/test/kotlin/com/gitlab/kordlib/core/entity/channel/TextChannelTest.kt
+++ b/core/src/test/kotlin/com/gitlab/kordlib/core/entity/channel/TextChannelTest.kt
@@ -1,10 +1,12 @@
 package com.gitlab.kordlib.core.entity.channel
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.ChannelType
 import com.gitlab.kordlib.core.cache.data.ChannelData
 import equality.GuildChannelEqualityTest
 import mockKord
 
+@OptIn(KordUnstableApi::class)
 @Suppress("DELEGATED_MEMBER_HIDES_SUPERTYPE_OVERRIDE")
 internal class TextChannelTest : GuildChannelEqualityTest<TextChannel> by GuildChannelEqualityTest({ id, guildId ->
     val kord = mockKord()

--- a/core/src/test/kotlin/com/gitlab/kordlib/core/entity/channel/VoiceChannelTest.kt
+++ b/core/src/test/kotlin/com/gitlab/kordlib/core/entity/channel/VoiceChannelTest.kt
@@ -1,10 +1,12 @@
 package com.gitlab.kordlib.core.entity.channel
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.ChannelType
 import com.gitlab.kordlib.core.cache.data.ChannelData
 import equality.GuildChannelEqualityTest
 import mockKord
 
+@OptIn(KordUnstableApi::class)
 @Suppress("DELEGATED_MEMBER_HIDES_SUPERTYPE_OVERRIDE")
 internal class VoiceChannelTest : GuildChannelEqualityTest<VoiceChannel> by GuildChannelEqualityTest({ id, guildId ->
     val kord = mockKord()

--- a/core/src/test/kotlin/regression/CacheMissRegression.kt
+++ b/core/src/test/kotlin/regression/CacheMissRegression.kt
@@ -2,6 +2,7 @@ package regression
 
 import com.gitlab.kordlib.cache.api.put
 import com.gitlab.kordlib.cache.map.MapDataCache
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.ChannelType
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.core.ClientResources
@@ -50,6 +51,7 @@ private val parser = Json {
     isLenient = true
 }
 
+@OptIn(KordUnstableApi::class)
 object FakeGateway : Gateway {
 
     val deferred = CompletableDeferred<Unit>()
@@ -111,6 +113,7 @@ class CrashingHandler(val client: HttpClient) : RequestHandler {
     }
 }
 
+@OptIn(KordUnstableApi::class)
 @EnabledIfEnvironmentVariable(named = "TARGET_BRANCH", matches = "master")
 class CacheMissingRegressions {
     lateinit var kord: Kord

--- a/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/Command.kt
+++ b/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/Command.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.gateway
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.*
 import kotlinx.serialization.*
 import kotlinx.serialization.builtins.serializer
@@ -31,6 +32,7 @@ sealed class Command {
             element("d", JsonObject.serializer().descriptor)
         }
 
+        @OptIn(KordUnstableApi::class)
         override fun serialize(encoder: Encoder, obj: Command) {
             val composite = encoder.beginStructure(descriptor)
             when (obj) {
@@ -69,6 +71,7 @@ sealed class Command {
 
 
 @Serializable
+@KordUnstableApi
 internal data class Identify(
         internal val token: String,
         val properties: IdentifyProperties,
@@ -84,6 +87,7 @@ internal data class Identify(
 }
 
 @Serializable
+@KordUnstableApi
 data class IdentifyProperties(
         @Required
         @SerialName("\$os")
@@ -95,6 +99,7 @@ data class IdentifyProperties(
 )
 
 @Serializable
+@KordUnstableApi
 data class GuildMembersChunkData(
         @SerialName("guild_id")
         val guildId: String,
@@ -115,6 +120,7 @@ data class GuildMembersChunkData(
 )
 
 @Serializable
+@KordUnstableApi
 data class Presence(
         val status: Status,
         val afk: Boolean,
@@ -123,6 +129,7 @@ data class Presence(
 )
 
 @Serializable
+@KordUnstableApi
 internal data class Resume(
         val token: String,
         @SerialName("session_id")
@@ -134,6 +141,7 @@ internal data class Resume(
 }
 
 @Serializable
+@KordUnstableApi
 data class RequestGuildMembers(
         @SerialName("guild_id")
         val guildId: List<String>,
@@ -145,6 +153,7 @@ data class RequestGuildMembers(
 ) : Command()
 
 @Serializable
+@KordUnstableApi
 data class UpdateVoiceStatus(
         @SerialName("guild_id")
         val guildId: String,
@@ -157,6 +166,7 @@ data class UpdateVoiceStatus(
 ) : Command()
 
 @Serializable
+@KordUnstableApi
 data class UpdateStatus(
         val since: Long? = null,
         val game: DiscordActivity? = null,

--- a/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/DefaultGateway.kt
+++ b/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/DefaultGateway.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.gateway
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.ratelimit.RateLimiter
 import com.gitlab.kordlib.gateway.GatewayCloseCode.*
 import com.gitlab.kordlib.gateway.handler.*
@@ -294,6 +295,7 @@ class DefaultGateway(private val data: DefaultGatewayData) : Gateway {
     }
 }
 
+@OptIn(KordUnstableApi::class)
 internal val GatewayConfiguration.identify get() = Identify(token, IdentifyProperties(os, name, name), false, 50, shard, presence, intents)
 
 internal val os: String get() = System.getProperty("os.name")

--- a/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/Event.kt
+++ b/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/Event.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.gateway
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.*
 import kotlinx.serialization.*
 import kotlinx.serialization.builtins.nullable
@@ -41,7 +42,7 @@ sealed class Event {
             element("d", JsonObject.serializer().descriptor, isOptional = true)
         }
 
-        @OptIn(ExperimentalSerializationApi::class)
+        @OptIn(ExperimentalSerializationApi::class, KordUnstableApi::class)
         override fun deserialize(decoder: Decoder): Event? {
             var op: OpCode? = null
             var data: Event? = null
@@ -86,7 +87,7 @@ sealed class Event {
             }
         }
 
-
+        @OptIn(KordUnstableApi::class)
         private fun getByDispatchEvent(index: Int, decoder: CompositeDecoder, name: String?, sequence: Int?) = when (name) {
             "RESUMED" -> Resumed(decoder.decodeSerializableElement(descriptor, index, ResumedData.serializer()), sequence)
             "READY" -> Ready(decoder.decodeSerializableElement(descriptor, index, ReadyData.serializer()), sequence)
@@ -192,6 +193,7 @@ object HeartbeatACK : Event()
 object Reconnect : Event()
 
 @Serializable
+@KordUnstableApi
 data class Hello(
         @SerialName("heartbeat_interval")
         val heartbeatInterval: Long,
@@ -199,9 +201,11 @@ data class Hello(
         val traces: List<String>
 ) : Event()
 
+@OptIn(KordUnstableApi::class)
 data class Ready(val data: ReadyData, override val sequence: Int?) : DispatchEvent()
 
 @Serializable
+@KordUnstableApi
 data class ReadyData(
         @SerialName("v")
         val version: Int,
@@ -216,6 +220,7 @@ data class ReadyData(
         val shard: DiscordShard?)
 
 @Serializable
+@KordUnstableApi
 data class Heartbeat(val data: Long) : Event() {
     @Serializer(Heartbeat::class)
     companion object : DeserializationStrategy<Heartbeat> {
@@ -227,9 +232,11 @@ data class Heartbeat(val data: Long) : Event() {
 }
 
 @Serializable
+@KordUnstableApi
 data class Resumed(val data: ResumedData, override val sequence: Int?) : DispatchEvent()
 
 @Serializable
+@KordUnstableApi
 data class ResumedData(
         @SerialName("_trace")
         val traces: List<String>
@@ -245,6 +252,7 @@ data class ResumedData(
 
 
 @Serializable
+@KordUnstableApi
 data class InvalidSession(val resumable: Boolean) : Event() {
     @Serializer(InvalidSession::class)
     companion object : DeserializationStrategy<InvalidSession> {
@@ -255,39 +263,77 @@ data class InvalidSession(val resumable: Boolean) : Event() {
     }
 }
 
-
+@OptIn(KordUnstableApi::class)
 data class ChannelCreate(val channel: DiscordChannel, override val sequence: Int?) : DispatchEvent()
+
+@OptIn(KordUnstableApi::class)
 data class ChannelUpdate(val channel: DiscordChannel, override val sequence: Int?) : DispatchEvent()
+
+@OptIn(KordUnstableApi::class)
 data class ChannelDelete(val channel: DiscordChannel, override val sequence: Int?) : DispatchEvent()
+
+@OptIn(KordUnstableApi::class)
 data class ChannelPinsUpdate(val pins: DiscordPinsUpdateData, override val sequence: Int?) : DispatchEvent()
 
+@OptIn(KordUnstableApi::class)
 data class TypingStart(val data: DiscordTyping, override val sequence: Int?) : DispatchEvent()
+
+@OptIn(KordUnstableApi::class)
 data class GuildCreate(val guild: DiscordGuild, override val sequence: Int?) : DispatchEvent()
+
+@OptIn(KordUnstableApi::class)
 data class GuildUpdate(val guild: DiscordGuild, override val sequence: Int?) : DispatchEvent()
+
+@OptIn(KordUnstableApi::class)
 data class GuildDelete(val guild: DiscordUnavailableGuild, override val sequence: Int?) : DispatchEvent()
+
+@OptIn(KordUnstableApi::class)
 data class GuildBanAdd(val ban: DiscordGuildBan, override val sequence: Int?) : DispatchEvent()
+
+@OptIn(KordUnstableApi::class)
 data class GuildBanRemove(val ban: DiscordGuildBan, override val sequence: Int?) : DispatchEvent()
+
+@OptIn(KordUnstableApi::class)
 data class GuildEmojisUpdate(val emoji: DiscordUpdatedEmojis, override val sequence: Int?) : DispatchEvent()
+
+@OptIn(KordUnstableApi::class)
 data class GuildIntegrationsUpdate(val integrations: DiscordGuildIntegrations, override val sequence: Int?) : DispatchEvent()
+
+@OptIn(KordUnstableApi::class)
 data class GuildMemberAdd(val member: DiscordAddedGuildMember, override val sequence: Int?) : DispatchEvent()
+
+@OptIn(KordUnstableApi::class)
 data class GuildMemberRemove(val member: DiscordRemovedGuildMember, override val sequence: Int?) : DispatchEvent()
+
+@OptIn(KordUnstableApi::class)
 data class GuildMemberUpdate(val member: DiscordUpdatedGuildMember, override val sequence: Int?) : DispatchEvent()
+
+@OptIn(KordUnstableApi::class)
 data class GuildRoleCreate(val role: DiscordGuildRole, override val sequence: Int?) : DispatchEvent()
+
+@OptIn(KordUnstableApi::class)
 data class GuildRoleUpdate(val role: DiscordGuildRole, override val sequence: Int?) : DispatchEvent()
+
+@OptIn(KordUnstableApi::class)
 data class GuildRoleDelete(val role: DiscordDeletedGuildRole, override val sequence: Int?) : DispatchEvent()
+
+@OptIn(KordUnstableApi::class)
 data class GuildMembersChunk(val data: GuildMembersChunkData, override val sequence: Int?) : DispatchEvent()
 
 /**
  * Sent when a new invite to a channel is created.
  */
+@KordUnstableApi
 data class InviteCreate(val invite: DiscordCreatedInvite, override val sequence: Int?) : DispatchEvent()
 
 /**
  * Sent when an invite is deleted.
  */
+@KordUnstableApi
 data class InviteDelete(val invite: DiscordDeletedInvite, override val sequence: Int?) : DispatchEvent()
 
 @Serializable
+@KordUnstableApi
 data class DiscordDeletedInvite(
         /**
          * The channel of the invite.
@@ -306,6 +352,7 @@ data class DiscordDeletedInvite(
 )
 
 @Serializable
+@KordUnstableApi
 data class DiscordCreatedInvite(
         /**
          * The channel the invite is for.
@@ -363,6 +410,7 @@ data class DiscordCreatedInvite(
 )
 
 @Serializable
+@KordUnstableApi
 data class DiscordInviteUser(
         val avatar: String? = null,
         val discriminator: String,
@@ -370,16 +418,32 @@ data class DiscordInviteUser(
         val username: String
 )
 
-data class MessageCreate(val message: DiscordMessage, override val sequence: Int?) : DispatchEvent()
+@OptIn(KordUnstableApi::class)
+data class MessageCreate (val message: DiscordMessage, override val sequence: Int?) : DispatchEvent()
+
+@OptIn(KordUnstableApi::class)
 data class MessageUpdate(val message: DiscordPartialMessage, override val sequence: Int?) : DispatchEvent()
+
+@OptIn(KordUnstableApi::class)
 data class MessageDelete(val message: DeletedMessage, override val sequence: Int?) : DispatchEvent()
+
+@OptIn(KordUnstableApi::class)
 data class MessageDeleteBulk(val messageBulk: BulkDeleteData, override val sequence: Int?) : DispatchEvent()
+
+@OptIn(KordUnstableApi::class)
 data class MessageReactionAdd(val reaction: MessageReaction, override val sequence: Int?) : DispatchEvent()
+
+@OptIn(KordUnstableApi::class)
 data class MessageReactionRemove(val reaction: MessageReaction, override val sequence: Int?) : DispatchEvent()
+
+@OptIn(KordUnstableApi::class)
 data class MessageReactionRemoveAll(val reactions: AllRemovedMessageReactions, override val sequence: Int?) : DispatchEvent()
+
+@OptIn(KordUnstableApi::class)
 data class MessageReactionRemoveEmoji(val reaction: DiscordRemovedEmoji, override val sequence: Int?) : DispatchEvent()
 
 @Serializable
+@KordUnstableApi
 data class DiscordRemovedEmoji(
         /**
          * The id of the channel.
@@ -406,6 +470,7 @@ data class DiscordRemovedEmoji(
 )
 
 @Serializable
+@KordUnstableApi
 data class DiscordRemovedReactionEmoji(
         /**
          * The id of the emoji.
@@ -417,8 +482,17 @@ data class DiscordRemovedReactionEmoji(
         val name: String
 )
 
+@OptIn(KordUnstableApi::class)
 data class PresenceUpdate(val presence: DiscordPresenceUpdateData, override val sequence: Int?) : DispatchEvent()
+
+@OptIn(KordUnstableApi::class)
 data class UserUpdate(val user: DiscordUser, override val sequence: Int?) : DispatchEvent()
+
+@OptIn(KordUnstableApi::class)
 data class VoiceStateUpdate(val voiceState: DiscordVoiceState, override val sequence: Int?) : DispatchEvent()
+
+@OptIn(KordUnstableApi::class)
 data class VoiceServerUpdate(val voiceServerUpdateData: DiscordVoiceServerUpdateData, override val sequence: Int?) : DispatchEvent()
+
+@OptIn(KordUnstableApi::class)
 data class WebhooksUpdate(val webhooksUpdateData: DiscordWebhooksUpdateData, override val sequence: Int?) : DispatchEvent()

--- a/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/GatewayConfiguration.kt
+++ b/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/GatewayConfiguration.kt
@@ -1,12 +1,15 @@
 package com.gitlab.kordlib.gateway
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.DiscordShard
 import com.gitlab.kordlib.gateway.builder.PresenceBuilder
 
 data class GatewayConfiguration(
         val token: String,
         val name: String,
+        @OptIn(KordUnstableApi::class)
         val shard: DiscordShard,
+        @OptIn(KordUnstableApi::class)
         val presence: Presence?,
         val threshold: Int,
         val intents: Intents?
@@ -24,10 +27,12 @@ data class GatewayConfigurationBuilder(
         /**
          * The shard the gateway will connect to.
          */
+        @OptIn(KordUnstableApi::class)
         var shard: DiscordShard = DiscordShard(0, 1),
         /**
          * The presence the bot should show on login.
          */
+        @OptIn(KordUnstableApi::class)
         var presence: Presence? = null,
         /**
          * A value between 50 and 250, representing the maximum amount of members in a guild

--- a/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/builder/PresenceBuilder.kt
+++ b/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/builder/PresenceBuilder.kt
@@ -1,6 +1,7 @@
 package com.gitlab.kordlib.gateway.builder
 
 import com.gitlab.kordlib.common.annotation.KordDsl
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.DiscordActivity
 import com.gitlab.kordlib.common.entity.ActivityType
 import com.gitlab.kordlib.common.entity.Status
@@ -10,28 +11,35 @@ import java.time.Instant
 
 @KordDsl
 class PresenceBuilder  {
+    @OptIn(KordUnstableApi::class)
     private var game: DiscordActivity? = null
     var status: Status = Status.Online
     var afk: Boolean = false
     var since: Instant? = null
 
     fun playing(name: String) {
+        @OptIn(KordUnstableApi::class)
         game = DiscordActivity(name, ActivityType.Game)
     }
 
     fun listening(name: String) {
+        @OptIn(KordUnstableApi::class)
         game = DiscordActivity(name, ActivityType.Listening)
     }
 
     fun streaming(name: String, url: String) {
+        @OptIn(KordUnstableApi::class)
         game = DiscordActivity(name, ActivityType.Streaming, url = url)
     }
 
     fun watching(name: String) {
+        @OptIn(KordUnstableApi::class)
         game = DiscordActivity(name, ActivityType.Watching)
     }
 
+    @OptIn(KordUnstableApi::class)
     fun toUpdateStatus(): UpdateStatus = UpdateStatus(since?.toEpochMilli(), game, status, afk)
 
+    @OptIn(KordUnstableApi::class)
     fun toPresence(): Presence = Presence(status, afk, since?.toEpochMilli(), game)
 }

--- a/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/handler/HandshakeHandler.kt
+++ b/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/handler/HandshakeHandler.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.gateway.handler
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.ratelimit.RateLimiter
 import com.gitlab.kordlib.common.ratelimit.consume
 import com.gitlab.kordlib.gateway.*
@@ -8,6 +9,7 @@ import kotlinx.atomicfu.atomic
 import kotlinx.atomicfu.update
 import kotlinx.coroutines.flow.Flow
 
+@OptIn(KordUnstableApi::class)
 internal class HandshakeHandler(
         flow: Flow<Event>,
         private val send: suspend (Command) -> Unit,

--- a/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/handler/HeartbeatHandler.kt
+++ b/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/handler/HeartbeatHandler.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.gateway.handler
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.gateway.*
 import kotlinx.atomicfu.atomic
 import kotlinx.atomicfu.update
@@ -8,6 +9,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlin.time.*
 
 @ObsoleteCoroutinesApi
+@OptIn(KordUnstableApi::class)
 internal class HeartbeatHandler(
         flow: Flow<Event>,
         private val send: suspend (Command) -> Unit,

--- a/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/handler/InvalidSessionHandler.kt
+++ b/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/handler/InvalidSessionHandler.kt
@@ -1,8 +1,10 @@
 package com.gitlab.kordlib.gateway.handler
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.gateway.*
 import kotlinx.coroutines.flow.Flow
 
+@OptIn(KordUnstableApi::class)
 internal class InvalidSessionHandler(
         flow: Flow<Event>,
         private val restart: suspend (event: Close) -> Unit

--- a/gateway/src/test/kotlin/gateway/DefaultGatewayTest.kt
+++ b/gateway/src/test/kotlin/gateway/DefaultGatewayTest.kt
@@ -1,5 +1,6 @@
 package gateway
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.ActivityType
 import com.gitlab.kordlib.common.entity.DiscordActivity
 import com.gitlab.kordlib.common.entity.Status
@@ -29,6 +30,7 @@ import kotlin.time.toKotlinDuration
 @KtorExperimentalAPI
 @ObsoleteCoroutinesApi
 @ExperimentalCoroutinesApi
+@KordUnstableApi
 class DefaultGatewayTest {
     @Test
     @Disabled

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/channel/CategoryCreateBuilder.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/channel/CategoryCreateBuilder.kt
@@ -4,15 +4,17 @@ import com.gitlab.kordlib.common.entity.ChannelType
 import com.gitlab.kordlib.common.entity.Overwrite
 import com.gitlab.kordlib.rest.builder.AuditRequestBuilder
 import com.gitlab.kordlib.common.annotation.KordDsl
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.rest.json.request.GuildCreateChannelRequest
 
 @KordDsl
-class CategoryCreateBuilder : AuditRequestBuilder<GuildCreateChannelRequest> {
+class CategoryCreateBuilder : AuditRequestBuilder<@OptIn(KordUnstableApi::class) GuildCreateChannelRequest> {
     override var reason: String? = null
     lateinit var name: String
     var position: Int? = null
     var nsfw: Boolean? = null
+    @OptIn(KordUnstableApi::class)
     val permissionOverwrites: MutableList<Overwrite> = mutableListOf()
 
     /**
@@ -29,6 +31,7 @@ class CategoryCreateBuilder : AuditRequestBuilder<GuildCreateChannelRequest> {
         permissionOverwrites += PermissionOverwriteBuilder("role", roleId).apply(builder).toOverwrite()
     }
 
+    @OptIn(KordUnstableApi::class)
     override fun toRequest(): GuildCreateChannelRequest = GuildCreateChannelRequest(
             name = name,
             position = position,

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/channel/CategoryModifyBuilder.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/channel/CategoryModifyBuilder.kt
@@ -4,10 +4,11 @@ import com.gitlab.kordlib.common.entity.Overwrite
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.rest.builder.AuditRequestBuilder
 import com.gitlab.kordlib.common.annotation.KordDsl
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.rest.json.request.ChannelModifyPatchRequest
 
 @KordDsl
-class CategoryModifyBuilder: AuditRequestBuilder<ChannelModifyPatchRequest> {
+class CategoryModifyBuilder: AuditRequestBuilder<@OptIn(KordUnstableApi::class) ChannelModifyPatchRequest> {
     override var reason: String? = null
     /**
      * The name of the category.
@@ -22,6 +23,7 @@ class CategoryModifyBuilder: AuditRequestBuilder<ChannelModifyPatchRequest> {
     /**
      *  The permission overwrites for this category.
      */
+    @OptIn(KordUnstableApi::class)
     var permissionOverwrites: MutableSet<Overwrite>? = null
 
 
@@ -39,6 +41,7 @@ class CategoryModifyBuilder: AuditRequestBuilder<ChannelModifyPatchRequest> {
         permissionOverwrites = (permissionOverwrites ?: mutableSetOf()).also { PermissionOverwriteBuilder("role", roleId).apply(builder).toOverwrite() }
     }
 
+    @OptIn(KordUnstableApi::class)
     override fun toRequest(): ChannelModifyPatchRequest = ChannelModifyPatchRequest(
             name = name,
             position = position,

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/channel/ChannelPermissionModifyBuilder.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/channel/ChannelPermissionModifyBuilder.kt
@@ -3,10 +3,13 @@ package com.gitlab.kordlib.rest.builder.channel
 import com.gitlab.kordlib.common.entity.Permissions
 import com.gitlab.kordlib.rest.builder.AuditRequestBuilder
 import com.gitlab.kordlib.common.annotation.KordDsl
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.rest.json.request.ChannelPermissionEditRequest
 
 @KordDsl
-class ChannelPermissionModifyBuilder(private var type: String) : AuditRequestBuilder<ChannelPermissionEditRequest> {
+class ChannelPermissionModifyBuilder(
+        private var type: String
+) : AuditRequestBuilder<@OptIn(KordUnstableApi::class) ChannelPermissionEditRequest> {
 
     override var reason: String? = null
 
@@ -16,10 +19,11 @@ class ChannelPermissionModifyBuilder(private var type: String) : AuditRequestBui
     var allowed: Permissions = Permissions()
 
     /**
-     * The permisssions that are explicitly denied for this channel.
+     * The permissions that are explicitly denied for this channel.
      */
     var denied: Permissions = Permissions()
 
+    @OptIn(KordUnstableApi::class)
     override fun toRequest(): ChannelPermissionEditRequest = ChannelPermissionEditRequest(allowed, denied, type)
 
 }

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/channel/EditGuildChannelBuilder.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/channel/EditGuildChannelBuilder.kt
@@ -4,10 +4,11 @@ import com.gitlab.kordlib.common.entity.Overwrite
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.rest.builder.AuditRequestBuilder
 import com.gitlab.kordlib.common.annotation.KordDsl
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.rest.json.request.ChannelModifyPatchRequest
 
 @KordDsl
-class TextChannelModifyBuilder : AuditRequestBuilder<ChannelModifyPatchRequest> {
+class TextChannelModifyBuilder : AuditRequestBuilder<@OptIn(KordUnstableApi::class) ChannelModifyPatchRequest> {
     override var reason: String? = null
     var name: String? = null
     var position: Int? = null
@@ -15,8 +16,10 @@ class TextChannelModifyBuilder : AuditRequestBuilder<ChannelModifyPatchRequest> 
     var nsfw: Boolean? = null
     var parentId: Snowflake? = null
     var rateLimitPerUser: Int? = null
+    @OptIn(KordUnstableApi::class)
     var permissionOverwrites: Set<Overwrite>? = null
 
+    @OptIn(KordUnstableApi::class)
     override fun toRequest(): ChannelModifyPatchRequest = ChannelModifyPatchRequest(
             name = name,
             position = position,
@@ -30,15 +33,17 @@ class TextChannelModifyBuilder : AuditRequestBuilder<ChannelModifyPatchRequest> 
 }
 
 @KordDsl
-class VoiceChannelModifyBuilder : AuditRequestBuilder<ChannelModifyPatchRequest> {
+class VoiceChannelModifyBuilder : AuditRequestBuilder<@OptIn(KordUnstableApi::class) ChannelModifyPatchRequest> {
     override var reason: String? = null
     var name: String? = null
     var position: Int? = null
     var parentId: Snowflake? = null
     var bitrate: Int? = null
     var userLimit: Int? = null
+    @OptIn(KordUnstableApi::class)
     var permissionOverwrites: Set<Overwrite>? = null
 
+    @OptIn(KordUnstableApi::class)
     override fun toRequest(): ChannelModifyPatchRequest = ChannelModifyPatchRequest(
             name = name,
             position = position,
@@ -50,15 +55,17 @@ class VoiceChannelModifyBuilder : AuditRequestBuilder<ChannelModifyPatchRequest>
 }
 
 @KordDsl
-class NewsChannelModifyBuilder : AuditRequestBuilder<ChannelModifyPatchRequest> {
+class NewsChannelModifyBuilder : AuditRequestBuilder<@OptIn(KordUnstableApi::class) ChannelModifyPatchRequest> {
     override var reason: String? = null
     var name: String? = null
     var position: Int? = null
     var topic: String? = null
     var nsfw: Boolean? = null
     var parentId: Snowflake? = null
+    @OptIn(KordUnstableApi::class)
     var permissionOverwrites: Set<Overwrite>? = null
 
+    @OptIn(KordUnstableApi::class)
     override fun toRequest(): ChannelModifyPatchRequest = ChannelModifyPatchRequest(
             name = name,
             position = position,
@@ -70,12 +77,14 @@ class NewsChannelModifyBuilder : AuditRequestBuilder<ChannelModifyPatchRequest> 
 }
 
 @KordDsl
-class StoreChannelModifyBuilder : AuditRequestBuilder<ChannelModifyPatchRequest> {
+class StoreChannelModifyBuilder : AuditRequestBuilder<@OptIn(KordUnstableApi::class) ChannelModifyPatchRequest> {
     override var reason: String? = null
     var name: String? = null
     var position: Int? = null
+    @OptIn(KordUnstableApi::class)
     val permissionOverwrites: MutableSet<Overwrite>? = null
 
+    @OptIn(KordUnstableApi::class)
     override fun toRequest(): ChannelModifyPatchRequest = ChannelModifyPatchRequest(
             name = name,
             position = position,

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/channel/InviteCreateBuilder.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/channel/InviteCreateBuilder.kt
@@ -2,12 +2,13 @@ package com.gitlab.kordlib.rest.builder.channel
 
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.common.annotation.KordDsl
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.TargetUserType
 import com.gitlab.kordlib.rest.builder.RequestBuilder
 import com.gitlab.kordlib.rest.json.request.InviteCreateRequest
 
 @KordDsl
-class InviteCreateBuilder : RequestBuilder<InviteCreateRequest> {
+class InviteCreateBuilder : RequestBuilder<@OptIn(KordUnstableApi::class) InviteCreateRequest> {
     /**
      * The duration of invite in seconds before expiry, or 0 for never. 86400 (24 hours) by default.
      */
@@ -38,6 +39,7 @@ class InviteCreateBuilder : RequestBuilder<InviteCreateRequest> {
      */
     var reason: String? = null
 
+    @OptIn(KordUnstableApi::class)
     override fun toRequest(): InviteCreateRequest = InviteCreateRequest(
             temporary = temporary,
             age = age,

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/channel/NewsChannelCreateBuilder.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/channel/NewsChannelCreateBuilder.kt
@@ -4,19 +4,22 @@ import com.gitlab.kordlib.common.entity.Overwrite
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.rest.builder.AuditRequestBuilder
 import com.gitlab.kordlib.common.annotation.KordDsl
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.ChannelType
 import com.gitlab.kordlib.rest.json.request.GuildCreateChannelRequest
 
 @KordDsl
-class NewsChannelCreateBuilder: AuditRequestBuilder<GuildCreateChannelRequest> {
+class NewsChannelCreateBuilder: AuditRequestBuilder<@OptIn(KordUnstableApi::class) GuildCreateChannelRequest> {
     override var reason: String? = null
     lateinit var name: String
     var topic: String? = null
     var nsfw: Boolean? = null
     var parentId: Snowflake? = null
     var position: Int? = null
+    @OptIn(KordUnstableApi::class)
     val permissionOverwrites: MutableList<Overwrite> = mutableListOf()
 
+    @OptIn(KordUnstableApi::class)
     override fun toRequest(): GuildCreateChannelRequest = GuildCreateChannelRequest(
             name = name,
             topic = topic,

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/channel/PermissionOverwriteBuilder.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/channel/PermissionOverwriteBuilder.kt
@@ -4,11 +4,13 @@ import com.gitlab.kordlib.common.entity.Overwrite
 import com.gitlab.kordlib.common.entity.Permissions
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.common.annotation.KordDsl
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 
 @KordDsl
 class PermissionOverwriteBuilder(private val type: String, private val id: Snowflake) {
     var allowed: Permissions = Permissions()
     var denied: Permissions = Permissions()
 
+    @OptIn(KordUnstableApi::class)
     fun toOverwrite(): Overwrite = Overwrite(id = id.value, allow = allowed.code, deny = denied.code, type = type)
 }

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/channel/TextChannelCreateBuilder.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/channel/TextChannelCreateBuilder.kt
@@ -4,11 +4,12 @@ import com.gitlab.kordlib.common.entity.ChannelType
 import com.gitlab.kordlib.common.entity.Overwrite
 import com.gitlab.kordlib.rest.builder.AuditRequestBuilder
 import com.gitlab.kordlib.common.annotation.KordDsl
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.rest.json.request.GuildCreateChannelRequest
 
 @KordDsl
-class TextChannelCreateBuilder : AuditRequestBuilder<GuildCreateChannelRequest> {
+class TextChannelCreateBuilder : AuditRequestBuilder<@OptIn(KordUnstableApi::class) GuildCreateChannelRequest> {
     override var reason: String? = null
     lateinit var name: String
     var topic: String? = null
@@ -16,8 +17,10 @@ class TextChannelCreateBuilder : AuditRequestBuilder<GuildCreateChannelRequest> 
     var position: Int? = null
     var parentId: Snowflake? = null
     var nsfw: Boolean? = null
+    @OptIn(KordUnstableApi::class)
     val permissionOverwrites: MutableList<Overwrite> = mutableListOf()
 
+    @OptIn(KordUnstableApi::class)
     override fun toRequest(): GuildCreateChannelRequest = GuildCreateChannelRequest(
             name = name,
             topic = topic,

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/channel/VoiceChannelCreateBuilder.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/channel/VoiceChannelCreateBuilder.kt
@@ -4,19 +4,22 @@ import com.gitlab.kordlib.common.entity.ChannelType
 import com.gitlab.kordlib.common.entity.Overwrite
 import com.gitlab.kordlib.rest.builder.AuditRequestBuilder
 import com.gitlab.kordlib.common.annotation.KordDsl
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.rest.json.request.GuildCreateChannelRequest
 
 @KordDsl
-class VoiceChannelCreateBuilder : AuditRequestBuilder<GuildCreateChannelRequest> {
+class VoiceChannelCreateBuilder : AuditRequestBuilder<@OptIn(KordUnstableApi::class) GuildCreateChannelRequest> {
     override var reason: String? = null
     lateinit var name: String
     var bitrate: Int? = null
     var userLimit: Int? = null
     var parentId: Snowflake? = null
     var position: Int? = null
+    @OptIn(KordUnstableApi::class)
     val permissionOverwrites: MutableList<Overwrite> = mutableListOf()
 
+    @OptIn(KordUnstableApi::class)
     override fun toRequest(): GuildCreateChannelRequest = GuildCreateChannelRequest(
             name = name,
             bitrate = bitrate,

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/guild/EmojiCreateBuilder.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/guild/EmojiCreateBuilder.kt
@@ -1,6 +1,7 @@
 package com.gitlab.kordlib.rest.builder.guild
 
 import com.gitlab.kordlib.common.annotation.KordDsl
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.rest.Image
 import com.gitlab.kordlib.rest.builder.AuditRequestBuilder
@@ -8,12 +9,13 @@ import com.gitlab.kordlib.rest.json.request.EmojiCreateRequest
 import com.gitlab.kordlib.rest.json.request.EmojiModifyRequest
 
 @KordDsl
-class EmojiCreateBuilder : AuditRequestBuilder<EmojiCreateRequest> {
+class EmojiCreateBuilder : AuditRequestBuilder<@OptIn(KordUnstableApi::class) EmojiCreateRequest> {
     override var reason: String? = null
     lateinit var name: String
     lateinit var image: Image
     var roles: Set<Snowflake> = emptySet()
 
+    @OptIn(KordUnstableApi::class)
     override fun toRequest(): EmojiCreateRequest = EmojiCreateRequest(
             name = name,
             image = image.dataUri,

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/guild/EmojiModifyBuilder.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/guild/EmojiModifyBuilder.kt
@@ -2,15 +2,17 @@ package com.gitlab.kordlib.rest.builder.guild
 
 import com.gitlab.kordlib.rest.builder.AuditRequestBuilder
 import com.gitlab.kordlib.common.annotation.KordDsl
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.rest.json.request.EmojiModifyRequest
 
 @KordDsl
-class EmojiModifyBuilder : AuditRequestBuilder<EmojiModifyRequest> {
+class EmojiModifyBuilder : AuditRequestBuilder<@OptIn(KordUnstableApi::class) EmojiModifyRequest> {
     override var reason: String? = null
     var name: String? = null
     var roles: Set<Snowflake>? = null
 
+    @OptIn(KordUnstableApi::class)
     override fun toRequest(): EmojiModifyRequest = EmojiModifyRequest(
             name = name,
             roles = roles?.map { it.value }

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/guild/GuildCreateBuilder.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/guild/GuildCreateBuilder.kt
@@ -1,6 +1,7 @@
 package com.gitlab.kordlib.rest.builder.guild
 
 import com.gitlab.kordlib.common.annotation.KordDsl
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.DefaultMessageNotificationLevel
 import com.gitlab.kordlib.common.entity.ExplicitContentFilter
 import com.gitlab.kordlib.common.entity.Snowflake
@@ -16,11 +17,12 @@ import com.gitlab.kordlib.rest.json.request.GuildRoleCreateRequest
 import kotlin.random.Random
 
 @KordDsl
-class GuildCreateBuilder : RequestBuilder<GuildCreateRequest> {
+class GuildCreateBuilder : RequestBuilder<@OptIn(KordUnstableApi::class) GuildCreateRequest> {
 
     /**
      * Iterator that generates unique ids for roles and channels..
      */
+    @OptIn(KordUnstableApi::class)
     val snowflakeGenerator by lazy(LazyThreadSafetyMode.NONE) {
         generateSequence { Random.nextLong(0, Long.MAX_VALUE) }.filter {
             it !in roles.map { role -> role.id?.toLong() }
@@ -43,6 +45,7 @@ class GuildCreateBuilder : RequestBuilder<GuildCreateRequest> {
     var explicitContentFilter: ExplicitContentFilter? = null
     var everyoneRole: RoleCreateBuilder? = null
     val roles: MutableList<GuildRoleCreateRequest> = mutableListOf()
+    @OptIn(KordUnstableApi::class)
     val channels: MutableList<GuildCreateChannelRequest> = mutableListOf()
 
     /**
@@ -60,21 +63,25 @@ class GuildCreateBuilder : RequestBuilder<GuildCreateRequest> {
      */
     val systemChannelId: Snowflake? = null
 
+    @OptIn(KordUnstableApi::class)//TODO, replace 'copy'
     inline fun textChannel(id: Snowflake = newUniqueSnowflake(), builder: TextChannelCreateBuilder.() -> Unit): Snowflake {
         channels.add(TextChannelCreateBuilder().apply(builder).toRequest().copy(id = id.value))
         return id
     }
 
+    @OptIn(KordUnstableApi::class)//TODO, replace 'copy'
     inline fun newsChannel(id: Snowflake = newUniqueSnowflake(), builder: NewsChannelCreateBuilder.() -> Unit): Snowflake {
         channels.add(NewsChannelCreateBuilder().apply(builder).toRequest().copy(id = id.value))
         return id
     }
 
+    @OptIn(KordUnstableApi::class)//TODO, replace 'copy'
     inline fun category(id: Snowflake = newUniqueSnowflake(), builder: CategoryCreateBuilder.() -> Unit): Snowflake {
         channels.add(CategoryCreateBuilder().apply(builder).toRequest().copy(id = id.value))
         return id
     }
 
+    @OptIn(KordUnstableApi::class)//TODO, replace 'copy'
     inline fun role(id: Snowflake = newUniqueSnowflake(), builder: RoleCreateBuilder.() -> Unit): Snowflake {
         roles += RoleCreateBuilder().apply(builder).toRequest().copy(id = id.value)
         return id
@@ -84,6 +91,7 @@ class GuildCreateBuilder : RequestBuilder<GuildCreateRequest> {
         everyoneRole = RoleCreateBuilder().apply(builder)
     }
 
+    @OptIn(KordUnstableApi::class)
     override fun toRequest(): GuildCreateRequest = GuildCreateRequest(
             name,
             region,

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/message/EmbedBuilder.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/message/EmbedBuilder.kt
@@ -1,6 +1,7 @@
 package com.gitlab.kordlib.rest.builder.message
 
 import com.gitlab.kordlib.common.annotation.KordDsl
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.rest.builder.RequestBuilder
 import com.gitlab.kordlib.rest.json.request.*
 import java.awt.Color
@@ -13,7 +14,7 @@ import java.time.format.DateTimeFormatter
  * Inline Markdown links are supported in in all description-like fields.
  */
 @KordDsl
-class EmbedBuilder : RequestBuilder<EmbedRequest> {
+class EmbedBuilder : RequestBuilder<@OptIn(KordUnstableApi::class) EmbedRequest> {
     /**
      * The title of the embed. Limited to the length of [Limits.title].
      */
@@ -92,6 +93,7 @@ class EmbedBuilder : RequestBuilder<EmbedRequest> {
         fields += Field().apply(builder)
     }
 
+    @OptIn(KordUnstableApi::class)
     override fun toRequest(): EmbedRequest = EmbedRequest(
             title,
             "embed",
@@ -107,18 +109,19 @@ class EmbedBuilder : RequestBuilder<EmbedRequest> {
     )
 
     @KordDsl
-    class Thumbnail : RequestBuilder<EmbedThumbnailRequest> {
+    class Thumbnail : RequestBuilder<@OptIn(KordUnstableApi::class) EmbedThumbnailRequest> {
 
         /**
          * The image url of the thumbnail. This field is required.
          */
         lateinit var url: String
 
+        @OptIn(KordUnstableApi::class)
         override fun toRequest() = EmbedThumbnailRequest(url)
     }
 
     @KordDsl
-    class Footer : RequestBuilder<EmbedFooterRequest> {
+    class Footer : RequestBuilder<@OptIn(KordUnstableApi::class) EmbedFooterRequest> {
 
         /**
          * The text of the footer. This field is required and limited to the length of [Limits.text].
@@ -126,10 +129,11 @@ class EmbedBuilder : RequestBuilder<EmbedRequest> {
         lateinit var text: String
 
         /**
-         * The icon url to displqy.
+         * The icon url to display.
          */
         var icon: String? = null
 
+        @OptIn(KordUnstableApi::class)
         override fun toRequest() = EmbedFooterRequest(text, icon)
 
         object Limits {
@@ -138,7 +142,7 @@ class EmbedBuilder : RequestBuilder<EmbedRequest> {
     }
 
     @KordDsl
-    class Author : RequestBuilder<EmbedAuthorRequest> {
+    class Author : RequestBuilder<@OptIn(KordUnstableApi::class) EmbedAuthorRequest> {
 
         /**
          * The name of the author. This field is required if [url] is not null.
@@ -155,6 +159,7 @@ class EmbedBuilder : RequestBuilder<EmbedRequest> {
          */
         var icon: String? = null
 
+        @OptIn(KordUnstableApi::class)
         override fun toRequest() = EmbedAuthorRequest(name, url, icon)
 
         object Limits {
@@ -166,7 +171,7 @@ class EmbedBuilder : RequestBuilder<EmbedRequest> {
     }
 
     @KordDsl
-    class Field : RequestBuilder<EmbedFieldRequest> {
+    class Field : RequestBuilder<@OptIn(KordUnstableApi::class) EmbedFieldRequest> {
 
         /**
          *  The value or 'description' of the [Field]. Limited to the length of [Limits.value].
@@ -179,6 +184,7 @@ class EmbedBuilder : RequestBuilder<EmbedRequest> {
         lateinit var name: String
         var inline: Boolean = false
 
+        @OptIn(KordUnstableApi::class)
         override fun toRequest() = EmbedFieldRequest(name, value, inline)
 
         object Limits {

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/message/MessageCreateBuilder.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/message/MessageCreateBuilder.kt
@@ -1,6 +1,7 @@
 package com.gitlab.kordlib.rest.builder.message
 
 import com.gitlab.kordlib.common.annotation.KordDsl
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.rest.builder.RequestBuilder
 import com.gitlab.kordlib.rest.json.request.AllowedMentions
@@ -13,7 +14,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 
 @KordDsl
-class MessageCreateBuilder : RequestBuilder<MultipartMessageCreateRequest> {
+class MessageCreateBuilder : RequestBuilder<@OptIn(KordUnstableApi::class)  MultipartMessageCreateRequest> {
     var content: String? = null
     var nonce: String? = null
     var tts: Boolean? = null
@@ -42,6 +43,7 @@ class MessageCreateBuilder : RequestBuilder<MultipartMessageCreateRequest> {
         allowedMentions = (allowedMentions ?: AllowedMentionsBuilder()).apply(block)
     }
 
+    @OptIn(KordUnstableApi::class)
     override fun toRequest(): MultipartMessageCreateRequest = MultipartMessageCreateRequest(
             MessageCreateRequest(content, nonce, tts, embed?.toRequest(), allowedMentions?.build()),
             files
@@ -77,6 +79,7 @@ class AllowedMentionsBuilder {
      */
     operator fun MentionTypes.unaryPlus() = types.add(this)
 
+    @OptIn(KordUnstableApi::class)
     fun build(): AllowedMentions = AllowedMentions(
             parse = types.map { it.serialName },
             users = users.map { it.value },

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/message/MessageModifyBuilder.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/message/MessageModifyBuilder.kt
@@ -2,11 +2,12 @@ package com.gitlab.kordlib.rest.builder.message
 
 import com.gitlab.kordlib.common.entity.Flags
 import com.gitlab.kordlib.common.annotation.KordDsl
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.rest.builder.RequestBuilder
 import com.gitlab.kordlib.rest.json.request.MessageEditPatchRequest
 
 @KordDsl
-class MessageModifyBuilder : RequestBuilder<MessageEditPatchRequest> {
+class MessageModifyBuilder : RequestBuilder<@OptIn(KordUnstableApi::class) MessageEditPatchRequest> {
     var content: String? = null
     var embed: EmbedBuilder? = null
     var flags: Flags? = null
@@ -26,5 +27,6 @@ class MessageModifyBuilder : RequestBuilder<MessageEditPatchRequest> {
     }
 
 
+    @OptIn(KordUnstableApi::class)
     override fun toRequest(): MessageEditPatchRequest = MessageEditPatchRequest(content, embed?.toRequest(), flags, allowedMentions?.build())
 }

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/user/CurrentUserModifyBuilder.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/user/CurrentUserModifyBuilder.kt
@@ -2,15 +2,17 @@ package com.gitlab.kordlib.rest.builder.user
 
 import com.gitlab.kordlib.rest.Image
 import com.gitlab.kordlib.common.annotation.KordDsl
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.rest.builder.RequestBuilder
 import com.gitlab.kordlib.rest.json.request.CurrentUserModifyRequest
 
 @KordDsl
-class CurrentUserModifyBuilder : RequestBuilder<CurrentUserModifyRequest> {
+class CurrentUserModifyBuilder : RequestBuilder<@OptIn(KordUnstableApi::class) CurrentUserModifyRequest> {
 
     var username: String? = null
     var avatar: Image? = null
 
+    @OptIn(KordUnstableApi::class)
     override fun toRequest(): CurrentUserModifyRequest = CurrentUserModifyRequest(username, avatar?.dataUri)
 
 }

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/user/GroupDMCreateBuilder.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/user/GroupDMCreateBuilder.kt
@@ -2,15 +2,17 @@ package com.gitlab.kordlib.rest.builder.user
 
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.common.annotation.KordDsl
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.rest.builder.RequestBuilder
 import com.gitlab.kordlib.rest.json.request.GroupDMCreateRequest
 
 @KordDsl
-class GroupDMCreateBuilder : RequestBuilder<GroupDMCreateRequest> {
+class GroupDMCreateBuilder : RequestBuilder<@OptIn(KordUnstableApi::class) GroupDMCreateRequest> {
 
     val tokens: MutableList<String> = mutableListOf()
     val nicknames: MutableMap<Snowflake, String> = mutableMapOf()
 
+    @OptIn(KordUnstableApi::class)
     override fun toRequest(): GroupDMCreateRequest = GroupDMCreateRequest(
             tokens.toList(),
             nicknames.mapKeys { it.value }

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/webhook/ExecuteWebhookBuilder.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/webhook/ExecuteWebhookBuilder.kt
@@ -1,6 +1,7 @@
 package com.gitlab.kordlib.rest.builder.webhook
 
 import com.gitlab.kordlib.common.annotation.KordDsl
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.rest.builder.RequestBuilder
 import com.gitlab.kordlib.rest.builder.message.EmbedBuilder
 import com.gitlab.kordlib.rest.json.request.EmbedRequest
@@ -12,12 +13,13 @@ import java.nio.file.Files
 import java.nio.file.Path
 
 @KordDsl
-class ExecuteWebhookBuilder: RequestBuilder<MultiPartWebhookExecuteRequest> {
+class ExecuteWebhookBuilder: RequestBuilder<@OptIn(KordUnstableApi::class) MultiPartWebhookExecuteRequest> {
     var content: String? = null
     var username: String? = null
     var avatarUrl: String? = null
     var tts: Boolean? = null
     private var file: Pair<String, java.io.InputStream>? = null
+    @OptIn(KordUnstableApi::class)
     val embeds: MutableList<EmbedRequest> = mutableListOf()
 
     fun setFile(name: String, content: java.io.InputStream) {
@@ -32,6 +34,7 @@ class ExecuteWebhookBuilder: RequestBuilder<MultiPartWebhookExecuteRequest> {
         embeds += EmbedBuilder().apply(builder).toRequest()
     }
 
+    @OptIn(KordUnstableApi::class)
     override fun toRequest() : MultiPartWebhookExecuteRequest = MultiPartWebhookExecuteRequest(
         WebhookExecuteRequest(content, username, avatarUrl, tts, embeds), file
     )

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/webhook/WebhookCreateBuilder.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/webhook/WebhookCreateBuilder.kt
@@ -2,14 +2,16 @@ package com.gitlab.kordlib.rest.builder.webhook
 
 import com.gitlab.kordlib.rest.builder.AuditRequestBuilder
 import com.gitlab.kordlib.common.annotation.KordDsl
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.rest.json.request.WebhookCreateRequest
 import com.gitlab.kordlib.rest.Image
 
 @KordDsl
-class WebhookCreateBuilder: AuditRequestBuilder<WebhookCreateRequest> {
+class WebhookCreateBuilder: AuditRequestBuilder<@OptIn(KordUnstableApi::class) WebhookCreateRequest> {
     override var reason: String? = null
     lateinit var name: String
     var avatar: Image? = null
 
+    @OptIn(KordUnstableApi::class)
     override fun toRequest() = WebhookCreateRequest(name, avatar?.dataUri)
 }

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/webhook/WebhookModifyBuilder.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/webhook/WebhookModifyBuilder.kt
@@ -2,17 +2,19 @@ package com.gitlab.kordlib.rest.builder.webhook
 
 import com.gitlab.kordlib.rest.builder.AuditRequestBuilder
 import com.gitlab.kordlib.common.annotation.KordDsl
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.rest.Image
 import com.gitlab.kordlib.rest.json.request.WebhookModifyRequest
 
 @KordDsl
-class WebhookModifyBuilder: AuditRequestBuilder<WebhookModifyRequest> {
+class WebhookModifyBuilder: AuditRequestBuilder<@OptIn(KordUnstableApi::class)  WebhookModifyRequest> {
     override var reason: String? = null
     var name: String? = null
     var avatar: Image? = null
     var channelId: Snowflake? = null
 
+    @OptIn(KordUnstableApi::class)
     override fun toRequest(): WebhookModifyRequest = WebhookModifyRequest(
             name = name,
             avatar = avatar?.dataUri,

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/request/ChannelFollowRequest.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/request/ChannelFollowRequest.kt
@@ -1,9 +1,11 @@
 package com.gitlab.kordlib.rest.json.request
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
+@KordUnstableApi
 class ChannelFollowRequest(
         @SerialName("webhook_channel_id")
         val webhookChannelId: String

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/request/ChannelRequests.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/request/ChannelRequests.kt
@@ -1,11 +1,13 @@
 package com.gitlab.kordlib.rest.json.request
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Overwrite
 import com.gitlab.kordlib.common.entity.Permissions
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
+@KordUnstableApi
 data class ChannelModifyPutRequest(
         val name: String,
         val position: Int,
@@ -23,6 +25,7 @@ data class ChannelModifyPutRequest(
 )
 
 @Serializable
+@KordUnstableApi
 data class ChannelModifyPatchRequest(
         val name: String? = null,
         val position: Int? = null,
@@ -40,4 +43,5 @@ data class ChannelModifyPatchRequest(
 )
 
 @Serializable
+@KordUnstableApi
 data class ChannelPermissionEditRequest(val allow: Permissions, val deny: Permissions, val type: String)

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/request/EmojiRequests.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/request/EmojiRequests.kt
@@ -1,8 +1,10 @@
 package com.gitlab.kordlib.rest.json.request
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import kotlinx.serialization.Serializable
 
 @Serializable
+@KordUnstableApi
 data class EmojiCreateRequest(
         val name: String,
         val image: String,
@@ -10,6 +12,7 @@ data class EmojiCreateRequest(
 )
 
 @Serializable
+@KordUnstableApi
 data class EmojiModifyRequest(
         val name: String? = null,
         val roles: List<String>? = null

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/request/GuildRequests.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/request/GuildRequests.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.rest.json.request
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.*
 import kotlinx.serialization.*
 import kotlinx.serialization.builtins.ListSerializer
@@ -9,6 +10,7 @@ import kotlinx.serialization.descriptors.buildSerialDescriptor
 import kotlinx.serialization.encoding.Encoder
 
 @Serializable
+@KordUnstableApi
 data class GuildCreateRequest(
         val name: String,
         val region: String? = null,
@@ -29,6 +31,7 @@ data class GuildCreateRequest(
 )
 
 @Serializable
+@KordUnstableApi
 data class GuildCreateChannelRequest(
         val name: String,
         val type: ChannelType? = null,

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/request/InviteCreateRequest.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/request/InviteCreateRequest.kt
@@ -1,9 +1,11 @@
 package com.gitlab.kordlib.rest.json.request
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.TargetUserType
 import kotlinx.serialization.*
 
 @Serializable
+@KordUnstableApi
 data class InviteCreateRequest(
         @SerialName("max_age")
         val age: Int? = null,

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/request/MessageRequests.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/request/MessageRequests.kt
@@ -1,10 +1,12 @@
 package com.gitlab.kordlib.rest.json.request
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.Flags
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
+@KordUnstableApi
 data class MessageCreateRequest(
         val content: String? = null,
         val nonce: String? = null,
@@ -15,14 +17,17 @@ data class MessageCreateRequest(
 )
 
 @Serializable
+@KordUnstableApi
 data class AllowedMentions(val parse: List<String>, val users: List<String>, val roles: List<String>)
 
+@KordUnstableApi
 data class MultipartMessageCreateRequest(
         val request: MessageCreateRequest,
         val files: List<Pair<String, java.io.InputStream>> = emptyList()
 )
 
 @Serializable
+@KordUnstableApi
 data class EmbedRequest(
         val title: String?,
         val type: String?,
@@ -39,6 +44,7 @@ data class EmbedRequest(
 
 
 @Serializable
+@KordUnstableApi
 data class EmbedFooterRequest(
         val text: String,
         @SerialName("icon_url")
@@ -46,12 +52,15 @@ data class EmbedFooterRequest(
 )
 
 @Serializable
+@KordUnstableApi
 data class EmbedImageRequest(val url: String)
 
 @Serializable
+@KordUnstableApi
 data class EmbedThumbnailRequest(val url: String)
 
 @Serializable
+@KordUnstableApi
 data class EmbedAuthorRequest(
         val name: String? = null,
         val url: String? = null,
@@ -60,6 +69,7 @@ data class EmbedAuthorRequest(
 )
 
 @Serializable
+@KordUnstableApi
 data class EmbedFieldRequest(
         val name: String,
         val value: String,
@@ -67,6 +77,7 @@ data class EmbedFieldRequest(
 )
 
 @Serializable
+@KordUnstableApi
 data class MessageEditPatchRequest(
         val content: String? = null,
         val embed: EmbedRequest? = null,
@@ -76,4 +87,5 @@ data class MessageEditPatchRequest(
 )
 
 @Serializable
+@KordUnstableApi
 data class BulkDeleteRequest(val messages: List<String>)

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/request/UserRequests.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/request/UserRequests.kt
@@ -1,27 +1,32 @@
 package com.gitlab.kordlib.rest.json.request
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
+@KordUnstableApi
 data class DMCreateRequest(
         @SerialName("recipient_id")
         val userId: String
 )
 
 @Serializable
+@KordUnstableApi
 data class GroupDMCreateRequest(
         @SerialName("access_tokens")
         val tokens: List<String>,
         val nick: Map<String, String>)
 
 @Serializable
+@KordUnstableApi
 data class CurrentUserModifyRequest(
         val username: String? = null,
         val avatar: String? = null
 )
 
 @Serializable
+@KordUnstableApi
 data class UserAddDMRequest(
         @SerialName("access_token")
         val token: String,

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/request/WebhookRequests.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/request/WebhookRequests.kt
@@ -1,12 +1,15 @@
 package com.gitlab.kordlib.rest.json.request
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import kotlinx.serialization.SerialName
 import kotlinx. serialization.Serializable
 
 @Serializable
+@KordUnstableApi
 data class WebhookCreateRequest(val name: String, val avatar: String?)
 
 @Serializable
+@KordUnstableApi
 data class WebhookModifyRequest(
         val name: String? = null,
         val avatar: String? = null,
@@ -15,6 +18,7 @@ data class WebhookModifyRequest(
 )
 
 @Serializable
+@KordUnstableApi
 data class WebhookExecuteRequest(
         val content: String?,
         val username: String? = null,
@@ -24,6 +28,7 @@ data class WebhookExecuteRequest(
         val embeds: List<EmbedRequest>? = null
 )
 
+@KordUnstableApi
 data class MultiPartWebhookExecuteRequest(
         val request: WebhookExecuteRequest,
         val file: Pair<String, java.io.InputStream>?

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/response/ApplicationInfoResponse.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/response/ApplicationInfoResponse.kt
@@ -2,6 +2,7 @@
 
 package com.gitlab.kordlib.rest.json.response
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.DiscordTeam
 import com.gitlab.kordlib.common.entity.DiscordUser
 import kotlinx.serialization.SerialName
@@ -11,6 +12,7 @@ import kotlinx.serialization.Serializable
  * Payload gotten from [GET /oauth2/applications/@me](https://discord.com/developers/docs/topics/oauth2#get-current-application-information)
  */
 @Serializable
+@KordUnstableApi
 data class ApplicationInfoResponse(
         val id: String,
         val name: String,

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/response/Audit.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/response/Audit.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.rest.json.response
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.*
 import kotlinx.serialization.*
 import kotlinx.serialization.builtins.ListSerializer
@@ -18,6 +19,7 @@ import mu.KotlinLogging
 private val auditLogger = KotlinLogging.logger { }
 
 @Serializable
+@KordUnstableApi
 data class AuditLogResponse(
         val webhooks: List<DiscordWebhook>,
         val users: List<DiscordUser>,
@@ -26,6 +28,7 @@ data class AuditLogResponse(
 )
 
 @Serializable
+@KordUnstableApi
 data class AuditLogEntryResponse(
         @SerialName("target_id")
         val targetId: String?,
@@ -39,6 +42,7 @@ data class AuditLogEntryResponse(
         val reason: String? = null
 )
 
+@KordUnstableApi
 @Serializable(with = AuditLogChangeResponse.AuditLogChangeSerializer::class)
 sealed class AuditLogChangeResponse<T> {
     abstract val old: T?
@@ -136,60 +140,131 @@ sealed class AuditLogChangeResponse<T> {
 }
 
 
+@KordUnstableApi
 data class HoistLogChange(override val old: Boolean?, override val new: Boolean?) : AuditLogChangeResponse<Boolean>()
+
+@KordUnstableApi
 data class NSFWLogChange(override val old: Boolean?, override val new: Boolean?) : AuditLogChangeResponse<Boolean>()
+
+@KordUnstableApi
 data class MentionableLogChange(override val old: Boolean?, override val new: Boolean?) : AuditLogChangeResponse<Boolean>()
+
+@KordUnstableApi
 data class TemporaryLogChange(override val old: Boolean?, override val new: Boolean?) : AuditLogChangeResponse<Boolean>()
+
+@KordUnstableApi
 data class DeafLogChange(override val old: Boolean?, override val new: Boolean?) : AuditLogChangeResponse<Boolean>()
+
+@KordUnstableApi
 data class MuteLogChange(override val old: Boolean?, override val new: Boolean?) : AuditLogChangeResponse<Boolean>()
+
+@KordUnstableApi
 data class WidgetEnabledLogChange(override val old: Boolean?, override val new: Boolean?) : AuditLogChangeResponse<Boolean>()
+
+@KordUnstableApi
 data class PermissionsLogChange(override val old: Permissions?, override val new: Permissions?) : AuditLogChangeResponse<Permissions>() {
     internal constructor(old: Int?, new: Int?) : this(old?.let { Permissions { +it } },
             new?.let { Permissions { +it } }
     )
 }
 
+@KordUnstableApi
 data class AllowLogChange(override val old: Permissions?, override val new: Permissions?) : AuditLogChangeResponse<Permissions>() {
     internal constructor(old: Int?, new: Int?) : this(old?.let { Permissions { +it } },
             new?.let { Permissions { +it } }
     )
 }
 
-
+@KordUnstableApi
 data class DenyLogChange(override val old: Permissions?, override val new: Permissions?) : AuditLogChangeResponse<Permissions>() {
     internal constructor(old: Int?, new: Int?) : this(old?.let { Permissions { +it } },
             new?.let { Permissions { +it } }
     )
 }
 
+@KordUnstableApi
 data class NameLogChange(override val old: String?, override val new: String?) : AuditLogChangeResponse<String>()
+
+@KordUnstableApi
 data class VanityUrlLogChange(override val old: String?, override val new: String?) : AuditLogChangeResponse<String>()
+
+@KordUnstableApi
 data class SplashHashLogChange(override val old: String?, override val new: String?) : AuditLogChangeResponse<String>()
+
+@KordUnstableApi
 data class RegionLogChange(override val old: String?, override val new: String?) : AuditLogChangeResponse<String>()
+
+@KordUnstableApi
 data class AFKChannelLogChange(override val old: String?, override val new: String?) : AuditLogChangeResponse<String>()
+
+@KordUnstableApi
 data class WidgetChannelLogChange(override val old: String?, override val new: String?) : AuditLogChangeResponse<String>()
+
+@KordUnstableApi
 data class IconHashLogChange(override val old: String?, override val new: String?) : AuditLogChangeResponse<String>()
+
+@KordUnstableApi
 data class OwnerLogChange(override val old: String?, override val new: String?) : AuditLogChangeResponse<String>()
+
+@KordUnstableApi
 data class TopicLogChange(override val old: String?, override val new: String?) : AuditLogChangeResponse<String>()
+
+@KordUnstableApi
 data class ApplicationLogChange(override val old: String?, override val new: String?) : AuditLogChangeResponse<String>()
+
+@KordUnstableApi
 data class CodeLogChange(override val old: String?, override val new: String?) : AuditLogChangeResponse<String>()
+
+@KordUnstableApi
 data class ChannelLogChange(override val old: String?, override val new: String?) : AuditLogChangeResponse<String>()
+
+@KordUnstableApi
 data class InviterLogChange(override val old: String?, override val new: String?) : AuditLogChangeResponse<String>()
+
+@KordUnstableApi
 data class NickLogChange(override val old: String?, override val new: String?) : AuditLogChangeResponse<String>()
+
+@KordUnstableApi
 data class AvatarHashLogChange(override val old: String?, override val new: String?) : AuditLogChangeResponse<String>()
+
+@KordUnstableApi
 data class IdLogChange(override val old: String?, override val new: String?) : AuditLogChangeResponse<String>()
+
+@KordUnstableApi
 data class AFKTimeoutLogChange(override val old: Int?, override val new: Int?) : AuditLogChangeResponse<Int>()
+
+@KordUnstableApi
 data class PruneDeleteDaysLogChange(override val old: Int?, override val new: Int?) : AuditLogChangeResponse<Int>()
+
+@KordUnstableApi
 data class PositionLogChange(override val old: Int?, override val new: Int?) : AuditLogChangeResponse<Int>()
+
+@KordUnstableApi
 data class BitrateLogChange(override val old: Int?, override val new: Int?) : AuditLogChangeResponse<Int>()
+
+@KordUnstableApi
 data class MaxUsesLogChange(override val old: Int?, override val new: Int?) : AuditLogChangeResponse<Int>()
+
+@KordUnstableApi
 data class UsesLogChange(override val old: Int?, override val new: Int?) : AuditLogChangeResponse<Int>()
+
+@KordUnstableApi
 data class MaxAgeLogChange(override val old: Int?, override val new: Int?) : AuditLogChangeResponse<Int>()
+
+@KordUnstableApi
 data class ColorLogChange(override val old: Int?, override val new: Int?) : AuditLogChangeResponse<Int>()
+
+@KordUnstableApi
 data class AddLogChange(override val old: List<DiscordAuditLogRoleChange>?, override val new: List<DiscordAuditLogRoleChange>?) : AuditLogChangeResponse<List<DiscordAuditLogRoleChange>>()
+
+@KordUnstableApi
 data class RemoveLogChange(override val old: List<DiscordAuditLogRoleChange>?, override val new: List<DiscordAuditLogRoleChange>?) : AuditLogChangeResponse<List<DiscordAuditLogRoleChange>>()
+
+@KordUnstableApi
 data class PermissionOverwriteLogChange(override val old: List<Overwrite>?, override val new: List<Overwrite>?) : AuditLogChangeResponse<List<Overwrite>>()
 
+
+@KordUnstableApi
 data class MFALogChange(override val old: MFALevel?, override val new: MFALevel?) : AuditLogChangeResponse<MFALevel>() {
     internal constructor(old: Int?, new: Int?) : this(
             MFALevel.values().firstOrNull { it.code == new },
@@ -197,6 +272,8 @@ data class MFALogChange(override val old: MFALevel?, override val new: MFALevel?
     )
 }
 
+
+@KordUnstableApi
 data class DefaultMessageNotificationLevelLogChange(override val old: DefaultMessageNotificationLevel?, override val new: DefaultMessageNotificationLevel?) : AuditLogChangeResponse<DefaultMessageNotificationLevel>() {
     internal constructor(old: Int?, new: Int?) : this(
             DefaultMessageNotificationLevel.values().firstOrNull { it.code == new },
@@ -204,6 +281,8 @@ data class DefaultMessageNotificationLevelLogChange(override val old: DefaultMes
     )
 }
 
+
+@KordUnstableApi
 data class VerificationLevelLogChange(override val old: VerificationLevel?, override val new: VerificationLevel?) : AuditLogChangeResponse<VerificationLevel>() {
     internal constructor(old: Int?, new: Int?) : this(
             VerificationLevel.values().firstOrNull { it.code == new },
@@ -211,6 +290,8 @@ data class VerificationLevelLogChange(override val old: VerificationLevel?, over
     )
 }
 
+
+@KordUnstableApi
 data class ExplicitContentFilterLogChange(override val old: ExplicitContentFilter?, override val new: ExplicitContentFilter?) : AuditLogChangeResponse<ExplicitContentFilter>() {
     internal constructor(old: Int?, new: Int?) : this(
             ExplicitContentFilter.values().firstOrNull { it.code == new },
@@ -218,6 +299,8 @@ data class ExplicitContentFilterLogChange(override val old: ExplicitContentFilte
     )
 }
 
+
+@KordUnstableApi
 object Unknown : AuditLogChangeResponse<Nothing>() {
     override val old = null
     override val new = null
@@ -289,6 +372,7 @@ enum class AuditLogEventResponse(val code: Int) {
 }
 
 @Serializable
+@KordUnstableApi
 data class AuditEntryInfoResponse(
         @SerialName("delete_member_days")
         val deleteMemberDays: String? = null,

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/response/BanResponse.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/response/BanResponse.kt
@@ -1,7 +1,9 @@
 package com.gitlab.kordlib.rest.json.response
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.DiscordUser
 import kotlinx.serialization.Serializable
 
 @Serializable
+@KordUnstableApi
 data class BanResponse(val reason: String?, val user: DiscordUser)

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/response/Channel.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/response/Channel.kt
@@ -1,7 +1,9 @@
 package com.gitlab.kordlib.rest.json.response
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.ChannelType
 import kotlinx.serialization.Serializable
 
 @Serializable
+@KordUnstableApi
 data class PartialChannelResponse(val name: String, val type: ChannelType)

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/response/Connection.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/response/Connection.kt
@@ -1,10 +1,12 @@
 package com.gitlab.kordlib.rest.json.response
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.DiscordGuildIntegrations
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
+@KordUnstableApi
 data class Connection(val id: String,
                       val name: String,
                       val type: String,
@@ -15,5 +17,6 @@ data class Connection(val id: String,
                       val friendSync: Boolean,
                       @SerialName("show_activity")
                       val showActivity: Boolean,
-                      val visibility: Int)
+                      val visibility: Int
+)
 //TODO add a visibility enum class

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/response/EmbedResponse.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/response/EmbedResponse.kt
@@ -1,9 +1,13 @@
 package com.gitlab.kordlib.rest.json.response
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class EmbedResponse(val enabled: Boolean,
-                         @SerialName("channel_id")
-                         val channelId: String)
+@KordUnstableApi
+data class EmbedResponse(
+        val enabled: Boolean,
+        @SerialName("channel_id")
+        val channelId: String,
+)

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/response/FollowedChannelResponse.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/response/FollowedChannelResponse.kt
@@ -1,9 +1,11 @@
 package com.gitlab.kordlib.rest.json.response
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
+@KordUnstableApi
 data class FollowedChannelResponse(
         @SerialName("channel_id")
         val channelId: String,

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/response/Gateway.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/response/Gateway.kt
@@ -1,12 +1,15 @@
 package com.gitlab.kordlib.rest.json.response
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
+@KordUnstableApi
 data class GatewayResponse(val url: String, val shards: Int)
 
 @Serializable
+@KordUnstableApi
 data class BotGatewayResponse(
         val url: String,
         val shards: Int,
@@ -15,6 +18,7 @@ data class BotGatewayResponse(
 )
 
 @Serializable
+@KordUnstableApi
 data class SessionStartLimitResponse(
         val total: Int,
         val remaining: Int,

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/response/IntegrationResponse.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/response/IntegrationResponse.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.rest.json.response
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.DiscordUser
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.PrimitiveKind
@@ -9,6 +10,7 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
 @Serializable
+@KordUnstableApi
 data class IntegrationResponse(
         val id: String,
         val name: String,
@@ -52,4 +54,5 @@ enum class IntegrationExpireBehavior(val code: Int) {
 }
 
 @Serializable
+@KordUnstableApi
 data class DiscordIntegrationsAccount(val id: String, val name: String)

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/response/Invite.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/response/Invite.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.rest.json.response
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.DiscordChannel
 import com.gitlab.kordlib.common.entity.DiscordPartialGuild
 import com.gitlab.kordlib.common.entity.DiscordUser
@@ -8,6 +9,7 @@ import kotlinx.serialization.*
 import kotlinx.serialization.internal.IntDescriptor
 
 @Serializable
+@KordUnstableApi
 data class InviteResponse(
         val code: String,
         val guild: DiscordPartialGuild? = null,
@@ -26,6 +28,7 @@ data class InviteResponse(
 
 
 @Serializable
+@KordUnstableApi
 data class InviteMetaDataResponse(
         val inviter: DiscordUser,
         val uses: Int,
@@ -39,4 +42,5 @@ data class InviteMetaDataResponse(
 )
 
 @Serializable
+@KordUnstableApi
 data class PartialInvite(val code: String? = null)

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/response/Prune.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/response/Prune.kt
@@ -1,9 +1,12 @@
 package com.gitlab.kordlib.rest.json.response
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import kotlinx.serialization.Serializable
 
 @Serializable
+@KordUnstableApi
 data class GetPruneResponse(val pruned: Int)
 
 @Serializable
+@KordUnstableApi
 data class PruneResponse(val pruned: Int?)

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/response/Voice.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/json/response/Voice.kt
@@ -1,6 +1,8 @@
 package com.gitlab.kordlib.rest.json.response
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import kotlinx.serialization.Serializable
 
 @Serializable
+@KordUnstableApi
 data class VoiceRegion(val id: String, val name: String, val vip: Boolean, val optimal: Boolean, val deprecated: Boolean, val custom: Boolean)

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/route/Route.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/route/Route.kt
@@ -1,6 +1,7 @@
 package com.gitlab.kordlib.rest.route
 
 import com.gitlab.kordlib.common.annotation.KordPreview
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.*
 import com.gitlab.kordlib.rest.json.optional
 import com.gitlab.kordlib.rest.json.response.*
@@ -17,6 +18,7 @@ import com.gitlab.kordlib.common.entity.DiscordEmoji as EmojiEntity
 internal const val REST_VERSION_PROPERTY_NAME = "com.gitlab.kordlib.rest.version"
 internal val restVersion get() = System.getenv(REST_VERSION_PROPERTY_NAME) ?: "v6"
 
+@OptIn(KordUnstableApi::class)
 sealed class Route<T>(
         val method: HttpMethod,
         val path: String,

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/service/ApplicationService.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/service/ApplicationService.kt
@@ -1,11 +1,13 @@
 package com.gitlab.kordlib.rest.service
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.rest.json.response.ApplicationInfoResponse
 import com.gitlab.kordlib.rest.request.RequestHandler
 import com.gitlab.kordlib.rest.route.Route
 
 class ApplicationService(handler: RequestHandler) : RestService(handler) {
 
+    @OptIn(KordUnstableApi::class)
     suspend fun getCurrentApplicationInfo() : ApplicationInfoResponse = call(Route.CurrentApplicationInfo)
 
 }

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/service/ChannelService.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/service/ChannelService.kt
@@ -1,6 +1,7 @@
 package com.gitlab.kordlib.rest.service
 
 import com.gitlab.kordlib.common.annotation.KordPreview
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.DiscordMessage
 import com.gitlab.kordlib.rest.builder.channel.*
 import com.gitlab.kordlib.rest.builder.message.MessageCreateBuilder
@@ -13,6 +14,7 @@ import com.gitlab.kordlib.rest.route.Route
 
 class ChannelService(requestHandler: RequestHandler) : RestService(requestHandler) {
 
+    @OptIn(KordUnstableApi::class)
     suspend inline fun createMessage(channelId: String, builder: MessageCreateBuilder.() -> Unit) = call(Route.MessagePost) {
         keys[Route.ChannelId] = channelId
         val multipartRequest = MessageCreateBuilder().apply(builder).toRequest()
@@ -92,6 +94,7 @@ class ChannelService(requestHandler: RequestHandler) : RestService(requestHandle
         reason?.let { header("X-Audit-Log-Reason", reason) }
     }
 
+    @OptIn(KordUnstableApi::class)
     suspend fun bulkDelete(channelId: String, messages: BulkDeleteRequest) = call(Route.BulkMessageDeletePost) {
         keys[Route.ChannelId] = channelId
         body(BulkDeleteRequest.serializer(), messages)
@@ -108,6 +111,7 @@ class ChannelService(requestHandler: RequestHandler) : RestService(requestHandle
         reason?.let { header("X-Audit-Log-Reason", reason) }
     }
 
+    @OptIn(KordUnstableApi::class)
     suspend fun editChannelPermissions(channelId: String, overwriteId: String, permissions: ChannelPermissionEditRequest, reason: String? = null) = call(Route.ChannelPermissionPut) {
         keys[Route.ChannelId] = channelId
         keys[Route.OverwriteId] = overwriteId
@@ -135,12 +139,14 @@ class ChannelService(requestHandler: RequestHandler) : RestService(requestHandle
         keys[Route.UserId] = userId
     }
 
+    @OptIn(KordUnstableApi::class)
     suspend fun addToGroup(channelId: String, userId: String, addUser: UserAddDMRequest) = call(Route.GroupDMUserPut) {
         keys[Route.ChannelId] = channelId
         keys[Route.UserId] = userId
         body(UserAddDMRequest.serializer(), addUser)
     }
 
+    @OptIn(KordUnstableApi::class)
     suspend inline fun createInvite(channelId: String, builder: InviteCreateBuilder.() -> Unit = {}) = call(Route.InvitePost) {
         keys[Route.ChannelId] = channelId
         val request = InviteCreateBuilder().apply(builder)
@@ -148,6 +154,7 @@ class ChannelService(requestHandler: RequestHandler) : RestService(requestHandle
         request.reason?.let { header("X-Audit-Log-Reason", it) }
     }
 
+    @OptIn(KordUnstableApi::class)
     suspend inline fun editMessage(channelId: String, messageId: String, builder: MessageModifyBuilder.() -> Unit) = call(Route.EditMessagePatch) {
         keys[Route.ChannelId] = channelId
         keys[Route.MessageId] = messageId
@@ -155,12 +162,14 @@ class ChannelService(requestHandler: RequestHandler) : RestService(requestHandle
     }
 
 
+    @OptIn(KordUnstableApi::class)
     suspend fun putChannel(channelId: String, channel: ChannelModifyPutRequest, reason: String? = null) = call(Route.ChannelPut) {
         keys[Route.ChannelId] = channelId
         body(ChannelModifyPutRequest.serializer(), channel)
         reason?.let { header("X-Audit-Log-Reason", reason) }
     }
 
+    @OptIn(KordUnstableApi::class)
     suspend fun patchChannel(channelId: String, channel: ChannelModifyPatchRequest, reason: String? = null) = call(Route.ChannelPatch) {
         keys[Route.ChannelId] = channelId
         body(ChannelModifyPatchRequest.serializer(), channel)
@@ -168,12 +177,14 @@ class ChannelService(requestHandler: RequestHandler) : RestService(requestHandle
     }
 
     @KordPreview
+    @OptIn(KordUnstableApi::class)
     suspend fun crossPost(channelId: String, messageId: String) : DiscordMessage = call(Route.MessageCrosspost) {
         keys[Route.ChannelId] = channelId
         keys[Route.MessageId] = messageId
     }
 
     @KordPreview
+    @OptIn(KordUnstableApi::class)
     suspend fun followNewsChannel(channelId: String, request: ChannelFollowRequest): FollowedChannelResponse = call(Route.NewsChannelFollow) {
         keys[Route.ChannelId] = channelId
         body(ChannelFollowRequest.serializer(), request)

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/service/EmojiService.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/service/EmojiService.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.rest.service
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.rest.builder.guild.EmojiCreateBuilder
 import com.gitlab.kordlib.rest.builder.guild.EmojiModifyBuilder
 import com.gitlab.kordlib.rest.json.request.EmojiCreateRequest
@@ -9,7 +10,7 @@ import com.gitlab.kordlib.rest.route.Route
 
 class EmojiService(requestHandler: RequestHandler) : RestService(requestHandler) {
 
-
+    @OptIn(KordUnstableApi::class)
     suspend inline fun createEmoji(guildId: String, builder: EmojiCreateBuilder.() -> Unit) = call(Route.GuildEmojiPost) {
         keys[Route.GuildId] = guildId
         val emoji = EmojiCreateBuilder().apply(builder)
@@ -18,6 +19,7 @@ class EmojiService(requestHandler: RequestHandler) : RestService(requestHandler)
         emoji.reason?.let { header("X-Audit-Log-Reason", it) }
     }
 
+    @OptIn(KordUnstableApi::class)
     @Deprecated("use the inline builder instead",  ReplaceWith("createEmoji(guildId) {  }") ,level = DeprecationLevel.WARNING)
     suspend fun createEmoji(guildId: String, emoji: EmojiCreateRequest, reason: String? = null) = call(Route.GuildEmojiPost) {
         keys[Route.GuildId] = guildId
@@ -31,6 +33,7 @@ class EmojiService(requestHandler: RequestHandler) : RestService(requestHandler)
         reason?.let { header("X-Audit-Log-Reason", reason) }
     }
 
+    @OptIn(KordUnstableApi::class)
     suspend inline fun modifyEmoji(guildId: String, emojiId: String, builder: EmojiModifyBuilder.() -> Unit) = call(Route.GuildEmojiPatch) {
         keys[Route.GuildId] = guildId
         keys[Route.EmojiId] = emojiId

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/service/GuildService.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/service/GuildService.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.rest.service
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.DiscordChannel
 import com.gitlab.kordlib.rest.builder.ban.BanCreateBuilder
 import com.gitlab.kordlib.rest.builder.channel.*
@@ -20,6 +21,7 @@ import com.gitlab.kordlib.common.entity.DiscordGuild
 class GuildService(requestHandler: RequestHandler) : RestService(requestHandler) {
 
     suspend inline fun createGuild(builder: GuildCreateBuilder.() -> Unit) = call(Route.GuildPost) {
+        @OptIn(KordUnstableApi::class)
         body(GuildCreateRequest.serializer(), GuildCreateBuilder().apply(builder).toRequest())
     }
 
@@ -54,6 +56,7 @@ class GuildService(requestHandler: RequestHandler) : RestService(requestHandler)
         keys[Route.GuildId] = guildId
     }
 
+    @OptIn(KordUnstableApi::class)
     suspend fun createGuildChannel(guildId: String, channel: GuildCreateChannelRequest, reason: String? = null) = call(Route.GuildChannelsPost) {
         keys[Route.GuildId] = guildId
         body(GuildCreateChannelRequest.serializer(), channel)
@@ -234,21 +237,25 @@ class GuildService(requestHandler: RequestHandler) : RestService(requestHandler)
 
 }
 
+@OptIn(KordUnstableApi::class)
 suspend inline fun GuildService.createTextChannel(guildId: String, builder: TextChannelCreateBuilder.() -> Unit): DiscordChannel {
     val createBuilder = TextChannelCreateBuilder().apply(builder)
     return createGuildChannel(guildId, createBuilder.toRequest(), createBuilder.reason)
 }
 
+@OptIn(KordUnstableApi::class)
 suspend inline fun GuildService.createNewsChannel(guildId: String, builder: NewsChannelCreateBuilder.() -> Unit): DiscordChannel {
     val createBuilder = NewsChannelCreateBuilder().apply(builder)
     return createGuildChannel(guildId, createBuilder.toRequest(), createBuilder.reason)
 }
 
+@OptIn(KordUnstableApi::class)
 suspend inline fun GuildService.createVoiceChannel(guildId: String, builder: VoiceChannelCreateBuilder.() -> Unit): DiscordChannel {
     val createBuilder = VoiceChannelCreateBuilder().apply(builder)
     return createGuildChannel(guildId, createBuilder.toRequest(), createBuilder.reason)
 }
 
+@OptIn(KordUnstableApi::class)
 suspend inline fun GuildService.createCategory(guildId: String, builder: CategoryCreateBuilder.() -> Unit): DiscordChannel {
     val createBuilder = CategoryCreateBuilder().apply(builder)
     return createGuildChannel(guildId, createBuilder.toRequest(), createBuilder.reason)

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/service/UserService.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/service/UserService.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.rest.service
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.rest.builder.user.CurrentUserModifyBuilder
 import com.gitlab.kordlib.rest.builder.user.GroupDMCreateBuilder
 import com.gitlab.kordlib.rest.json.request.CurrentUserModifyRequest
@@ -31,14 +32,17 @@ class UserService(requestHandler: RequestHandler) : RestService(requestHandler) 
 
     suspend fun getUserConnections() = call(Route.UserConnectionsGet)
 
+    @OptIn(KordUnstableApi::class)
     suspend fun createDM(dm: DMCreateRequest) = call(Route.DMPost) {
         body(DMCreateRequest.serializer(), dm)
     }
 
+    @OptIn(KordUnstableApi::class)
     suspend inline fun createGroupDM(builder: GroupDMCreateBuilder.() -> Unit) = call(Route.DMPost) {
         body(GroupDMCreateRequest.serializer(), GroupDMCreateBuilder().apply(builder).toRequest())
     }
 
+    @OptIn(KordUnstableApi::class)
     suspend inline fun modifyCurrentUser(builder: CurrentUserModifyBuilder.() -> Unit) = call(Route.CurrentUserPatch) {
         body(CurrentUserModifyRequest.serializer(), CurrentUserModifyBuilder().apply(builder).toRequest())
     }

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/service/WebhookService.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/service/WebhookService.kt
@@ -1,6 +1,7 @@
 package com.gitlab.kordlib.rest.service
 
 import com.gitlab.kordlib.common.annotation.KordExperimental
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.rest.builder.webhook.ExecuteWebhookBuilder
 import com.gitlab.kordlib.rest.builder.webhook.WebhookCreateBuilder
 import com.gitlab.kordlib.rest.builder.webhook.WebhookModifyBuilder
@@ -13,6 +14,7 @@ import kotlinx.serialization.json.JsonObject
 
 class WebhookService(requestHandler: RequestHandler) : RestService(requestHandler) {
 
+    @KordUnstableApi
     suspend inline fun createWebhook(channelId: String, builder: WebhookCreateBuilder.() -> Unit) = call(Route.WebhookPost) {
         keys[Route.ChannelId] = channelId
         val createBuilder = WebhookCreateBuilder().apply(builder)
@@ -37,6 +39,7 @@ class WebhookService(requestHandler: RequestHandler) : RestService(requestHandle
         keys[Route.WebhookToken] = token
     }
 
+    @KordUnstableApi
     suspend inline fun modifyWebhook(webhookId: String, builder: WebhookModifyBuilder.() -> Unit) = call(Route.WebhookPatch) {
         keys[Route.WebhookId] = webhookId
         val modifyBuilder = WebhookModifyBuilder().apply(builder)
@@ -44,6 +47,7 @@ class WebhookService(requestHandler: RequestHandler) : RestService(requestHandle
         modifyBuilder.reason?.let { header("X-Audit-Log-Reason", it) }
     }
 
+    @KordUnstableApi
     suspend inline fun modifyWebhookWithToken(webhookId: String, token: String, builder: WebhookModifyBuilder.() -> Unit) = call(Route.WebhookByTokenPatch) {
         keys[Route.WebhookId] = webhookId
         keys[Route.WebhookToken] = token
@@ -63,6 +67,7 @@ class WebhookService(requestHandler: RequestHandler) : RestService(requestHandle
         reason?.let { header("X-Audit-Log-Reason", reason) }
     }
 
+    @KordUnstableApi
     suspend inline fun executeWebhook(webhookId: String, token: String, wait: Boolean, builder: ExecuteWebhookBuilder.() -> Unit) = call(Route.ExecuteWebhookPost) {
         keys[Route.WebhookId] = webhookId
         keys[Route.WebhookToken] = token

--- a/rest/src/test/kotlin/com/gitlab/kordlib/rest/builder/CategoryModifyBuilderTest.kt
+++ b/rest/src/test/kotlin/com/gitlab/kordlib/rest/builder/CategoryModifyBuilderTest.kt
@@ -1,9 +1,11 @@
 package com.gitlab.kordlib.rest.builder
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.rest.builder.channel.CategoryModifyBuilder
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
+@OptIn(KordUnstableApi::class)
 class CategoryModifyBuilderTest {
 
     @Test

--- a/rest/src/test/kotlin/com/gitlab/kordlib/rest/builder/EditGuildChannelBuilderTest.kt
+++ b/rest/src/test/kotlin/com/gitlab/kordlib/rest/builder/EditGuildChannelBuilderTest.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.rest.builder
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.rest.builder.channel.NewsChannelModifyBuilder
 import com.gitlab.kordlib.rest.builder.channel.StoreChannelModifyBuilder
 import com.gitlab.kordlib.rest.builder.channel.TextChannelModifyBuilder
@@ -7,6 +8,7 @@ import com.gitlab.kordlib.rest.builder.channel.VoiceChannelModifyBuilder
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
+@OptIn(KordUnstableApi::class)
 class EditGuildChannelBuilderTest {
 
     @Test

--- a/rest/src/test/kotlin/com/gitlab/kordlib/rest/builder/EmojiModifyBuilderTest.kt
+++ b/rest/src/test/kotlin/com/gitlab/kordlib/rest/builder/EmojiModifyBuilderTest.kt
@@ -1,7 +1,9 @@
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.rest.builder.guild.EmojiModifyBuilder
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
+@OptIn(KordUnstableApi::class)
 class EmojiModifyBuilderTest {
 
     @Test

--- a/rest/src/test/kotlin/com/gitlab/kordlib/rest/json/AuditLogResponseTest.kt
+++ b/rest/src/test/kotlin/com/gitlab/kordlib/rest/json/AuditLogResponseTest.kt
@@ -1,10 +1,12 @@
 package com.gitlab.kordlib.rest.json
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.rest.json.response.AuditLogResponse
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.parse
 import org.junit.jupiter.api.Test
 
+@OptIn(KordUnstableApi::class)
 object AuditLogResponseTest {
 
     @Test

--- a/rest/src/test/kotlin/com/gitlab/kordlib/rest/ratelimit/AbstractRequestRateLimiterTest.kt
+++ b/rest/src/test/kotlin/com/gitlab/kordlib/rest/ratelimit/AbstractRequestRateLimiterTest.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.rest.ratelimit
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.DiscordGuild
 import com.gitlab.kordlib.rest.request.JsonRequest
 import com.gitlab.kordlib.rest.route.Route
@@ -20,6 +21,7 @@ import kotlin.time.toJavaDuration
 
 @ExperimentalTime
 @ExperimentalCoroutinesApi
+@OptIn(KordUnstableApi::class)
 abstract class AbstractRequestRateLimiterTest {
 
     abstract fun newRequestRateLimiter(clock: Clock) : RequestRateLimiter

--- a/rest/src/test/kotlin/com/gitlab/kordlib/rest/services/RestServiceTest.kt
+++ b/rest/src/test/kotlin/com/gitlab/kordlib/rest/services/RestServiceTest.kt
@@ -1,5 +1,6 @@
 package com.gitlab.kordlib.rest.services
 
+import com.gitlab.kordlib.common.annotation.KordUnstableApi
 import com.gitlab.kordlib.common.entity.*
 import com.gitlab.kordlib.rest.Image
 import com.gitlab.kordlib.rest.json.request.*
@@ -33,6 +34,7 @@ fun imageBinary(path: String): Image {
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @EnabledIfEnvironmentVariable(named = "TARGET_BRANCH", matches = "master")
+@OptIn(KordUnstableApi::class)
 class RestServiceTest {
 
     private val publicGuildId = Snowflake(322850917248663552)


### PR DESCRIPTION
This is a WIP PR to discuss the current progress on annotating parts of the API that would be considered unstable. #50

While implementing this I encountered some issues:

* In an ideal world, just annotating the constructors of unstable data classes would suffice. 
After all it will only be constructors gaining an extra argument that would cause breaking changes. 
This however isn't the full truth, data classes generate a `copy` method based on the primary constructor.
Changing the constructor would also break the `copy` method and there is no way to annotate generated methods.
This leads to the unfortunate conclusion that the entire class has to be annotated as unstable, even though it
is only the constructor and copy method that could break binary compatibility.

* Kord makes extensive use of inline functions when building requests, this causes the implementation of these 
functions to be copied directly into the user's code. These implementations often involve interacting with the
unstable API. Meaning that unless we mark those parts of our API unstable as well, we will eventually break
user's bytecode without changing our stable API. A long-term solution might be to un-inline our entire API, 
regaining control of this part of the API at the cost of performance.

* Kotlin allows exhaustive checks on enums and sealed classes. A scenario where Discord introduces a new value
to an exhaustive set would result in us adding that value to the enum or sealed class. 
All user code that depends on this set being exhaustive will then have the option to break.
I don't think there's a good long-term solution here that allows us to introduce these new fields to core in a non-breaking way.


Looking at these issues collectively, I don't think there's a easy way for us to negotiate a fast-moving and stable API.
The path with the least headaches might be to keep any breaking change to minor versions after all, 
anything else I fear would turn in too many compromises for too little gain.