### PR TITLE
Fix member edit return value

### DIFF
--- a/core/src/test/kotlin/com/gitlab/kordlib/core/rest/RestTest.kt
+++ b/core/src/test/kotlin/com/gitlab/kordlib/core/rest/RestTest.kt
@@ -219,17 +219,12 @@ class RestServiceTest {
 //TODO Add Group Channel Tests
 
     @Test
-    @Disabled("Member is not added to guild yet due to Guild#addGuildMember")
     @Order(11)
     fun `member in guild`() = runBlocking {
         guild.members.toList()
         //TODO add member to guild
 
-        guild.getMember(userId).edit {
-            nickname = "my nickname"
-            muted = true
-            deafened = true
-        }
+        guild.getMember(userId)
 
         guild.editSelfNickname("Kord")
         //deleteGuildMember(guildId, user)

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/route/Route.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/route/Route.kt
@@ -187,7 +187,7 @@ sealed class Route<T>(
         : Route<DiscordGuildMember?>(HttpMethod.Put, "/guilds/$GuildId/members/$UserId", DiscordGuildMember.serializer().optional)
 
     object GuildMemberPatch
-        : Route<Unit>(HttpMethod.Patch, "/guilds/$GuildId/members/$UserId", NoStrategy)
+        : Route<DiscordGuildMember>(HttpMethod.Patch, "/guilds/$GuildId/members/$UserId", DiscordGuildMember.serializer())
 
     object GuildCurrentUserNickPatch
         : Route<String>(HttpMethod.Patch, "/guilds/$GuildId/members/@me/nick", String.serializer())

--- a/rest/src/main/kotlin/com/gitlab/kordlib/rest/service/GuildService.kt
+++ b/rest/src/main/kotlin/com/gitlab/kordlib/rest/service/GuildService.kt
@@ -111,12 +111,12 @@ class GuildService(requestHandler: RequestHandler) : RestService(requestHandler)
     }
 
     @OptIn(ExperimentalContracts::class)
-    suspend inline fun modifyGuildMember(guildId: Snowflake, userId: Snowflake, builder: MemberModifyBuilder.() -> Unit) {
+    suspend inline fun modifyGuildMember(guildId: Snowflake, userId: Snowflake, builder: MemberModifyBuilder.() -> Unit): DiscordGuildMember {
         contract {
             callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
         }
 
-        call(Route.GuildMemberPatch) {
+        return call(Route.GuildMemberPatch) {
             keys[Route.GuildId] = guildId
             keys[Route.UserId] = userId
             val modifyBuilder = MemberModifyBuilder().apply(builder)


### PR DESCRIPTION
Makes `Member#edit` return the new member object. This isn't in accordance to the official documentation, but is in accordance to reality. See https://canary.discord.com/channels/556525343595298817/631147109311053844/781851814546898974

![image](https://user-images.githubusercontent.com/18498008/100514808-ed7a0c00-3177-11eb-907e-9a1560762a8b.png)
