### PR TITLE
Provide meaningful toString

### DIFF
--- a/common/src/main/kotlin/com/gitlab/kordlib/common/entity/Permission.kt
+++ b/common/src/main/kotlin/com/gitlab/kordlib/common/entity/Permission.kt
@@ -1,6 +1,8 @@
 package com.gitlab.kordlib.common.entity
 
-import kotlinx.serialization.*
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.Serializer
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
@@ -12,6 +14,8 @@ import kotlin.contracts.contract
 
 @Serializable(with = Permissions.Companion::class)
 class Permissions constructor(val code: Int) {
+
+    val values: Set<Permission> get() = Permission.values().filter { it.code and code == it.code }.toSet()
 
     operator fun plus(permission: Permission): Permissions = Permissions(this.code or permission.code)
 
@@ -31,6 +35,10 @@ class Permissions constructor(val code: Int) {
         val builder = PermissionsBuilder(code)
         builder.apply(block)
         return builder.permissions()
+    }
+
+    override fun toString(): String {
+        return "Permissions(values=${values.joinToString(", ")})"
     }
 
     @Serializer(forClass = Permissions::class)

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/ClientResources.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/ClientResources.kt
@@ -12,6 +12,6 @@ class ClientResources(
         val intents: Intents?
 ) {
     override fun toString(): String {
-        return "ClientResources(token='$token', shardCount=$shardCount, httpClient=$httpClient, defaultStrategy=$defaultStrategy, intents=$intents)"
+        return "ClientResources(shardCount=$shardCount, httpClient=$httpClient, defaultStrategy=$defaultStrategy, intents=$intents)"
     }
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/ClientResources.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/ClientResources.kt
@@ -10,4 +10,8 @@ class ClientResources(
         val httpClient: HttpClient,
         val defaultStrategy: EntitySupplyStrategy<*>,
         val intents: Intents?
-)
+) {
+    override fun toString(): String {
+        return "ClientResources(token='$token', shardCount=$shardCount, httpClient=$httpClient, defaultStrategy=$defaultStrategy, intents=$intents)"
+    }
+}

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/Kord.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/Kord.kt
@@ -154,7 +154,7 @@ class Kord(
     }
 
     override fun toString(): String {
-        return "Kord(resources=$resources, cache=$cache, gateway=$gateway, rest=$rest, selfId=$selfId, eventPublisher=$eventPublisher, dispatcher=$dispatcher, interceptor=$interceptor, defaultSupplier=$defaultSupplier, unsafe=$unsafe)"
+        return "Kord(resources=$resources, cache=$cache, gateway=$gateway, rest=$rest, selfId=$selfId)"
     }
 
     companion object {

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/Kord.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/Kord.kt
@@ -3,6 +3,7 @@ package com.gitlab.kordlib.core
 import com.gitlab.kordlib.cache.api.DataCache
 import com.gitlab.kordlib.common.annotation.KordExperimental
 import com.gitlab.kordlib.common.annotation.KordUnsafe
+
 import com.gitlab.kordlib.common.entity.DiscordShard
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.common.entity.Status
@@ -150,6 +151,10 @@ class Kord(
         val kord = other as? Kord ?: return false
 
         return resources.token == kord.resources.token
+    }
+
+    override fun toString(): String {
+        return "Kord(resources=$resources, cache=$cache, gateway=$gateway, rest=$rest, selfId=$selfId, eventPublisher=$eventPublisher, dispatcher=$dispatcher, interceptor=$interceptor, defaultSupplier=$defaultSupplier, unsafe=$unsafe)"
     }
 
     companion object {

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/Unsafe.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/Unsafe.kt
@@ -68,7 +68,7 @@ class Unsafe(private val kord: Kord) {
             WebhookBehavior(id, kord)
 
     override fun toString(): String {
-        return "Unsafe(kord=$kord)"
+        return "Unsafe"
     }
 
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/Unsafe.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/Unsafe.kt
@@ -2,6 +2,7 @@ package com.gitlab.kordlib.core
 
 import com.gitlab.kordlib.common.annotation.KordExperimental
 import com.gitlab.kordlib.common.annotation.KordUnsafe
+
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.core.behavior.*
 import com.gitlab.kordlib.core.behavior.channel.*
@@ -65,5 +66,9 @@ class Unsafe(private val kord: Kord) {
 
     fun webhook(id: Snowflake): WebhookBehavior =
             WebhookBehavior(id, kord)
+
+    override fun toString(): String {
+        return "Unsafe(kord=$kord)"
+    }
 
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/GuildBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/GuildBehavior.kt
@@ -23,16 +23,12 @@ import com.gitlab.kordlib.rest.builder.role.RoleCreateBuilder
 import com.gitlab.kordlib.rest.builder.role.RolePositionsModifyBuilder
 import com.gitlab.kordlib.rest.json.request.CurrentUserNicknameModifyRequest
 import com.gitlab.kordlib.rest.request.RestRequestException
-import com.gitlab.kordlib.rest.service.createCategory
-import com.gitlab.kordlib.rest.service.createNewsChannel
-import com.gitlab.kordlib.rest.service.createTextChannel
-import com.gitlab.kordlib.rest.service.createVoiceChannel
+import com.gitlab.kordlib.rest.service.*
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import java.util.*
-import com.gitlab.kordlib.rest.service.RestClient
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
@@ -379,6 +375,10 @@ interface GuildBehavior : Entity, Strategizable {
                 is GuildBehavior -> other.id == id
                 is PartialGuild -> other.id == id
                 else -> false
+            }
+
+            override fun toString(): String {
+                return "GuildBehavior(id=$id, kord=$kord, supplier$supplier)"
             }
         }
     }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/GuildEmojiBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/GuildEmojiBehavior.kt
@@ -60,6 +60,10 @@ interface GuildEmojiBehavior : Entity, Strategizable {
                 is GuildEmojiBehavior -> other.id == id
                 else -> false
             }
+
+            override fun toString(): String {
+                return "GuildEmoijBehavior(id=$id, guildId=$guildId, kord=$kord, supplier=$supplier)"
+            }
         }
     }
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/MemberBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/MemberBehavior.kt
@@ -204,6 +204,10 @@ interface MemberBehavior : Entity, UserBehavior {
                 is UserBehavior -> other.id == id
                 else -> false
             }
+
+            override fun toString(): String {
+                return "MemberBehavior(id=$id, guildId=$guildId, kord=$kord, supplier=$supplier)"
+            }
         }
     }
 

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/MessageBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/MessageBehavior.kt
@@ -1,24 +1,21 @@
 package com.gitlab.kordlib.core.behavior
 
 import com.gitlab.kordlib.common.annotation.KordPreview
+import com.gitlab.kordlib.common.entity.Permission
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.common.exception.RequestException
 import com.gitlab.kordlib.core.Kord
 import com.gitlab.kordlib.core.behavior.channel.MessageChannelBehavior
 import com.gitlab.kordlib.core.cache.data.MessageData
-import com.gitlab.kordlib.core.cache.data.UserData
 import com.gitlab.kordlib.core.entity.*
 import com.gitlab.kordlib.core.exception.EntityNotFoundException
-import com.gitlab.kordlib.core.paginateForwards
 import com.gitlab.kordlib.core.supplier.EntitySupplier
 import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy
 import com.gitlab.kordlib.rest.builder.message.MessageModifyBuilder
+import com.gitlab.kordlib.rest.request.RestRequestException
 import com.gitlab.kordlib.rest.service.RestClient
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
 import java.util.*
-import com.gitlab.kordlib.rest.request.RestRequestException
-import com.gitlab.kordlib.common.entity.Permission
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
@@ -189,6 +186,10 @@ interface MessageBehavior : Entity, Strategizable {
             override fun equals(other: Any?): Boolean = when (other) {
                 is MessageBehavior -> other.id == id && other.channelId == channelId
                 else -> false
+            }
+
+            override fun toString(): String {
+                return "MessageBehavior(id=$id, channelId=$channelId, kord=$kord, supplier=$supplier)"
             }
         }
     }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/RoleBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/RoleBehavior.kt
@@ -89,6 +89,11 @@ interface RoleBehavior : Entity, Strategizable {
                 is RoleBehavior -> other.id == id && other.guildId == guildId
                 else -> false
             }
+
+            override fun toString(): String {
+                return "RoleBehavior(id=$id, guildId=$guildId, kord=$kord, "
+            }
+
         }
     }
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/UserBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/UserBehavior.kt
@@ -13,7 +13,6 @@ import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy
 import com.gitlab.kordlib.rest.json.request.DMCreateRequest
 import com.gitlab.kordlib.rest.request.RestRequestException
 import com.gitlab.kordlib.rest.service.RestClient
