### PR TITLE
Fix preview_asset field

### DIFF
--- a/common/src/main/kotlin/entity/DiscordMessage.kt
+++ b/common/src/main/kotlin/entity/DiscordMessage.kt
@@ -118,7 +118,7 @@ data class DiscordMessageSticker(
         val tags: Optional<String> = Optional.Missing(),
         val asset: String,
         @SerialName("preview_asset")
-        val previewAsset: String?,
+        val previewAsset: Optional<String?> = Optional.Missing(),
         @SerialName("format_type")
         val formatType: MessageStickerType,
 )

--- a/common/src/main/kotlin/entity/DiscordMessage.kt
+++ b/common/src/main/kotlin/entity/DiscordMessage.kt
@@ -118,6 +118,7 @@ data class DiscordMessageSticker(
         val tags: Optional<String> = Optional.Missing(),
         val asset: String,
         @SerialName("preview_asset")
+        // https://github.com/kordlib/kord/issues/207
         val previewAsset: Optional<String?> = Optional.Missing(),
         @SerialName("format_type")
         val formatType: MessageStickerType,

--- a/core/src/main/kotlin/cache/data/MessageStickerData.kt
+++ b/core/src/main/kotlin/cache/data/MessageStickerData.kt
@@ -14,7 +14,7 @@ data class MessageStickerData(
         val description: String,
         val tags: Optional<String> = Optional.Missing(),
         val asset: String,
-        val previewAsset: String?,
+        val previewAsset: Optional<String?> = Optional.Missing(),
         val formatType: MessageStickerType,
 ) {
 

--- a/core/src/main/kotlin/entity/MessageSticker.kt
+++ b/core/src/main/kotlin/entity/MessageSticker.kt
@@ -50,7 +50,7 @@ class MessageSticker(val data: MessageStickerData, override val kord: Kord) : Ko
      * The sticker preview image has asset (currently private).
      */
     val previewAsset: String?
-        get() = data.previewAsset
+        get() = data.previewAsset.value
 
     /**
      * The type of sticker image.


### PR DESCRIPTION
preview_asset can be optional in contrast to what [The discord docs](https://discord.com/developers/docs/resources/channel#message-object-message-sticker-structure) state