### PR TITLE
Add allowed permissions to webhook execute

### DIFF
--- a/rest/src/main/kotlin/builder/interaction/PublicInteractionBuilder.kt
+++ b/rest/src/main/kotlin/builder/interaction/PublicInteractionBuilder.kt
@@ -4,11 +4,8 @@ import dev.kord.common.annotation.KordDsl
 import dev.kord.common.annotation.KordPreview
 import dev.kord.common.entity.AllowedMentions
 import dev.kord.common.entity.InteractionResponseType
-import dev.kord.common.entity.optional.Optional
-import dev.kord.common.entity.optional.OptionalBoolean
+import dev.kord.common.entity.optional.*
 import dev.kord.common.entity.optional.delegate.delegate
-import dev.kord.common.entity.optional.mapList
-import dev.kord.common.entity.optional.optional
 import dev.kord.rest.builder.RequestBuilder
 import dev.kord.rest.builder.message.AllowedMentionsBuilder
 import dev.kord.rest.builder.message.EmbedBuilder
@@ -32,8 +29,8 @@ class PublicInteractionResponseCreateBuilder :
     private var _embeds: Optional<MutableList<EmbedBuilder>> = Optional.Missing()
     var embeds: MutableList<EmbedBuilder>? by ::_embeds.delegate()
 
-    private var _allowedMentions: Optional<AllowedMentions> = Optional.Missing()
-    var allowedMentions: AllowedMentions? by ::_allowedMentions.delegate()
+    private var _allowedMentions: Optional<AllowedMentionsBuilder> = Optional.Missing()
+    var allowedMentions: AllowedMentionsBuilder? by ::_allowedMentions.delegate()
 
 
     private var _tts: OptionalBoolean = OptionalBoolean.Missing
@@ -42,12 +39,17 @@ class PublicInteractionResponseCreateBuilder :
     val files: MutableList<Pair<String, InputStream>> = mutableListOf()
 
 
-    @OptIn(ExperimentalContracts::class)
-    inline fun allowedMentions(builder: AllowedMentionsBuilder.() -> Unit) {
-        contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
-        allowedMentions = AllowedMentionsBuilder().apply(builder).build()
-    }
 
+    /**
+     * Configures the mentions that should trigger a mention (aka ping). Not calling this function will result in the default behavior
+     * (ping everything), calling this function but not configuring it before the request is build will result in all
+     * pings being ignored.
+     */
+    @OptIn(ExperimentalContracts::class)
+    inline fun allowedMentions(block: AllowedMentionsBuilder.() -> Unit = {}) {
+        contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
+        allowedMentions = (allowedMentions ?: AllowedMentionsBuilder()).apply(block)
+    }
 
     @OptIn(ExperimentalContracts::class)
     inline fun embed(builder: EmbedBuilder.() -> Unit) {
@@ -75,7 +77,7 @@ class PublicInteractionResponseCreateBuilder :
                 InteractionApplicationCommandCallbackData(
                     content = _content,
                     embeds = _embeds.mapList { it.toRequest() },
-                    allowedMentions = _allowedMentions,
+                    allowedMentions = _allowedMentions.map { it.build() },
                     tts = _tts
                 ).optional()
             ),
@@ -95,17 +97,22 @@ class PublicInteractionResponseModifyBuilder :
     private var _embeds: Optional<MutableList<EmbedBuilder>> = Optional.Missing()
     var embeds: MutableList<EmbedBuilder>? by ::_embeds.delegate()
 
-    private var _allowedMentions: Optional<AllowedMentions> = Optional.Missing()
-    var allowedMentions: AllowedMentions? by ::_allowedMentions.delegate()
+    private var _allowedMentions: Optional<AllowedMentionsBuilder> = Optional.Missing()
+    var allowedMentions: AllowedMentionsBuilder? by ::_allowedMentions.delegate()
 
     val files: MutableList<Pair<String, InputStream>> = mutableListOf()
 
