### PR TITLE
Fix Color conversion from java.awt.Color.

### DIFF
--- a/common/src/main/kotlin/com/gitlab/kordlib/common/Color.kt
+++ b/common/src/main/kotlin/com/gitlab/kordlib/common/Color.kt
@@ -10,18 +10,20 @@ import kotlinx.serialization.encoding.Encoder
 
 
 @Serializable(with = Color.Serializer::class)
-class Color(val rgb: Int) {
+class Color(rgb: Int) {
     constructor(red: Int, green: Int, blue: Int) : this(rgb(red, green, blue))
+
+    val rgb = rgb and 0xFFFFFF
 
     val red: Int get() = (rgb shr 16) and 0xFF
     val green: Int get() = (rgb shr 8) and 0xFF
     val blue: Int get() = (rgb shr 0) and 0xFF
 
     init {
-        require(rgb in MIN_COLOR..MAX_COLOR) { "RGB should be in range of $MIN_COLOR..$MAX_COLOR but was $rgb" }
+        require(this.rgb in MIN_COLOR..MAX_COLOR) { "RGB should be in range of $MIN_COLOR..$MAX_COLOR but was ${this.rgb}" }
     }
 
-    override fun toString(): String = "Color(red=$red,blue=$blue,green=$green)"
+    override fun toString(): String = "Color(red=$red,green=$green,blue=$blue)"
 
     override fun hashCode(): Int = rgb.hashCode()
 

--- a/common/src/test/kotlin/ColorTests.kt
+++ b/common/src/test/kotlin/ColorTests.kt
@@ -1,4 +1,5 @@
 import com.gitlab.kordlib.common.Color
+import com.gitlab.kordlib.common.kColor
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import kotlin.test.assertEquals
@@ -6,7 +7,6 @@ import kotlin.test.assertEquals
 class ColorTests {
     @Test
     fun `Color throws if invalid rgb value is provided`() {
-        assertThrows<IllegalArgumentException> { Color(-1) }
         assertThrows<IllegalArgumentException> { Color(256, 256, 300) }
     }
 
@@ -22,7 +22,20 @@ class ColorTests {
         assertEquals(255, white.green)
         assertEquals(255, white.blue)
         assertEquals(0xFFFFFF, white.rgb)
+    }
 
+    @Test
+    fun `java to kColor conversion`() {
+        val color = java.awt.Color.decode("#DBD0B4").kColor
 
+        assertEquals(219, color.red)
+        assertEquals(208, color.green)
+        assertEquals(180, color.blue)
+    }
+
+    @Test
+    fun `Color implementation should drop alpha values if given`() {
+        val color = Color(0x1E1F2E3D)
+        assertEquals(0x1F2E3D, color.rgb)
     }
 }


### PR DESCRIPTION
PR include:
  * Fix java.awt.Color to com.gitlab.kordlib.common.Color conversion (essentially dropping alpha values).
  * Change the order of color class string representation (from `.toString()`) in rgb standard order.
  * Added test for it.