### PR TITLE
better scoping for InteractionData from function

### DIFF
--- a/core/src/main/kotlin/cache/data/InteractionData.kt
+++ b/core/src/main/kotlin/cache/data/InteractionData.kt
@@ -27,8 +27,8 @@ data class InteractionData(
     val version: Int
 ) {
     companion object {
-        fun from(event: InteractionCreate): InteractionData {
-            return with(event.interaction) {
+        fun from(interaction: DiscordInteraction): InteractionData {
+            return with(interaction) {
                 InteractionData(
                     id,
                     type,

--- a/core/src/main/kotlin/gateway/handler/InteractionEventHandler.kt
+++ b/core/src/main/kotlin/gateway/handler/InteractionEventHandler.kt
@@ -32,7 +32,7 @@ class InteractionEventHandler(
     }
 
     private suspend fun handle(event: InteractionCreate, shard: Int) {
-        val data = InteractionData.from(event)
+        val data = InteractionData.from(event.interaction)
         val interaction = Interaction.from(data, kord)
         coreFlow.emit(InteractionCreateEvent(interaction, kord, shard))
     }


### PR DESCRIPTION
This change's the form to accept a DiscordIntraction instead of the event itself if the object is being used outside of the event's context.