-import io.ktor.http.HttpStatusCode
 import java.util.*
 
 /**
@@ -101,6 +100,10 @@ interface UserBehavior : Entity, Strategizable {
             override fun equals(other: Any?): Boolean = when(other) {
                 is UserBehavior -> other.id == id
                 else -> false
+            }
+
+            override fun toString(): String {
+                return "UserBehavior(id=$id, kord=kord, supplier=$supplier)"
             }
         }
     }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/WebhookBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/WebhookBehavior.kt
@@ -51,7 +51,7 @@ interface WebhookBehavior : Entity, Strategizable {
         internal operator fun invoke(
                 id: Snowflake,
                 kord: Kord,
-                strategy: EntitySupplyStrategy<*> = kord.resources.defaultStrategy
+                strategy: EntitySupplyStrategy<*> = kord.resources.defaultStrategy,
         ): WebhookBehavior = object : WebhookBehavior {
             override val id: Snowflake = id
             override val kord: Kord = kord
@@ -63,9 +63,13 @@ interface WebhookBehavior : Entity, Strategizable {
                 is WebhookBehavior -> other.id == id
                 else -> false
             }
-        }
-    }
 
+            override fun toString(): String {
+                return "WebhookBehavior(id=$id, kord=$kord, supplier=$supplier)"
+            }
+        }
+
+    }
 }
 
 /**

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/CategoryBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/CategoryBehavior.kt
@@ -60,7 +60,7 @@ interface CategoryBehavior : GuildChannelBehavior {
      * Returns a new [CategoryBehavior] with the given [strategy].
      */
     override fun withStrategy(
-            strategy: EntitySupplyStrategy<*>
+            strategy: EntitySupplyStrategy<*>,
     ): CategoryBehavior = CategoryBehavior(guildId, id, kord, strategy)
 
     companion object {
@@ -68,7 +68,7 @@ interface CategoryBehavior : GuildChannelBehavior {
                 guildId: Snowflake,
                 id: Snowflake,
                 kord: Kord,
-                strategy: EntitySupplyStrategy<*> = kord.resources.defaultStrategy
+                strategy: EntitySupplyStrategy<*> = kord.resources.defaultStrategy,
         ): CategoryBehavior = object : CategoryBehavior {
             override val guildId: Snowflake = guildId
             override val id: Snowflake = id
@@ -77,10 +77,14 @@ interface CategoryBehavior : GuildChannelBehavior {
 
             override fun hashCode(): Int = Objects.hash(id, guildId)
 
-            override fun equals(other: Any?): Boolean = when(other) {
+            override fun equals(other: Any?): Boolean = when (other) {
                 is GuildChannelBehavior -> other.id == id && other.guildId == guildId
                 is ChannelBehavior -> other.id == id
                 else -> false
+            }
+
+            override fun toString(): String {
+                return "CategoryBehavior(id=$id, guildId=$guildId, kord=$kord, supplier=$supplier)"
             }
 
         }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/ChannelBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/ChannelBehavior.kt
@@ -51,7 +51,7 @@ interface ChannelBehavior : Entity, Strategizable {
     /**
      * Returns a new [ChannelBehavior] with the given [strategy].
      */
-    override fun withStrategy(strategy: EntitySupplyStrategy<*>) : ChannelBehavior = ChannelBehavior(id, kord, strategy)
+    override fun withStrategy(strategy: EntitySupplyStrategy<*>): ChannelBehavior = ChannelBehavior(id, kord, strategy)
 
     companion object {
         internal operator fun invoke(id: Snowflake, kord: Kord, strategy: EntitySupplyStrategy<*> = kord.resources.defaultStrategy) = object : ChannelBehavior {
@@ -62,9 +62,13 @@ interface ChannelBehavior : Entity, Strategizable {
 
             override fun hashCode(): Int = Objects.hash(id)
 
-            override fun equals(other: Any?): Boolean = when(other) {
+            override fun equals(other: Any?): Boolean = when (other) {
                 is ChannelBehavior -> other.id == id
                 else -> false
+            }
+
+            override fun toString(): String {
+                return "ChannelBehavior(id=$id, kord=$kord, supplier=$supplier)"
             }
         }
     }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/GuildChannelBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/GuildChannelBehavior.kt
@@ -143,6 +143,10 @@ interface GuildChannelBehavior : ChannelBehavior, Strategizable {
                 is ChannelBehavior -> other.id == id
                 else -> false
             }
+
+            override fun toString(): String {
+                return "GuildChannelBehavior(id=$id, guildId=$guildId, kord=$kord, supplier=$supplier)"
+            }
         }
     }
 

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/GuildMessageChannelBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/GuildMessageChannelBehavior.kt
@@ -21,8 +21,6 @@ import java.util.*
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
-import kotlin.time.days
-import kotlin.time.toJavaDuration
 
 /**
  * The behavior of a Discord message channel associated to a [guild].
@@ -102,6 +100,10 @@ interface GuildMessageChannelBehavior : GuildChannelBehavior, MessageChannelBeha
                 is GuildChannelBehavior -> other.id == id && other.guildId == guildId
                 is ChannelBehavior -> other.id == id
                 else -> false
+            }
+
+            override fun toString(): String {
+                return "GuildMessageChannelBehavior(id=$id, guildId=$guildId, kord=$kord, supplier=$supplier)"
             }
         }
     }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/MessageChannelBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/MessageChannelBehavior.kt
@@ -234,6 +234,10 @@ interface MessageChannelBehavior : ChannelBehavior, Strategizable {
                 is ChannelBehavior -> other.id == id
                 else -> false
             }
+
+            override fun toString(): String {
+                return "MessageChannelBehavior(id=$id, kord=$kord, supplier=$supplier)"
+            }
         }
     }
 

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/NewsChannelBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/NewsChannelBehavior.kt
@@ -1,6 +1,7 @@
 package com.gitlab.kordlib.core.behavior.channel
 
 import com.gitlab.kordlib.common.annotation.KordPreview
+import com.gitlab.kordlib.common.entity.Permission
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.common.exception.RequestException
 import com.gitlab.kordlib.core.Kord
@@ -11,11 +12,10 @@ import com.gitlab.kordlib.core.exception.EntityNotFoundException
 import com.gitlab.kordlib.core.supplier.EntitySupplier
 import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy
 import com.gitlab.kordlib.rest.builder.channel.NewsChannelModifyBuilder
+import com.gitlab.kordlib.rest.json.request.ChannelFollowRequest
 import com.gitlab.kordlib.rest.request.RestRequestException
 import com.gitlab.kordlib.rest.service.patchNewsChannel
 import java.util.*
-import com.gitlab.kordlib.common.entity.Permission
-import com.gitlab.kordlib.rest.json.request.ChannelFollowRequest
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
@@ -73,6 +73,10 @@ interface NewsChannelBehavior : GuildMessageChannelBehavior {
                 is GuildChannelBehavior -> other.id == id && other.guildId == guildId
                 is ChannelBehavior -> other.id == id
                 else -> false
+            }
+
+            override fun toString(): String {
+                return "NewsChannelBehavior(id=$id, guildId=$guildId, kord=$kord, supplier=$supplier)"
             }
         }
     }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/StoreChannelBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/StoreChannelBehavior.kt
@@ -57,6 +57,10 @@ interface StoreChannelBehavior : GuildChannelBehavior {
                 is ChannelBehavior -> other.id == id
                 else -> false
             }
+
+            override fun toString(): String {
+                return "StoreChannelBehavior(id=$id, guildId=$guildId, kord=$kord, supplier=$supplier)"
+            }
         }
     }
 

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/TextChannelBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/TextChannelBehavior.kt
@@ -58,6 +58,10 @@ interface TextChannelBehavior : GuildMessageChannelBehavior {
                 is ChannelBehavior -> other.id == id
                 else -> false
             }
+
+            override fun toString(): String {
+                return "TextChannelBehavior(id=$id, guildId=$guildId, kord=$kord, supplier$supplier)"
+            }
         }
     }
 

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/VoiceChannelBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/VoiceChannelBehavior.kt
@@ -1,6 +1,7 @@
 package com.gitlab.kordlib.core.behavior.channel
 
 import com.gitlab.kordlib.cache.api.query
+
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.common.exception.RequestException
 import com.gitlab.kordlib.core.Kord
@@ -75,6 +76,10 @@ interface VoiceChannelBehavior : GuildChannelBehavior {
                 is GuildChannelBehavior -> other.id == id && other.guildId == guildId
                 is ChannelBehavior -> other.id == id
                 else -> false
+            }
+
+            override fun toString(): String {
+                return "VoiceChannelBehavior(id=$id, guildId=$guildId, kord=$kord, supplier=$supplier)"
             }
         }
     }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/cache/CachingGateway.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/cache/CachingGateway.kt
@@ -25,4 +25,8 @@ class CachingGateway(
     init {
         gateway.events.filterIsInstance<Close>().onEach { removeKordData() }.launchIn(this)
     }
+
+    override fun toString(): String {
+        return "CachingGateway(cache=$cache, gateway=$gateway)"
+    }
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/cache/DataCacheView.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/cache/DataCacheView.kt
@@ -43,6 +43,10 @@ class DataCacheView(private val cache: DataCache) : DataCache by cache {
         return cache.getEntry<T>(type)?.let { DataEntryCacheView(it, getDescription(type), keys) }
     }
 
+    override fun toString(): String {
+        return "DataCacheView(cache=$cache)"
+    }
+
 }
 
 private class DataEntryCacheView<T : Any>(

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Activity.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Activity.kt
@@ -27,6 +27,10 @@ class Activity(val data: ActivityData) {
     internal fun toGatewayActivity() =
             com.gitlab.kordlib.common.entity.DiscordActivity(name, type, url)
 
+    override fun toString(): String {
+        return "Activity(data=$data)"
+    }
+
     data class Party(val id: String, val currentSize: Int, val maxSize: Int)
     data class Assets(val largeImage: String?, val largeText: String?, val smallImage: String?, val smallText: String?)
     data class Secrets(val join: String?, val spectate: String?, val match: String?)

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/ApplicationInfo.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/ApplicationInfo.kt
@@ -65,4 +65,9 @@ class ApplicationInfo(
         is ApplicationInfo -> other.id == id
         else -> false
     }
+
+    override fun toString(): String {
+        return "ApplicationInfo(data=$data, kord=$kord, supplier=$supplier)"
+    }
+
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Attachment.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Attachment.kt
@@ -62,4 +62,8 @@ data class Attachment(val data: AttachmentData, override val kord: Kord) : Entit
         else -> false
     }
 
+    override fun toString(): String {
+        return "Attachment(data=$data, kord=$kord)"
+    }
+
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Ban.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Ban.kt
@@ -56,5 +56,9 @@ class Ban(
      */
     override fun withStrategy(strategy: EntitySupplyStrategy<*>) : Ban = Ban(data, kord, strategy.supply(kord))
 
+    override fun toString(): String {
+        return "Ban(data=$data, kord=$kord, supplier=$supplier)"
+    }
+
 }
 

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Embed.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Embed.kt
@@ -192,4 +192,8 @@ data class Embed(val data: EmbedData, override val kord: Kord) : KordObject {
         builder.timestamp = timestamp
 
     }
+
+    override fun toString(): String {
+        return "Embed(data=$data, kord=$kord, fields=$fields)"
+    }
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Guild.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Guild.kt
@@ -413,4 +413,9 @@ class Guild(
         is GuildBehavior -> other.id == id
         else -> false
     }
+
+    override fun toString(): String {
+        return "Guild(data=$data, kord=$kord, supplier=$supplier)"
+    }
+
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/GuildEmoji.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/GuildEmoji.kt
@@ -11,7 +11,6 @@ import com.gitlab.kordlib.core.supplier.EntitySupplier
 import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy
 import com.gitlab.kordlib.core.toSnowflakeOrNull
 import com.gitlab.kordlib.rest.builder.guild.EmojiModifyBuilder
-import io.ktor.utils.io.bits.withMemory
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filter
@@ -151,6 +150,10 @@ class GuildEmoji(
     override fun equals(other: Any?): Boolean = when (other) {
         is GuildEmoji -> other.id == id && other.guildId == guildId
         else -> super.equals(other)
+    }
+
+    override fun toString(): String {
+        return "GuildEmoji(data=$data, kord=$kord, supplier=$supplier)"
     }
 
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/GuildPreview.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/GuildPreview.kt
@@ -4,7 +4,6 @@ import com.gitlab.kordlib.common.entity.GuildFeature
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.core.Kord
 import com.gitlab.kordlib.core.cache.data.GuildPreviewData
-import com.gitlab.kordlib.core.supplier.EntitySupplier
 
 class GuildPreview(
         val data: GuildPreviewData,
@@ -58,5 +57,9 @@ class GuildPreview(
      * The description for the guild.
      */
     val description: String? get() = data.description
+
+    override fun toString(): String {
+        return "GuildPreview(data=$data, kord=$kord)"
+    }
 
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Integration.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Integration.kt
@@ -171,6 +171,11 @@ class Integration(
         is Integration -> other.id == id && other.guildId == guildId
         else -> false
     }
+
+    override fun toString(): String {
+        return "Integration(data=$data, kord=$kord, supplier=$supplier)"
+    }
+
 }
 
 /**

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Invite.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Invite.kt
@@ -133,4 +133,8 @@ data class Invite(
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): Invite =
             Invite(data, kord, strategy.supply(kord))
 
+    override fun toString(): String {
+        return "Invite(data=$data, kord=$kord, supplier=$supplier)"
+    }
+
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Member.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Member.kt
@@ -117,4 +117,8 @@ class Member(
         else -> false
     }
 
+    override fun toString(): String {
+        return "Member(memberData=$memberData)"
+    }
+
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Message.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Message.kt
@@ -4,19 +4,19 @@ import com.gitlab.kordlib.common.entity.MessageType
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.common.exception.RequestException
 import com.gitlab.kordlib.core.Kord
-import com.gitlab.kordlib.core.behavior.GuildBehavior
 import com.gitlab.kordlib.core.behavior.MessageBehavior
-import com.gitlab.kordlib.core.behavior.RoleBehavior
 import com.gitlab.kordlib.core.behavior.UserBehavior
 import com.gitlab.kordlib.core.behavior.channel.ChannelBehavior
 import com.gitlab.kordlib.core.cache.data.MessageData
-import com.gitlab.kordlib.core.entity.channel.*
+import com.gitlab.kordlib.core.entity.channel.Channel
+import com.gitlab.kordlib.core.entity.channel.GuildChannel
+import com.gitlab.kordlib.core.entity.channel.GuildMessageChannel
+import com.gitlab.kordlib.core.entity.channel.MessageChannel
 import com.gitlab.kordlib.core.exception.EntityNotFoundException
 import com.gitlab.kordlib.core.supplier.EntitySupplier
 import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy
 import com.gitlab.kordlib.core.supplier.getChannelOf
 import com.gitlab.kordlib.core.supplier.getChannelOfOrNull
-import com.gitlab.kordlib.core.toSnowflakeOrNull
 import kotlinx.coroutines.flow.*
 import java.time.Instant
 import java.time.format.DateTimeFormatter
@@ -241,6 +241,10 @@ class Message(
     override fun equals(other: Any?): Boolean = when (other) {
         is MessageBehavior -> other.id == id && other.channelId == channelId
         else -> false
+    }
+
+    override fun toString(): String {
+        return "Message(data=$data, kord=$kord, supplier=$supplier)"
     }
 
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/PartialGuild.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/PartialGuild.kt
@@ -6,12 +6,9 @@ import com.gitlab.kordlib.common.exception.RequestException
 import com.gitlab.kordlib.core.Kord
 import com.gitlab.kordlib.core.behavior.GuildBehavior
 import com.gitlab.kordlib.core.cache.data.PartialGuildData
-import com.gitlab.kordlib.core.entity.channel.Channel
 import com.gitlab.kordlib.core.exception.EntityNotFoundException
 import com.gitlab.kordlib.core.supplier.EntitySupplier
 import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy
-import com.gitlab.kordlib.core.supplier.getChannelOf
-import com.gitlab.kordlib.core.supplier.getChannelOfOrNull
 import com.gitlab.kordlib.rest.Image
 import java.util.*
 
@@ -88,5 +85,9 @@ class PartialGuild(
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): PartialGuild =
             PartialGuild(data, kord, strategy.supply(kord))
+
+    override fun toString(): String {
+        return "PartialGuild(data=$data, kord=$kord, supplier=$supplier)"
+    }
 
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/PermissionOverwrite.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/PermissionOverwrite.kt
@@ -7,7 +7,7 @@ import com.gitlab.kordlib.core.cache.data.PermissionOverwriteData
 import com.gitlab.kordlib.rest.json.request.ChannelPermissionEditRequest
 
 open class PermissionOverwrite constructor(
-        val data: PermissionOverwriteData
+        val data: PermissionOverwriteData,
 ) {
     val allowed: Permissions get() = Permissions(data.allowed)
     val denied: Permissions get() = Permissions(data.denied)
@@ -48,5 +48,15 @@ open class PermissionOverwrite constructor(
                 else -> throw IllegalArgumentException("unknown PermissionOverwrite.Type: $type")
             }
         }
+
+        override fun toString(): String {
+            return "Type(value='$value')"
+        }
+
     }
+
+    override fun toString(): String {
+        return "PermissionOverwrite(target=$target, type=$type, allowed=$allowed, denied$denied)"
+    }
+
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/PermissionOverwrite.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/PermissionOverwrite.kt
@@ -56,7 +56,7 @@ open class PermissionOverwrite constructor(
     }
 
     override fun toString(): String {
-        return "PermissionOverwrite(target=$target, type=$type, allowed=$allowed, denied$denied)"
+        return "PermissionOverwrite(target=$target, type=$type, allowed=$allowed, denied=$denied)"
     }
 
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/PermissionOverwriteEntity.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/PermissionOverwriteEntity.kt
@@ -76,4 +76,8 @@ class PermissionOverwriteEntity(
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): PermissionOverwriteEntity =
             PermissionOverwriteEntity(guildId, channelId, data, kord, strategy.supply(kord))
 
+    override fun toString(): String {
+        return "PermissionOverwriteEntity(target=$target, type=$type, allowed=$allowed, denied=$denied, kord=$kord, supplier=$supplier)"
+    }
+
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Presence.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Presence.kt
@@ -59,12 +59,20 @@ class Presence(
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): Presence =
             Presence(data, kord, strategy.supply(kord))
 
+    override fun toString(): String {
+        return "Presence(data=$data, kord=$kord, supplier=$supplier)"
+    }
+
 }
 
 class ClientStatus(val data: ClientStatusData) {
     val desktop: Client.Desktop? get() = data.desktop?.let { Client.Desktop(it) }
     val mobile: Client.Mobile? get() = data.mobile?.let { Client.Mobile(it) }
     val web: Client.Web? get() = data.web?.let { Client.Web(it) }
+
+    override fun toString(): String {
+        return "ClientStatus(data=$data)"
+    }
 
     sealed class Client(val status: Status) {
         class Desktop(status: Status) : Client(status)

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Reaction.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Reaction.kt
@@ -40,5 +40,8 @@ class Reaction(val data: ReactionData, override val kord: Kord) : KordObject {
      */
     val isAnimated: Boolean get() = data.emojiAnimated
 
+    override fun toString(): String {
+        return "Reaction(data=$data, kord=$kord)"
+    }
 
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Region.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Region.kt
@@ -2,7 +2,6 @@ package com.gitlab.kordlib.core.entity
 
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.core.Kord
-import com.gitlab.kordlib.core.behavior.MessageBehavior
 import com.gitlab.kordlib.core.cache.data.RegionData
 import java.util.*
 
@@ -26,4 +25,9 @@ class Region(val data: RegionData, override val kord: Kord) : Entity {
         is Region -> other.id == id
         else -> false
     }
+
+    override fun toString(): String {
+        return "Region(data=$data, kord=$kord)"
+    }
+
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Role.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Role.kt
@@ -53,4 +53,8 @@ data class Role(
         else -> false
     }
 
+    override fun toString(): String {
+        return "Role(data=$data, kord=$kord, supplier=$supplier)"
+    }
+
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Team.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Team.kt
@@ -2,13 +2,13 @@ package com.gitlab.kordlib.core.entity
 
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.common.entity.TeamMembershipState
+import com.gitlab.kordlib.common.exception.RequestException
 import com.gitlab.kordlib.core.Kord
 import com.gitlab.kordlib.core.cache.data.TeamData
 import com.gitlab.kordlib.core.cache.data.TeamMemberData
-import com.gitlab.kordlib.common.exception.RequestException
+import com.gitlab.kordlib.core.exception.EntityNotFoundException
 import com.gitlab.kordlib.core.supplier.EntitySupplier
 import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy
-import com.gitlab.kordlib.core.exception.EntityNotFoundException
 
 /**
  * A Discord [developer team](https://discord.com/developers/docs/topics/teams) which can own applications.
@@ -55,6 +55,11 @@ class Team(val data: TeamData, override val kord: Kord, override val supplier: E
     suspend fun getUserOrNUll(): User? = supplier.getUserOrNull(ownerUserId)
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): Team = Team(data, kord, strategy.supply(kord))
+
+    override fun toString(): String {
+        return "Team(data=$data, kord=$kord, supplier=$supplier)"
+    }
+
 }
 
 /**
@@ -87,4 +92,9 @@ class TeamMember(val data: TeamMemberData, val kord: Kord) {
      * Utility method that gets the user from Kord.
      */
     suspend fun getUser() = kord.getUser(userId)
+
+    override fun toString(): String {
+        return "TeamMember(data=$data, kord=$kord)"
+    }
+
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/User.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/User.kt
@@ -69,6 +69,10 @@ open class User(
      */
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): User = User(data, kord, strategy.supply(kord))
 
+    override fun toString(): String {
+        return "User(data=$data, kord=$kord, supplier=$supplier)"
+    }
+
     data class Avatar(val data: UserData, override val kord: Kord) : KordObject {
 
         /**
@@ -125,6 +129,11 @@ open class User(
          * Requests to get the avatar of the user as an [Image], prioritizing gif for animated avatars and png for others.
          */
         suspend fun getImage(): Image = Image.fromUrl(kord.resources.httpClient, url)
+
+        override fun toString(): String {
+            return "Avatar(data=$data, kord=$kord)"
+        }
+
     }
 
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/VoiceState.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/VoiceState.kt
@@ -84,4 +84,8 @@ class VoiceState(
      */
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): VoiceState = VoiceState(data, kord, strategy.supply(kord))
 
+    override fun toString(): String {
+        return "VoiceState(data=$data, kord=$kord, supplier=$supplier)"
+    }
+
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Webhook.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Webhook.kt
@@ -86,4 +86,8 @@ data class Webhook(
         else -> false
     }
 
+    override fun toString(): String {
+        return "Webhook(data=$data, kord=$kord, supplier=$supplier)"
+    }
+
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/channel/CategorizableChannel.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/channel/CategorizableChannel.kt
@@ -7,9 +7,6 @@ import com.gitlab.kordlib.core.entity.Invite
 import com.gitlab.kordlib.core.toSnowflakeOrNull
 import com.gitlab.kordlib.rest.builder.channel.InviteCreateBuilder
 import com.gitlab.kordlib.rest.request.RestRequestException
-import kotlin.contracts.ExperimentalContracts
-import kotlin.contracts.InvocationKind
-import kotlin.contracts.contract
 
 /**
  * An instance of a Discord channel associated to a [category].

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/channel/Category.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/channel/Category.kt
@@ -17,7 +17,7 @@ import java.util.*
 class Category(
         override val data: ChannelData,
         override val kord: Kord,
-        override val supplier: EntitySupplier = kord.defaultSupplier
+        override val supplier: EntitySupplier = kord.defaultSupplier,
 ) : GuildChannel, CategoryBehavior {
 
     override val guildId: Snowflake
@@ -45,6 +45,10 @@ class Category(
         is GuildChannelBehavior -> other.id == id && other.guildId == guildId
         is ChannelBehavior -> other.id == id
         else -> false
+    }
+
+    override fun toString(): String {
+        return "Category(data=$data, kord=$kord, supplier=$supplier)"
     }
 
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/channel/DmChannel.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/channel/DmChannel.kt
@@ -63,4 +63,9 @@ data class DmChannel(
         is ChannelBehavior -> other.id == id
         else -> false
     }
+
+    override fun toString(): String {
+        return "DmChannel(data=$data, kord=$kord, supplier=$supplier)"
+    }
+
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/channel/NewsChannel.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/channel/NewsChannel.kt
@@ -33,4 +33,9 @@ data class NewsChannel(
      */
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): NewsChannel =
             NewsChannel(data, kord, strategy.supply(kord))
+
+    override fun toString(): String {
+        return "NewsChannel(data=$data, kord=$kord, supplier=$supplier)"
+    }
+
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/channel/StoreChannel.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/channel/StoreChannel.kt
@@ -34,4 +34,9 @@ data class StoreChannel(
         is ChannelBehavior -> other.id == id
         else -> false
     }
+
+    override fun toString(): String {
+        return "StoreChannel(data=$data, kord=$kord, supplier=$supplier)"
+    }
+
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/channel/TextChannel.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/channel/TextChannel.kt
@@ -44,4 +44,8 @@ class TextChannel(
         else -> false
     }
 
+    override fun toString(): String {
+        return "TextChannel(data=$data, kord=$kord, supplier=$supplier)"
+    }
+
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/channel/VoiceChannel.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/channel/VoiceChannel.kt
@@ -45,4 +45,9 @@ class VoiceChannel(
         is ChannelBehavior -> other.id == id
         else -> false
     }
+
+    override fun toString(): String {
+        return "VoiceChannel(data=$data, kord=$kord, supplier=$supplier)"
+    }
+
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/event/PresenceUpdateEvent.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/event/PresenceUpdateEvent.kt
@@ -79,4 +79,8 @@ class PresenceUpdateEvent(
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): PresenceUpdateEvent =
             PresenceUpdateEvent(oldUser, user, guildId, old, presence, shard, strategy.supply(kord))
+
+    override fun toString(): String {
+        return "PresenceUpdateEvent(oldUser=$oldUser, user=$user, guildId=$guildId, old=$old, presence=$presence, shard=$shard, supplier=$supplier)"
+    }
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/event/UserUpdateEvent.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/event/UserUpdateEvent.kt
@@ -9,4 +9,8 @@ class UserUpdateEvent(
         override val shard: Int
 ) : Event {
     override val kord: Kord get() = user.kord
+
+    override fun toString(): String {
+        return "UserUpdateEvent(old=$old, user=$user, shard=$shard)"
+    }
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/event/VoiceServerUpdateEvent.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/event/VoiceServerUpdateEvent.kt
@@ -25,4 +25,8 @@ class VoiceServerUpdateEvent(
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): VoiceServerUpdateEvent =
             VoiceServerUpdateEvent(token, guildId, endpoint, kord, shard, strategy.supply(kord))
+
+    override fun toString(): String {
+        return "VoiceServerUpdateEvent(token='$token', guildId=$guildId, endpoint='$endpoint', kord=$kord, shard=$shard, supplier=$supplier)"
+    }
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/event/VoiceStateUpdateEvent.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/event/VoiceStateUpdateEvent.kt
@@ -9,4 +9,8 @@ class VoiceStateUpdateEvent(
         override val shard: Int
 ) : Event {
     override val kord: Kord get() = state.kord
+
+    override fun toString(): String {
+        return "VoiceStateUpdateEvent(old=$old, state=$state, shard=$shard)"
+    }
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/event/WebhookUpdateEvent.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/event/WebhookUpdateEvent.kt
@@ -35,4 +35,8 @@ class WebhookUpdateEvent(
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): WebhookUpdateEvent =
             WebhookUpdateEvent(guildId, channelId, kord, shard, strategy.supply(kord))
 
+    override fun toString(): String {
+        return "WebhookUpdateEvent(guildId=$guildId, channelId=$channelId, kord=$kord, shard=$shard, supplier=$supplier)"
+    }
+
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/event/channel/ChannelCreateEvent.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/event/channel/ChannelCreateEvent.kt
@@ -10,9 +10,38 @@ interface ChannelCreateEvent : Event {
         get() = channel.kord
 }
 
-class CategoryCreateEvent (override val channel: Category, override val shard: Int) : ChannelCreateEvent
-class DMChannelCreateEvent (override val channel: DmChannel, override val shard: Int) : ChannelCreateEvent
-class NewsChannelCreateEvent (override val channel: NewsChannel, override val shard: Int) : ChannelCreateEvent
-class StoreChannelCreateEvent (override val channel: StoreChannel, override val shard: Int) : ChannelCreateEvent
-class TextChannelCreateEvent (override val channel: TextChannel, override val shard: Int) : ChannelCreateEvent
-class VoiceChannelCreateEvent (override val channel: VoiceChannel, override val shard: Int) : ChannelCreateEvent
+class CategoryCreateEvent(override val channel: Category, override val shard: Int) : ChannelCreateEvent {
+    override fun toString(): String {
+        return "CategoryCreateEvent(channel=$channel, shard=$shard)"
+    }
+}
+
+class DMChannelCreateEvent(override val channel: DmChannel, override val shard: Int) : ChannelCreateEvent {
+    override fun toString(): String {
+        return "DMChannelCreateEvent(channel=$channel, shard=$shard)"
+    }
+}
+
+class NewsChannelCreateEvent(override val channel: NewsChannel, override val shard: Int) : ChannelCreateEvent {
+    override fun toString(): String {
+        return "NewsChannelCreateEvent(channel=$channel, shard=$shard)"
+    }
+}
+
+class StoreChannelCreateEvent(override val channel: StoreChannel, override val shard: Int) : ChannelCreateEvent {
+    override fun toString(): String {
+        return "StoreChannelCreateEvent(channel=$channel, shard=$shard)"
+    }
+}
+
+class TextChannelCreateEvent(override val channel: TextChannel, override val shard: Int) : ChannelCreateEvent {
+    override fun toString(): String {
+        return "TextChannelCreateEvent(channel=$channel, shard=$shard)"
+    }
+}
+
+class VoiceChannelCreateEvent(override val channel: VoiceChannel, override val shard: Int) : ChannelCreateEvent {
+    override fun toString(): String {
+        return "VoiceChannelCreateEvent(channel=$channel, shard=$shard)"
+    }
+}

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/event/channel/ChannelDeleteEvent.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/event/channel/ChannelDeleteEvent.kt
@@ -10,9 +10,38 @@ interface ChannelDeleteEvent : Event {
         get() = channel.kord
 }
 
-class CategoryDeleteEvent (override val channel: Category, override val shard: Int) : ChannelDeleteEvent
-class DMChannelDeleteEvent (override val channel: DmChannel, override val shard: Int) : ChannelDeleteEvent
-class NewsChannelDeleteEvent (override val channel: NewsChannel, override val shard: Int) : ChannelDeleteEvent
-class StoreChannelDeleteEvent (override val channel: StoreChannel, override val shard: Int) : ChannelDeleteEvent
-class TextChannelDeleteEvent (override val channel: TextChannel, override val shard: Int) : ChannelDeleteEvent
-class VoiceChannelDeleteEvent (override val channel: VoiceChannel, override val shard: Int) : ChannelDeleteEvent
+class CategoryDeleteEvent(override val channel: Category, override val shard: Int) : ChannelDeleteEvent {
+    override fun toString(): String {
+        return "CategoryDeleteEvent(channel=$channel, shard=$shard)"
+    }
+}
+
+class DMChannelDeleteEvent(override val channel: DmChannel, override val shard: Int) : ChannelDeleteEvent {
+    override fun toString(): String {
+        return "DMChannelDeleteEvent(channel=$channel, shard=$shard)"
+    }
+}
+
+class NewsChannelDeleteEvent(override val channel: NewsChannel, override val shard: Int) : ChannelDeleteEvent {
+    override fun toString(): String {
+        return "NewsChannelDeleteEvent(channel=$channel, shard=$shard)"
+    }
+}
+
+class StoreChannelDeleteEvent(override val channel: StoreChannel, override val shard: Int) : ChannelDeleteEvent {
+    override fun toString(): String {
+        return "StoreChannelDeleteEvent(channel=$channel, shard=$shard)"
+    }
+}
+
+class TextChannelDeleteEvent(override val channel: TextChannel, override val shard: Int) : ChannelDeleteEvent {
+    override fun toString(): String {
+        return "TextChannelDeleteEvent(channel=$channel, shard=$shard)"
+    }
+}
+
+class VoiceChannelDeleteEvent(override val channel: VoiceChannel, override val shard: Int) : ChannelDeleteEvent {
+    override fun toString(): String {
+        return "VoiceChannelDeleteEvent(channel=$channel, shard=$shard)"
+    }
+}

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/event/channel/ChannelPinsUpdateEvent.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/event/channel/ChannelPinsUpdateEvent.kt
@@ -28,4 +28,8 @@ class ChannelPinsUpdateEvent(
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): ChannelPinsUpdateEvent =
             ChannelPinsUpdateEvent(channelId, lastPinTimestamp, kord, shard, strategy.supply(kord))
+
+    override fun toString(): String {
+        return "ChannelPinsUpdateEvent(channelId=$channelId, lastPinTimestamp=$lastPinTimestamp, kord=$kord, shard=$shard, supplier=$supplier)"
+    }
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/event/channel/ChannelUpdateEvent.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/event/channel/ChannelUpdateEvent.kt
@@ -10,9 +10,38 @@ interface ChannelUpdateEvent : Event {
         get() = channel.kord
 }
 
-class CategoryUpdateEvent (override val channel: Category, override val shard: Int) : ChannelUpdateEvent
-class DMChannelUpdateEvent (override val channel: DmChannel, override val shard: Int) : ChannelUpdateEvent
-class NewsChannelUpdateEvent (override val channel: NewsChannel, override val shard: Int) : ChannelUpdateEvent
-class StoreChannelUpdateEvent (override val channel: StoreChannel, override val shard: Int) : ChannelUpdateEvent
-class TextChannelUpdateEvent (override val channel: TextChannel, override val shard: Int) : ChannelUpdateEvent
-class VoiceChannelUpdateEvent (override val channel: VoiceChannel, override val shard: Int) : ChannelUpdateEvent
+class CategoryUpdateEvent(override val channel: Category, override val shard: Int) : ChannelUpdateEvent {
+    override fun toString(): String {
+        return "CategoryUpdateEvent(channel=$channel, shard=$shard)"
+    }
+}
+
+class DMChannelUpdateEvent(override val channel: DmChannel, override val shard: Int) : ChannelUpdateEvent {
+    override fun toString(): String {
+        return "DMChannelUpdateEvent(channel=$channel, shard=$shard)"
+    }
+}
+
+class NewsChannelUpdateEvent(override val channel: NewsChannel, override val shard: Int) : ChannelUpdateEvent {
+    override fun toString(): String {
+        return "NewsChannelUpdateEvent(channel=$channel, shard=$shard)"
+    }
+}
+
+class StoreChannelUpdateEvent(override val channel: StoreChannel, override val shard: Int) : ChannelUpdateEvent {
+    override fun toString(): String {
+        return "StoreChannelUpdateEvent(channel=$channel, shard=$shard)"
+    }
+}
+
+class TextChannelUpdateEvent(override val channel: TextChannel, override val shard: Int) : ChannelUpdateEvent {
+    override fun toString(): String {
+        return "TextChannelUpdateEvent(channel=$channel, shard=$shard)"
+    }
+}
+
+class VoiceChannelUpdateEvent(override val channel: VoiceChannel, override val shard: Int) : ChannelUpdateEvent {
+    override fun toString(): String {
+        return "VoiceChannelUpdateEvent(channel=$channel, shard=$shard)"
+    }
+}

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/event/channel/TypingStartEvent.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/event/channel/TypingStartEvent.kt
@@ -85,4 +85,8 @@ class TypingStartEvent(
                     supplier
             )
 
+    override fun toString(): String {
+        return "TypingStartEvent(channelId=$channelId, userId=$userId, guildId=$guildId, started=$started, kord=$kord, shard=$shard, supplier=$supplier)"
+    }
+
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/event/gateway/Events.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/event/gateway/Events.kt
@@ -24,46 +24,78 @@ sealed class DisconnectEvent : GatewayEvent() {
     /**
      * A Gateway was detached, all resources tied to that gateway should be freed.
      */
-    class DetachEvent(override val kord: Kord, override val shard: Int): DisconnectEvent()
+    class DetachEvent(override val kord: Kord, override val shard: Int): DisconnectEvent() {
+        override fun toString(): String {
+            return "DetachEvent(kord=$kord, shard=$shard)"
+        }
+    }
 
     /**
      * The user closed the Gateway connection.
      */
-    class UserCloseEvent(override val kord: Kord, override val shard: Int): DisconnectEvent()
+    class UserCloseEvent(override val kord: Kord, override val shard: Int): DisconnectEvent() {
+        override fun toString(): String {
+            return "UserCloseEvent(kord=$kord, shard=$shard)"
+        }
+    }
 
     /**
      * The connection was closed because of a timeout, probably due to a loss of internet connection.
      */
-    class TimeoutEvent(override val kord: Kord, override val shard: Int): DisconnectEvent()
+    class TimeoutEvent(override val kord: Kord, override val shard: Int): DisconnectEvent() {
+        override fun toString(): String {
+            return "TimeoutEvent(kord=$kord, shard=$shard)"
+        }
+    }
 
     /**
      * Discord closed the connection with a [closeCode].
      *
      * @param recoverable true if the gateway will automatically try to reconnect.
      */
-    class DiscordCloseEvent(override val kord: Kord, override val shard: Int, val closeCode: GatewayCloseCode, val recoverable: Boolean): DisconnectEvent()
+    class DiscordCloseEvent(override val kord: Kord, override val shard: Int, val closeCode: GatewayCloseCode, val recoverable: Boolean): DisconnectEvent() {
+        override fun toString(): String {
+            return "DiscordCloseEvent(kord=$kord, shard=$shard, closeCode=$closeCode, recoverable=$recoverable)"
+        }
+    }
 
     /**
      *  The Gateway has failed to establish a connection too many times and will not try to reconnect anymore.
      *  The user is free to manually connect again using [Gateway.start], otherwise all resources linked to the Gateway should free and the Gateway [detached][Gateway.detach].
      */
-    class RetryLimitReachedEvent(override val kord: Kord, override val shard: Int): DisconnectEvent()
+    class RetryLimitReachedEvent(override val kord: Kord, override val shard: Int): DisconnectEvent() {
+        override fun toString(): String {
+            return "RetryLimitReachedEvent(kord=$kord, shard=$shard)"
+        }
+    }
 
     /**
      * Discord requested a reconnect, the gateway will close and attempt to resume the session.
      */
-    class ReconnectingEvent(override val kord: Kord, override val shard: Int) : DisconnectEvent()
+    class ReconnectingEvent(override val kord: Kord, override val shard: Int) : DisconnectEvent() {
+        override fun toString(): String {
+            return "ReconnectingEvent(kord=$kord, shard=$shard)"
+        }
+    }
 
     /**
      * The gateway closed and will attempt to start a new session.
      */
-    class SessionReset(override val kord: Kord, override val shard: Int) : DisconnectEvent()
+    class SessionReset(override val kord: Kord, override val shard: Int) : DisconnectEvent() {
+        override fun toString(): String {
+            return "SessionReset(kord=$kord, shard=$shard)"
+        }
+    }
 
     /**
      * Discord is no longer responding to the gateway commands, the connection will be closed and an attempt to resume the session will be made.
      * Any [commands][Command] send recently might not complete, and won't be automatically requeued.
      */
-    class ZombieConnectionEvent(override val kord: Kord, override val shard: Int) : DisconnectEvent()
+    class ZombieConnectionEvent(override val kord: Kord, override val shard: Int) : DisconnectEvent() {
+        override fun toString(): String {
+            return "ZombieConnectionEvent(kord=$kord, shard=$shard)"
+        }
+    }
 
 }
 
@@ -81,6 +113,14 @@ class ReadyEvent (
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): ReadyEvent =
             ReadyEvent(gatewayVersion, guildIds, self, sessionId, kord, shard, strategy.supply(kord))
+
+    override fun toString(): String {
+        return "ReadyEvent(gatewayVersion=$gatewayVersion, guildIds=$guildIds, self=$self, sessionId='$sessionId', kord=$kord, shard=$shard, supplier=$supplier)"
+    }
 }
 
-class ResumedEvent(override val kord: Kord, override val shard: Int) : GatewayEvent()
+class ResumedEvent(override val kord: Kord, override val shard: Int) : GatewayEvent() {
+    override fun toString(): String {
+        return "ResumedEvent(kord=$kord, shard=$shard)"
+    }
+}

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/event/guild/BanAddEvent.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/event/guild/BanAddEvent.kt
@@ -58,4 +58,8 @@ class BanAddEvent(
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): BanAddEvent =
             BanAddEvent(user, guildId, shard, strategy.supply(kord))
+
+    override fun toString(): String {
+        return "BanAddEvent(user=$user, guildId=$guildId, shard=$shard, supplier=$supplier)"
+    }
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/event/guild/BanRemoveEvent.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/event/guild/BanRemoveEvent.kt
@@ -27,4 +27,8 @@ class BanRemoveEvent(
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): BanRemoveEvent =
             BanRemoveEvent(user, guildId, shard, strategy.supply(kord))
+
+    override fun toString(): String {
+        return "BanRemoveEvent(user=$user, guildId=$guildId, shard=$shard, supplier=$supplier)"
+    }
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/event/guild/EmojisUpdateEvent.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/event/guild/EmojisUpdateEvent.kt
@@ -26,4 +26,8 @@ class EmojisUpdateEvent(
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): EmojisUpdateEvent =
             EmojisUpdateEvent(guildId, emojis, kord, shard, strategy.supply(kord))
+
+    override fun toString(): String {
+        return "EmojisUpdateEvent(guildId=$guildId, emojis=$emojis, kord=$kord, shard=$shard, supplier=$supplier)"
+    }
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/event/guild/GuildCreateEvent.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/event/guild/GuildCreateEvent.kt
@@ -6,4 +6,8 @@ import com.gitlab.kordlib.core.event.Event
 
 class GuildCreateEvent (val guild: Guild, override val shard: Int) : Event {
     override val kord: Kord get() = guild.kord
+
+    override fun toString(): String {
+        return "GuildCreateEvent(guild=$guild, shard=$shard)"
+    }
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/event/guild/GuildDeleteEvent.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/event/guild/GuildDeleteEvent.kt
@@ -11,4 +11,10 @@ class GuildDeleteEvent(
         val guild: Guild?,
         override val kord: Kord,
         override val shard: Int
-) : Event
+) : Event {
+
+    override fun toString(): String {
+        return "GuildDeleteEvent(guildId=$guildId, unavailable=$unavailable, guild=$guild, kord=$kord, shard=$shard)"
+    }
+
+}

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/event/guild/GuildUpdateEvent.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/event/guild/GuildUpdateEvent.kt
@@ -6,4 +6,7 @@ import com.gitlab.kordlib.core.event.Event
 
 class GuildUpdateEvent (val guild: Guild, override val shard: Int) : Event {
     override val kord: Kord get() = guild.kord
+    override fun toString(): String {
+        return "GuildUpdateEvent(guild=$guild, shard=$shard)"
+    }
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/event/guild/IntegrationsUpdateEvent.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/event/guild/IntegrationsUpdateEvent.kt
@@ -24,4 +24,8 @@ class IntegrationsUpdateEvent(
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): IntegrationsUpdateEvent =
             IntegrationsUpdateEvent(guildId, kord, shard, strategy.supply(kord))
+
+    override fun toString(): String {
+        return "IntegrationsUpdateEvent(guildId=$guildId, kord=$kord, shard=$shard, supplier=$supplier)"
+    }
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/event/guild/InviteCreateEvent.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/event/guild/InviteCreateEvent.kt
@@ -165,4 +165,8 @@ class InviteCreateEvent(
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): InviteCreateEvent =
             InviteCreateEvent(data, kord, shard, supplier)
+
+    override fun toString(): String {
+        return "InviteCreateEvent(data=$data, kord=$kord, shard=$shard, supplier=$supplier)"
+    }
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/event/guild/InviteDeleteEvent.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/event/guild/InviteDeleteEvent.kt
@@ -66,4 +66,8 @@ class InviteDeleteEvent(
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): InviteDeleteEvent =
             InviteDeleteEvent(data, kord, shard, strategy.supply(kord))
 
+    override fun toString(): String {
+        return "InviteDeleteEvent(data=$data, kord=$kord, shard=$shard, supplier=$supplier)"
+    }
+
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/event/guild/MemberChunksEvent.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/event/guild/MemberChunksEvent.kt
@@ -26,4 +26,8 @@ class MemberChunksEvent(
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): MemberChunksEvent =
             MemberChunksEvent(guildId, members, kord, shard, strategy.supply(kord))
+
+    override fun toString(): String {
+        return "MemberChunksEvent(guildId=$guildId, members=$members, kord=$kord, shard=$shard, supplier=$supplier)"
+    }
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/event/guild/MemberJoinEvent.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/event/guild/MemberJoinEvent.kt
@@ -29,4 +29,8 @@ class MemberJoinEvent(
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): MemberJoinEvent =
             MemberJoinEvent(member, shard, strategy.supply(kord))
 
+    override fun toString(): String {
+        return "MemberJoinEvent(member=$member, shard=$shard, supplier=$supplier)"
+    }
+
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/event/guild/MemberLeaveEvent.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/event/guild/MemberLeaveEvent.kt
@@ -7,7 +7,7 @@ import com.gitlab.kordlib.core.entity.Guild
 import com.gitlab.kordlib.core.entity.User
 import com.gitlab.kordlib.core.event.Event
 
-class MemberLeaveEvent (val user: User, val guildId: Snowflake, override val shard: Int) : Event {
+class MemberLeaveEvent(val user: User, val guildId: Snowflake, override val shard: Int) : Event {
 
     override val kord: Kord get() = user.kord
 
@@ -16,5 +16,9 @@ class MemberLeaveEvent (val user: User, val guildId: Snowflake, override val sha
     suspend fun getGuild(): Guild = guild.asGuild()
 
     suspend fun getGuildOrNull(): Guild? = guild.asGuildOrNull()
+
+    override fun toString(): String {
+        return "MemberLeaveEvent(user=$user, guildId=$guildId, shard=$shard)"
+    }
 
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/event/guild/MemberUpdateEvent.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/event/guild/MemberUpdateEvent.kt
@@ -55,4 +55,8 @@ class MemberUpdateEvent(
                     shard,
                     strategy.supply(kord)
             )
+
+    override fun toString(): String {
+        return "MemberUpdateEvent(old=$old, guildId=$guildId, memberId=$memberId, currentRoleIds=$currentRoleIds, currentNickName='$currentNickName', premiumSince=$premiumSince, kord=$kord, shard=$shard, supplier=$supplier)"
+    }
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/event/message/MessageBulkDeleteEvent.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/event/message/MessageBulkDeleteEvent.kt
@@ -37,4 +37,8 @@ class MessageBulkDeleteEvent(
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): MessageBulkDeleteEvent =
             MessageBulkDeleteEvent(messageIds, messages, channelId, guildId, kord, shard, strategy.supply(kord))
 
+    override fun toString(): String {
+        return "MessageBulkDeleteEvent(messageIds=$messageIds, messages=$messages, channelId=$channelId, guildId=$guildId, kord=$kord, shard=$shard, supplier=$supplier)"
+    }
+
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/event/message/MessageCreateEvent.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/event/message/MessageCreateEvent.kt
@@ -31,4 +31,8 @@ class MessageCreateEvent(
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): Strategizable =
             MessageCreateEvent(message, guildId, member, shard, strategy.supply(message.kord))
+
+    override fun toString(): String {
+        return "MessageCreateEvent(message=$message, guildId=$guildId, member=$member, shard=$shard, supplier=$supplier)"
+    }
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/event/message/MessageDeleteEvent.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/event/message/MessageDeleteEvent.kt
@@ -36,4 +36,8 @@ class MessageDeleteEvent(
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): MessageDeleteEvent =
             MessageDeleteEvent(messageId, channelId, guildId, message, kord, shard, strategy.supply(kord))
+
+    override fun toString(): String {
+        return "MessageDeleteEvent(messageId=$messageId, channelId=$channelId, guildId=$guildId, message=$message, kord=$kord, shard=$shard, supplier=$supplier)"
+    }
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/event/message/MessageUpdateEvent.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/event/message/MessageUpdateEvent.kt
@@ -38,4 +38,8 @@ class MessageUpdateEvent (
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): MessageUpdateEvent =
             MessageUpdateEvent(messageId, channelId, new, old, kord, shard, strategy.supply(kord))
+
+    override fun toString(): String {
+        return "MessageUpdateEvent(messageId=$messageId, channelId=$channelId, new=$new, old=$old, kord=$kord, shard=$shard, supplier=$supplier)"
+    }
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/event/message/ReactionAddEvent.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/event/message/ReactionAddEvent.kt
@@ -52,4 +52,8 @@ class ReactionAddEvent(
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): ReactionAddEvent =
             ReactionAddEvent(userId, channelId, messageId, guildId, emoji, kord, shard, strategy.supply(kord))
+
+    override fun toString(): String {
+        return "ReactionAddEvent(userId=$userId, channelId=$channelId, messageId=$messageId, guildId=$guildId, emoji=$emoji, kord=$kord, shard=$shard, supplier=$supplier)"
+    }
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/event/message/ReactionRemoveAllEvent.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/event/message/ReactionRemoveAllEvent.kt
@@ -40,4 +40,8 @@ class ReactionRemoveAllEvent(
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): ReactionRemoveAllEvent =
             ReactionRemoveAllEvent(channelId, messageId, guildId, kord, shard, strategy.supply(kord))
+
+    override fun toString(): String {
+        return "ReactionRemoveAllEvent(channelId=$channelId, messageId=$messageId, guildId=$guildId, kord=$kord, shard=$shard, supplier=$supplier)"
+    }
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/event/message/ReactionRemoveEmojiEvent.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/event/message/ReactionRemoveEmojiEvent.kt
@@ -64,4 +64,8 @@ class ReactionRemoveEmojiEvent(
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): ReactionRemoveAllEvent =
             ReactionRemoveAllEvent(channelId, messageId, guildId, kord, shard, strategy.supply(kord))
+
+    override fun toString(): String {
+        return "ReactionRemoveEmojiEvent(data=$data, kord=$kord, shard=$shard, supplier=$supplier)"
+    }
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/event/message/ReactionRemoveEvent.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/event/message/ReactionRemoveEvent.kt
@@ -55,4 +55,8 @@ class ReactionRemoveEvent(
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): ReactionRemoveEvent =
             ReactionRemoveEvent(userId, channelId, messageId, guildId, emoji, kord, shard, strategy.supply(kord))
+
+    override fun toString(): String {
+        return "ReactionRemoveEvent(userId=$userId, channelId=$channelId, messageId=$messageId, guildId=$guildId, emoji=$emoji, kord=$kord, shard=$shard, supplier=$supplier)"
+    }
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/event/role/RoleCreateEvent.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/event/role/RoleCreateEvent.kt
@@ -10,10 +10,10 @@ import com.gitlab.kordlib.core.event.Event
 import com.gitlab.kordlib.core.supplier.EntitySupplier
 import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy
 
-class RoleCreateEvent (
+class RoleCreateEvent(
         val role: Role,
         override val shard: Int,
-        override val supplier: EntitySupplier = role.kord.defaultSupplier
+        override val supplier: EntitySupplier = role.kord.defaultSupplier,
 ) : Event, Strategizable {
 
     override val kord: Kord get() = role.kord
@@ -24,8 +24,12 @@ class RoleCreateEvent (
 
     suspend fun getGuild(): Guild = supplier.getGuild(guildId)
 
-    suspend fun getGuildOrNull():Guild? = supplier.getGuildOrNull(guildId)
+    suspend fun getGuildOrNull(): Guild? = supplier.getGuildOrNull(guildId)
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): RoleCreateEvent =
             RoleCreateEvent(role, shard, strategy.supply(kord))
+
+    override fun toString(): String {
+        return "RoleCreateEvent(role=$role, shard=$shard, supplier=$supplier)"
+    }
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/event/role/RoleDeleteEvent.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/event/role/RoleDeleteEvent.kt
@@ -27,4 +27,8 @@ class RoleDeleteEvent(
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): RoleDeleteEvent =
             RoleDeleteEvent(guildId, roleId, role, kord, shard, strategy.supply(kord))
+
+    override fun toString(): String {
+        return "RoleDeleteEvent(guildId=$guildId, roleId=$roleId, role=$role, kord=$kord, shard=$shard, supplier=$supplier)"
+    }
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/event/role/RoleUpdateEvent.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/event/role/RoleUpdateEvent.kt
@@ -28,4 +28,8 @@ class RoleUpdateEvent(
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): RoleUpdateEvent =
             RoleUpdateEvent(role, shard, strategy.supply(kord))
+
+    override fun toString(): String {
+        return "RoleUpdateEvent(role=$role, shard=$shard, supplier=$supplier)"
+    }
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/gateway/MasterGateway.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/gateway/MasterGateway.kt
@@ -35,4 +35,8 @@ class MasterGateway(
 
     suspend fun stopAll() = gateways.values.forEach { it.stop() }
 
+    override fun toString(): String {
+        return "MasterGateway(gateways=$gateways)"
+    }
+
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/supplier/CacheEntitySupplier.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/supplier/CacheEntitySupplier.kt
@@ -2,6 +2,7 @@ package com.gitlab.kordlib.core.supplier
 
 import com.gitlab.kordlib.cache.api.DataCache
 import com.gitlab.kordlib.cache.api.query
+
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.common.exception.RequestException
 import com.gitlab.kordlib.core.Kord
@@ -244,6 +245,10 @@ class CacheEntitySupplier(private val kord: Kord) : EntitySupplier {
         val data = cache.query<UserData> { UserData::id eq id.longValue }.singleOrNull() ?: return null
 
         return User(data, kord)
+    }
+
+    override fun toString(): String {
+        return "CacheEntitySupplier(kord=$kord, cache=$cache)"
     }
 
 

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/supplier/CacheEntitySupplier.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/supplier/CacheEntitySupplier.kt
@@ -248,7 +248,7 @@ class CacheEntitySupplier(private val kord: Kord) : EntitySupplier {
     }
 
     override fun toString(): String {
-        return "CacheEntitySupplier(kord=$kord, cache=$cache)"
+        return "CacheEntitySupplier(cache=$cache)"
     }
 
 

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/supplier/EntitySupplyStrategy.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/supplier/EntitySupplyStrategy.kt
@@ -22,6 +22,7 @@ interface EntitySupplyStrategy<T : EntitySupplier> {
 
             override fun supply(kord: Kord): RestEntitySupplier = RestEntitySupplier(kord)
 
+            override fun toString(): String = "EntitySupplyStrategy.rest"
         }
 
         /**
@@ -32,6 +33,7 @@ interface EntitySupplyStrategy<T : EntitySupplier> {
 
             override fun supply(kord: Kord): CacheEntitySupplier = CacheEntitySupplier(kord)
 
+            override fun toString(): String = "EntitySupplyStrategy.cache"
         }
 
         /**
@@ -43,6 +45,7 @@ interface EntitySupplyStrategy<T : EntitySupplier> {
 
             override fun supply(kord: Kord): EntitySupplier = cache.supply(kord).withFallback(rest.supply(kord))
 
+            override fun toString(): String = "EntitySupplyStrategy.cacheWithRestFallback"
         }
 
         /**

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/supplier/FallbackEntitySupplier.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/supplier/FallbackEntitySupplier.kt
@@ -4,8 +4,6 @@ import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.core.entity.*
 import com.gitlab.kordlib.core.entity.channel.Channel
 import com.gitlab.kordlib.core.entity.channel.GuildChannel
-import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy.Companion.cache
-import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy.Companion.rest
 import com.gitlab.kordlib.core.switchIfEmpty
 import kotlinx.coroutines.flow.Flow
 
@@ -100,9 +98,8 @@ private class FallbackEntitySupplier(val first: EntitySupplier, val second: Enti
     override suspend fun getWebhookWithTokenOrNull(id: Snowflake, token: String): Webhook? =
             first.getWebhookWithTokenOrNull(id, token) ?: second.getWebhookWithTokenOrNull(id, token)
 
-    override fun toString(): String = buildToString("FallbackEntitySupplier"){
-        property("first", first)
-        property("second", second)
+    override fun toString(): String {
+        return "FallbackEntitySupplier(first=$first, second=$second)"
     }
 }
 

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/supplier/FallbackEntitySupplier.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/supplier/FallbackEntitySupplier.kt
@@ -100,5 +100,9 @@ private class FallbackEntitySupplier(val first: EntitySupplier, val second: Enti
     override suspend fun getWebhookWithTokenOrNull(id: Snowflake, token: String): Webhook? =
             first.getWebhookWithTokenOrNull(id, token) ?: second.getWebhookWithTokenOrNull(id, token)
 
+    override fun toString(): String = buildToString("FallbackEntitySupplier"){
+        property("first", first)
+        property("second", second)
+    }
 }
 

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/supplier/RestEntitySupplier.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/supplier/RestEntitySupplier.kt
@@ -277,4 +277,9 @@ class RestEntitySupplier(val kord: Kord) : EntitySupplier {
         return ApplicationInfo(ApplicationInfoData.from(response), kord)
     }
 
+
+    override fun toString(): String {
+        return "RestEntitySupplier(kord=$kord, rest=$kord.rest)"
+    }
+
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/supplier/RestEntitySupplier.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/supplier/RestEntitySupplier.kt
@@ -279,7 +279,7 @@ class RestEntitySupplier(val kord: Kord) : EntitySupplier {
 
 
     override fun toString(): String {
-        return "RestEntitySupplier(kord=$kord, rest=$kord.rest)"
+        return "RestEntitySupplier(rest=${kord.rest})"
     }
 
 }

--- a/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/Gateway.kt
+++ b/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/Gateway.kt
@@ -81,6 +81,10 @@ interface Gateway {
             override suspend fun stop() {}
 
             override suspend fun detach() {}
+
+            override fun toString(): String {
+                return "Gateway.None"
+            }
         }
 
         /**


### PR DESCRIPTION
This PR aims to add meaningful toString implementations for core classes to facilitate debugging. Most of these follow the data class-like approach of `ClassName(p1Name=p1Value, p2Name=p2Value, ...)`. 
Exceptions to these are behaviors (since they don't have constructors), who instead display the Snowflake IDs they are made up of,
and the bitshift classes like Permissions; those display their enum values instead.