### PR TITLE
Multiple files support

### DIFF
--- a/rest/src/main/kotlin/builder/interaction/FollowupMessageBuilders.kt
+++ b/rest/src/main/kotlin/builder/interaction/FollowupMessageBuilders.kt
@@ -6,15 +6,11 @@ import dev.kord.common.entity.AllowedMentions
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
 import dev.kord.common.entity.optional.delegate.delegate
-import dev.kord.common.entity.optional.map
 import dev.kord.common.entity.optional.mapList
 import dev.kord.rest.builder.RequestBuilder
 import dev.kord.rest.builder.message.AllowedMentionsBuilder
 import dev.kord.rest.builder.message.EmbedBuilder
-import dev.kord.rest.json.request.EmbedRequest
-import dev.kord.rest.json.request.FollowupMessageCreateRequest
-import dev.kord.rest.json.request.FollowupMessageModifyRequest
-import dev.kord.rest.json.request.MultipartFollowupMessageCreateRequest
+import dev.kord.rest.json.request.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.InputStream
@@ -27,12 +23,15 @@ import kotlin.contracts.contract
 @KordPreview
 @KordDsl
 class PublicFollowupMessageModifyBuilder :
-    RequestBuilder<FollowupMessageModifyRequest> {
+    RequestBuilder<MultipartFollowupMessageModifyRequest> {
     private var _content: Optional<String> = Optional.Missing()
     var content: String? by ::_content.delegate()
 
     private var _embeds: Optional<MutableList<EmbedBuilder>> = Optional.Missing()
     var embeds: MutableList<EmbedBuilder>? by ::_embeds.delegate()
+
+    val files: MutableList<Pair<String, InputStream>> = mutableListOf()
+
 
     private var _allowedMentions: Optional<AllowedMentions> = Optional.Missing()
     var allowedMentions: AllowedMentions? by ::_allowedMentions.delegate()
@@ -44,6 +43,15 @@ class PublicFollowupMessageModifyBuilder :
         embeds!! += EmbedBuilder().apply(builder)
     }
 
+
+    fun addFile(name: String, content: InputStream) {
+        files += name to content
+    }
+
+    suspend fun addFile(path: Path) = withContext(Dispatchers.IO) {
+        addFile(path.fileName.toString(), Files.newInputStream(path))
+    }
+
     @OptIn(ExperimentalContracts::class)
     inline fun allowedMentions(builder: AllowedMentionsBuilder.() -> Unit) {
         contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
@@ -51,11 +59,14 @@ class PublicFollowupMessageModifyBuilder :
     }
 
 
-    override fun toRequest(): FollowupMessageModifyRequest {
-        return FollowupMessageModifyRequest(
-            _content,
-            _embeds.mapList { it.toRequest() },
-            _allowedMentions
+    override fun toRequest(): MultipartFollowupMessageModifyRequest {
+        return MultipartFollowupMessageModifyRequest(
+            FollowupMessageModifyRequest(
+                _content,
+                _embeds.mapList { it.toRequest() },
+                _allowedMentions
+            ),
+            files
         )
     }
 }

--- a/rest/src/main/kotlin/builder/webhook/EditWebhookMessageBuilder.kt
+++ b/rest/src/main/kotlin/builder/webhook/EditWebhookMessageBuilder.kt
@@ -5,17 +5,25 @@ import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.delegate.delegate
 import dev.kord.rest.builder.RequestBuilder
 import dev.kord.rest.builder.message.EmbedBuilder
+import dev.kord.rest.json.request.MultipartWebhookEditMessageRequest
 import dev.kord.rest.json.request.WebhookEditMessageRequest
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.InputStream
+import java.nio.file.Files
+import java.nio.file.Path
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
-class EditWebhookMessageBuilder : RequestBuilder<WebhookEditMessageRequest> {
+class EditWebhookMessageBuilder : RequestBuilder<MultipartWebhookEditMessageRequest> {
 
     private var _content: Optional<String> = Optional.Missing()
     var content: String? by ::_content.delegate()
 
     var embeds: MutableList<EmbedBuilder> = mutableListOf()
+
+    val files: MutableList<Pair<String, InputStream>> = mutableListOf()
 
     private var _allowedMentions: Optional<AllowedMentions> = Optional.Missing()
     var allowedMentions: AllowedMentions? by ::_allowedMentions.delegate()
@@ -28,7 +36,19 @@ class EditWebhookMessageBuilder : RequestBuilder<WebhookEditMessageRequest> {
         embeds.add(EmbedBuilder().apply(builder))
     }
 
-    override fun toRequest(): WebhookEditMessageRequest = WebhookEditMessageRequest(
-        _content, Optional.missingOnEmpty(embeds.map(EmbedBuilder::toRequest)), _allowedMentions
+    fun addFile(name: String, content: InputStream) {
+        files += name to content
+    }
+
+    suspend fun addFile(path: Path) = withContext(Dispatchers.IO) {
+        addFile(path.fileName.toString(), Files.newInputStream(path))
+    }
+
+
+    override fun toRequest(): MultipartWebhookEditMessageRequest = MultipartWebhookEditMessageRequest(
+        WebhookEditMessageRequest(
+            _content, Optional.missingOnEmpty(embeds.map(EmbedBuilder::toRequest)), _allowedMentions
+        ),
+        files
     )
 }

--- a/rest/src/main/kotlin/builder/webhook/ExecuteWebhookBuilder.kt
+++ b/rest/src/main/kotlin/builder/webhook/ExecuteWebhookBuilder.kt
@@ -44,6 +44,7 @@ class ExecuteWebhookBuilder: RequestBuilder<MultiPartWebhookExecuteRequest> {
     suspend fun addFile(path: Path) = withContext(Dispatchers.IO) {
         addFile(path.fileName.toString(), Files.newInputStream(path))
     }
+
     @OptIn(ExperimentalContracts::class)
     inline fun embed(builder: EmbedBuilder.() -> Unit) {
         contract {

--- a/rest/src/main/kotlin/json/request/InteractionsRequests.kt
+++ b/rest/src/main/kotlin/json/request/InteractionsRequests.kt
@@ -9,6 +9,7 @@ import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import java.io.InputStream
 
 @Serializable
 @KordPreview

--- a/rest/src/main/kotlin/json/request/InteractionsRequests.kt
+++ b/rest/src/main/kotlin/json/request/InteractionsRequests.kt
@@ -99,5 +99,4 @@ data class FollowupMessageModifyRequest(
 data class MultipartFollowupMessageModifyRequest(
     val request: FollowupMessageModifyRequest,
     val files: List<Pair<String, java.io.InputStream>> = emptyList(),
-
-    )
+)

--- a/rest/src/main/kotlin/json/request/InteractionsRequests.kt
+++ b/rest/src/main/kotlin/json/request/InteractionsRequests.kt
@@ -9,7 +9,6 @@ import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import java.io.InputStream
 
 @Serializable
 @KordPreview
@@ -94,3 +93,10 @@ data class FollowupMessageModifyRequest(
     @SerialName("allowed_mentions")
     val allowedMentions: Optional<AllowedMentions> = Optional.Missing(),
 )
+
+@KordPreview
+data class MultipartFollowupMessageModifyRequest(
+    val request: FollowupMessageModifyRequest,
+    val files: List<Pair<String, java.io.InputStream>> = emptyList(),
+
+    )

--- a/rest/src/main/kotlin/json/request/WebhookRequests.kt
+++ b/rest/src/main/kotlin/json/request/WebhookRequests.kt
@@ -30,8 +30,8 @@ data class WebhookExecuteRequest(
 )
 
 data class MultiPartWebhookExecuteRequest(
-    val request: WebhookExecuteRequest,
-    val file: Pair<String, java.io.InputStream>?
+        val request: WebhookExecuteRequest,
+        val files: List<Pair<String, java.io.InputStream>> = emptyList()
 )
 
 @Serializable

--- a/rest/src/main/kotlin/json/request/WebhookRequests.kt
+++ b/rest/src/main/kotlin/json/request/WebhookRequests.kt
@@ -40,3 +40,8 @@ data class WebhookEditMessageRequest(
     val embeds: Optional<List<EmbedRequest>> = Optional.Missing(),
     val allowedMentions: Optional<AllowedMentions> = Optional.Missing()
 )
+
+data class MultipartWebhookEditMessageRequest(
+    val request: WebhookEditMessageRequest,
+    val files: List<Pair<String, java.io.InputStream>> = emptyList()
+)

--- a/rest/src/main/kotlin/service/InteractionService.kt
+++ b/rest/src/main/kotlin/service/InteractionService.kt
@@ -177,6 +177,19 @@ class InteractionService(requestHandler: RequestHandler) : RestService(requestHa
         request.files.forEach { file(it) }
     }
 
+
+    suspend fun modifyFollowupMessage(
+        applicationId: Snowflake,
+        interactionToken: String,
+        messageId: Snowflake,
+        request: FollowupMessageModifyRequest
+    ) = call(Route.FollowupMessageModify) {
+        keys[Route.ApplicationId] = applicationId
+        keys[Route.InteractionToken] = interactionToken
+        keys[Route.MessageId] = messageId
+        body(FollowupMessageModifyRequest.serializer(), request)
+    }
+
     suspend fun getGlobalCommand(applicationId: Snowflake, commandId: Snowflake) =
         call(Route.GlobalApplicationCommandGet) {
             keys[Route.ApplicationId] = applicationId

--- a/rest/src/main/kotlin/service/InteractionService.kt
+++ b/rest/src/main/kotlin/service/InteractionService.kt
@@ -168,12 +168,13 @@ class InteractionService(requestHandler: RequestHandler) : RestService(requestHa
         applicationId: Snowflake,
         interactionToken: String,
         messageId: Snowflake,
-        request: FollowupMessageModifyRequest
+        request: MultipartFollowupMessageModifyRequest
     ) = call(Route.FollowupMessageModify) {
         keys[Route.ApplicationId] = applicationId
         keys[Route.InteractionToken] = interactionToken
         keys[Route.MessageId] = messageId
-        body(FollowupMessageModifyRequest.serializer(), request)
+        body(FollowupMessageModifyRequest.serializer(), request.request)
+        request.files.forEach { file(it) }
     }
 
     suspend fun getGlobalCommand(applicationId: Snowflake, commandId: Snowflake) =

--- a/rest/src/main/kotlin/service/WebhookService.kt
+++ b/rest/src/main/kotlin/service/WebhookService.kt
@@ -157,7 +157,8 @@ class WebhookService(requestHandler: RequestHandler) : RestService(requestHandle
             keys[Route.WebhookToken] = token
             keys[Route.MessageId] = messageId
             val body = EditWebhookMessageBuilder().apply(builder).toRequest()
-            body(WebhookEditMessageRequest.serializer(), body)
+            body(WebhookEditMessageRequest.serializer(), body.request)
+            body.files.onEach { file(it) }
         }
     }
 }

--- a/rest/src/main/kotlin/service/WebhookService.kt
+++ b/rest/src/main/kotlin/service/WebhookService.kt
@@ -118,7 +118,7 @@ class WebhookService(requestHandler: RequestHandler) : RestService(requestHandle
             parameter("wait", "$wait")
             val request = ExecuteWebhookBuilder().apply(builder).toRequest()
             body(WebhookExecuteRequest.serializer(), request.request)
-            request.file?.let { file(it) }
+            request.files.forEach { file(it) }
         }
     }
 


### PR DESCRIPTION
This added support for multiple file uploads for requests mentioned in #226.
However, the webhook edit endpoint is still unimplemented. (#217)