### PR TITLE
Fix memory issues related to Permission combining

### DIFF
--- a/common/src/main/kotlin/DiscordBitSet.kt
+++ b/common/src/main/kotlin/DiscordBitSet.kt
@@ -70,7 +70,7 @@ class DiscordBitSet(internal var data: LongArray) {
     }
 
     operator fun plus(another: DiscordBitSet): DiscordBitSet {
-        val dist = LongArray(size)
+        val dist = LongArray(data.size)
         data.copyInto(dist)
         val copy = DiscordBitSet(dist)
         copy.add(another)
@@ -78,7 +78,7 @@ class DiscordBitSet(internal var data: LongArray) {
     }
 
     operator fun minus(another: DiscordBitSet): DiscordBitSet {
-        val dist = LongArray(size)
+        val dist = LongArray(data.size)
         data.copyInto(dist)
         val copy = DiscordBitSet(dist)
         copy.remove(another)

--- a/common/src/main/kotlin/entity/Permission.kt
+++ b/common/src/main/kotlin/entity/Permission.kt
@@ -131,6 +131,7 @@ sealed class Permission(val code: DiscordBitSet) {
     object ManageGuild : Permission(0x00000020)
     object AddReactions : Permission(0x00000040)
     object ViewAuditLog : Permission(0x00000080)
+    object Stream : Permission(0x00000200)
     object ViewChannel : Permission(0x00000400)
     object SendMessages : Permission(0x00000800)
     object SendTTSMessages : Permission(0x00001000)

--- a/common/src/main/kotlin/entity/Permission.kt
+++ b/common/src/main/kotlin/entity/Permission.kt
@@ -155,7 +155,7 @@ sealed class Permission(val code: DiscordBitSet) {
     object ManageEmojis : Permission(0x40000000)
     object UseSlashCommands : Permission(0x80000000)
     object RequestToSpeak : Permission(0x100000000)
-    object All : Permission(Permission.values.fold(EmptyBitSet()) { acc, value -> acc + value.code })
+    object All : Permission(values.fold(EmptyBitSet()) { acc, value -> acc.add(value.code); acc })
 
     companion object {
         val values: Set<Permission>

--- a/common/src/test/kotlin/json/PermissionsTest.kt
+++ b/common/src/test/kotlin/json/PermissionsTest.kt
@@ -1,14 +1,27 @@
 package json
 
 import dev.kord.common.DiscordBitSet
-import dev.kord.common.entity.DiscordRole
-import dev.kord.common.entity.Permissions
+import dev.kord.common.EmptyBitSet
+import dev.kord.common.entity.*
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import org.junit.jupiter.api.Test
 
 class PermissionsTest {
+
+    @Test
+    fun `adding permissions together does not swallow the universe`() {
+        Permission.values.fold(Permissions(DiscordBitSet(0))) { acc, permission ->
+            acc + permission
+        }
+    }
+
+    @Test
+    fun `Permission All does not swallow the universe`() {
+        Permission.All //oh yeah, this is worthy of a test
+    }
+
     @Test
     fun `permissions serialization test`() {
         val expected = buildJsonObject {


### PR DESCRIPTION
Fixes issues with combining Permissions through the `+` operator, as well as those caused by `Permission.All`.