### PR TITLE
Fix some serializer issues

### DIFF
--- a/common/src/main/kotlin/entity/DiscordActivity.kt
+++ b/common/src/main/kotlin/entity/DiscordActivity.kt
@@ -7,10 +7,7 @@ import dev.kord.common.entity.optional.OptionalSnowflake
 import kotlinx.serialization.*
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.serializer
-import kotlinx.serialization.descriptors.PrimitiveKind
-import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
-import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.descriptors.listSerialDescriptor
+import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
@@ -86,27 +83,27 @@ data class DiscordActivityEmoji(
 @Serializable
 data class DiscordActivityParty(
         val id: Optional<String> = Optional.Missing(),
-        val size: Optional<DiscordActivityPartSize> = Optional.Missing()
+        val size: Optional<DiscordActivityPartySize> = Optional.Missing()
 )
 
-@Serializable
-data class DiscordActivityPartSize(
+@Serializable(DiscordActivityPartySize.Serializer::class)
+data class DiscordActivityPartySize(
         val current: Int,
         val maximum: Int
 ) {
-    internal object Serializer: KSerializer<DiscordActivityPartSize> {
+    internal object Serializer: KSerializer<DiscordActivityPartySize> {
         @OptIn(ExperimentalSerializationApi::class)
         override val descriptor: SerialDescriptor
             get() = listSerialDescriptor(Int.serializer().descriptor)
 
         private val delegate = ListSerializer(Int.serializer())
 
-        override fun deserialize(decoder: Decoder): DiscordActivityPartSize {
+        override fun deserialize(decoder: Decoder): DiscordActivityPartySize {
             val (current, maximum) = delegate.deserialize(decoder)
-            return DiscordActivityPartSize(current, maximum)
+            return DiscordActivityPartySize(current, maximum)
         }
 
-        override fun serialize(encoder: Encoder, value: DiscordActivityPartSize) {
+        override fun serialize(encoder: Encoder, value: DiscordActivityPartySize) {
             delegate.serialize(encoder, listOf(value.current, value.maximum))
         }
     }

--- a/gateway/src/main/kotlin/Command.kt
+++ b/gateway/src/main/kotlin/Command.kt
@@ -166,7 +166,7 @@ data class RequestGuildMembers(
         val limit: OptionalInt = OptionalInt.Missing,
         val presences: OptionalBoolean = OptionalBoolean.Missing,
         @SerialName("user_ids")
-        val userIds: Optional<Iterable<Snowflake>> = Optional.Missing(),
+        val userIds: Optional<Set<Snowflake>> = Optional.Missing(),
         val nonce: Optional<String> = Optional.Missing()
 ) : Command() {
 

--- a/rest/src/main/kotlin/json/request/EmojiRequests.kt
+++ b/rest/src/main/kotlin/json/request/EmojiRequests.kt
@@ -8,11 +8,11 @@ import kotlinx.serialization.Serializable
 data class EmojiCreateRequest(
         val name: String,
         val image: String,
-        val roles: Iterable<Snowflake>
+        val roles: Set<Snowflake>
 )
 
 @Serializable
 data class EmojiModifyRequest(
         val name: Optional<String> = Optional.Missing(),
-        val roles: Optional<Iterable<Snowflake>?> = Optional.Missing()
+        val roles: Optional<Set<Snowflake>?> = Optional.Missing()
 )

--- a/rest/src/main/kotlin/json/request/GuildRequests.kt
+++ b/rest/src/main/kotlin/json/request/GuildRequests.kt
@@ -93,7 +93,7 @@ data class GuildMemberAddRequest(
         @SerialName("access_token")
         val token: String,
         val nick: Optional<String> = Optional.Missing(),
-        val roles: Optional<Iterable<Snowflake>> = Optional.Missing(),
+        val roles: Optional<Set<Snowflake>> = Optional.Missing(),
         val mute: OptionalBoolean = OptionalBoolean.Missing,
         val deaf: OptionalBoolean = OptionalBoolean.Missing,
 )
@@ -101,7 +101,7 @@ data class GuildMemberAddRequest(
 @Serializable
 data class GuildMemberModifyRequest(
         val nick: Optional<String?> = Optional.Missing(),
-        val roles: Optional<Iterable<Snowflake>?> = Optional.Missing(),
+        val roles: Optional<Set<Snowflake>?> = Optional.Missing(),
         val mute: OptionalBoolean? = OptionalBoolean.Missing,
         val deaf: OptionalBoolean? = OptionalBoolean.Missing,
         @SerialName("channel_id")


### PR DESCRIPTION
This links up the serializer for DiscordActivityPartySize (and fixes a typo) and replaces the `Iterable` type with something more precise in the serializable classes since kxser seems to stumble on those.