### PR TITLE
Have Members consider User equality

### DIFF
--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Member.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Member.kt
@@ -7,6 +7,7 @@ import com.gitlab.kordlib.common.exception.RequestException
 import com.gitlab.kordlib.core.Kord
 import com.gitlab.kordlib.core.behavior.MemberBehavior
 import com.gitlab.kordlib.core.behavior.RoleBehavior
+import com.gitlab.kordlib.core.behavior.UserBehavior
 import com.gitlab.kordlib.core.cache.data.MemberData
 import com.gitlab.kordlib.core.cache.data.UserData
 import com.gitlab.kordlib.core.supplier.EntitySupplier
@@ -112,6 +113,7 @@ class Member(
 
     override fun equals(other: Any?): Boolean = when(other) {
         is MemberBehavior -> other.id == id && other.guildId == guildId
+        is UserBehavior -> other.id == id
         else -> false
     }
 

--- a/core/src/test/kotlin/com/gitlab/kordlib/core/entity/MemberTest.kt
+++ b/core/src/test/kotlin/com/gitlab/kordlib/core/entity/MemberTest.kt
@@ -8,6 +8,8 @@ import equality.GuildEntityEqualityTest
 import io.mockk.every
 import io.mockk.mockk
 import mockKord
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
 
 internal class MemberTest : GuildEntityEqualityTest<Member> by GuildEntityEqualityTest({ id, guildId ->
     val kord = mockKord()
@@ -21,4 +23,22 @@ internal class MemberTest : GuildEntityEqualityTest<Member> by GuildEntityEquali
     Member(memberData, userData, kord)
 }), BehaviorEqualityTest<Member> {
     override fun Member.behavior(): Entity = MemberBehavior(guildId = guildId, id = id, kord = kord)
+
+    @Test
+    fun `members equal users with the same ID`() {
+        val kord = mockKord()
+        val memberData = mockk<MemberData>()
+        every { memberData.userId } returns 0L
+        every { memberData.guildId } returns 1L
+
+        val userData = mockk<UserData>()
+        every { userData.id } returns 0L
+        val member = Member(memberData, userData, kord)
+        val user = User(userData, kord)
+
+        assertEquals(member, user)
+        assertEquals(user, member)
+    }
+
+
 }


### PR DESCRIPTION
Fixes an user where a `Member` would fail equality with a `User` of the same ID.