### PR TITLE
Don't retrieve unknown channels as guildchannels

### DIFF
--- a/core/src/main/kotlin/supplier/CacheEntitySupplier.kt
+++ b/core/src/main/kotlin/supplier/CacheEntitySupplier.kt
@@ -112,7 +112,7 @@ class CacheEntitySupplier(private val kord: Kord) : EntitySupplier {
 
     override fun getGuildChannels(guildId: Snowflake): Flow<GuildChannel> = cache.query<ChannelData> {
         idEq(ChannelData::guildId, guildId)
-    }.asFlow().map { Channel.from(it, kord) as GuildChannel }
+    }.asFlow().map { Channel.from(it, kord) }.filterIsInstance()
 
     override fun getChannelPins(channelId: Snowflake): Flow<Message> = cache.query<MessageData> {
         idEq(MessageData::channelId, channelId)

--- a/core/src/main/kotlin/supplier/EntitySupplier.kt
+++ b/core/src/main/kotlin/supplier/EntitySupplier.kt
@@ -8,6 +8,7 @@ import dev.kord.core.entity.channel.GuildChannel
 import dev.kord.core.entity.channel.MessageChannel
 import dev.kord.core.exception.EntityNotFoundException
 import kotlinx.coroutines.flow.Flow
+import dev.kord.common.entity.ChannelType.Unknown
 
 /**
  * An abstraction that allows for requesting Discord entities.
@@ -87,7 +88,7 @@ interface EntitySupplier {
     suspend fun getChannel(id: Snowflake): Channel = getChannelOrNull(id)!!
 
     /**
-     * Requests the [channels][GuildChannel] of the [Guild] with the given [guildId].
+     * Requests the [channels][GuildChannel] of the [Guild] with the given [guildId], channels with an [Unknown] type will be filtered out of the list.
      *
      * The returned flow is lazily executed, any [RequestException] will be thrown on
      * [terminal operators](https://kotlinlang.org/docs/reference/coroutines/flow.html#terminal-flow-operators) instead.


### PR DESCRIPTION
Channels with an unknown type won't be considered guild channels by our type system. Not returning them even though they technically are part of the guild is a quick and dirty fix until we consider a better approach.