### PR TITLE
Fix Groovy DSL example

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ repositories {
     mavenCentral()
     // Kord Snapshots Repository (Optional):
     maven {
-        url = "https://oss.sonatype.org/content/repositories/snapshots"
+        url "https://oss.sonatype.org/content/repositories/snapshots"
     }
 
 }

--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ e.g: `0.7.x-SNAPSHOT`
 repositories {
     mavenCentral()
     // Kord Snapshots Repository (Optional):
-    maven("https://oss.sonatype.org/content/repositories/snapshots")
+    maven {
+        url = "https://oss.sonatype.org/content/repositories/snapshots"
+    }
 
 }
 ```


### PR DESCRIPTION
The existing example doesn't actually work, because Groovy is dumb

```
Could not find method maven() for arguments [https://oss.sonatype.org/content/repositories/snapshots] on repository container of type org.gradle.api.internal.artifacts.dsl.DefaultRepositoryHandler.
```