-
+    /**
+     * Configures the mentions that should trigger a mention (aka ping). Not calling this function will result in the default behavior
+     * (ping everything), calling this function but not configuring it before the request is build will result in all
+     * pings being ignored.
+     */
     @OptIn(ExperimentalContracts::class)
-    inline fun allowedMentions(builder: AllowedMentionsBuilder.() -> Unit) {
-        contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
-        allowedMentions = AllowedMentionsBuilder().apply(builder).build()
+    inline fun allowedMentions(block: AllowedMentionsBuilder.() -> Unit = {}) {
+        contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
+        allowedMentions = (allowedMentions ?: AllowedMentionsBuilder()).apply(block)
     }
+
 
 
     @OptIn(ExperimentalContracts::class)
@@ -128,7 +135,7 @@ class PublicInteractionResponseModifyBuilder :
             InteractionResponseModifyRequest(
                 content = _content,
                 embeds = _embeds.mapList { it.toRequest() },
-                allowedMentions = _allowedMentions,
+                allowedMentions = _allowedMentions.map { it.build() },
             ),
             files
         )

--- a/rest/src/main/kotlin/builder/message/MessageCreateBuilder.kt
+++ b/rest/src/main/kotlin/builder/message/MessageCreateBuilder.kt
@@ -76,7 +76,9 @@ class MessageCreateBuilder : RequestBuilder<MultipartMessageCreateRequest> {
      * (ping everything), calling this function but not configuring it before the request is build will result in all
      * pings being ignored.
      */
+    @OptIn(ExperimentalContracts::class)
     inline fun allowedMentions(block: AllowedMentionsBuilder.() -> Unit = {}) {
+        contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
         allowedMentions = (allowedMentions ?: AllowedMentionsBuilder()).apply(block)
     }
 

--- a/rest/src/main/kotlin/builder/message/MessageModifyBuilder.kt
+++ b/rest/src/main/kotlin/builder/message/MessageModifyBuilder.kt
@@ -43,9 +43,7 @@ class MessageModifyBuilder : RequestBuilder<MessageEditPatchRequest> {
      */
     @OptIn(ExperimentalContracts::class)
     inline fun allowedMentions(block: AllowedMentionsBuilder.() -> Unit = {}) {
-        contract {
-            callsInPlace(block, InvocationKind.EXACTLY_ONCE)
-        }
+        contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
         allowedMentions = (allowedMentions ?: AllowedMentionsBuilder()).apply(block)
     }
 

--- a/rest/src/main/kotlin/json/request/WebhookRequests.kt
+++ b/rest/src/main/kotlin/json/request/WebhookRequests.kt
@@ -26,7 +26,7 @@ data class WebhookExecuteRequest(
     val avatar: Optional<String> = Optional.Missing(),
     val tts: OptionalBoolean = OptionalBoolean.Missing,
     val embeds: Optional<List<EmbedRequest>> = Optional.Missing(),
-    val allowedMentions: Optional<AllowedMentions> = Optional.Missing()
+    val allowedMentions: Optional<AllowedMentions?> = Optional.Missing()
 )
 
 data class MultiPartWebhookExecuteRequest(

--- a/rest/src/main/kotlin/json/request/WebhookRequests.kt
+++ b/rest/src/main/kotlin/json/request/WebhookRequests.kt
@@ -26,7 +26,7 @@ data class WebhookExecuteRequest(
     val avatar: Optional<String> = Optional.Missing(),
     val tts: OptionalBoolean = OptionalBoolean.Missing,
     val embeds: Optional<List<EmbedRequest>> = Optional.Missing(),
-    val allowedMentions: Optional<AllowedMentions?> = Optional.Missing()
+    val allowedMentions: Optional<AllowedMentions> = Optional.Missing()
 )
 
 data class MultiPartWebhookExecuteRequest(


### PR DESCRIPTION
also unifies the behaviors between implementing builders