### PR TITLE
Add temp fix for vanity url

### DIFF
--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/GuildBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/GuildBehavior.kt
@@ -358,7 +358,13 @@ interface GuildBehavior : Entity, Strategizable {
      * @throws [RestRequestException] if something went wrong during the request.
      */
     suspend fun getVanityUrl(): String? {
-        val identifier = kord.rest.guild.getVanityInvite(id.value).code ?: return null
+        val identifier = try { //migration for 0.6.x, an actual proper fix is on the 0.7.x branch
+            kord.rest.guild.getVanityInvite(id.value).code
+        } catch(exception: RestRequestException){
+            if(exception.message.orEmpty().contains("50020")) return null
+            else throw exception
+        }
+
         return "https://discord.gg/$identifier"
     }
 


### PR DESCRIPTION
Fixes `GuildBehavior#getVanityUrl` throwing an exception when it should throw null instead.

It's not an optimal solution but it's consistent and works, this is a backport of the fix on 0.7.x and is thus temporary anyhow.