### PR TITLE
Url encode headers

### DIFF
--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/request/RequestBuilder.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/request/RequestBuilder.kt
@@ -1,8 +1,7 @@
 package com.gitlab.kordlib.rest.request
 
 import com.gitlab.kordlib.rest.route.Route
-import io.ktor.http.HeadersBuilder
-import io.ktor.http.ParametersBuilder
+import io.ktor.http.*
 import kotlinx.serialization.SerializationStrategy
 
 class RequestBuilder<T>(private val route: Route<T>, keySize: Int = 2) {
@@ -23,7 +22,7 @@ class RequestBuilder<T>(private val route: Route<T>, keySize: Int = 2) {
 
     fun parameter(key: String, value: Any) = parameters.append(key, value.toString())
 
-    fun header(key: String, value: String) = headers.append(key, value)
+    fun header(key: String, value: String) = headers.append(key, value.encodeURLQueryComponent())
 
     fun file(name: String, input: java.io.InputStream) {
         files.add(name to input)

--- a/rest/src/test/kotlin/com/gitlab/kordlib/rest/services/RestServiceTest.kt
+++ b/rest/src/test/kotlin/com/gitlab/kordlib/rest/services/RestServiceTest.kt
@@ -7,6 +7,7 @@ import com.gitlab.kordlib.rest.ratelimit.ExclusionRequestRateLimiter
 import com.gitlab.kordlib.rest.request.KtorRequestHandler
 import com.gitlab.kordlib.rest.request.RequestHandler
 import com.gitlab.kordlib.rest.service.RestClient
+import com.gitlab.kordlib.rest.service.createTextChannel
 import io.ktor.client.HttpClient
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.*
@@ -108,7 +109,16 @@ class RestServiceTest {
     @Test
     @Order(3)
     fun `create channel`() = runBlocking {
-        val channel = rest.guild.createGuildChannel(guildId, GuildCreateChannelRequest("BOT TEST RUN"))
+        val channel = rest.guild.createTextChannel(guildId) {
+            name = "BOT TEST RUN"
+            reason = """
+                a multiline
+                
+                reason
+                
+                to check if encoding is okay
+            """.trimIndent()
+        }
         channelId = channel.id
 
         rest.channel.getChannel(channel.id)


### PR DESCRIPTION
Kord doesn't URL encode header values by default, leading to issues like `reason` fields failing on multi-line values and improper encoding of non-latin characters.

This is fixed by calling `encodeURLQueryComponent` on values passed through `RequestBuilder#header`.