### PR TITLE
Fix WebhookType.Incoming

### DIFF
--- a/common/src/main/kotlin/entity/DiscordWebhook.kt
+++ b/common/src/main/kotlin/entity/DiscordWebhook.kt
@@ -58,7 +58,7 @@ sealed class WebhookType(val value: Int) {
             get() = PrimitiveSerialDescriptor("type", PrimitiveKind.INT)
 
         override fun deserialize(decoder: Decoder): WebhookType = when(val value = decoder.decodeInt()) {
-            0 -> Incoming
+            1 -> Incoming
             2 -> ChannelFollower
             else -> Unknown(value)
         }


### PR DESCRIPTION
Incoming is actually type `1`, not type `0` 😊

Found this out while trying to retrieve webhooks in my own server, but all webhooks were showing up as "Unknown"