### PR TITLE
Add support for editing the original interaction with files

### DIFF
--- a/rest/src/main/kotlin/json/request/InteractionsRequests.kt
+++ b/rest/src/main/kotlin/json/request/InteractionsRequests.kt
@@ -36,6 +36,11 @@ data class InteractionResponseModifyRequest(
     val allowedMentions: Optional<AllowedMentions> = Optional.Missing(),
 )
 
+@KordPreview
+data class MultipartInteractionResponseModifyRequest(
+    val request: InteractionResponseModifyRequest,
+    val files: List<Pair<String, java.io.InputStream>> = emptyList(),
+)
 
 @Serializable
 @KordPreview

--- a/rest/src/main/kotlin/service/InteractionService.kt
+++ b/rest/src/main/kotlin/service/InteractionService.kt
@@ -2,11 +2,17 @@ package dev.kord.rest.service
 
 import dev.kord.common.annotation.KordPreview
 import dev.kord.common.entity.DiscordApplicationCommand
+import dev.kord.common.entity.DiscordMessage
 import dev.kord.common.entity.Snowflake
+import dev.kord.rest.builder.interaction.InteractionResponseModifyBuilder
+import dev.kord.rest.builder.message.MessageCreateBuilder
 import dev.kord.rest.json.request.*
 import dev.kord.rest.request.RequestHandler
 import dev.kord.rest.route.Route
 import kotlinx.serialization.builtins.ListSerializer
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 
 @KordPreview
 class InteractionService(requestHandler: RequestHandler) : RestService(requestHandler) {
@@ -105,15 +111,22 @@ class InteractionService(requestHandler: RequestHandler) : RestService(requestHa
             body(InteractionResponseCreateRequest.serializer(), request)
         }
 
+    @OptIn(ExperimentalContracts::class)
+    suspend inline fun modifyInteractionResponse(applicationId: Snowflake, interactionToken: String, builder: InteractionResponseModifyBuilder.() -> Unit): DiscordMessage {
+        contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
+        val multipartRequest = InteractionResponseModifyBuilder().apply(builder).toRequest()
+        return modifyInteractionResponse(applicationId, interactionToken, multipartRequest)
+    }
+
     suspend fun modifyInteractionResponse(
         applicationId: Snowflake,
         interactionToken: String,
-        request: InteractionResponseModifyRequest
+        multipartRequest: MultipartInteractionResponseModifyRequest
     ) = call(Route.OriginalInteractionResponseModify) {
         keys[Route.ApplicationId] = applicationId
         keys[Route.InteractionToken] = interactionToken
-        body(InteractionResponseModifyRequest.serializer(), request)
-
+        body(InteractionResponseModifyRequest.serializer(), multipartRequest.request)
+        multipartRequest.files.forEach { file(it) }
     }
 
     suspend fun deleteOriginalInteractionResponse(applicationId: Snowflake, interactionToken: String) =


### PR DESCRIPTION
Related to #226

I made it similar to how Kord handles "normal" message file sending, currently it works fine.

Keep in mind that this only changes stuff in the REST module, I haven't changed anything in the core module. (maybe someone could do this later?)

![image](https://user-images.githubusercontent.com/9496359/112864418-2c6c8f80-908e-11eb-969a-f253b2aef93f.png)

```kotlin
            val kordMessage = rest.interaction.modifyInteractionResponse(
                applicationId,
                request.token
            ) {
                this.content = message.content
                this.addFile("ayaya.png", File("L:\\Pictures\\ExNJki9U8AAzsQe.jpg").inputStream())
                this.addFile("owo.png", File("L:\\Pictures\\1580734785123.png").inputStream())
            }
```

(For now this only adds editing original interactions with files, maybe I will do the webhook edit also in this pull request... or maybe in a different pull request!)