### PR TITLE
Fix bug that will only start one shard

### DIFF
--- a/core/src/main/kotlin/gateway/MasterGateway.kt
+++ b/core/src/main/kotlin/gateway/MasterGateway.kt
@@ -57,7 +57,7 @@ class MasterGateway(
 
     suspend fun sendAll(command: Command) = gateways.values.forEach { it.send(command) }
 
-    suspend fun detachAll() = coroutineScope { gateways.values.forEach { launch { it.detach() } } }
+    suspend fun detachAll() = gateways.values.forEach { it.detach() }
 
     suspend fun stopAll() = coroutineScope {
         gateways.values.forEach { launch { it.stop() } }

--- a/core/src/main/kotlin/gateway/MasterGateway.kt
+++ b/core/src/main/kotlin/gateway/MasterGateway.kt
@@ -59,9 +59,7 @@ class MasterGateway(
 
     suspend fun detachAll() = gateways.values.forEach { it.detach() }
 
-    suspend fun stopAll() = coroutineScope {
-        gateways.values.forEach { launch { it.stop() } }
-    }
+    suspend fun stopAll() = gateways.values.forEach { it.stop() }
 
     override fun toString(): String {
         return "MasterGateway(gateways=$gateways)"

--- a/core/src/main/kotlin/gateway/MasterGateway.kt
+++ b/core/src/main/kotlin/gateway/MasterGateway.kt
@@ -57,7 +57,7 @@ class MasterGateway(
 
     suspend fun sendAll(command: Command) = gateways.values.forEach { it.send(command) }
 
-    suspend fun detachAll() = gateways.values.forEach { it.detach() }
+    suspend fun detachAll() = coroutineScope { gateways.values.forEach { launch { it.detach() } } }
 
     suspend fun stopAll() = coroutineScope {
         gateways.values.forEach { launch { it.stop() } }

--- a/core/src/main/kotlin/gateway/MasterGateway.kt
+++ b/core/src/main/kotlin/gateway/MasterGateway.kt
@@ -59,7 +59,9 @@ class MasterGateway(
 
     suspend fun detachAll() = gateways.values.forEach { it.detach() }
 
-    suspend fun stopAll() = gateways.values.forEach { it.stop() }
+    suspend fun stopAll() = coroutineScope {
+        gateways.values.forEach { launch { it.stop() } }
+    }
 
     override fun toString(): String {
         return "MasterGateway(gateways=$gateways)"


### PR DESCRIPTION
All shards will get started by this function:
```kotlin    
   /**
     * Calls [Gateway.start] on each Gateway in [gateways], changing the [GatewayConfiguration.shard] for each Gateway.
     */
    suspend fun start(configuration: GatewayConfiguration): Unit =
        gateways.entries.forEach { (shard, gateway) ->
            val config = configuration.copy(shard = configuration.shard.copy(index = shard))
             gateway.start(config)
        }
    
```

The problem is that Gateway.start() is a suspending functions which suspends as long as the gateway is active
As forEach executes all elements one by one on the same thread the first element calls gateway.start and blocks the coroutines
Therefore the other shards never get started.

I fixed this by wrapping start in coroutineScope {} and launch a new coroutine for every gateway.
This should still let the behavior remain, that Kord.login/MasterGateway.start blocks as long as the Gateway is active but each Gateway instance is in it's on child coroutine

Fixes #195 