### PR TITLE
fix: Resolve issue about the onShutDown function for Live entities

### DIFF
--- a/core/src/main/kotlin/live/LiveGuild.kt
+++ b/core/src/main/kotlin/live/LiveGuild.kt
@@ -21,7 +21,7 @@ import kotlinx.coroutines.Dispatchers
 
 @KordPreview
 fun Guild.live(dispatcher: CoroutineDispatcher = Dispatchers.Default): LiveGuild =
-    LiveGuild(dispatcher, this)
+    LiveGuild(this, dispatcher)
 
 @KordPreview
 inline fun Guild.live(dispatcher: CoroutineDispatcher = Dispatchers.Default, block: LiveGuild.() -> Unit) =
@@ -124,8 +124,8 @@ fun LiveGuild.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(cons
 
 @KordPreview
 class LiveGuild(
-    dispatcher: CoroutineDispatcher,
-    guild: Guild
+    guild: Guild,
+    dispatcher: CoroutineDispatcher = Dispatchers.Default
 ) : AbstractLiveKordEntity(dispatcher), KordEntity by guild {
 
     var guild: Guild = guild

--- a/core/src/main/kotlin/live/LiveGuild.kt
+++ b/core/src/main/kotlin/live/LiveGuild.kt
@@ -16,12 +16,16 @@ import dev.kord.core.event.role.RoleDeleteEvent
 import dev.kord.core.event.role.RoleUpdateEvent
 import dev.kord.core.event.user.PresenceUpdateEvent
 import dev.kord.core.event.user.VoiceStateUpdateEvent
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 
 @KordPreview
-fun Guild.live(): LiveGuild = LiveGuild(this)
+fun Guild.live(dispatcher: CoroutineDispatcher = Dispatchers.Default): LiveGuild =
+    LiveGuild(dispatcher, this)
 
 @KordPreview
-inline fun Guild.live(block: LiveGuild.() -> Unit) = this.live().apply(block)
+inline fun Guild.live(dispatcher: CoroutineDispatcher = Dispatchers.Default, block: LiveGuild.() -> Unit) =
+    this.live(dispatcher).apply(block)
 
 @KordPreview
 fun LiveGuild.onEmojisUpdate(block: suspend (EmojisUpdateEvent) -> Unit) = on(consumer = block)
@@ -119,7 +123,10 @@ fun LiveGuild.onGuildUpdate(block: suspend (GuildUpdateEvent) -> Unit) = on(cons
 fun LiveGuild.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
 
 @KordPreview
-class LiveGuild(guild: Guild) : AbstractLiveKordEntity(), KordEntity by guild {
+class LiveGuild(
+    dispatcher: CoroutineDispatcher,
+    guild: Guild
+) : AbstractLiveKordEntity(dispatcher), KordEntity by guild {
 
     var guild: Guild = guild
         private set

--- a/core/src/main/kotlin/live/LiveKordEntity.kt
+++ b/core/src/main/kotlin/live/LiveKordEntity.kt
@@ -33,6 +33,8 @@ abstract class AbstractLiveKordEntity : LiveKordEntity {
     private val mutex = Mutex()
     private val running = atomic(true)
 
+    private var onShutDown: (() -> Unit)? = null
+
     @Suppress("EXPERIMENTAL_API_USAGE")
     override val events: Flow<Event>
         get() = kord.events
@@ -42,7 +44,15 @@ abstract class AbstractLiveKordEntity : LiveKordEntity {
 
     protected abstract fun filter(event: Event): Boolean
     protected abstract fun update(event: Event)
-    override fun shutDown() = running.update { false }
+
+    override fun shutDown() {
+        running.update { false }
+        onShutDown?.invoke()
+    }
+
+    fun onShutDown(action: (() -> Unit)?){
+        onShutDown = action
+    }
 
 }
 

--- a/core/src/main/kotlin/live/LiveMember.kt
+++ b/core/src/main/kotlin/live/LiveMember.kt
@@ -9,12 +9,15 @@ import dev.kord.core.event.guild.GuildDeleteEvent
 import dev.kord.core.event.guild.MemberLeaveEvent
 import dev.kord.core.event.guild.MemberUpdateEvent
 import dev.kord.core.live.channel.LiveGuildChannel
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 
 @KordPreview
-fun Member.live() = LiveMember(this)
+fun Member.live(dispatcher: CoroutineDispatcher = Dispatchers.Default) = LiveMember(dispatcher, this)
 
 @KordPreview
-inline fun Member.live(block: LiveMember.() -> Unit) = this.live().apply(block)
+inline fun Member.live(dispatcher: CoroutineDispatcher = Dispatchers.Default, block: LiveMember.() -> Unit) =
+    this.live(dispatcher).apply(block)
 
 @KordPreview
 fun LiveMember.onLeave(block: suspend (MemberLeaveEvent) -> Unit) = on(consumer = block)
@@ -40,7 +43,10 @@ inline fun LiveGuildChannel.onShutDown(crossinline block: suspend (Event) -> Uni
 fun LiveGuildChannel.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
 
 @KordPreview
-class LiveMember(member: Member) : AbstractLiveKordEntity(), KordEntity by member {
+class LiveMember(
+    dispatcher: CoroutineDispatcher,
+    member: Member
+) : AbstractLiveKordEntity(dispatcher), KordEntity by member {
     var member = member
         private set
 

--- a/core/src/main/kotlin/live/LiveMember.kt
+++ b/core/src/main/kotlin/live/LiveMember.kt
@@ -25,6 +25,10 @@ fun LiveMember.onUpdate(block: suspend (MemberUpdateEvent) -> Unit) = on(consume
 @KordPreview
 fun LiveMember.onBanAdd(block: suspend (BanAddEvent) -> Unit) = on(consumer = block)
 
+@Deprecated(
+    "This method cannot intercept a manual shutdown",
+    replaceWith = ReplaceWith("AbstractLiveKordEntity.onShutDown(() -> Unit)")
+)
 @KordPreview
 inline fun LiveGuildChannel.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
     if (it is MemberLeaveEvent || it is BanAddEvent || it is GuildDeleteEvent) {

--- a/core/src/main/kotlin/live/LiveMember.kt
+++ b/core/src/main/kotlin/live/LiveMember.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 
 @KordPreview
-fun Member.live(dispatcher: CoroutineDispatcher = Dispatchers.Default) = LiveMember(dispatcher, this)
+fun Member.live(dispatcher: CoroutineDispatcher = Dispatchers.Default) = LiveMember(this, dispatcher)
 
 @KordPreview
 inline fun Member.live(dispatcher: CoroutineDispatcher = Dispatchers.Default, block: LiveMember.() -> Unit) =
@@ -44,8 +44,8 @@ fun LiveGuildChannel.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = 
 
 @KordPreview
 class LiveMember(
-    dispatcher: CoroutineDispatcher,
-    member: Member
+    member: Member,
+    dispatcher: CoroutineDispatcher = Dispatchers.Default
 ) : AbstractLiveKordEntity(dispatcher), KordEntity by member {
     var member = member
         private set

--- a/core/src/main/kotlin/live/LiveMember.kt
+++ b/core/src/main/kotlin/live/LiveMember.kt
@@ -28,10 +28,6 @@ fun LiveMember.onUpdate(block: suspend (MemberUpdateEvent) -> Unit) = on(consume
 @KordPreview
 fun LiveMember.onBanAdd(block: suspend (BanAddEvent) -> Unit) = on(consumer = block)
 
-@Deprecated(
-    "This method cannot intercept a manual shutdown",
-    replaceWith = ReplaceWith("AbstractLiveKordEntity.onShutDown(() -> Unit)")
-)
 @KordPreview
 inline fun LiveGuildChannel.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
     if (it is MemberLeaveEvent || it is BanAddEvent || it is GuildDeleteEvent) {

--- a/core/src/main/kotlin/live/LiveMessage.kt
+++ b/core/src/main/kotlin/live/LiveMessage.kt
@@ -56,6 +56,10 @@ fun LiveMessage.onCreate(block: suspend (MessageCreateEvent) -> Unit) = on(consu
 @KordPreview
 fun LiveMessage.onUpdate(block: suspend (MessageUpdateEvent) -> Unit) = on(consumer = block)
 
+@Deprecated(
+    "This method cannot intercept a manual shutdown",
+    replaceWith = ReplaceWith("AbstractLiveKordEntity.onShutDown(() -> Unit)")
+)
 @KordPreview
 inline fun LiveMessage.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
     if (it is MessageDeleteEvent || it is MessageBulkDeleteEvent

--- a/core/src/main/kotlin/live/LiveMessage.kt
+++ b/core/src/main/kotlin/live/LiveMessage.kt
@@ -59,10 +59,6 @@ fun LiveMessage.onCreate(block: suspend (MessageCreateEvent) -> Unit) = on(consu
 @KordPreview
 fun LiveMessage.onUpdate(block: suspend (MessageUpdateEvent) -> Unit) = on(consumer = block)
 
-@Deprecated(
-    "This method cannot intercept a manual shutdown",
-    replaceWith = ReplaceWith("AbstractLiveKordEntity.onShutDown(() -> Unit)")
-)
 @KordPreview
 inline fun LiveMessage.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
     if (it is MessageDeleteEvent || it is MessageBulkDeleteEvent

--- a/core/src/main/kotlin/live/LiveMessage.kt
+++ b/core/src/main/kotlin/live/LiveMessage.kt
@@ -13,13 +13,16 @@ import dev.kord.core.event.channel.ChannelDeleteEvent
 import dev.kord.core.event.guild.GuildDeleteEvent
 import dev.kord.core.event.message.*
 import dev.kord.core.supplier.EntitySupplyStrategy
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 
 @KordPreview
-suspend fun Message.live() =
-    LiveMessage(this, withStrategy(EntitySupplyStrategy.cacheWithRestFallback).getGuildOrNull()?.id)
+suspend fun Message.live(dispatcher: CoroutineDispatcher = Dispatchers.Default) =
+    LiveMessage(dispatcher, this, withStrategy(EntitySupplyStrategy.cacheWithRestFallback).getGuildOrNull()?.id)
 
 @KordPreview
-suspend fun Message.live(block: LiveMessage.() -> Unit) = this.live().apply(block)
+suspend fun Message.live(dispatcher: CoroutineDispatcher = Dispatchers.Default, block: LiveMessage.() -> Unit) =
+    this.live(dispatcher).apply(block)
 
 @KordPreview
 fun LiveMessage.onReactionAdd(block: suspend (ReactionAddEvent) -> Unit) = on(consumer = block)
@@ -82,7 +85,11 @@ fun LiveMessage.onChannelDelete(block: suspend (ChannelDeleteEvent) -> Unit) = o
 fun LiveMessage.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
 
 @KordPreview
-class LiveMessage(message: Message, val guildId: Snowflake?) : AbstractLiveKordEntity(), KordEntity by message {
+class LiveMessage(
+    dispatcher: CoroutineDispatcher,
+    message: Message,
+    val guildId: Snowflake?
+) : AbstractLiveKordEntity(dispatcher), KordEntity by message {
 
     var message: Message = message
         private set

--- a/core/src/main/kotlin/live/LiveMessage.kt
+++ b/core/src/main/kotlin/live/LiveMessage.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.Dispatchers
 
 @KordPreview
 suspend fun Message.live(dispatcher: CoroutineDispatcher = Dispatchers.Default) =
-    LiveMessage(dispatcher, this, withStrategy(EntitySupplyStrategy.cacheWithRestFallback).getGuildOrNull()?.id)
+    LiveMessage(this, withStrategy(EntitySupplyStrategy.cacheWithRestFallback).getGuildOrNull()?.id, dispatcher)
 
 @KordPreview
 suspend fun Message.live(dispatcher: CoroutineDispatcher = Dispatchers.Default, block: LiveMessage.() -> Unit) =
@@ -86,9 +86,9 @@ fun LiveMessage.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(co
 
 @KordPreview
 class LiveMessage(
-    dispatcher: CoroutineDispatcher,
     message: Message,
-    val guildId: Snowflake?
+    val guildId: Snowflake?,
+    dispatcher: CoroutineDispatcher = Dispatchers.Default
 ) : AbstractLiveKordEntity(dispatcher), KordEntity by message {
 
     var message: Message = message

--- a/core/src/main/kotlin/live/LiveRole.kt
+++ b/core/src/main/kotlin/live/LiveRole.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 
 @KordPreview
-fun Role.live(dispatcher: CoroutineDispatcher = Dispatchers.Default) = LiveRole(dispatcher, this)
+fun Role.live(dispatcher: CoroutineDispatcher = Dispatchers.Default) = LiveRole(this, dispatcher)
 
 @KordPreview
 inline fun Role.live(dispatcher: CoroutineDispatcher = Dispatchers.Default, block: LiveRole.() -> Unit) =
@@ -39,8 +39,8 @@ fun LiveRole.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consu
 
 @KordPreview
 class LiveRole(
-    dispatcher: CoroutineDispatcher,
-    role: Role
+    role: Role,
+    dispatcher: CoroutineDispatcher = Dispatchers.Default
 ) : AbstractLiveKordEntity(dispatcher), KordEntity by role {
     var role = role
         private set

--- a/core/src/main/kotlin/live/LiveRole.kt
+++ b/core/src/main/kotlin/live/LiveRole.kt
@@ -7,12 +7,15 @@ import dev.kord.core.event.Event
 import dev.kord.core.event.guild.GuildDeleteEvent
 import dev.kord.core.event.role.RoleDeleteEvent
 import dev.kord.core.event.role.RoleUpdateEvent
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 
 @KordPreview
-fun Role.live() = LiveRole(this)
+fun Role.live(dispatcher: CoroutineDispatcher = Dispatchers.Default) = LiveRole(dispatcher, this)
 
 @KordPreview
-inline fun Role.live(block: LiveRole.() -> Unit) = this.live().apply(block)
+inline fun Role.live(dispatcher: CoroutineDispatcher = Dispatchers.Default, block: LiveRole.() -> Unit) =
+    this.live(dispatcher).apply(block)
 
 @KordPreview
 fun LiveRole.onDelete(block: suspend (RoleDeleteEvent) -> Unit) = on(consumer = block)
@@ -35,7 +38,10 @@ inline fun LiveRole.onShutDown(crossinline block: suspend (Event) -> Unit) = on<
 fun LiveRole.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
 
 @KordPreview
-class LiveRole(role: Role) : AbstractLiveKordEntity(), KordEntity by role {
+class LiveRole(
+    dispatcher: CoroutineDispatcher,
+    role: Role
+) : AbstractLiveKordEntity(dispatcher), KordEntity by role {
     var role = role
         private set
 

--- a/core/src/main/kotlin/live/LiveRole.kt
+++ b/core/src/main/kotlin/live/LiveRole.kt
@@ -23,10 +23,6 @@ fun LiveRole.onDelete(block: suspend (RoleDeleteEvent) -> Unit) = on(consumer = 
 @KordPreview
 fun LiveRole.onUpdate(block: suspend (RoleUpdateEvent) -> Unit) = on(consumer = block)
 
-@Deprecated(
-    "This method cannot intercept a manual shutdown",
-    replaceWith = ReplaceWith("AbstractLiveKordEntity.onShutDown(() -> Unit)")
-)
 @KordPreview
 inline fun LiveRole.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
     if (it is RoleDeleteEvent || it is GuildDeleteEvent) {

--- a/core/src/main/kotlin/live/LiveRole.kt
+++ b/core/src/main/kotlin/live/LiveRole.kt
@@ -20,6 +20,10 @@ fun LiveRole.onDelete(block: suspend (RoleDeleteEvent) -> Unit) = on(consumer = 
 @KordPreview
 fun LiveRole.onUpdate(block: suspend (RoleUpdateEvent) -> Unit) = on(consumer = block)
 
+@Deprecated(
+    "This method cannot intercept a manual shutdown",
+    replaceWith = ReplaceWith("AbstractLiveKordEntity.onShutDown(() -> Unit)")
+)
 @KordPreview
 inline fun LiveRole.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
     if (it is RoleDeleteEvent || it is GuildDeleteEvent) {

--- a/core/src/main/kotlin/live/LiveUser.kt
+++ b/core/src/main/kotlin/live/LiveUser.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 
 @KordPreview
-fun User.live(dispatcher: CoroutineDispatcher = Dispatchers.Default) = LiveUser(dispatcher, this)
+fun User.live(dispatcher: CoroutineDispatcher = Dispatchers.Default) = LiveUser(this, dispatcher)
 
 @KordPreview
 inline fun User.live(
@@ -22,8 +22,8 @@ fun LiveUser.onUpdate(block: suspend (UserUpdateEvent) -> Unit) = on(consumer = 
 
 @KordPreview
 class LiveUser(
-    dispatcher: CoroutineDispatcher,
-    user: User
+    user: User,
+    dispatcher: CoroutineDispatcher = Dispatchers.Default
 ) : AbstractLiveKordEntity(dispatcher), KordEntity by user {
 
     var user: User = user

--- a/core/src/main/kotlin/live/LiveUser.kt
+++ b/core/src/main/kotlin/live/LiveUser.kt
@@ -5,18 +5,26 @@ import dev.kord.core.entity.KordEntity
 import dev.kord.core.entity.User
 import dev.kord.core.event.Event
 import dev.kord.core.event.user.UserUpdateEvent
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 
 @KordPreview
-fun User.live() = LiveUser(this)
+fun User.live(dispatcher: CoroutineDispatcher = Dispatchers.Default) = LiveUser(dispatcher, this)
 
 @KordPreview
-inline fun User.live(block: LiveUser.() -> Unit) = this.live().apply(block)
+inline fun User.live(
+    dispatcher: CoroutineDispatcher = Dispatchers.Default,
+    block: LiveUser.() -> Unit
+) = this.live(dispatcher).apply(block)
 
 @KordPreview
 fun LiveUser.onUpdate(block: suspend (UserUpdateEvent) -> Unit) = on(consumer = block)
 
 @KordPreview
-class LiveUser(user: User) : AbstractLiveKordEntity(), KordEntity by user {
+class LiveUser(
+    dispatcher: CoroutineDispatcher,
+    user: User
+) : AbstractLiveKordEntity(dispatcher), KordEntity by user {
 
     var user: User = user
         private set

--- a/core/src/main/kotlin/live/channel/LiveCategory.kt
+++ b/core/src/main/kotlin/live/channel/LiveCategory.kt
@@ -22,6 +22,10 @@ fun LiveCategory.onCreate(block: suspend (CategoryCreateEvent) -> Unit) = on(con
 @KordPreview
 fun LiveCategory.onUpdate(block: suspend (CategoryUpdateEvent) -> Unit) = on(consumer = block)
 
+@Deprecated(
+    "This method cannot intercept a manual shutdown",
+    replaceWith = ReplaceWith("AbstractLiveKordEntity.onShutDown(() -> Unit)")
+)
 @KordPreview
 inline fun LiveCategory.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
     if (it is CategoryDeleteEvent || it is GuildDeleteEvent) {

--- a/core/src/main/kotlin/live/channel/LiveCategory.kt
+++ b/core/src/main/kotlin/live/channel/LiveCategory.kt
@@ -28,10 +28,6 @@ fun LiveCategory.onCreate(block: suspend (CategoryCreateEvent) -> Unit) = on(con
 @KordPreview
 fun LiveCategory.onUpdate(block: suspend (CategoryUpdateEvent) -> Unit) = on(consumer = block)
 
-@Deprecated(
-    "This method cannot intercept a manual shutdown",
-    replaceWith = ReplaceWith("AbstractLiveKordEntity.onShutDown(() -> Unit)")
-)
 @KordPreview
 inline fun LiveCategory.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
     if (it is CategoryDeleteEvent || it is GuildDeleteEvent) {

--- a/core/src/main/kotlin/live/channel/LiveCategory.kt
+++ b/core/src/main/kotlin/live/channel/LiveCategory.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.Dispatchers
 
 @KordPreview
 fun Category.live(dispatcher: CoroutineDispatcher = Dispatchers.Default) =
-    LiveCategory(dispatcher, this)
+    LiveCategory(this, dispatcher)
 
 @KordPreview
 inline fun Category.live(
@@ -47,8 +47,8 @@ fun LiveCategory.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(c
 
 @KordPreview
 class LiveCategory(
-    dispatcher: CoroutineDispatcher,
-    channel: Category
+    channel: Category,
+    dispatcher: CoroutineDispatcher = Dispatchers.Default
 ) : LiveChannel(dispatcher), KordEntity by channel {
 
     override var channel: Category = channel

--- a/core/src/main/kotlin/live/channel/LiveCategory.kt
+++ b/core/src/main/kotlin/live/channel/LiveCategory.kt
@@ -9,12 +9,18 @@ import dev.kord.core.event.channel.CategoryDeleteEvent
 import dev.kord.core.event.channel.CategoryUpdateEvent
 import dev.kord.core.event.guild.GuildDeleteEvent
 import dev.kord.core.live.on
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 
 @KordPreview
-fun Category.live() = LiveCategory(this)
+fun Category.live(dispatcher: CoroutineDispatcher = Dispatchers.Default) =
+    LiveCategory(dispatcher, this)
 
 @KordPreview
-inline fun Category.live(block: LiveCategory.() -> Unit) = this.live().apply(block)
+inline fun Category.live(
+    dispatcher: CoroutineDispatcher = Dispatchers.Default,
+    block: LiveCategory.() -> Unit
+) = this.live(dispatcher).apply(block)
 
 @KordPreview
 fun LiveCategory.onCreate(block: suspend (CategoryCreateEvent) -> Unit) = on(consumer = block)
@@ -40,7 +46,10 @@ fun LiveCategory.onDelete(block: suspend (CategoryDeleteEvent) -> Unit) = on(con
 fun LiveCategory.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
 
 @KordPreview
-class LiveCategory(channel: Category) : LiveChannel(), KordEntity by channel {
+class LiveCategory(
+    dispatcher: CoroutineDispatcher,
+    channel: Category
+) : LiveChannel(dispatcher), KordEntity by channel {
 
     override var channel: Category = channel
         private set

--- a/core/src/main/kotlin/live/channel/LiveChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveChannel.kt
@@ -88,7 +88,7 @@ fun LiveChannel.onGuildCreate(block: suspend (GuildCreateEvent) -> Unit) = on(co
 fun LiveChannel.onGuildUpdate(block: suspend (GuildUpdateEvent) -> Unit) = on(consumer = block)
 
 @KordPreview
-abstract class LiveChannel(dispatcher: CoroutineDispatcher) : AbstractLiveKordEntity(dispatcher) {
+abstract class LiveChannel(dispatcher: CoroutineDispatcher = Dispatchers.Default) : AbstractLiveKordEntity(dispatcher) {
 
     abstract val channel: Channel
 

--- a/core/src/main/kotlin/live/channel/LiveChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveChannel.kt
@@ -14,19 +14,22 @@ import dev.kord.core.event.message.*
 import dev.kord.core.event.user.VoiceStateUpdateEvent
 import dev.kord.core.live.AbstractLiveKordEntity
 import dev.kord.core.live.on
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 
 @KordPreview
-fun Channel.live() = when (this) {
-    is DmChannel -> this.live()
-    is NewsChannel -> this.live()
-    is StoreChannel -> this.live()
-    is TextChannel -> this.live()
-    is VoiceChannel -> this.live()
+fun Channel.live(dispatcher: CoroutineDispatcher = Dispatchers.Default) = when (this) {
+    is DmChannel -> this.live(dispatcher)
+    is NewsChannel -> this.live(dispatcher)
+    is StoreChannel -> this.live(dispatcher)
+    is TextChannel -> this.live(dispatcher)
+    is VoiceChannel -> this.live(dispatcher)
     else -> error("unsupported channel type")
 }
 
 @KordPreview
-inline fun Channel.live(block: LiveChannel.() -> Unit) = this.live().apply(block)
+inline fun Channel.live(dispatcher: CoroutineDispatcher = Dispatchers.Default, block: LiveChannel.() -> Unit) =
+    this.live(dispatcher).apply(block)
 
 @KordPreview
 fun LiveChannel.onVoiceStateUpdate(block: suspend (VoiceStateUpdateEvent) -> Unit) = on(consumer = block)
@@ -85,7 +88,7 @@ fun LiveChannel.onGuildCreate(block: suspend (GuildCreateEvent) -> Unit) = on(co
 fun LiveChannel.onGuildUpdate(block: suspend (GuildUpdateEvent) -> Unit) = on(consumer = block)
 
 @KordPreview
-abstract class LiveChannel : AbstractLiveKordEntity() {
+abstract class LiveChannel(dispatcher: CoroutineDispatcher) : AbstractLiveKordEntity(dispatcher) {
 
     abstract val channel: Channel
 

--- a/core/src/main/kotlin/live/channel/LiveDmChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveDmChannel.kt
@@ -9,12 +9,17 @@ import dev.kord.core.event.channel.DMChannelDeleteEvent
 import dev.kord.core.event.channel.DMChannelUpdateEvent
 import dev.kord.core.event.guild.GuildDeleteEvent
 import dev.kord.core.live.on
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 
 @KordPreview
-fun DmChannel.live() = LiveDmChannel(this)
+fun DmChannel.live(dispatcher: CoroutineDispatcher = Dispatchers.Default) = LiveDmChannel(dispatcher, this)
 
 @KordPreview
-inline fun DmChannel.live(block: LiveDmChannel.() -> Unit) = this.live().apply(block)
+inline fun DmChannel.live(
+    dispatcher: CoroutineDispatcher = Dispatchers.Default,
+    block: LiveDmChannel.() -> Unit
+) = this.live(dispatcher).apply(block)
 
 @KordPreview
 fun LiveDmChannel.onCreate(block: suspend (DMChannelCreateEvent) -> Unit) = on(consumer = block)
@@ -40,7 +45,10 @@ fun LiveDmChannel.onDelete(block: suspend (DMChannelDeleteEvent) -> Unit) = on(c
 fun LiveDmChannel.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
 
 @KordPreview
-class LiveDmChannel(channel: DmChannel) : LiveChannel(), KordEntity by channel {
+class LiveDmChannel(
+    dispatcher: CoroutineDispatcher,
+    channel: DmChannel
+) : LiveChannel(dispatcher), KordEntity by channel {
 
     override var channel: DmChannel = channel
         private set

--- a/core/src/main/kotlin/live/channel/LiveDmChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveDmChannel.kt
@@ -22,6 +22,10 @@ fun LiveDmChannel.onCreate(block: suspend (DMChannelCreateEvent) -> Unit) = on(c
 @KordPreview
 fun LiveDmChannel.onUpdate(block: suspend (DMChannelUpdateEvent) -> Unit) = on(consumer = block)
 
+@Deprecated(
+    "This method cannot intercept a manual shutdown",
+    replaceWith = ReplaceWith("AbstractLiveKordEntity.onShutDown(() -> Unit)")
+)
 @KordPreview
 inline fun LiveDmChannel.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
     if (it is DMChannelDeleteEvent || it is GuildDeleteEvent) {

--- a/core/src/main/kotlin/live/channel/LiveDmChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveDmChannel.kt
@@ -27,10 +27,6 @@ fun LiveDmChannel.onCreate(block: suspend (DMChannelCreateEvent) -> Unit) = on(c
 @KordPreview
 fun LiveDmChannel.onUpdate(block: suspend (DMChannelUpdateEvent) -> Unit) = on(consumer = block)
 
-@Deprecated(
-    "This method cannot intercept a manual shutdown",
-    replaceWith = ReplaceWith("AbstractLiveKordEntity.onShutDown(() -> Unit)")
-)
 @KordPreview
 inline fun LiveDmChannel.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
     if (it is DMChannelDeleteEvent || it is GuildDeleteEvent) {

--- a/core/src/main/kotlin/live/channel/LiveDmChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveDmChannel.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 
 @KordPreview
-fun DmChannel.live(dispatcher: CoroutineDispatcher = Dispatchers.Default) = LiveDmChannel(dispatcher, this)
+fun DmChannel.live(dispatcher: CoroutineDispatcher = Dispatchers.Default) = LiveDmChannel(this, dispatcher)
 
 @KordPreview
 inline fun DmChannel.live(
@@ -46,8 +46,8 @@ fun LiveDmChannel.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(
 
 @KordPreview
 class LiveDmChannel(
-    dispatcher: CoroutineDispatcher,
-    channel: DmChannel
+    channel: DmChannel,
+    dispatcher: CoroutineDispatcher = Dispatchers.Default
 ) : LiveChannel(dispatcher), KordEntity by channel {
 
     override var channel: DmChannel = channel

--- a/core/src/main/kotlin/live/channel/LiveGuildChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveGuildChannel.kt
@@ -29,10 +29,6 @@ fun LiveGuildChannel.onCreate(block: suspend (ChannelCreateEvent) -> Unit) = on(
 @KordPreview
 fun LiveGuildChannel.onUpdate(block: suspend (ChannelUpdateEvent) -> Unit) = on(consumer = block)
 
-@Deprecated(
-    "This method cannot intercept a manual shutdown",
-    replaceWith = ReplaceWith("AbstractLiveKordEntity.onShutDown(() -> Unit)")
-)
 @KordPreview
 inline fun LiveGuildChannel.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
     if (it is ChannelDeleteEvent || it is GuildDeleteEvent) {

--- a/core/src/main/kotlin/live/channel/LiveGuildChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveGuildChannel.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.Dispatchers
 
 @KordPreview
 fun GuildChannel.live(dispatcher: CoroutineDispatcher = Dispatchers.Default) =
-    LiveGuildChannel(dispatcher, this)
+    LiveGuildChannel(this, dispatcher)
 
 @KordPreview
 inline fun GuildChannel.live(
@@ -48,8 +48,8 @@ fun LiveGuildChannel.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = 
 
 @KordPreview
 class LiveGuildChannel(
-    dispatcher: CoroutineDispatcher,
-    channel: GuildChannel
+    channel: GuildChannel,
+    dispatcher: CoroutineDispatcher = Dispatchers.Default
 ) : LiveChannel(dispatcher), KordEntity by channel {
 
     override var channel: GuildChannel = channel

--- a/core/src/main/kotlin/live/channel/LiveGuildChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveGuildChannel.kt
@@ -10,12 +10,18 @@ import dev.kord.core.event.channel.ChannelDeleteEvent
 import dev.kord.core.event.channel.ChannelUpdateEvent
 import dev.kord.core.event.guild.GuildDeleteEvent
 import dev.kord.core.live.on
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 
 @KordPreview
-fun GuildChannel.live() = LiveGuildChannel(this)
+fun GuildChannel.live(dispatcher: CoroutineDispatcher = Dispatchers.Default) =
+    LiveGuildChannel(dispatcher, this)
 
 @KordPreview
-inline fun GuildChannel.live(block: LiveGuildChannel.() -> Unit) = this.live().apply(block)
+inline fun GuildChannel.live(
+    dispatcher: CoroutineDispatcher = Dispatchers.Default,
+    block: LiveGuildChannel.() -> Unit
+) = this.live(dispatcher).apply(block)
 
 @KordPreview
 fun LiveGuildChannel.onCreate(block: suspend (ChannelCreateEvent) -> Unit) = on(consumer = block)
@@ -41,7 +47,10 @@ fun LiveGuildChannel.onDelete(block: suspend (ChannelDeleteEvent) -> Unit) = on(
 fun LiveGuildChannel.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
 
 @KordPreview
-class LiveGuildChannel(channel: GuildChannel) : LiveChannel(), KordEntity by channel {
+class LiveGuildChannel(
+    dispatcher: CoroutineDispatcher,
+    channel: GuildChannel
+) : LiveChannel(dispatcher), KordEntity by channel {
 
     override var channel: GuildChannel = channel
         private set

--- a/core/src/main/kotlin/live/channel/LiveGuildChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveGuildChannel.kt
@@ -23,6 +23,10 @@ fun LiveGuildChannel.onCreate(block: suspend (ChannelCreateEvent) -> Unit) = on(
 @KordPreview
 fun LiveGuildChannel.onUpdate(block: suspend (ChannelUpdateEvent) -> Unit) = on(consumer = block)
 
+@Deprecated(
+    "This method cannot intercept a manual shutdown",
+    replaceWith = ReplaceWith("AbstractLiveKordEntity.onShutDown(() -> Unit)")
+)
 @KordPreview
 inline fun LiveGuildChannel.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
     if (it is ChannelDeleteEvent || it is GuildDeleteEvent) {

--- a/core/src/main/kotlin/live/channel/LiveGuildMessageChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveGuildMessageChannel.kt
@@ -28,10 +28,6 @@ fun LiveGuildMessageChannel.onCreate(block: suspend (ChannelCreateEvent) -> Unit
 @KordPreview
 fun LiveGuildMessageChannel.onUpdate(block: suspend (ChannelUpdateEvent) -> Unit) = on(consumer = block)
 
-@Deprecated(
-    "This method cannot intercept a manual shutdown",
-    replaceWith = ReplaceWith("AbstractLiveKordEntity.onShutDown(() -> Unit)")
-)
 @KordPreview
 inline fun LiveGuildMessageChannel.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
     if (it is ChannelDeleteEvent || it is GuildDeleteEvent) {

--- a/core/src/main/kotlin/live/channel/LiveGuildMessageChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveGuildMessageChannel.kt
@@ -9,12 +9,18 @@ import dev.kord.core.event.channel.ChannelDeleteEvent
 import dev.kord.core.event.channel.ChannelUpdateEvent
 import dev.kord.core.event.guild.GuildDeleteEvent
 import dev.kord.core.live.on
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 
 @KordPreview
-fun GuildMessageChannel.live() = LiveGuildMessageChannel(this)
+fun GuildMessageChannel.live(dispatcher: CoroutineDispatcher = Dispatchers.Default) =
+    LiveGuildMessageChannel(dispatcher, this)
 
 @KordPreview
-inline fun GuildMessageChannel.live(block: LiveGuildMessageChannel.() -> Unit) = this.live().apply(block)
+inline fun GuildMessageChannel.live(
+    dispatcher: CoroutineDispatcher = Dispatchers.Default,
+    block: LiveGuildMessageChannel.() -> Unit
+) = this.live(dispatcher).apply(block)
 
 @KordPreview
 fun LiveGuildMessageChannel.onCreate(block: suspend (ChannelCreateEvent) -> Unit) = on(consumer = block)
@@ -40,7 +46,10 @@ fun LiveGuildMessageChannel.onChannelDelete(block: suspend (ChannelDeleteEvent) 
 fun LiveGuildMessageChannel.onDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
 
 @KordPreview
-class LiveGuildMessageChannel(channel: GuildMessageChannel) : LiveChannel(), KordEntity by channel {
+class LiveGuildMessageChannel(
+    dispatcher: CoroutineDispatcher,
+    channel: GuildMessageChannel
+) : LiveChannel(dispatcher), KordEntity by channel {
 
     override var channel: GuildMessageChannel = channel
         private set

--- a/core/src/main/kotlin/live/channel/LiveGuildMessageChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveGuildMessageChannel.kt
@@ -22,6 +22,10 @@ fun LiveGuildMessageChannel.onCreate(block: suspend (ChannelCreateEvent) -> Unit
 @KordPreview
 fun LiveGuildMessageChannel.onUpdate(block: suspend (ChannelUpdateEvent) -> Unit) = on(consumer = block)
 
+@Deprecated(
+    "This method cannot intercept a manual shutdown",
+    replaceWith = ReplaceWith("AbstractLiveKordEntity.onShutDown(() -> Unit)")
+)
 @KordPreview
 inline fun LiveGuildMessageChannel.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
     if (it is ChannelDeleteEvent || it is GuildDeleteEvent) {

--- a/core/src/main/kotlin/live/channel/LiveGuildMessageChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveGuildMessageChannel.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.Dispatchers
 
 @KordPreview
 fun GuildMessageChannel.live(dispatcher: CoroutineDispatcher = Dispatchers.Default) =
-    LiveGuildMessageChannel(dispatcher, this)
+    LiveGuildMessageChannel(this, dispatcher)
 
 @KordPreview
 inline fun GuildMessageChannel.live(
@@ -47,8 +47,8 @@ fun LiveGuildMessageChannel.onDelete(block: suspend (GuildDeleteEvent) -> Unit) 
 
 @KordPreview
 class LiveGuildMessageChannel(
-    dispatcher: CoroutineDispatcher,
-    channel: GuildMessageChannel
+    channel: GuildMessageChannel,
+    dispatcher: CoroutineDispatcher = Dispatchers.Default
 ) : LiveChannel(dispatcher), KordEntity by channel {
 
     override var channel: GuildMessageChannel = channel

--- a/core/src/main/kotlin/live/channel/LiveVoiceChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveVoiceChannel.kt
@@ -28,10 +28,6 @@ fun LiveVoiceChannel.onCreate(block: suspend (VoiceChannelCreateEvent) -> Unit) 
 @KordPreview
 fun LiveVoiceChannel.onUpdate(block: suspend (VoiceChannelUpdateEvent) -> Unit) = on(consumer = block)
 
-@Deprecated(
-    "This method cannot intercept a manual shutdown",
-    replaceWith = ReplaceWith("AbstractLiveKordEntity.onShutDown(() -> Unit)")
-)
 @KordPreview
 inline fun LiveVoiceChannel.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
     if (it is VoiceChannelDeleteEvent || it is GuildDeleteEvent) {

--- a/core/src/main/kotlin/live/channel/LiveVoiceChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveVoiceChannel.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.Dispatchers
 
 @KordPreview
 fun VoiceChannel.live(dispatcher: CoroutineDispatcher = Dispatchers.Default) =
-    LiveVoiceChannel(dispatcher, this)
+    LiveVoiceChannel(this, dispatcher)
 
 @KordPreview
 inline fun VoiceChannel.live(
@@ -47,8 +47,8 @@ fun LiveVoiceChannel.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = 
 
 @KordPreview
 class LiveVoiceChannel(
-    dispatcher: CoroutineDispatcher,
-    channel: VoiceChannel
+    channel: VoiceChannel,
+    dispatcher: CoroutineDispatcher = Dispatchers.Default
 ) : LiveChannel(dispatcher), KordEntity by channel {
 
     override var channel: VoiceChannel = channel

--- a/core/src/main/kotlin/live/channel/LiveVoiceChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveVoiceChannel.kt
@@ -22,6 +22,10 @@ fun LiveVoiceChannel.onCreate(block: suspend (VoiceChannelCreateEvent) -> Unit) 
 @KordPreview
 fun LiveVoiceChannel.onUpdate(block: suspend (VoiceChannelUpdateEvent) -> Unit) = on(consumer = block)
 
+@Deprecated(
+    "This method cannot intercept a manual shutdown",
+    replaceWith = ReplaceWith("AbstractLiveKordEntity.onShutDown(() -> Unit)")
+)
 @KordPreview
 inline fun LiveVoiceChannel.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
     if (it is VoiceChannelDeleteEvent || it is GuildDeleteEvent) {

--- a/core/src/main/kotlin/live/channel/LiveVoiceChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveVoiceChannel.kt
@@ -9,12 +9,18 @@ import dev.kord.core.event.channel.VoiceChannelDeleteEvent
 import dev.kord.core.event.channel.VoiceChannelUpdateEvent
 import dev.kord.core.event.guild.GuildDeleteEvent
 import dev.kord.core.live.on
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 
 @KordPreview
-fun VoiceChannel.live() = LiveVoiceChannel(this)
+fun VoiceChannel.live(dispatcher: CoroutineDispatcher = Dispatchers.Default) =
+    LiveVoiceChannel(dispatcher, this)
 
 @KordPreview
-inline fun VoiceChannel.live(block: LiveVoiceChannel.() -> Unit) = this.live().apply(block)
+inline fun VoiceChannel.live(
+    dispatcher: CoroutineDispatcher = Dispatchers.Default,
+    block: LiveVoiceChannel.() -> Unit
+) = this.live(dispatcher).apply(block)
 
 @KordPreview
 fun LiveVoiceChannel.onCreate(block: suspend (VoiceChannelCreateEvent) -> Unit) = on(consumer = block)
@@ -40,7 +46,10 @@ fun LiveVoiceChannel.onDelete(block: suspend (VoiceChannelDeleteEvent) -> Unit) 
 fun LiveVoiceChannel.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
 
 @KordPreview
-class LiveVoiceChannel(channel: VoiceChannel) : LiveChannel(), KordEntity by channel {
+class LiveVoiceChannel(
+    dispatcher: CoroutineDispatcher,
+    channel: VoiceChannel
+) : LiveChannel(dispatcher), KordEntity by channel {
 
     override var channel: VoiceChannel = channel
         private set


### PR DESCRIPTION
# Context

Currently, when using the method `onShutDown` of LiveEntity classes, the method only intercept the shutdown by events, not manually 

## Before

### Manual
```kt
val message = // create message
val live = message.live()
live.onShutDown {
   // Never called
}
live.shutdown()
```

### Event
```kt
val message = // create message
val live = message.live()
live.onShutDown {
   // Is called
}
message.delete()
```

## Now

This issue is resolve with the attribut `onShutDown` present in _AbstractLiveKordEntity_

```kt
val message = // create message
val live = message.live()
live.onShutDown {
   // Is called
}

message.delete()
//or
live.shutdown()
```