### PR TITLE
Add channel creation to categories

### DIFF
--- a/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/CategoryBehavior.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/behavior/channel/CategoryBehavior.kt
@@ -1,23 +1,32 @@
 package com.gitlab.kordlib.core.behavior.channel
 
+import com.gitlab.kordlib.common.annotation.DeprecatedSinceKord
 import com.gitlab.kordlib.common.entity.Snowflake
 import com.gitlab.kordlib.common.exception.RequestException
 import com.gitlab.kordlib.core.Kord
+import com.gitlab.kordlib.core.behavior.GuildBehavior
 import com.gitlab.kordlib.core.cache.data.ChannelData
-import com.gitlab.kordlib.core.entity.channel.CategorizableChannel
-import com.gitlab.kordlib.core.entity.channel.Category
-import com.gitlab.kordlib.core.entity.channel.Channel
+import com.gitlab.kordlib.core.entity.channel.*
 import com.gitlab.kordlib.core.exception.EntityNotFoundException
 import com.gitlab.kordlib.core.supplier.EntitySupplier
 import com.gitlab.kordlib.core.supplier.EntitySupplyStrategy
 import com.gitlab.kordlib.core.supplier.getChannelOf
 import com.gitlab.kordlib.rest.builder.channel.CategoryModifyBuilder
+import com.gitlab.kordlib.rest.builder.channel.NewsChannelCreateBuilder
+import com.gitlab.kordlib.rest.builder.channel.TextChannelCreateBuilder
+import com.gitlab.kordlib.rest.builder.channel.VoiceChannelCreateBuilder
 import com.gitlab.kordlib.rest.request.RestRequestException
+import com.gitlab.kordlib.rest.service.createNewsChannel
+import com.gitlab.kordlib.rest.service.createTextChannel
+import com.gitlab.kordlib.rest.service.createVoiceChannel
 import com.gitlab.kordlib.rest.service.patchCategory
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterIsInstance
 import java.util.*
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 
 /**
  * The behavior of a Discord category associated to a [guild].
@@ -102,4 +111,69 @@ suspend fun CategoryBehavior.edit(builder: CategoryModifyBuilder.() -> Unit): Ca
     val data = ChannelData.from(response)
 
     return Channel.from(data, kord) as Category
+}
+
+/**
+ * Requests to create a new text channel with this category as parent.
+ *
+ * @return The created [TextChannel].
+ *
+ * @throws [RestRequestException] if something went wrong during the request.
+ */
+
+@OptIn(ExperimentalContracts::class)
+suspend inline fun CategoryBehavior.createTextChannel(name: String, builder: TextChannelCreateBuilder.() -> Unit = {}): TextChannel {
+    contract {
+        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+    }
+    val response = kord.rest.guild.createTextChannel(guildId, name) {
+        builder()
+        parentId = id
+    }
+    val data = ChannelData.from(response)
+
+    return Channel.from(data, kord) as TextChannel
+}
+
+
+/**
+ * Requests to create a new voice channel with this category as parent.
+ *
+ * @return The created [VoiceChannel].
+ *
+ * @throws [RestRequestException] if something went wrong during the request.
+ */
+@OptIn(ExperimentalContracts::class)
+suspend inline fun CategoryBehavior.createVoiceChannel(name: String, builder: VoiceChannelCreateBuilder.() -> Unit = {}): VoiceChannel {
+    contract {
+        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+    }
+    val response = kord.rest.guild.createVoiceChannel(guildId, name) {
+        builder()
+        parentId = id
+    }
+    val data = ChannelData.from(response)
+
+    return Channel.from(data, kord) as VoiceChannel
+}
+
+/**
+ * Requests to create a new news channel with this category as parent.
+ *
+ * @return The created [NewsChannel].
+ *
+ * @throws [RestRequestException] if something went wrong during the request.
+ */
+@OptIn(ExperimentalContracts::class)
+suspend inline fun CategoryBehavior.createNewsChannel(name: String, builder: NewsChannelCreateBuilder.() -> Unit = {}): NewsChannel {
+    contract {
+        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+    }
+    val response = kord.rest.guild.createNewsChannel(guildId, name) {
+        builder()
+        parentId = id
+    }
+    val data = ChannelData.from(response)
+
+    return Channel.from(data, kord) as NewsChannel
 }

--- a/core/src/test/kotlin/com/gitlab/kordlib/core/rest/RestTest.kt
+++ b/core/src/test/kotlin/com/gitlab/kordlib/core/rest/RestTest.kt
@@ -5,10 +5,7 @@ import com.gitlab.kordlib.common.annotation.KordExperimental
 import com.gitlab.kordlib.common.entity.*
 import com.gitlab.kordlib.core.Kord
 import com.gitlab.kordlib.core.behavior.*
-import com.gitlab.kordlib.core.behavior.channel.createMessage
-import com.gitlab.kordlib.core.behavior.channel.createWebhook
-import com.gitlab.kordlib.core.behavior.channel.edit
-import com.gitlab.kordlib.core.behavior.channel.editRolePermission
+import com.gitlab.kordlib.core.behavior.channel.*
 import com.gitlab.kordlib.core.entity.Guild
 import com.gitlab.kordlib.core.entity.ReactionEmoji
 import com.gitlab.kordlib.core.entity.channel.GuildMessageChannel
@@ -378,6 +375,18 @@ class RestServiceTest {
         }
 
         assert(exception.error != null)
+    }
+
+    @Test
+    @Order(21)
+    fun `category channel creation`(): Unit = runBlocking {
+        val category = guild.createCategory("my category")
+
+        val textChannel = category.createTextChannel("test child text channel")
+        assert(textChannel.category == category)
+
+        val voiceChannel = category.createVoiceChannel("test child voice channel")
+        assert(voiceChannel.category == category)
     }
 
     @Test


### PR DESCRIPTION
Depends on #108 

Adds the ability to create channels from a category, automatically assigning the parent ID to the category.

```kotlin
category.createTextChannel("channel") {
    //....
}
```