### PR TITLE
Remove live message events override

### DIFF
--- a/core/src/main/kotlin/com/gitlab/kordlib/core/live/LiveEntity.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/live/LiveEntity.kt
@@ -34,7 +34,7 @@ abstract class AbstractLiveEntity : LiveEntity {
     private val running = atomic(true)
 
     @Suppress("EXPERIMENTAL_API_USAGE")
-    final override val events: Flow<Event>
+    override val events: Flow<Event>
         get() = kord.events
                 .takeWhile { running.value }
                 .filter { filter(it) }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/live/LiveEntity.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/live/LiveEntity.kt
@@ -34,7 +34,7 @@ abstract class AbstractLiveEntity : LiveEntity {
     private val running = atomic(true)
 
     @Suppress("EXPERIMENTAL_API_USAGE")
-    override val events: Flow<Event>
+    final override val events: Flow<Event>
         get() = kord.events
                 .takeWhile { running.value }
                 .filter { filter(it) }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/live/LiveMessage.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/live/LiveMessage.kt
@@ -22,9 +22,6 @@ class LiveMessage(message: Message, val guildId: Snowflake?) : AbstractLiveEntit
     var message: Message = message
         private set
 
-    override val events: Flow<Event>
-        get() = message.kord.events
-
     override fun filter(event: Event): Boolean = when (event) {
         is ReactionAddEvent -> event.messageId == message.id
         is ReactionRemoveEvent -> event.messageId == message.id


### PR DESCRIPTION
Events come from `kord`, which is the same instance for a given bot. Disallowing overrides prevents us from accidentally skipping the live filter.