### PR TITLE
Fixed getting user's avatar url

### DIFF
--- a/core/src/main/kotlin/com/gitlab/kordlib/core/entity/User.kt
+++ b/core/src/main/kotlin/com/gitlab/kordlib/core/entity/User.kt
@@ -121,7 +121,7 @@ open class User(
             val hash = data.avatar ?: return defaultUrl
             if (!isAnimated && format == Image.Format.GIF) return null
 
-            return "https://cdn.discordapp.com/avatars/${data.id}/$hash.${format.extension}"
+            return "https://cdn.discordapp.com/avatars/${data.id.value}/$hash.${format.extension}"
         }
 
         /**
@@ -138,7 +138,7 @@ open class User(
             val hash = data.avatar ?: return defaultUrl
             if (!isAnimated && format == Image.Format.GIF) return null
 
-            return "https://cdn.discordapp.com/avatars/${data.id}/$hash.${format.extension}?size=${size.maxRes}"
+            return "https://cdn.discordapp.com/avatars/${data.id.value}/$hash.${format.extension}?size=${size.maxRes}"
         }
 
         /**


### PR DESCRIPTION
User.avatar.url wasn't returning a proper avatar url.
It looked like so:
`https://cdn.discordapp.com/avatars/Snowflake(value=246604909451935745)/2ea115febfda75a80ae0a7e81fd9adea.png`
