### PR TITLE
Deprecate BroadcastChannel for SharedFlow

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -16,7 +16,7 @@ object  Versions {
     const val junitJupiterEngine = junit5
     const val sl4j = "1.7.30"
     const val bintray = "1.8.5"
-    const val mockk = "1.10.0"
+    const val mockk = "1.10.2"
 }
 
 @Suppress("ObjectPropertyName")

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -2,7 +2,7 @@ object  Versions {
     const val kotlin = "1.4.10"
     const val kotlinxSerialization = "1.0.0"
     const val ktor = "1.4.1"
-    const val kotlinxCoroutines = "1.4.0-M1"
+    const val kotlinxCoroutines = "1.4.0"
     const val kotlinLogging = "2.0.3"
     const val atomicFu = "0.14.4"
     const val binaryCompatibilityValidator = "0.2.3"

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/builder/kord/KordBuilder.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/builder/kord/KordBuilder.kt
@@ -15,7 +15,6 @@ import com.gitlab.kordlib.core.exception.KordInitializationException
 import com.gitlab.kordlib.core.gateway.MasterGateway
 import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy
 import com.gitlab.kordlib.gateway.DefaultGateway
-import com.gitlab.kordlib.gateway.DefaultGatewayData
 import com.gitlab.kordlib.gateway.Gateway
 import com.gitlab.kordlib.gateway.Intents
 import com.gitlab.kordlib.gateway.retry.LinearRetry
@@ -27,15 +26,13 @@ import com.gitlab.kordlib.rest.request.RequestHandler
 import com.gitlab.kordlib.rest.request.isError
 import com.gitlab.kordlib.rest.route.Route
 import com.gitlab.kordlib.rest.service.RestClient
-import io.ktor.client.HttpClient
-import io.ktor.client.request.get
-import io.ktor.client.statement.HttpResponse
-import io.ktor.client.statement.readText
-import io.ktor.http.HttpStatusCode
+import io.ktor.client.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.channels.BroadcastChannel
-import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import mu.KotlinLogging
@@ -45,8 +42,15 @@ import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 import kotlin.time.seconds
 
-operator fun DefaultGateway.Companion.invoke(resources: ClientResources, retry: Retry = LinearRetry(2.seconds, 60.seconds, 10)) =
-        DefaultGateway(DefaultGatewayData("wss://gateway.discord.gg/", resources.httpClient, retry, BucketRateLimiter(120, 60.seconds), BucketRateLimiter(1, 5.seconds)))
+operator fun DefaultGateway.Companion.invoke(resources: ClientResources, retry: Retry = LinearRetry(2.seconds, 60.seconds, 10)): DefaultGateway {
+    return DefaultGateway {
+        url = "wss://gateway.discord.gg/"
+        client = resources.httpClient
+        reconnectRetry = retry
+        sendRateLimiter = BucketRateLimiter(120, 60.seconds)
+        identifyRateLimiter = BucketRateLimiter(1, 5.seconds)
+    }
+}
 
 private val logger = KotlinLogging.logger { }
 
@@ -70,6 +74,16 @@ class KordBuilder(val token: String) {
      * Enable adding a [Runtime.addShutdownHook] to log out of the [Gateway] when the process is killed.
      */
     var enableShutdownHook: Boolean = true
+
+    /**
+     * The event flow used by [Kord.eventFlow] to publish [events][Kord.events].
+     * 
+     *
+     * By default a [MutableSharedFlow] with an `extraBufferCapacity` of `Int.MAX_VALUE`.
+     */
+    var eventFlow: MutableSharedFlow<Event> = MutableSharedFlow(
+            extraBufferCapacity = Int.MAX_VALUE
+    )
 
     /**
      * The [CoroutineDispatcher] kord uses to launch suspending tasks. [Dispatchers.Default] by default.
@@ -244,8 +258,6 @@ class KordBuilder(val token: String) {
 
         val self = getBotIdFromToken(token)
 
-        val eventPublisher = BroadcastChannel<Event>(1)
-
         if (enableShutdownHook) {
             Runtime.getRuntime().addShutdownHook(thread(false) {
                 runBlocking {
@@ -260,7 +272,7 @@ class KordBuilder(val token: String) {
                 gateway,
                 rest,
                 self,
-                eventPublisher,
+                eventFlow,
                 defaultDispatcher
         )
     }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/builder/kord/KordRestOnlyBuilder.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/builder/kord/KordRestOnlyBuilder.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.BroadcastChannel
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableSharedFlow
 
 @KordExperimental
 class KordRestOnlyBuilder(val token: String) {
@@ -61,15 +62,13 @@ class KordRestOnlyBuilder(val token: String) {
         val rest = RestClient(handlerBuilder(resources))
         val selfId = getBotIdFromToken(token)
 
-        val eventPublisher = BroadcastChannel<Event>(1)
-
         return Kord(
                 resources,
                 DataCache.none(),
                 MasterGateway(mapOf(0 to Gateway.none())),
                 rest,
                 selfId,
-                eventPublisher,
+                MutableSharedFlow(),
                 defaultDispatcher
         )
     }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/gateway/handler/BaseGatewayEventHandler.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/gateway/handler/BaseGatewayEventHandler.kt
@@ -5,6 +5,7 @@ import com.gitlab.kordlib.core.Kord
 import com.gitlab.kordlib.core.gateway.MasterGateway
 import com.gitlab.kordlib.gateway.Gateway
 import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import com.gitlab.kordlib.core.event.Event as CoreEvent
 import com.gitlab.kordlib.gateway.Event as GatewayEvent
 
@@ -12,7 +13,7 @@ abstract class BaseGatewayEventHandler(
         protected val kord: Kord,
         protected val gateway: MasterGateway,
         protected val cache: DataCache,
-        protected val coreEventChannel: SendChannel<CoreEvent>
+        protected val coreFlow: MutableSharedFlow<CoreEvent>
 ) {
 
     abstract suspend fun handle(event: GatewayEvent, shard: Int)

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/gateway/handler/ChannelEventHandler.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/gateway/handler/ChannelEventHandler.kt
@@ -13,7 +13,7 @@ import com.gitlab.kordlib.core.gateway.MasterGateway
 import com.gitlab.kordlib.core.toInstant
 import com.gitlab.kordlib.core.toSnowflakeOrNull
 import com.gitlab.kordlib.gateway.*
-import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import com.gitlab.kordlib.core.event.Event as CoreEvent
 
 @Suppress("EXPERIMENTAL_API_USAGE")
@@ -21,8 +21,8 @@ internal class ChannelEventHandler(
         kord: Kord,
         gateway: MasterGateway,
         cache: DataCache,
-        coreEventChannel: SendChannel<CoreEvent>
-) : BaseGatewayEventHandler(kord, gateway, cache, coreEventChannel) {
+        coreFlow: MutableSharedFlow<CoreEvent>
+) : BaseGatewayEventHandler(kord, gateway, cache, coreFlow) {
 
     override suspend fun handle(event: Event, shard: Int) = when (event) {
         is ChannelCreate -> handle(event, shard)
@@ -47,7 +47,7 @@ internal class ChannelEventHandler(
             else -> error("unknown channel: $channel")
         }
 
-        coreEventChannel.send(coreEvent)
+        coreFlow.emit(coreEvent)
     }
 
     private suspend fun handle(event: ChannelUpdate, shard: Int) {
@@ -64,7 +64,7 @@ internal class ChannelEventHandler(
             else -> error("unknown channel: $channel")
         }
 
-        coreEventChannel.send(coreEvent)
+        coreFlow.emit(coreEvent)
     }
 
     private suspend fun handle(event: ChannelDelete, shard: Int) {
@@ -81,7 +81,7 @@ internal class ChannelEventHandler(
             else -> error("unknown channel: $channel")
         }
 
-        coreEventChannel.send(coreEvent)
+        coreFlow.emit(coreEvent)
     }
 
     private suspend fun handle(event: ChannelPinsUpdate, shard: Int) = with(event.pins) {
@@ -91,7 +91,7 @@ internal class ChannelEventHandler(
             it.copy(lastPinTimestamp = lastPinTimestamp ?: it.lastPinTimestamp)
         }
 
-        coreEventChannel.send(coreEvent)
+        coreFlow.emit(coreEvent)
     }
 
     private suspend fun handle(event: TypingStart, shard: Int) = with(event.data) {
@@ -104,7 +104,7 @@ internal class ChannelEventHandler(
                 shard
         )
 
-        coreEventChannel.send(coreEvent)
+        coreFlow.emit(coreEvent)
     }
 
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/gateway/handler/GatewayEventInterceptor.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/gateway/handler/GatewayEventInterceptor.kt
@@ -6,8 +6,7 @@ import com.gitlab.kordlib.core.gateway.MasterGateway
 import com.gitlab.kordlib.gateway.Event
 import io.ktor.util.*
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.channels.SendChannel
-import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -21,17 +20,17 @@ class GatewayEventInterceptor(
         private val kord: Kord,
         private val gateway: MasterGateway,
         cache: DataCache,
-        coreEventChannel: SendChannel<CoreEvent>,
+        coreFlow: MutableSharedFlow<CoreEvent>,
 ) {
 
     private val listeners = listOf(
-            MessageEventHandler(kord, gateway, cache, coreEventChannel),
-            ChannelEventHandler(kord, gateway, cache, coreEventChannel),
-            GuildEventHandler(kord, gateway, cache, coreEventChannel),
-            LifeCycleEventHandler(kord, gateway, cache, coreEventChannel),
-            UserEventHandler(kord, gateway, cache, coreEventChannel),
-            VoiceEventHandler(kord, gateway, cache, coreEventChannel),
-            WebhookEventHandler(kord, gateway, cache, coreEventChannel)
+            MessageEventHandler(kord, gateway, cache, coreFlow),
+            ChannelEventHandler(kord, gateway, cache, coreFlow),
+            GuildEventHandler(kord, gateway, cache, coreFlow),
+            LifeCycleEventHandler(kord, gateway, cache, coreFlow),
+            UserEventHandler(kord, gateway, cache, coreFlow),
+            VoiceEventHandler(kord, gateway, cache, coreFlow),
+            WebhookEventHandler(kord, gateway, cache, coreFlow)
     )
 
     suspend fun start() = gateway.events

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/gateway/handler/LifeCycleEventHandler.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/gateway/handler/LifeCycleEventHandler.kt
@@ -12,7 +12,7 @@ import com.gitlab.kordlib.core.event.gateway.ReadyEvent
 import com.gitlab.kordlib.core.event.gateway.ResumedEvent
 import com.gitlab.kordlib.core.gateway.MasterGateway
 import com.gitlab.kordlib.gateway.*
-import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import com.gitlab.kordlib.core.event.Event as CoreEvent
 
 @Suppress("EXPERIMENTAL_API_USAGE")
@@ -20,22 +20,22 @@ internal class LifeCycleEventHandler(
         kord: Kord,
         gateway: MasterGateway,
         cache: DataCache,
-        coreEventChannel: SendChannel<CoreEvent>
-) : BaseGatewayEventHandler(kord, gateway, cache, coreEventChannel) {
+        coreFlow: MutableSharedFlow<CoreEvent>
+) : BaseGatewayEventHandler(kord, gateway, cache, coreFlow) {
 
     override suspend fun handle(event: Event, shard: Int) = when (event) {
         is Ready -> handle(event, shard)
-        is Resumed -> coreEventChannel.send(ResumedEvent(kord, shard))
-        Reconnect -> coreEventChannel.send(ConnectEvent(kord, shard))
+        is Resumed -> coreFlow.emit(ResumedEvent(kord, shard))
+        Reconnect -> coreFlow.emit(ConnectEvent(kord, shard))
         is Close -> when (event) {
-            Close.Detach -> coreEventChannel.send(DisconnectEvent.DetachEvent(kord, shard))
-            Close.UserClose -> coreEventChannel.send(DisconnectEvent.UserCloseEvent(kord, shard))
-            Close.Timeout -> coreEventChannel.send(DisconnectEvent.TimeoutEvent(kord, shard))
-            is Close.DiscordClose -> coreEventChannel.send(DisconnectEvent.DiscordCloseEvent(kord, shard, event.closeCode, event.recoverable))
-            Close.Reconnecting -> coreEventChannel.send(DisconnectEvent.ReconnectingEvent(kord, shard))
-            Close.ZombieConnection -> coreEventChannel.send(DisconnectEvent.ZombieConnectionEvent(kord, shard))
-            Close.RetryLimitReached -> coreEventChannel.send(DisconnectEvent.RetryLimitReachedEvent(kord, shard))
-            Close.SessionReset -> coreEventChannel.send(DisconnectEvent.SessionReset(kord, shard))
+            Close.Detach -> coreFlow.emit(DisconnectEvent.DetachEvent(kord, shard))
+            Close.UserClose -> coreFlow.emit(DisconnectEvent.UserCloseEvent(kord, shard))
+            Close.Timeout -> coreFlow.emit(DisconnectEvent.TimeoutEvent(kord, shard))
+            is Close.DiscordClose -> coreFlow.emit(DisconnectEvent.DiscordCloseEvent(kord, shard, event.closeCode, event.recoverable))
+            Close.Reconnecting -> coreFlow.emit(DisconnectEvent.ReconnectingEvent(kord, shard))
+            Close.ZombieConnection -> coreFlow.emit(DisconnectEvent.ZombieConnectionEvent(kord, shard))
+            Close.RetryLimitReached -> coreFlow.emit(DisconnectEvent.RetryLimitReachedEvent(kord, shard))
+            Close.SessionReset -> coreFlow.emit(DisconnectEvent.SessionReset(kord, shard))
         }
 
         else -> Unit
@@ -47,6 +47,6 @@ internal class LifeCycleEventHandler(
 
         cache.put(self)
 
-        coreEventChannel.send(ReadyEvent(event.data.version, guilds, User(self, kord), sessionId, kord, shard))
+        coreFlow.emit(ReadyEvent(event.data.version, guilds, User(self, kord), sessionId, kord, shard))
     }
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/gateway/handler/UserEventHandler.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/gateway/handler/UserEventHandler.kt
@@ -9,9 +9,8 @@ import com.gitlab.kordlib.core.entity.User
 import com.gitlab.kordlib.core.event.UserUpdateEvent
 import com.gitlab.kordlib.core.gateway.MasterGateway
 import com.gitlab.kordlib.gateway.Event
-import com.gitlab.kordlib.gateway.Gateway
 import com.gitlab.kordlib.gateway.UserUpdate
-import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.singleOrNull
 import com.gitlab.kordlib.core.event.Event as CoreEvent
@@ -21,8 +20,8 @@ internal class UserEventHandler(
         kord: Kord,
         gateway: MasterGateway,
         cache: DataCache,
-        coreEventChannel: SendChannel<CoreEvent>
-) : BaseGatewayEventHandler(kord, gateway, cache, coreEventChannel) {
+        coreFlow: MutableSharedFlow<CoreEvent>
+) : BaseGatewayEventHandler(kord, gateway, cache, coreFlow) {
 
     override suspend fun handle(event: Event, shard: Int) = when (event) {
         is UserUpdate -> handle(event, shard)
@@ -38,7 +37,7 @@ internal class UserEventHandler(
         cache.put(data)
         val new = User(data, kord)
 
-        coreEventChannel.send(UserUpdateEvent(old, new, shard))
+        coreFlow.emit(UserUpdateEvent(old, new, shard))
     }
 
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/gateway/handler/VoiceEventHandler.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/gateway/handler/VoiceEventHandler.kt
@@ -11,10 +11,9 @@ import com.gitlab.kordlib.core.event.VoiceServerUpdateEvent
 import com.gitlab.kordlib.core.event.VoiceStateUpdateEvent
 import com.gitlab.kordlib.core.gateway.MasterGateway
 import com.gitlab.kordlib.gateway.Event
-import com.gitlab.kordlib.gateway.Gateway
 import com.gitlab.kordlib.gateway.VoiceServerUpdate
 import com.gitlab.kordlib.gateway.VoiceStateUpdate
-import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.singleOrNull
 import com.gitlab.kordlib.core.event.Event as CoreEvent
@@ -24,8 +23,8 @@ internal class VoiceEventHandler(
         kord: Kord,
         gateway: MasterGateway,
         cache: DataCache,
-        coreEventChannel: SendChannel<CoreEvent>
-) : BaseGatewayEventHandler(kord, gateway, cache, coreEventChannel) {
+        coreFlow: MutableSharedFlow<CoreEvent>
+) : BaseGatewayEventHandler(kord, gateway, cache, coreFlow) {
 
     override suspend fun handle(event: Event, shard: Int) = when (event) {
         is VoiceStateUpdate -> handle(event, shard)
@@ -42,11 +41,11 @@ internal class VoiceEventHandler(
         cache.put(data)
         val new = VoiceState(data, kord)
 
-        coreEventChannel.send( VoiceStateUpdateEvent(old, new, shard))
+        coreFlow.emit( VoiceStateUpdateEvent(old, new, shard))
     }
 
     private suspend fun handle(event: VoiceServerUpdate, shard: Int) = with(event.voiceServerUpdateData) {
-        coreEventChannel.send(VoiceServerUpdateEvent(token, Snowflake(guildId), endpoint, kord, shard))
+        coreFlow.emit(VoiceServerUpdateEvent(token, Snowflake(guildId), endpoint, kord, shard))
     }
 
 }

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/gateway/handler/WebhookEventHandler.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/gateway/handler/WebhookEventHandler.kt
@@ -6,9 +6,8 @@ import com.gitlab.kordlib.core.Kord
 import com.gitlab.kordlib.core.event.WebhookUpdateEvent
 import com.gitlab.kordlib.core.gateway.MasterGateway
 import com.gitlab.kordlib.gateway.Event
-import com.gitlab.kordlib.gateway.Gateway
 import com.gitlab.kordlib.gateway.WebhooksUpdate
-import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import com.gitlab.kordlib.core.event.Event as CoreEvent
 
 @Suppress("EXPERIMENTAL_API_USAGE")
@@ -16,8 +15,8 @@ internal class WebhookEventHandler(
         kord: Kord,
         gateway: MasterGateway,
         cache: DataCache,
-        coreEventChannel: SendChannel<CoreEvent>
-) : BaseGatewayEventHandler(kord, gateway, cache, coreEventChannel) {
+        coreFlow: MutableSharedFlow<CoreEvent>
+) : BaseGatewayEventHandler(kord, gateway, cache, coreFlow) {
 
     override suspend fun handle(event: Event, shard: Int) = when (event) {
         is WebhooksUpdate -> handle(event, shard)
@@ -25,7 +24,7 @@ internal class WebhookEventHandler(
     }
 
     private suspend fun handle(event: WebhooksUpdate, shard: Int) = with(event.webhooksUpdateData) {
-        coreEventChannel.send(WebhookUpdateEvent(Snowflake(guildId), Snowflake(channelId), kord, shard))
+        coreFlow.emit(WebhookUpdateEvent(Snowflake(guildId), Snowflake(channelId), kord, shard))
     }
 
 }

--- a/core/src/test/kotlin/com/gitlab/kordlib/core/KordTest.kt
+++ b/core/src/test/kotlin/com/gitlab/kordlib/core/KordTest.kt
@@ -12,7 +12,7 @@ internal class KordTest {
     @Test
     @OptIn(KordExperimental::class)
     fun `Kord life cycle is correctly ended on shutdown`() {
-        val kord = Kord.restOnly(System.getenv("token"))
+        val kord = Kord.restOnly(System.getenv("KORD_TEST_TOKEN"))
         val lock = CountDownLatch(1)
         kord.events.onCompletion { lock.countDown() }.launchIn(kord)
 

--- a/core/src/test/kotlin/com/gitlab/kordlib/core/KordTest.kt
+++ b/core/src/test/kotlin/com/gitlab/kordlib/core/KordTest.kt
@@ -1,0 +1,29 @@
+package com.gitlab.kordlib.core
+
+import com.gitlab.kordlib.common.annotation.KordExperimental
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onCompletion
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CountDownLatch
+
+internal class KordTest {
+
+    @Test
+    @OptIn(KordExperimental::class)
+    fun `Kord life cycle is correctly ended on shutdown`() {
+        val kord = Kord.restOnly(System.getenv("token"))
+        val lock = CountDownLatch(1)
+        kord.events.onCompletion { lock.countDown() }.launchIn(kord)
+
+        runBlocking {
+            kord.shutdown()
+
+            withTimeout(1000) {
+                //put blocking call on separate thread.
+                GlobalScope.launch(Dispatchers.IO) { lock.await() }.join()
+            }
+        }
+    }
+
+}

--- a/core/src/test/kotlin/regression/CacheMissRegression.kt
+++ b/core/src/test/kotlin/regression/CacheMissRegression.kt
@@ -27,10 +27,10 @@ import io.ktor.content.*
 import io.ktor.http.*
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.channels.BroadcastChannel
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runBlockingTest
 import kotlinx.serialization.SerializationStrategy
@@ -38,6 +38,8 @@ import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.test.BeforeTest
 import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
@@ -54,12 +56,10 @@ object FakeGateway : Gateway {
 
     val deferred = CompletableDeferred<Unit>()
 
-    override val events: Flow<Event>
-        get() = emptyFlow()
+    override val events: SharedFlow<Event> = MutableSharedFlow<Event>()
 
     @ExperimentalTime
-    override val ping: Duration
-        get() = Duration.ZERO
+    override val ping: StateFlow<Duration?> = MutableStateFlow(null)
 
     override suspend fun detach() {}
 
@@ -71,6 +71,8 @@ object FakeGateway : Gateway {
     override suspend fun stop() {
         deferred.complete(Unit)
     }
+
+    override val coroutineContext: CoroutineContext = EmptyCoroutineContext + SupervisorJob()
 }
 
 class CrashingHandler(val client: HttpClient) : RequestHandler {
@@ -126,7 +128,7 @@ class CacheMissingRegressions {
                 MasterGateway(mapOf(0 to FakeGateway)),
                 RestClient(CrashingHandler(resources.httpClient)),
                 getBotIdFromToken(token),
-                BroadcastChannel(1),
+                MutableSharedFlow(extraBufferCapacity = Int.MAX_VALUE),
                 Dispatchers.Default
         )
     }

--- a/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/Gateway.kt
+++ b/gateway/src/main/kotlin/com/gitlab/kordlib/gateway/Gateway.kt
@@ -1,18 +1,16 @@
 package com.gitlab.kordlib.gateway
 
-import com.gitlab.kordlib.common.entity.DiscordShard
-import com.gitlab.kordlib.common.entity.Status
 import com.gitlab.kordlib.gateway.builder.PresenceBuilder
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
+import io.ktor.util.*
+import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.consumeAsFlow
-import kotlinx.coroutines.flow.emptyFlow
-import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.*
+import mu.KotlinLogging
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.time.Duration
 
 /**
@@ -22,19 +20,21 @@ import kotlin.time.Duration
  * through [events] and send [commands](https://discord.com/developers/docs/topics/gateway#commands-and-events-gateway-commands)
  * through [send].
  */
-interface Gateway {
+interface Gateway : CoroutineScope {
     /**
      * The incoming [events](https://discord.com/developers/docs/topics/gateway#commands-and-events-gateway-events)
      * of the Gateway. Users should expect these [Flows](Flow) to be hot and remain open for the entire lifecycle of the
      * Gateway.
      */
-    val events: Flow<Event>
+    val events: SharedFlow<Event>
 
     /**
-     * The duration between the last [Heartbeat] and [HeartbeatACK]. If no [Heartbeat] has been received yet,
-     * [Duration.INFINITE] will be returned.
+     * The duration between the last [Heartbeat] and [HeartbeatACK].
+     *
+     * This flow will have a [value][StateFlow.value] of `null` if the gateway is not
+     * [active][Gateway.start], or no [HeartbeatACK] has been received yet.
      */
-    val ping: Duration
+    val ping: StateFlow<Duration?>
 
     /**
      * Starts a reconnection gateway connection with the given [configuration].
@@ -68,11 +68,13 @@ interface Gateway {
     companion object {
         private object None : Gateway {
 
-            override val events: Flow<Event>
-                get() = emptyFlow()
+            override val coroutineContext: CoroutineContext = EmptyCoroutineContext + SupervisorJob()
 
-            override val ping: Duration
-                get() = Duration.ZERO
+            override val events: SharedFlow<Event>
+                get() = MutableSharedFlow()
+
+            override val ping: StateFlow<Duration?>
+                get() = MutableStateFlow(null)
 
             override suspend fun send(command: Command) {}
 
@@ -80,7 +82,9 @@ interface Gateway {
 
             override suspend fun stop() {}
 
-            override suspend fun detach() {}
+            override suspend fun detach() {
+                (this as CoroutineScope).cancel()
+            }
 
             override fun toString(): String {
                 return "Gateway.None"
@@ -90,7 +94,7 @@ interface Gateway {
         /**
          * Returns a [Gateway] with no-op behavior, an empty [Gateway.events] flow and a ping of [Duration.ZERO].
          */
-        fun none() : Gateway = None
+        fun none(): Gateway = None
 
     }
 }
@@ -134,6 +138,29 @@ suspend inline fun Gateway.start(token: String, config: GatewayConfigurationBuil
     val builder = GatewayConfigurationBuilder(token)
     builder.apply(config)
     start(builder.build())
+}
+
+/**
+ * Logger used to report throwables caught in [Gateway.on].
+ */
+@PublishedApi
+internal val gatewayOnLogger = KotlinLogging.logger("Gateway.on")
+
+/**
+ * Convenience method that will invoke the [consumer] on every event [T] created by [Gateway.events].
+ *
+ * The events are buffered in an [unlimited][Channel.UNLIMITED] [buffer][Flow.buffer] and
+ * [launched][CoroutineScope.launch] in the supplied [scope], which is [Gateway] by default.
+ * Each event will be [launched][CoroutineScope.launch] inside the [scope] separately and
+ * any thrown [Throwable] will be caught and logged.
+ *
+ * The returned [Job] is a reference to the created coroutine, call [Job.cancel] to cancel the processing of any further
+ * events for this [consumer].
+ */
+inline fun <reified T : Event> Gateway.on(scope: CoroutineScope = this, crossinline consumer: T.() -> Unit): Job {
+    return this.events.buffer(Channel.UNLIMITED).filterIsInstance<T>().onEach {
+        launch { it.runCatching { it.consumer() }.onFailure(gatewayOnLogger::error) }
+    }.launchIn(scope)
 }
 
 /**

--- a/gateway/src/test/kotlin/gateway/DefaultGatewayTest.kt
+++ b/gateway/src/test/kotlin/gateway/DefaultGatewayTest.kt
@@ -57,7 +57,7 @@ class DefaultGatewayTest {
                 "!status" -> when (words.getOrNull(1)) {
                     "playing" -> gateway.send(UpdateStatus(status = Status.Online, afk = false, game = DiscordActivity("Kord", ActivityType.Game)))
                 }
-                "!ping" -> gateway.send(UpdateStatus(status = Status.Online, afk = false, game = DiscordActivity("Ping is ${gateway.ping.toLongMilliseconds()}", ActivityType.Game)))
+                "!ping" -> gateway.send(UpdateStatus(status = Status.Online, afk = false, game = DiscordActivity("Ping is ${gateway.ping.value?.toLongMilliseconds()}", ActivityType.Game)))
             }
         }.launchIn(GlobalScope)
 


### PR DESCRIPTION
This PR replaces the usage of `BroadcastChannel` with `SharedFlow` in `Gateway` and `Kord`, and transforms `Gateway#ping` in a `StateFlow`.

Side effects this has caused:

### Kord

* ´Kord#events´ will no longer complete/cancel when `Kord#shutdown` is called. Users who desire this behavior should `Flow#launchIn` Kord's coroutine scope instead.
* Kord's coroutine scope will cancel when `Kord#shutdown` is called.
* Kord now depends on a `MutableStateFlow` in its constructor, which is configurable via `KordBuilder` and its restOnly equivalent to allow configuring behavior pertaining to replay cache and buffer size.

### Gateway

* `Gateway#events` will no longer complete/cancel when `Gateway#detach` is called. Users who desire this behavior should `Flow#launchIn` the gateway's coroutine scope instead.
* DefaultGateway's coroutine scope will cancel when `DefaultGateway#shutdown` is called. 
* Added `Gateway#on`, behaving similarly to `Kord#on`.
* DefaultGateway now depends on a `MutableStateFlow`, which is configurable via `DefaultGatewayBuilder` to allow configuring behavior pertaining to replay cache and buffer size.
* `Gateway#Duration` is now a `StateFlow<Duration?>` and will set its value to `null` whenever it is not active.
* MasterGateway's `averageDuration` has received similar behavior, it won't count null durations towards its average, and returns null if none of the `MasterGateway.gateways` have a duration.
