### PR TITLE
Add contracts

### DIFF
--- a/buildSrc/src/main/kotlin/BinaryCompatibility.kt
+++ b/buildSrc/src/main/kotlin/BinaryCompatibility.kt
@@ -73,7 +73,21 @@ class BinaryCompatibilityPlugin : Plugin<Project> {
                         }
                     }
 
+                    class IgnoreGenerated : japicmp.filter.ClassFilter {
+
+                        //ClassName$lowerCaseMethodName$optionalNumber
+                        val generatedNestedClass = Regex(pattern = """\w+(\$\p{Lower}\w*)+(\$\d+)*""")
+                        override fun matches(classBinary: CtClass): Boolean {
+                            return when {
+                                classBinary.name.any { it.isDigit() } -> true
+                                classBinary.name.matches(generatedNestedClass) -> true
+                                else -> false
+                            }
+                        }
+                    }
+
                     addExcludeFilter(IgnoreInlinedLambdaFilter::class.java)
+                    addExcludeFilter(IgnoreGenerated::class.java)
 
                 }
 

--- a/common/src/main/kotlin/com/gitlab/kordlib/common/entity/DiscordUser.kt
+++ b/common/src/main/kotlin/com/gitlab/kordlib/common/entity/DiscordUser.kt
@@ -7,6 +7,9 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.internal.IntDescriptor
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 
 @Serializable
 data class DiscordUser(
@@ -60,7 +63,11 @@ data class UserFlags constructor(val code: Int) {
         else -> this
     }
 
+    @OptIn(ExperimentalContracts::class)
     inline fun copy(block: UserFlagsBuilder.() -> Unit): UserFlags {
+        contract {
+            callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+        }
         val builder = UserFlagsBuilder(code)
         builder.apply(block)
         return builder.flags()

--- a/common/src/main/kotlin/com/gitlab/kordlib/common/entity/Permission.kt
+++ b/common/src/main/kotlin/com/gitlab/kordlib/common/entity/Permission.kt
@@ -6,6 +6,9 @@ import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 
 @Serializable(with = Permissions.Companion::class)
 class Permissions constructor(val code: Int) {
@@ -20,7 +23,11 @@ class Permissions constructor(val code: Int) {
         return this.code and permission.code == permission.code
     }
 
+    @OptIn(ExperimentalContracts::class)
     inline fun copy(block: PermissionsBuilder.() -> Unit): Permissions {
+        contract {
+            callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+        }
         val builder = PermissionsBuilder(code)
         builder.apply(block)
         return builder.permissions()

--- a/common/src/main/kotlin/com/gitlab/kordlib/common/ratelimit/RateLimiter.kt
+++ b/common/src/main/kotlin/com/gitlab/kordlib/common/ratelimit/RateLimiter.kt
@@ -1,5 +1,9 @@
 package com.gitlab.kordlib.common.ratelimit
 
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+
 /**
  * A rate limiter that limits the amount of [consume] invocations that can be made over a certain period.
  */
@@ -18,7 +22,11 @@ interface RateLimiter {
  *
  * @param action The action that correlates to a single permit.
  */
+@OptIn(ExperimentalContracts::class)
 suspend inline fun <T> RateLimiter.consume(action: () -> T): T {
+    contract {
+        callsInPlace(action, InvocationKind.EXACTLY_ONCE)
+    }
     consume()
     return action()
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/GuildBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/GuildBehavior.kt
@@ -33,6 +33,9 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import java.util.*
 import com.gitlab.kordlib.rest.service.RestClient
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 
 /**
  * The behavior of a [Discord Guild](https://discord.com/developers/docs/resources/guild).
@@ -389,14 +392,22 @@ interface GuildBehavior : Entity, Strategizable {
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
+@OptIn(ExperimentalContracts::class)
 suspend inline fun GuildBehavior.edit(builder: GuildModifyBuilder.() -> Unit): Guild {
+    contract {
+        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+    }
     val response = kord.rest.guild.modifyGuild(id.value, builder)
     val data = GuildData.from(response)
 
     return Guild(data, kord)
 }
 
+@OptIn(ExperimentalContracts::class)
 suspend inline fun GuildBehavior.createEmoji(builder: EmojiCreateBuilder.() -> Unit) {
+    contract {
+        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+    }
     kord.rest.emoji.createEmoji(guildId = id.value, builder = builder)
 }
 
@@ -407,7 +418,11 @@ suspend inline fun GuildBehavior.createEmoji(builder: EmojiCreateBuilder.() -> U
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
+@OptIn(ExperimentalContracts::class)
 suspend inline fun GuildBehavior.createTextChannel(builder: TextChannelCreateBuilder.() -> Unit): TextChannel {
+    contract {
+        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+    }
     val response = kord.rest.guild.createTextChannel(id.value, builder)
     val data = ChannelData.from(response)
 
@@ -421,8 +436,11 @@ suspend inline fun GuildBehavior.createTextChannel(builder: TextChannelCreateBui
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
-@Suppress("NAME_SHADOWING")
+@OptIn(ExperimentalContracts::class)
 suspend inline fun GuildBehavior.createVoiceChannel(builder: VoiceChannelCreateBuilder.() -> Unit): VoiceChannel {
+    contract {
+        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+    }
     val response = kord.rest.guild.createVoiceChannel(id.value, builder)
     val data = ChannelData.from(response)
 
@@ -436,8 +454,12 @@ suspend inline fun GuildBehavior.createVoiceChannel(builder: VoiceChannelCreateB
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
+@OptIn(ExperimentalContracts::class)
 @KordPreview
 suspend inline fun GuildBehavior.createNewsChannel(builder: NewsChannelCreateBuilder.() -> Unit): NewsChannel {
+    contract {
+        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+    }
     val response = kord.rest.guild.createNewsChannel(id.value, builder)
     val data = ChannelData.from(response)
 
@@ -451,7 +473,11 @@ suspend inline fun GuildBehavior.createNewsChannel(builder: NewsChannelCreateBui
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
+@OptIn(ExperimentalContracts::class)
 suspend inline fun GuildBehavior.createCategory(builder: CategoryCreateBuilder.() -> Unit): Category {
+    contract {
+        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+    }
     val response = kord.rest.guild.createCategory(id.value, builder)
     val data = ChannelData.from(response)
 
@@ -463,7 +489,11 @@ suspend inline fun GuildBehavior.createCategory(builder: CategoryCreateBuilder.(
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
+@OptIn(ExperimentalContracts::class)
 suspend inline fun GuildBehavior.swapChannelPositions(builder: GuildChannelPositionModifyBuilder.() -> Unit) {
+    contract {
+        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+    }
     kord.rest.guild.modifyGuildChannelPosition(id.value, builder)
 }
 
@@ -476,8 +506,11 @@ suspend inline fun GuildBehavior.swapChannelPositions(builder: GuildChannelPosit
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
-@Suppress("NAME_SHADOWING")
+@OptIn(ExperimentalContracts::class)
 suspend inline fun GuildBehavior.swapRolePositions(builder: RolePositionsModifyBuilder.() -> Unit): Flow<Role> {
+    contract {
+        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+    }
     val response = kord.rest.guild.modifyGuildRolePosition(id.value, builder)
     return response.asFlow().map { RoleData.from(id.value, it) }.map { Role(it, kord) }
 
@@ -490,8 +523,11 @@ suspend inline fun GuildBehavior.swapRolePositions(builder: RolePositionsModifyB
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
-@Suppress("NAME_SHADOWING")
+@OptIn(ExperimentalContracts::class)
 suspend inline fun GuildBehavior.addRole(builder: RoleCreateBuilder.() -> Unit): Role {
+    contract {
+        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+    }
     val response = kord.rest.guild.createGuildRole(id.value, builder)
     val data = RoleData.from(id.value, response)
 
@@ -503,7 +539,11 @@ suspend inline fun GuildBehavior.addRole(builder: RoleCreateBuilder.() -> Unit):
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
+@OptIn(ExperimentalContracts::class)
 suspend inline fun GuildBehavior.ban(userId: Snowflake, builder: BanCreateBuilder.() -> Unit) {
+    contract {
+        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+    }
     kord.rest.guild.addGuildBan(guildId = id.value, userId = userId.value, builder = builder)
 }
 

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/MemberBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/MemberBehavior.kt
@@ -14,6 +14,9 @@ import com.gitlab.kordlib.rest.builder.ban.BanCreateBuilder
 import com.gitlab.kordlib.rest.builder.member.MemberModifyBuilder
 import com.gitlab.kordlib.rest.request.RestRequestException
 import java.util.*
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 
 /**
  * The behavior of a [Discord Member](https://discord.com/developers/docs/resources/guild#guild-member-object).
@@ -191,13 +194,23 @@ interface MemberBehavior : Entity, UserBehavior {
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
-suspend inline fun MemberBehavior.ban(builder: BanCreateBuilder.() -> Unit = {}) = guild.ban(id, builder)
+@OptIn(ExperimentalContracts::class)
+suspend inline fun MemberBehavior.ban(builder: BanCreateBuilder.() -> Unit = {}) {
+    contract {
+        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+    }
+    guild.ban(id, builder)
+}
 
 /**
  * Requests to edit this member.
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
+@OptIn(ExperimentalContracts::class)
 suspend inline fun MemberBehavior.edit(builder: MemberModifyBuilder.() -> Unit) {
+    contract {
+        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+    }
     kord.rest.guild.modifyGuildMember(guildId.value, id.value, builder)
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/MessageBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/MessageBehavior.kt
@@ -19,6 +19,9 @@ import kotlinx.coroutines.flow.map
 import java.util.*
 import com.gitlab.kordlib.rest.request.RestRequestException
 import com.gitlab.kordlib.common.entity.Permission
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 
 /**
  * The behavior of a [Discord Message](https://discord.com/developers/docs/resources/channel#message-object).
@@ -199,7 +202,11 @@ interface MessageBehavior : Entity, Strategizable {
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
+@OptIn(ExperimentalContracts::class)
 suspend inline fun MessageBehavior.edit(builder: MessageModifyBuilder.() -> Unit): Message {
+    contract {
+        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+    }
     val response = kord.rest.channel.editMessage(channelId = channelId.value, messageId = id.value, builder = builder)
     val data = MessageData.from(response)
 

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/RoleBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/RoleBehavior.kt
@@ -16,6 +16,9 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.map
 import java.util.*
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 
 /**
  * The behavior of a [Discord Role](https://discord.com/developers/docs/topics/permissions#role-object) associated to a [guild].
@@ -97,8 +100,11 @@ interface RoleBehavior : Entity, Strategizable {
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
-@Suppress("NAME_SHADOWING")
+@OptIn(ExperimentalContracts::class)
 suspend inline fun RoleBehavior.edit(builder: RoleModifyBuilder.() -> Unit): Role {
+    contract {
+        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+    }
     val response = kord.rest.guild.modifyGuildRole(guildId = guildId.value, roleId = id.value, builder = builder)
     val data = RoleData.from(id.value, response)
 

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/WebhookBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/WebhookBehavior.kt
@@ -14,6 +14,9 @@ import com.gitlab.kordlib.rest.builder.webhook.ExecuteWebhookBuilder
 import com.gitlab.kordlib.rest.builder.webhook.WebhookModifyBuilder
 import com.gitlab.kordlib.rest.request.RestRequestException
 import java.util.*
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 
 /**
  * The behavior of a [Discord Webhook](https://discord.com/developers/docs/resources/webhook).
@@ -72,8 +75,11 @@ interface WebhookBehavior : Entity, Strategizable {
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
-@Suppress("NAME_SHADOWING")
+@OptIn(ExperimentalContracts::class)
 suspend inline fun WebhookBehavior.edit(builder: WebhookModifyBuilder.() -> Unit): Webhook {
+    contract {
+        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+    }
     val response = kord.rest.webhook.modifyWebhook(id.value, builder)
     val data = WebhookData.from(response)
 
@@ -87,8 +93,11 @@ suspend inline fun WebhookBehavior.edit(builder: WebhookModifyBuilder.() -> Unit
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
-@Suppress("NAME_SHADOWING")
+@OptIn(ExperimentalContracts::class)
 suspend inline fun WebhookBehavior.edit(token: String, builder: WebhookModifyBuilder.() -> Unit): Webhook {
+    contract {
+        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+    }
     val response = kord.rest.webhook.modifyWebhookWithToken(id.value, token, builder)
     val data = WebhookData.from(response)
 
@@ -100,7 +109,11 @@ suspend inline fun WebhookBehavior.edit(token: String, builder: WebhookModifyBui
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
+@OptIn(ExperimentalContracts::class)
 suspend inline fun WebhookBehavior.execute(token: String, builder: ExecuteWebhookBuilder.() -> Unit): Message {
+    contract {
+        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+    }
     val response = kord.rest.webhook.executeWebhook(
             token = token,
             webhookId = id.value,
@@ -119,7 +132,11 @@ suspend inline fun WebhookBehavior.execute(token: String, builder: ExecuteWebhoo
  * This is a 'fire and forget' variant of [execute]. It will not wait for a response and might not throw an
  * Exception if the request wasn't executed.
  */
+@OptIn(ExperimentalContracts::class)
 suspend inline fun WebhookBehavior.executeIgnored(token: String, builder: ExecuteWebhookBuilder.() -> Unit) {
+    contract {
+        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+    }
     kord.rest.webhook.executeWebhook(token = token, webhookId = id.value, wait = false, builder = builder)
 }
 

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/GuildChannelBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/GuildChannelBehavior.kt
@@ -20,6 +20,9 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.withIndex
 import java.util.*
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 
 /**
  * The behavior of a Discord channel associated to a [guild].
@@ -150,7 +153,11 @@ interface GuildChannelBehavior : ChannelBehavior, Strategizable {
  *
  *  @throws [RestRequestException] if something went wrong during the request.
  */
+@OptIn(ExperimentalContracts::class)
 suspend inline fun GuildChannelBehavior.editRolePermission(roleId: Snowflake, builder: ChannelPermissionModifyBuilder.() -> Unit) {
+    contract {
+        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+    }
     kord.rest.channel.editRolePermission(channelId = id.value, roleId = roleId.value, builder = builder)
 }
 
@@ -159,6 +166,10 @@ suspend inline fun GuildChannelBehavior.editRolePermission(roleId: Snowflake, bu
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
+@OptIn(ExperimentalContracts::class)
 suspend inline fun GuildChannelBehavior.editMemberPermission(memberId: Snowflake, builder: ChannelPermissionModifyBuilder.() -> Unit) {
+    contract {
+        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+    }
     kord.rest.channel.editMemberPermissions(channelId = id.value, memberId = memberId.value, builder = builder)
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/GuildMessageChannelBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/GuildMessageChannelBehavior.kt
@@ -18,6 +18,9 @@ import kotlinx.coroutines.flow.flow
 import java.time.Duration
 import java.time.Instant
 import java.util.*
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 import kotlin.time.days
 import kotlin.time.toJavaDuration
 
@@ -111,7 +114,11 @@ interface GuildMessageChannelBehavior : GuildChannelBehavior, MessageChannelBeha
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
+@OptIn(ExperimentalContracts::class)
 suspend inline fun GuildMessageChannelBehavior.createWebhook(builder: WebhookCreateBuilder.() -> Unit): Webhook {
+    contract {
+        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+    }
     val response = kord.rest.webhook.createWebhook(id.value, builder)
     val data = WebhookData.from(response)
 

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/MessageChannelBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/MessageChannelBehavior.kt
@@ -265,7 +265,7 @@ suspend inline fun MessageChannelBehavior.createEmbed(block: EmbedBuilder.() -> 
     contract {
         callsInPlace(block, InvocationKind.EXACTLY_ONCE)
     }
-    createMessage { embed(block) }
+    return createMessage { embed(block) }
 }
 
 /**

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/MessageChannelBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/MessageChannelBehavior.kt
@@ -20,6 +20,9 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 import java.time.Instant
 import java.util.*
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 import kotlin.coroutines.coroutineContext
 import kotlin.time.TimeMark
 import kotlin.time.seconds
@@ -241,7 +244,11 @@ interface MessageChannelBehavior : ChannelBehavior, Strategizable {
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
+@OptIn(ExperimentalContracts::class)
 suspend inline fun MessageChannelBehavior.createMessage(builder: MessageCreateBuilder.() -> Unit): Message {
+    contract {
+        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+    }
     val response = kord.rest.channel.createMessage(id.value, builder)
     val data = MessageData.from(response)
 
@@ -253,7 +260,13 @@ suspend inline fun MessageChannelBehavior.createMessage(builder: MessageCreateBu
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
-suspend inline fun MessageChannelBehavior.createEmbed(block: EmbedBuilder.() -> Unit): Message = createMessage { embed(block) }
+@OptIn(ExperimentalContracts::class)
+suspend inline fun MessageChannelBehavior.createEmbed(block: EmbedBuilder.() -> Unit): Message {
+    contract {
+        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+    }
+    createMessage { embed(block) }
+}
 
 /**
  * Requests to trigger the typing indicator for the bot in this channel.
@@ -268,7 +281,11 @@ suspend inline fun MessageChannelBehavior.createEmbed(block: EmbedBuilder.() -> 
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
+@OptIn(ExperimentalContracts::class)
 suspend inline fun <T : MessageChannelBehavior> T.withTyping(block: T.() -> Unit) {
+    contract {
+        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+    }
     var typing = true
 
     kord.launch(context = coroutineContext) {

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/NewsChannelBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/NewsChannelBehavior.kt
@@ -16,6 +16,9 @@ import com.gitlab.kordlib.rest.service.patchNewsChannel
 import java.util.*
 import com.gitlab.kordlib.common.entity.Permission
 import com.gitlab.kordlib.rest.json.request.ChannelFollowRequest
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 
 /**
  * The behavior of a Discord News Channel associated to a guild.
@@ -83,7 +86,11 @@ interface NewsChannelBehavior : GuildMessageChannelBehavior {
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
+@OptIn(ExperimentalContracts::class)
 suspend inline fun NewsChannelBehavior.edit(builder: NewsChannelModifyBuilder.() -> Unit): NewsChannel {
+    contract {
+        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+    }
     val response = kord.rest.channel.patchNewsChannel(id.value, builder)
     val data = ChannelData.from(response)
 

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/VoiceChannelBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/VoiceChannelBehavior.kt
@@ -18,6 +18,9 @@ import com.gitlab.kordlib.rest.service.patchVoiceChannel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import java.util.*
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 
 /**
  * The behavior of a Discord Voice Channel associated to a guild.
@@ -85,7 +88,11 @@ interface VoiceChannelBehavior : GuildChannelBehavior {
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
+@OptIn(ExperimentalContracts::class)
 suspend inline fun VoiceChannelBehavior.edit(builder: VoiceChannelModifyBuilder.() -> Unit): VoiceChannel {
+    contract {
+        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+    }
     val response = kord.rest.channel.patchVoiceChannel(id.value, builder)
 
     val data = ChannelData.from(response)

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/builder/kord/KordBuilder.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/builder/kord/KordBuilder.kt
@@ -42,6 +42,9 @@ import kotlinx.serialization.json.JsonConfiguration
 import kotlinx.serialization.parse
 import mu.KotlinLogging
 import kotlin.concurrent.thread
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 import kotlin.time.seconds
 
 operator fun DefaultGateway.Companion.invoke(resources: ClientResources, retry: Retry = LinearRetry(2.seconds, 60.seconds, 10)) =
@@ -142,7 +145,11 @@ class KordBuilder(val token: String) {
      * }
      * ```
      */
+    @OptIn(ExperimentalContracts::class)
     inline fun intents(builder: Intents.IntentsBuilder.() -> Unit) {
+        contract {
+            callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+        }
         intents = Intents { builder() }
     }
 

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/GuildEmoji.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/GuildEmoji.kt
@@ -16,6 +16,9 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filter
 import java.util.*
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 
 /**
  * An instance of a [Discord emoji](https://discord.com/developers/docs/resources/emoji#emoji-object) belonging to a specific guild.
@@ -114,7 +117,11 @@ class GuildEmoji(
      *
      *  @throws [RequestException] if anything went wrong during the request.
      */
+    @OptIn(ExperimentalContracts::class)
     suspend inline fun edit(builder: EmojiModifyBuilder.() -> Unit) {
+        contract {
+            callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+        }
         kord.rest.emoji.modifyEmoji(guildId = guildId.value, emojiId = id.value, builder = builder)
     }
 

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Integration.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Integration.kt
@@ -18,6 +18,9 @@ import java.time.Duration
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.*
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 
 /**
  * A [Discord integration](https://discord.com/developers/docs/resources/guild#get-guild-integrations).
@@ -177,7 +180,11 @@ class Integration(
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
+@OptIn(ExperimentalContracts::class)
 suspend inline fun Integration.edit(builder: IntegrationModifyBuilder.() -> Unit) {
+    contract {
+        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+    }
     kord.rest.guild.modifyGuildIntegration(guildId.value, id.value, builder)
 }
 

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/channel/CategorizableChannel.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/channel/CategorizableChannel.kt
@@ -7,6 +7,9 @@ import com.gitlab.kordlib.core.entity.Invite
 import com.gitlab.kordlib.core.toSnowflakeOrNull
 import com.gitlab.kordlib.rest.builder.channel.InviteCreateBuilder
 import com.gitlab.kordlib.rest.request.RestRequestException
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 
 /**
  * An instance of a Discord channel associated to a [category].
@@ -35,7 +38,11 @@ interface CategorizableChannel : GuildChannel {
      * @return the created [Invite].
      * @throws RestRequestException if something went wrong during the request.
      */
+    @OptIn(ExperimentalContracts::class)
     suspend fun createInvite(builder: InviteCreateBuilder.() -> Unit): Invite {
+        contract {
+            callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+        }
         val response = kord.rest.channel.createInvite(id.value, builder)
         val data = InviteData.from(response)
 

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/channel/CategorizableChannel.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/channel/CategorizableChannel.kt
@@ -38,11 +38,7 @@ interface CategorizableChannel : GuildChannel {
      * @return the created [Invite].
      * @throws RestRequestException if something went wrong during the request.
      */
-    @OptIn(ExperimentalContracts::class)
     suspend fun createInvite(builder: InviteCreateBuilder.() -> Unit): Invite {
-        contract {
-            callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
-        }
         val response = kord.rest.channel.createInvite(id.value, builder)
         val data = InviteData.from(response)
 

--- a/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/Gateway.kt
+++ b/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/Gateway.kt
@@ -10,6 +10,9 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.receiveAsFlow
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 import kotlin.time.Duration
 
 /**
@@ -88,7 +91,11 @@ interface Gateway {
     }
 }
 
+@OptIn(ExperimentalContracts::class)
 suspend inline fun Gateway.editPresence(builder: PresenceBuilder.() -> Unit) {
+    contract {
+        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+    }
     val status = PresenceBuilder().apply(builder).toUpdateStatus()
     send(status)
 }
@@ -115,7 +122,11 @@ suspend inline fun Gateway.editPresence(builder: PresenceBuilder.() -> Unit) {
  * @param token The Discord token of the bot.
  * @param config additional configuration for the gateway.
  */
+@OptIn(ExperimentalContracts::class)
 suspend inline fun Gateway.start(token: String, config: GatewayConfigurationBuilder.() -> Unit = {}) {
+    contract {
+        callsInPlace(config, InvocationKind.EXACTLY_ONCE)
+    }
     val builder = GatewayConfigurationBuilder(token)
     builder.apply(config)
     start(builder.build())

--- a/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/GatewayConfiguration.kt
+++ b/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/GatewayConfiguration.kt
@@ -2,6 +2,9 @@ package com.gitlab.kordlib.gateway
 
 import com.gitlab.kordlib.common.entity.DiscordShard
 import com.gitlab.kordlib.gateway.builder.PresenceBuilder
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 
 data class GatewayConfiguration(
         val token: String,
@@ -41,7 +44,11 @@ data class GatewayConfigurationBuilder(
     /**
      * Calls the [builder] on a new [PresenceBuilder] and assigns the result to [presence].
      */
+    @OptIn(ExperimentalContracts::class)
     inline fun presence(builder: PresenceBuilder.() -> Unit) {
+        contract {
+            callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+        }
         presence = PresenceBuilder().apply(builder).toPresence()
     }
 

--- a/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/Intent.kt
+++ b/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/Intent.kt
@@ -7,6 +7,9 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlin.RequiresOptIn.*
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 
 /**
  * Some intents are defined as "Privileged" due to the sensitive nature of the data and cannot be used by Kord without enabling them.
@@ -171,7 +174,11 @@ data class Intents internal constructor(val code: Int) {
     /**
      * copy this [Intents] and apply the [block] to it.
      */
+    @OptIn(ExperimentalContracts::class)
     inline fun copy(block: IntentsBuilder.() -> Unit): Intents {
+        contract {
+            callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+        }
         val builder = IntentsBuilder(code)
         builder.apply(block)
         return builder.flags()

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/channel/CategoryCreateBuilder.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/channel/CategoryCreateBuilder.kt
@@ -6,6 +6,9 @@ import com.gitlab.kordlib.rest.builder.AuditRequestBuilder
 import com.gitlab.kordlib.common.annotation.KordDsl
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.rest.json.request.GuildCreateChannelRequest
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 
 @KordDsl
 class CategoryCreateBuilder : AuditRequestBuilder<GuildCreateChannelRequest> {
@@ -18,14 +21,22 @@ class CategoryCreateBuilder : AuditRequestBuilder<GuildCreateChannelRequest> {
     /**
      * adds a [Overwrite] for the [memberId].
      */
+    @OptIn(ExperimentalContracts::class)
     inline fun addMemberOverwrite(memberId: Snowflake, builder: PermissionOverwriteBuilder.() -> Unit){
+        contract {
+            callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+        }
         permissionOverwrites += PermissionOverwriteBuilder("member", memberId).apply(builder).toOverwrite()
     }
 
     /**
      * adds a [Overwrite] for the [roleId].
      */
+    @OptIn(ExperimentalContracts::class)
     inline fun addRoleOverwrite(roleId: Snowflake, builder: PermissionOverwriteBuilder.() -> Unit){
+        contract {
+            callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+        }
         permissionOverwrites += PermissionOverwriteBuilder("role", roleId).apply(builder).toOverwrite()
     }
 

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/channel/CategoryModifyBuilder.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/channel/CategoryModifyBuilder.kt
@@ -5,6 +5,9 @@ import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.rest.builder.AuditRequestBuilder
 import com.gitlab.kordlib.common.annotation.KordDsl
 import com.gitlab.kordlib.rest.json.request.ChannelModifyPatchRequest
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 
 @KordDsl
 class CategoryModifyBuilder: AuditRequestBuilder<ChannelModifyPatchRequest> {
@@ -28,14 +31,22 @@ class CategoryModifyBuilder: AuditRequestBuilder<ChannelModifyPatchRequest> {
     /**
      * adds a [Overwrite] for the [memberId].
      */
+    @OptIn(ExperimentalContracts::class)
     inline fun addMemberOverwrite(memberId: Snowflake, builder: PermissionOverwriteBuilder.() -> Unit){
+        contract {
+            callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+        }
         permissionOverwrites = (permissionOverwrites ?: mutableSetOf()).also { it.add(PermissionOverwriteBuilder("member", memberId).apply(builder).toOverwrite()) }
     }
 
     /**
      * adds a [Overwrite] for the [roleId].
      */
+    @OptIn(ExperimentalContracts::class)
     inline fun addRoleOverwrite(roleId: Snowflake, builder: PermissionOverwriteBuilder.() -> Unit){
+        contract {
+            callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+        }
         permissionOverwrites = (permissionOverwrites ?: mutableSetOf()).also { PermissionOverwriteBuilder("role", roleId).apply(builder).toOverwrite() }
     }
 

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/guild/GuildCreateBuilder.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/guild/GuildCreateBuilder.kt
@@ -13,6 +13,9 @@ import com.gitlab.kordlib.rest.builder.role.RoleCreateBuilder
 import com.gitlab.kordlib.rest.json.request.GuildCreateChannelRequest
 import com.gitlab.kordlib.rest.json.request.GuildCreateRequest
 import com.gitlab.kordlib.rest.json.request.GuildRoleCreateRequest
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 import kotlin.random.Random
 
 @KordDsl
@@ -60,27 +63,47 @@ class GuildCreateBuilder : RequestBuilder<GuildCreateRequest> {
      */
     val systemChannelId: Snowflake? = null
 
+    @OptIn(ExperimentalContracts::class)
     inline fun textChannel(id: Snowflake = newUniqueSnowflake(), builder: TextChannelCreateBuilder.() -> Unit): Snowflake {
+        contract {
+            callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+        }
         channels.add(TextChannelCreateBuilder().apply(builder).toRequest().copy(id = id.value))
         return id
     }
 
+    @OptIn(ExperimentalContracts::class)
     inline fun newsChannel(id: Snowflake = newUniqueSnowflake(), builder: NewsChannelCreateBuilder.() -> Unit): Snowflake {
+        contract {
+            callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+        }
         channels.add(NewsChannelCreateBuilder().apply(builder).toRequest().copy(id = id.value))
         return id
     }
 
+    @OptIn(ExperimentalContracts::class)
     inline fun category(id: Snowflake = newUniqueSnowflake(), builder: CategoryCreateBuilder.() -> Unit): Snowflake {
+        contract {
+            callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+        }
         channels.add(CategoryCreateBuilder().apply(builder).toRequest().copy(id = id.value))
         return id
     }
 
+    @OptIn(ExperimentalContracts::class)
     inline fun role(id: Snowflake = newUniqueSnowflake(), builder: RoleCreateBuilder.() -> Unit): Snowflake {
+        contract {
+            callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+        }
         roles += RoleCreateBuilder().apply(builder).toRequest().copy(id = id.value)
         return id
     }
 
+    @OptIn(ExperimentalContracts::class)
     inline fun everyoneRole(builder: RoleCreateBuilder.() -> Unit) {
+        contract {
+            callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+        }
         everyoneRole = RoleCreateBuilder().apply(builder)
     }
 

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/message/MessageModifyBuilder.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/message/MessageModifyBuilder.kt
@@ -4,6 +4,9 @@ import com.gitlab.kordlib.common.entity.Flags
 import com.gitlab.kordlib.common.annotation.KordDsl
 import com.gitlab.kordlib.rest.builder.RequestBuilder
 import com.gitlab.kordlib.rest.json.request.MessageEditPatchRequest
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 
 @KordDsl
 class MessageModifyBuilder : RequestBuilder<MessageEditPatchRequest> {
@@ -12,7 +15,11 @@ class MessageModifyBuilder : RequestBuilder<MessageEditPatchRequest> {
     var flags: Flags? = null
     var allowedMentions: AllowedMentionsBuilder? = null
 
+    @OptIn(ExperimentalContracts::class)
     inline fun embed(block: EmbedBuilder.() -> Unit) {
+        contract {
+            callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+        }
         embed = (embed ?: EmbedBuilder()).also(block)
     }
 
@@ -21,7 +28,11 @@ class MessageModifyBuilder : RequestBuilder<MessageEditPatchRequest> {
      * (ping everything), calling this function but not configuring it before the request is build will result in all
      * pings being ignored.
      */
+    @OptIn(ExperimentalContracts::class)
     inline fun allowedMentions(block: AllowedMentionsBuilder.() -> Unit = {}) {
+        contract {
+            callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+        }
         allowedMentions = (allowedMentions ?: AllowedMentionsBuilder()).apply(block)
     }
 

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/webhook/ExecuteWebhookBuilder.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/builder/webhook/ExecuteWebhookBuilder.kt
@@ -10,6 +10,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.nio.file.Files
 import java.nio.file.Path
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 
 @KordDsl
 class ExecuteWebhookBuilder: RequestBuilder<MultiPartWebhookExecuteRequest> {
@@ -28,7 +31,11 @@ class ExecuteWebhookBuilder: RequestBuilder<MultiPartWebhookExecuteRequest> {
         setFile(path.fileName.toString(), Files.newInputStream(path))
     }
 
+    @OptIn(ExperimentalContracts::class)
     inline fun embed(builder: EmbedBuilder.() -> Unit) {
+        contract {
+            callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+        }
         embeds += EmbedBuilder().apply(builder).toRequest()
     }
 

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/ratelimit/RequestRateLimiter.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/ratelimit/RequestRateLimiter.kt
@@ -3,6 +3,9 @@ package com.gitlab.kordlib.rest.ratelimit
 import com.gitlab.kordlib.rest.request.Request
 import java.lang.Exception
 import java.time.Instant
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 
 /**
  * A rate limiter that follows [Discord's rate limits](https://discord.com/developers/docs/topics/rate-limits) for
@@ -22,10 +25,14 @@ interface RequestRateLimiter {
  * [Awaits][RequestRateLimiter.await] the rate limits for the [request] and then runs [consumer].
  * Throws an [IllegalStateException] if the supplied [RequestToken] was not completed.
  */
+@OptIn(ExperimentalContracts::class)
 suspend inline fun <T> RequestRateLimiter.consume(
         request: Request<*, *>,
         consumer: (token: RequestToken) -> T
 ): T {
+    contract {
+        callsInPlace(consumer, InvocationKind.EXACTLY_ONCE)
+    }
     val token = await(request)
     try {
         val result = consumer(token)

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/service/ChannelService.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/service/ChannelService.kt
@@ -1,23 +1,34 @@
 package com.gitlab.kordlib.rest.service
 
 import com.gitlab.kordlib.common.annotation.KordPreview
+import com.gitlab.kordlib.common.entity.DiscordChannel
 import com.gitlab.kordlib.common.entity.DiscordMessage
 import com.gitlab.kordlib.rest.builder.channel.*
 import com.gitlab.kordlib.rest.builder.message.MessageCreateBuilder
 import com.gitlab.kordlib.rest.builder.message.MessageModifyBuilder
 import com.gitlab.kordlib.rest.json.request.*
 import com.gitlab.kordlib.rest.json.response.FollowedChannelResponse
+import com.gitlab.kordlib.rest.json.response.InviteResponse
 import com.gitlab.kordlib.rest.request.RequestHandler
 import com.gitlab.kordlib.rest.route.Position
 import com.gitlab.kordlib.rest.route.Route
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 
 class ChannelService(requestHandler: RequestHandler) : RestService(requestHandler) {
 
-    suspend inline fun createMessage(channelId: String, builder: MessageCreateBuilder.() -> Unit) = call(Route.MessagePost) {
-        keys[Route.ChannelId] = channelId
-        val multipartRequest = MessageCreateBuilder().apply(builder).toRequest()
-        body(MessageCreateRequest.serializer(), multipartRequest.request)
-        multipartRequest.files.forEach { file(it) }
+    @OptIn(ExperimentalContracts::class)
+    suspend inline fun createMessage(channelId: String, builder: MessageCreateBuilder.() -> Unit): DiscordMessage {
+        contract {
+            callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+        }
+        return call(Route.MessagePost) {
+            keys[Route.ChannelId] = channelId
+            val multipartRequest = MessageCreateBuilder().apply(builder).toRequest()
+            body(MessageCreateRequest.serializer(), multipartRequest.request)
+            multipartRequest.files.forEach { file(it) }
+        }
     }
 
     suspend fun getMessages(channelId: String, position: Position? = null, limit: Int = 50) = call(Route.MessagesGet) {
@@ -141,17 +152,29 @@ class ChannelService(requestHandler: RequestHandler) : RestService(requestHandle
         body(UserAddDMRequest.serializer(), addUser)
     }
 
-    suspend inline fun createInvite(channelId: String, builder: InviteCreateBuilder.() -> Unit = {}) = call(Route.InvitePost) {
-        keys[Route.ChannelId] = channelId
-        val request = InviteCreateBuilder().apply(builder)
-        body(InviteCreateRequest.serializer(), request.toRequest())
-        request.reason?.let { header("X-Audit-Log-Reason", it) }
+    @OptIn(ExperimentalContracts::class)
+    suspend inline fun createInvite(channelId: String, builder: InviteCreateBuilder.() -> Unit = {}): InviteResponse {
+        contract {
+            callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+        }
+        return call(Route.InvitePost) {
+            keys[Route.ChannelId] = channelId
+            val request = InviteCreateBuilder().apply(builder)
+            body(InviteCreateRequest.serializer(), request.toRequest())
+            request.reason?.let { header("X-Audit-Log-Reason", it) }
+        }
     }
 
-    suspend inline fun editMessage(channelId: String, messageId: String, builder: MessageModifyBuilder.() -> Unit) = call(Route.EditMessagePatch) {
-        keys[Route.ChannelId] = channelId
-        keys[Route.MessageId] = messageId
-        body(MessageEditPatchRequest.serializer(), MessageModifyBuilder().apply(builder).toRequest())
+    @OptIn(ExperimentalContracts::class)
+    suspend inline fun editMessage(channelId: String, messageId: String, builder: MessageModifyBuilder.() -> Unit): DiscordMessage {
+        contract {
+            callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+        }
+        return call(Route.EditMessagePatch) {
+            keys[Route.ChannelId] = channelId
+            keys[Route.MessageId] = messageId
+            body(MessageEditPatchRequest.serializer(), MessageModifyBuilder().apply(builder).toRequest())
+        }
     }
 
 
@@ -181,27 +204,60 @@ class ChannelService(requestHandler: RequestHandler) : RestService(requestHandle
 
 }
 
-suspend inline fun ChannelService.patchTextChannel(channelId: String, builder: TextChannelModifyBuilder.() -> Unit) =
-        patchChannel(channelId, TextChannelModifyBuilder().apply(builder).toRequest())
+@OptIn(ExperimentalContracts::class)
+suspend inline fun ChannelService.patchTextChannel(channelId: String, builder: TextChannelModifyBuilder.() -> Unit): DiscordChannel {
+    contract {
+        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+    }
+    return patchChannel(channelId, TextChannelModifyBuilder().apply(builder).toRequest())
+}
 
-suspend inline fun ChannelService.patchVoiceChannel(channelId: String, builder: VoiceChannelModifyBuilder.() -> Unit) =
-        patchChannel(channelId, VoiceChannelModifyBuilder().apply(builder).toRequest())
+@OptIn(ExperimentalContracts::class)
+suspend inline fun ChannelService.patchVoiceChannel(channelId: String, builder: VoiceChannelModifyBuilder.() -> Unit) : DiscordChannel {
+    contract {
+        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+    }
+    return patchChannel(channelId, VoiceChannelModifyBuilder().apply(builder).toRequest())
+}
 
-suspend inline fun ChannelService.patchStoreChannel(channelId: String, builder: StoreChannelModifyBuilder.() -> Unit) =
-        patchChannel(channelId, StoreChannelModifyBuilder().apply(builder).toRequest())
+@OptIn(ExperimentalContracts::class)
+suspend inline fun ChannelService.patchStoreChannel(channelId: String, builder: StoreChannelModifyBuilder.() -> Unit): DiscordChannel {
+    contract {
+        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+    }
+    return patchChannel(channelId, StoreChannelModifyBuilder().apply(builder).toRequest())
+}
 
-suspend inline fun ChannelService.patchNewsChannel(channelId: String, builder: NewsChannelModifyBuilder.() -> Unit) =
-        patchChannel(channelId, NewsChannelModifyBuilder().apply(builder).toRequest())
+@OptIn(ExperimentalContracts::class)
+suspend inline fun ChannelService.patchNewsChannel(channelId: String, builder: NewsChannelModifyBuilder.() -> Unit): DiscordChannel {
+    contract {
+        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+    }
+    return patchChannel(channelId, NewsChannelModifyBuilder().apply(builder).toRequest())
+}
 
-suspend inline fun ChannelService.patchCategory(channelId: String, builder: CategoryModifyBuilder.() -> Unit) =
-        patchChannel(channelId, CategoryModifyBuilder().apply(builder).toRequest())
+@OptIn(ExperimentalContracts::class)
+suspend inline fun ChannelService.patchCategory(channelId: String, builder: CategoryModifyBuilder.() -> Unit) : DiscordChannel {
+    contract {
+        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+    }
+    return patchChannel(channelId, CategoryModifyBuilder().apply(builder).toRequest())
+}
 
+@OptIn(ExperimentalContracts::class)
 suspend inline fun ChannelService.editMemberPermissions(channelId: String, memberId: String, builder: ChannelPermissionModifyBuilder.() -> Unit) {
+    contract {
+        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+    }
     val modifyBuilder = ChannelPermissionModifyBuilder("member").apply(builder)
     editChannelPermissions(channelId, memberId, modifyBuilder.toRequest(), modifyBuilder.reason)
 }
 
+@OptIn(ExperimentalContracts::class)
 suspend inline fun ChannelService.editRolePermission(channelId: String, roleId: String, builder: ChannelPermissionModifyBuilder.() -> Unit) {
+    contract {
+        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+    }
     val modifyBuilder = ChannelPermissionModifyBuilder("role").apply(builder)
     editChannelPermissions(channelId, roleId, modifyBuilder.toRequest(), modifyBuilder.reason)
 }

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/service/GuildService.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/service/GuildService.kt
@@ -24,11 +24,11 @@ import kotlin.contracts.contract
 class GuildService(requestHandler: RequestHandler) : RestService(requestHandler) {
 
     @OptIn(ExperimentalContracts::class)
-    suspend inline fun createGuild(builder: GuildCreateBuilder.() -> Unit) {
+    suspend inline fun createGuild(builder: GuildCreateBuilder.() -> Unit): DiscordGuild {
         contract {
             callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
         }
-        call(Route.GuildPost) {
+        return call(Route.GuildPost) {
             body(GuildCreateRequest.serializer(), GuildCreateBuilder().apply(builder).toRequest())
         }
     }

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/service/GuildService.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/service/GuildService.kt
@@ -1,6 +1,8 @@
 package com.gitlab.kordlib.rest.service
 
 import com.gitlab.kordlib.common.entity.DiscordChannel
+import com.gitlab.kordlib.common.entity.DiscordGuild
+import com.gitlab.kordlib.common.entity.DiscordRole
 import com.gitlab.kordlib.rest.builder.ban.BanCreateBuilder
 import com.gitlab.kordlib.rest.builder.channel.*
 import com.gitlab.kordlib.rest.builder.guild.GuildCreateBuilder
@@ -15,12 +17,20 @@ import com.gitlab.kordlib.rest.json.request.*
 import com.gitlab.kordlib.rest.request.RequestHandler
 import com.gitlab.kordlib.rest.route.Position
 import com.gitlab.kordlib.rest.route.Route
-import com.gitlab.kordlib.common.entity.DiscordGuild
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 
 class GuildService(requestHandler: RequestHandler) : RestService(requestHandler) {
 
-    suspend inline fun createGuild(builder: GuildCreateBuilder.() -> Unit) = call(Route.GuildPost) {
-        body(GuildCreateRequest.serializer(), GuildCreateBuilder().apply(builder).toRequest())
+    @OptIn(ExperimentalContracts::class)
+    suspend inline fun createGuild(builder: GuildCreateBuilder.() -> Unit) {
+        contract {
+            callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+        }
+        call(Route.GuildPost) {
+            body(GuildCreateRequest.serializer(), GuildCreateBuilder().apply(builder).toRequest())
+        }
     }
 
     /**
@@ -39,11 +49,18 @@ class GuildService(requestHandler: RequestHandler) : RestService(requestHandler)
         keys[Route.GuildId] = guildId
     }
 
-    suspend inline fun modifyGuild(guildId: String, builder: GuildModifyBuilder.() -> Unit) = call(Route.GuildPatch) {
-        keys[Route.GuildId] = guildId
-        val modifyBuilder = GuildModifyBuilder().apply(builder)
-        body(GuildModifyRequest.serializer(), modifyBuilder.toRequest())
-        modifyBuilder.reason?.let { header("X-Audit-Log-Reason", it) }
+    @OptIn(ExperimentalContracts::class)
+    suspend inline fun modifyGuild(guildId: String, builder: GuildModifyBuilder.() -> Unit): DiscordGuild {
+        contract {
+            callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+        }
+
+        return call(Route.GuildPatch) {
+            keys[Route.GuildId] = guildId
+            val modifyBuilder = GuildModifyBuilder().apply(builder)
+            body(GuildModifyRequest.serializer(), modifyBuilder.toRequest())
+            modifyBuilder.reason?.let { header("X-Audit-Log-Reason", it) }
+        }
     }
 
     suspend fun deleteGuild(guildId: String) = call(Route.GuildDelete) {
@@ -60,11 +77,18 @@ class GuildService(requestHandler: RequestHandler) : RestService(requestHandler)
         reason?.let { header("X-Audit-Log-Reason", it) }
     }
 
-    suspend inline fun modifyGuildChannelPosition(guildId: String, builder: GuildChannelPositionModifyBuilder.() -> Unit) = call(Route.GuildChannelsPatch) {
-        keys[Route.GuildId] = guildId
-        val modifyBuilder = GuildChannelPositionModifyBuilder().apply(builder)
-        body(GuildChannelPositionModifyRequest.Serializer, modifyBuilder.toRequest())
-        modifyBuilder.reason?.let { header("X-Audit-Log-Reason", it) }
+    @OptIn(ExperimentalContracts::class)
+    suspend inline fun modifyGuildChannelPosition(guildId: String, builder: GuildChannelPositionModifyBuilder.() -> Unit) {
+        contract {
+            callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+        }
+
+        call(Route.GuildChannelsPatch) {
+            keys[Route.GuildId] = guildId
+            val modifyBuilder = GuildChannelPositionModifyBuilder().apply(builder)
+            body(GuildChannelPositionModifyRequest.Serializer, modifyBuilder.toRequest())
+            modifyBuilder.reason?.let { header("X-Audit-Log-Reason", it) }
+        }
     }
 
     suspend fun getGuildMember(guildId: String, userId: String) = call(Route.GuildMemberGet) {
@@ -86,12 +110,19 @@ class GuildService(requestHandler: RequestHandler) : RestService(requestHandler)
         body(GuildMemberAddRequest.serializer(), MemberAddBuilder().also(builder).toRequest())
     }
 
-    suspend inline fun modifyGuildMember(guildId: String, userId: String, builder: MemberModifyBuilder.() -> Unit) = call(Route.GuildMemberPatch) {
-        keys[Route.GuildId] = guildId
-        keys[Route.UserId] = userId
-        val modifyBuilder = MemberModifyBuilder().apply(builder)
-        body(GuildMemberModifyRequest.serializer(), modifyBuilder.toRequest())
-        modifyBuilder.reason?.let { header("X-Audit-Log-Reason", it) }
+    @OptIn(ExperimentalContracts::class)
+    suspend inline fun modifyGuildMember(guildId: String, userId: String, builder: MemberModifyBuilder.() -> Unit) {
+        contract {
+            callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+        }
+
+        call(Route.GuildMemberPatch) {
+            keys[Route.GuildId] = guildId
+            keys[Route.UserId] = userId
+            val modifyBuilder = MemberModifyBuilder().apply(builder)
+            body(GuildMemberModifyRequest.serializer(), modifyBuilder.toRequest())
+            modifyBuilder.reason?.let { header("X-Audit-Log-Reason", it) }
+        }
     }
 
     suspend fun addRoleToGuildMember(guildId: String, userId: String, roleId: String, reason: String? = null) = call(Route.GuildMemberRolePut) {
@@ -123,12 +154,19 @@ class GuildService(requestHandler: RequestHandler) : RestService(requestHandler)
         keys[Route.UserId] = userId
     }
 
-    suspend inline fun addGuildBan(guildId: String, userId: String, builder: BanCreateBuilder.() -> Unit) = call(Route.GuildBanPut) {
-        keys[Route.GuildId] = guildId
-        keys[Route.UserId] = userId
-        val createBuilder = BanCreateBuilder().apply(builder)
-        body(GuildBanAddRequest.serializer(), createBuilder.toRequest())
-        createBuilder.reason?.let { header("X-Audit-Log-Reason", it) }
+    @OptIn(ExperimentalContracts::class)
+    suspend inline fun addGuildBan(guildId: String, userId: String, builder: BanCreateBuilder.() -> Unit) {
+        contract {
+            callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+        }
+
+        call(Route.GuildBanPut) {
+            keys[Route.GuildId] = guildId
+            keys[Route.UserId] = userId
+            val createBuilder = BanCreateBuilder().apply(builder)
+            body(GuildBanAddRequest.serializer(), createBuilder.toRequest())
+            createBuilder.reason?.let { header("X-Audit-Log-Reason", it) }
+        }
     }
 
     suspend fun deleteGuildBan(guildId: String, userId: String, reason: String? = null) = call(Route.GuildBanDelete) {
@@ -141,11 +179,18 @@ class GuildService(requestHandler: RequestHandler) : RestService(requestHandler)
         keys[Route.GuildId] = guildId
     }
 
-    suspend inline fun createGuildRole(guildId: String, builder: RoleCreateBuilder.() -> Unit = {}) = call(Route.GuildRolePost) {
-        keys[Route.GuildId] = guildId
-        val createBuilder = RoleCreateBuilder().apply(builder)
-        body(GuildRoleCreateRequest.serializer(), createBuilder.toRequest())
-        createBuilder.reason?.let { header("X-Audit-Log-Reason", it) }
+    @OptIn(ExperimentalContracts::class)
+    suspend inline fun createGuildRole(guildId: String, builder: RoleCreateBuilder.() -> Unit = {}): DiscordRole {
+        contract {
+            callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+        }
+
+        return call(Route.GuildRolePost) {
+            keys[Route.GuildId] = guildId
+            val createBuilder = RoleCreateBuilder().apply(builder)
+            body(GuildRoleCreateRequest.serializer(), createBuilder.toRequest())
+            createBuilder.reason?.let { header("X-Audit-Log-Reason", it) }
+        }
     }
 
     suspend inline fun modifyGuildRolePosition(guildId: String, builder: RolePositionsModifyBuilder.() -> Unit) = call(Route.GuildRolesPatch) {

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/service/RestClient.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/service/RestClient.kt
@@ -6,6 +6,9 @@ import com.gitlab.kordlib.rest.request.KtorRequestHandler
 import com.gitlab.kordlib.rest.request.RequestHandler
 import com.gitlab.kordlib.rest.request.RequestBuilder
 import com.gitlab.kordlib.rest.route.Route
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 
 class RestClient(requestHandler: RequestHandler) : RestService(requestHandler) {
     val auditLog: AuditLogService = AuditLogService(requestHandler)
@@ -27,10 +30,16 @@ class RestClient(requestHandler: RequestHandler) : RestService(requestHandler) {
      * @param route The route to which to send a request.
      * @param block The configuration for this request.
      */
+    @OptIn(ExperimentalContracts::class)
     @KordUnsafe
     @KordExperimental
-    suspend inline fun <T> unsafe(route: Route<T>, block: RequestBuilder<T>.() -> Unit): T = call(route) {
-        block()
+    suspend inline fun <T> unsafe(route: Route<T>, block: RequestBuilder<T>.() -> Unit): T {
+        contract {
+            callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+        }
+        return call(route) {
+            block()
+        }
     }
 
     companion object {

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/service/RestService.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/service/RestService.kt
@@ -3,11 +3,18 @@ package com.gitlab.kordlib.rest.service
 import com.gitlab.kordlib.rest.request.RequestHandler
 import com.gitlab.kordlib.rest.request.RequestBuilder
 import com.gitlab.kordlib.rest.route.Route
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 
 abstract class RestService(@PublishedApi internal val requestHandler: RequestHandler) {
 
+    @OptIn(ExperimentalContracts::class)
     @PublishedApi
     internal suspend inline fun <T> call(route: Route<T>, builder: RequestBuilder<T>.() -> Unit = {}): T {
+        contract {
+            callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+        }
         val request = RequestBuilder(route).apply(builder).build()
         return requestHandler.handle(request)
     }

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/service/UserService.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/service/UserService.kt
@@ -1,5 +1,7 @@
 package com.gitlab.kordlib.rest.service
 
+import com.gitlab.kordlib.common.entity.DiscordChannel
+import com.gitlab.kordlib.common.entity.DiscordUser
 import com.gitlab.kordlib.rest.builder.user.CurrentUserModifyBuilder
 import com.gitlab.kordlib.rest.builder.user.GroupDMCreateBuilder
 import com.gitlab.kordlib.rest.json.request.CurrentUserModifyRequest
@@ -8,6 +10,9 @@ import com.gitlab.kordlib.rest.json.request.GroupDMCreateRequest
 import com.gitlab.kordlib.rest.request.RequestHandler
 import com.gitlab.kordlib.rest.route.Position
 import com.gitlab.kordlib.rest.route.Route
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 
 class UserService(requestHandler: RequestHandler) : RestService(requestHandler) {
 
@@ -35,12 +40,26 @@ class UserService(requestHandler: RequestHandler) : RestService(requestHandler) 
         body(DMCreateRequest.serializer(), dm)
     }
 
-    suspend inline fun createGroupDM(builder: GroupDMCreateBuilder.() -> Unit) = call(Route.DMPost) {
-        body(GroupDMCreateRequest.serializer(), GroupDMCreateBuilder().apply(builder).toRequest())
+    @OptIn(ExperimentalContracts::class)
+    suspend inline fun createGroupDM(builder: GroupDMCreateBuilder.() -> Unit): DiscordChannel {
+        contract {
+            callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+        }
+
+        return call(Route.DMPost) {
+            body(GroupDMCreateRequest.serializer(), GroupDMCreateBuilder().apply(builder).toRequest())
+        }
     }
 
-    suspend inline fun modifyCurrentUser(builder: CurrentUserModifyBuilder.() -> Unit) = call(Route.CurrentUserPatch) {
-        body(CurrentUserModifyRequest.serializer(), CurrentUserModifyBuilder().apply(builder).toRequest())
+    @OptIn(ExperimentalContracts::class)
+    suspend inline fun modifyCurrentUser(builder: CurrentUserModifyBuilder.() -> Unit): DiscordUser {
+        contract {
+            callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+        }
+
+        return call(Route.CurrentUserPatch) {
+            body(CurrentUserModifyRequest.serializer(), CurrentUserModifyBuilder().apply(builder).toRequest())
+        }
     }
 
 }


### PR DESCRIPTION
Adds contracts to all(?) kord builder functions to communicate their 'invoke exactly once' nature.
Closes #4 