### PR TITLE
Allow sending multiple files in a single follow up message

### DIFF
--- a/rest/src/main/kotlin/builder/interaction/InteractionsBuilder.kt
+++ b/rest/src/main/kotlin/builder/interaction/InteractionsBuilder.kt
@@ -266,15 +266,15 @@ class FollowupMessageCreateBuilder : RequestBuilder<MultipartFollowupMessageCrea
     private var _allowedMentions: Optional<AllowedMentions> = Optional.Missing()
     var allowedMentions: AllowedMentions? by ::_allowedMentions.delegate()
 
-    private var file: Pair<String, java.io.InputStream>? = null
+    val files: MutableList<Pair<String, InputStream>> = mutableListOf()
     var embeds: MutableList<EmbedRequest> = mutableListOf()
 
-    fun setFile(name: String, content: java.io.InputStream) {
-        file = name to content
+    fun addFile(name: String, content: InputStream) {
+        files += name to content
     }
 
-    suspend fun setFile(path: Path) = withContext(Dispatchers.IO) {
-        setFile(path.fileName.toString(), Files.newInputStream(path))
+    suspend fun addFile(path: Path) = withContext(Dispatchers.IO) {
+        addFile(path.fileName.toString(), Files.newInputStream(path))
     }
 
     @OptIn(ExperimentalContracts::class)
@@ -295,7 +295,7 @@ class FollowupMessageCreateBuilder : RequestBuilder<MultipartFollowupMessageCrea
                 embeds = Optional.missingOnEmpty(embeds),
                 allowedMentions = _allowedMentions
             ),
-            file,
+            files,
         )
 
 }

--- a/rest/src/main/kotlin/json/request/InteractionsRequests.kt
+++ b/rest/src/main/kotlin/json/request/InteractionsRequests.kt
@@ -58,7 +58,7 @@ class InteractionApplicationCommandCallbackData(
 @KordPreview
 data class MultipartFollowupMessageCreateRequest(
     val request: FollowupMessageCreateRequest,
-    val file: Pair<String, InputStream>?
+    val files: List<Pair<String, java.io.InputStream>> = emptyList(),
 )
 
 @Serializable

--- a/rest/src/main/kotlin/service/InteractionService.kt
+++ b/rest/src/main/kotlin/service/InteractionService.kt
@@ -132,7 +132,7 @@ class InteractionService(requestHandler: RequestHandler) : RestService(requestHa
         keys[Route.InteractionToken] = interactionToken
         parameter("wait", "$wait")
         body(FollowupMessageCreateRequest.serializer(), multipart.request)
-        multipart.file?.let { file(it) }
+        multipart.files.forEach { file(it) }
 
     }
 


### PR DESCRIPTION
I think the title already explains what this does: Multiple files can be attached in a single follow up message and currently Kord only supported a single files in a follow up message, while Discord supports multiple files... So this PR fixes this issue! And that's it.