### PR TITLE
0.6.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.6.10
+
+## Fixes
+
+* Fixed `Guild#getVanityUrl` throwing an exception when a guild did not support vanity invites. #104
+* Fixed `Embed#fields` always returning empty. #105
+
 # 0.6.9
 
 ## Fixes

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/GuildBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/GuildBehavior.kt
@@ -358,7 +358,13 @@ interface GuildBehavior : Entity, Strategizable {
      * @throws [RestRequestException] if something went wrong during the request.
      */
     suspend fun getVanityUrl(): String? {
-        val identifier = kord.rest.guild.getVanityInvite(id.value).code ?: return null
+        val identifier = try { //migration for 0.6.x, an actual proper fix is on the 0.7.x branch
+            kord.rest.guild.getVanityInvite(id.value).code
+        } catch(exception: RestRequestException){
+            if(exception.message.orEmpty().contains("50020")) return null
+            else throw exception
+        }
+
         return "https://discord.gg/$identifier"
     }
 

--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Embed.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/Embed.kt
@@ -84,7 +84,7 @@ data class Embed(val data: EmbedData, override val kord: Kord) : KordObject {
     /**
      * The embed fields.
      */
-    val fields: List<Field> = emptyList()
+    val fields: List<Field> get() = data.fields.map { Field(it, kord) }
 
     /**
      * The type of embeds, this is an non-exhaustive list.


### PR DESCRIPTION
# 0.6.10

## Fixes

* Fixed `Guild#getVanityUrl` throwing an exception when a guild did not support vanity invites. #104
* Fixed `Embed#fields` always returning empty. #105
