### PR TITLE
Do not throw when getting author member

### DIFF
--- a/core/src/main/kotlin/entity/Message.kt
+++ b/core/src/main/kotlin/entity/Message.kt
@@ -218,7 +218,7 @@ class Message(
      */
     suspend fun getAuthorAsMember(): Member? {
         val author = author ?: return null
-        val guildId = getGuild().id
+        val guildId = getGuildOrNull()?.id ?: return null
         return author.asMember(guildId)
     }
 


### PR DESCRIPTION
Current implementation of `Message#getAuthorAsMember` throws when the message was not created in a guild. This change makes it return null instead, as it claims in the docs.