### PR TITLE
Improve Kord.on

### DIFF
--- a/core/src/main/kotlin/com/gitlab/kordlib/core/Kord.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/Kord.kt
@@ -189,7 +189,7 @@ class Kord(
  * The events are buffered in an [unlimited][CoroutineChannel.UNLIMITED] [buffer][Flow.buffer] and
  * [launched][CoroutineScope.launch] in the supplied [scope], which is [Kord] by default.
  * Each event will be [launched][CoroutineScope.launch] inside the [scope] separately and
- * any thrown [Throwable] will be caught and logged. The flow will [retry][Flow.retry] infinitely on error.
+ * any thrown [Throwable] will be caught and logged.
  *
  * The returned [Job] is a reference to the created coroutine, call [Job.cancel] to cancel the processing of any further
  * events.
@@ -198,9 +198,5 @@ inline fun <reified T : Event> Kord.on(scope: CoroutineScope = this, noinline co
         events.buffer(CoroutineChannel.UNLIMITED).filterIsInstance<T>()
                 .onEach {
                     scope.launch { runCatching { consumer(it) }.onFailure { kordLogger.catching(it) } }
-                }
-                .retry {
-                    kordLogger.catching(it)
-                    true
                 }
                 .launchIn(scope)

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/Kord.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/Kord.kt
@@ -184,10 +184,23 @@ class Kord(
 }
 
 /**
- * Convenience method that will invoke the [consumer] on every event [T], the consumer is launched in the given [scope]
- * or [Kord] by default and will not propagate any exceptions.
+ * Convenience method that will invoke the [consumer] on every event [T] created by [Kord.events].
+ *
+ * The events are buffered in an [unlimited][CoroutineChannel.UNLIMITED] [buffer][Flow.buffer] and
+ * [launched][CoroutineScope.launch] in the supplied [scope], which is [Kord] by default.
+ * Each event will be [launched][CoroutineScope.launch] inside the [scope] separately and
+ * any thrown [Throwable] will be caught and logged. The flow will [retry][Flow.retry] infinitely on error.
+ *
+ * The returned [Job] is a reference to the created coroutine, call [Job.cancel] to cancel the processing of any further
+ * events.
  */
-inline fun <reified T : Event> Kord.on(scope: CoroutineScope = this, noinline consumer: suspend T.() -> Unit) =
-        events.buffer(CoroutineChannel.UNLIMITED).filterIsInstance<T>().onEach {
-            runCatching { consumer(it) }.onFailure { kordLogger.catching(it) }
-        }.catch { kordLogger.catching(it) }.launchIn(scope)
+inline fun <reified T : Event> Kord.on(scope: CoroutineScope = this, noinline consumer: suspend T.() -> Unit): Job =
+        events.buffer(CoroutineChannel.UNLIMITED).filterIsInstance<T>()
+                .onEach {
+                    scope.launch { runCatching { consumer(it) }.onFailure { kordLogger.catching(it) } }
+                }
+                .retry {
+                    kordLogger.catching(it)
+                    true
+                }
+                .launchIn(scope)


### PR DESCRIPTION
Provides a more detailed documentation on the behaviour of `Kord.on`, also changes the behaviour to run consumers in parallel and retry infinitely (not sure what even could throw) on errors.