### PR TITLE
feat/Job for live entity

### DIFF
--- a/core/src/main/kotlin/gateway/handler/GuildEventHandler.kt
+++ b/core/src/main/kotlin/gateway/handler/GuildEventHandler.kt
@@ -90,7 +90,7 @@ internal class GuildEventHandler(
         cache.put(data)
         event.guild.cache()
 
-        coreFlow.emit(GuildCreateEvent(Guild(data, kord), shard))
+        coreFlow.emit(GuildUpdateEvent(Guild(data, kord), shard))
     }
 
     private suspend fun handle(event: GuildDelete, shard: Int) = with(event.guild) {

--- a/core/src/main/kotlin/live/LiveGuild.kt
+++ b/core/src/main/kotlin/live/LiveGuild.kt
@@ -125,7 +125,7 @@ fun LiveGuild.onGuildCreate(block: suspend (GuildCreateEvent) -> Unit) = on(cons
 fun LiveGuild.onGuildUpdate(block: suspend (GuildUpdateEvent) -> Unit) = on(consumer = block)
 
 @Deprecated(
-    "The block is not called when the entity is deleted because the live entity is shutdown",
+    "The block is not called when the entity is deleted because the live entity is shut down",
     ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
     DeprecationLevel.ERROR
 )

--- a/core/src/main/kotlin/live/LiveGuild.kt
+++ b/core/src/main/kotlin/live/LiveGuild.kt
@@ -6,7 +6,6 @@ import dev.kord.core.entity.Guild
 import dev.kord.core.entity.KordEntity
 import dev.kord.core.entity.ReactionEmoji
 import dev.kord.core.event.Event
-import dev.kord.core.event.channel.CategoryCreateEvent
 import dev.kord.core.event.channel.ChannelCreateEvent
 import dev.kord.core.event.channel.ChannelDeleteEvent
 import dev.kord.core.event.channel.ChannelUpdateEvent
@@ -118,10 +117,6 @@ fun LiveGuild.onChannelUpdate(block: suspend (ChannelUpdateEvent) -> Unit) = on(
 @KordPreview
 fun LiveGuild.onChannelDelete(block: suspend (ChannelDeleteEvent) -> Unit) = on(consumer = block)
 
-@Deprecated(
-    "The block is never called because the guild is already created",
-    ReplaceWith("Kord.on<GuildCreateEvent>")
-)
 @KordPreview
 fun LiveGuild.onGuildCreate(block: suspend (GuildCreateEvent) -> Unit) = on(consumer = block)
 
@@ -130,7 +125,7 @@ fun LiveGuild.onGuildUpdate(block: suspend (GuildUpdateEvent) -> Unit) = on(cons
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("LiveGuild.onShutDown((() -> Unit)?)")
+    ReplaceWith("onShutDown(block)")
 )
 @KordPreview
 fun LiveGuild.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
@@ -144,49 +139,46 @@ class LiveGuild(
     var guild: Guild = guild
         private set
 
-    override fun filter(event: Event): Boolean {
-        println(event)
-        return when (event) {
-            is EmojisUpdateEvent -> event.guildId == guild.id
+    override fun filter(event: Event): Boolean = when (event) {
+        is EmojisUpdateEvent -> event.guildId == guild.id
 
-            is IntegrationsUpdateEvent -> event.guildId == guild.id
+        is IntegrationsUpdateEvent -> event.guildId == guild.id
 
-            is BanAddEvent -> event.guildId == guild.id
-            is BanRemoveEvent -> event.guildId == guild.id
+        is BanAddEvent -> event.guildId == guild.id
+        is BanRemoveEvent -> event.guildId == guild.id
 
-            is PresenceUpdateEvent -> event.guildId == guild.id
+        is PresenceUpdateEvent -> event.guildId == guild.id
 
-            is VoiceServerUpdateEvent -> event.guildId == guild.id
-            is VoiceStateUpdateEvent -> event.state.guildId == guild.id
+        is VoiceServerUpdateEvent -> event.guildId == guild.id
+        is VoiceStateUpdateEvent -> event.state.guildId == guild.id
 
-            is WebhookUpdateEvent -> event.guildId == guild.id
+        is WebhookUpdateEvent -> event.guildId == guild.id
 
-            is RoleCreateEvent -> event.guildId == guild.id
-            is RoleUpdateEvent -> event.guildId == guild.id
-            is RoleDeleteEvent -> event.guildId == guild.id
+        is RoleCreateEvent -> event.guildId == guild.id
+        is RoleUpdateEvent -> event.guildId == guild.id
+        is RoleDeleteEvent -> event.guildId == guild.id
 
-            is MemberJoinEvent -> event.guildId == guild.id
-            is MemberUpdateEvent -> event.guildId == guild.id
-            is MemberLeaveEvent -> event.guildId == guild.id
+        is MemberJoinEvent -> event.guildId == guild.id
+        is MemberUpdateEvent -> event.guildId == guild.id
+        is MemberLeaveEvent -> event.guildId == guild.id
 
-            is ReactionAddEvent -> event.guildId == guild.id
-            is ReactionRemoveEvent -> event.guildId == guild.id
-            is ReactionRemoveAllEvent -> event.guildId == guild.id
+        is ReactionAddEvent -> event.guildId == guild.id
+        is ReactionRemoveEvent -> event.guildId == guild.id
+        is ReactionRemoveAllEvent -> event.guildId == guild.id
 
-            is MessageCreateEvent -> event.guildId == guild.id
-            is MessageUpdateEvent -> event.new.guildId.value == guild.id
-            is MessageDeleteEvent -> event.guildId == guild.id
+        is MessageCreateEvent -> event.guildId == guild.id
+        is MessageUpdateEvent -> event.new.guildId.value == guild.id
+        is MessageDeleteEvent -> event.guildId == guild.id
 
-            is ChannelCreateEvent -> event.channel.data.guildId.value == guild.id
-            is ChannelUpdateEvent -> event.channel.data.guildId.value == guild.id
-            is ChannelDeleteEvent -> event.channel.data.guildId.value == guild.id
+        is ChannelCreateEvent -> event.channel.data.guildId.value == guild.id
+        is ChannelUpdateEvent -> event.channel.data.guildId.value == guild.id
+        is ChannelDeleteEvent -> event.channel.data.guildId.value == guild.id
 
-            is GuildCreateEvent -> event.guild.id == guild.id
-            is GuildUpdateEvent -> event.guild.id == guild.id
-            is GuildDeleteEvent -> event.guildId == guild.id
+        is GuildCreateEvent -> event.guild.id == guild.id
+        is GuildUpdateEvent -> event.guild.id == guild.id
+        is GuildDeleteEvent -> event.guildId == guild.id
 
-            else -> false
-        }
+        else -> false
     }
 
     override fun update(event: Event): Unit = when (event) {
@@ -223,7 +215,7 @@ class LiveGuild(
         ), kord)
 
         is GuildUpdateEvent -> guild = event.guild
-        is GuildDeleteEvent -> shutdown()
+        is GuildDeleteEvent -> shutDown()
         else -> Unit
     }
 

--- a/core/src/main/kotlin/live/LiveGuild.kt
+++ b/core/src/main/kotlin/live/LiveGuild.kt
@@ -119,6 +119,10 @@ fun LiveGuild.onGuildCreate(block: suspend (GuildCreateEvent) -> Unit) = on(cons
 @KordPreview
 fun LiveGuild.onGuildUpdate(block: suspend (GuildUpdateEvent) -> Unit) = on(consumer = block)
 
+@Deprecated(
+    "The block is not called when the entity is deleted because the live entity is shutdown",
+    ReplaceWith("LiveGuild.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 fun LiveGuild.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
 

--- a/core/src/main/kotlin/live/LiveGuild.kt
+++ b/core/src/main/kotlin/live/LiveGuild.kt
@@ -17,6 +17,7 @@ import dev.kord.core.event.role.RoleDeleteEvent
 import dev.kord.core.event.role.RoleUpdateEvent
 import dev.kord.core.event.user.PresenceUpdateEvent
 import dev.kord.core.event.user.VoiceStateUpdateEvent
+import dev.kord.core.live.exception.LiveCancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 
@@ -219,7 +220,7 @@ class LiveGuild(
         ), kord)
 
         is GuildUpdateEvent -> guild = event.guild
-        is GuildDeleteEvent -> shutDown()
+        is GuildDeleteEvent -> shutDown(LiveCancellationException(event, "The guild is deleted"))
         else -> Unit
     }
 

--- a/core/src/main/kotlin/live/LiveGuild.kt
+++ b/core/src/main/kotlin/live/LiveGuild.kt
@@ -126,7 +126,7 @@ fun LiveGuild.onGuildUpdate(block: suspend (GuildUpdateEvent) -> Unit) = on(cons
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shut down",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)", "kotlinx.coroutines.job"),
     DeprecationLevel.ERROR
 )
 @KordPreview

--- a/core/src/main/kotlin/live/LiveGuild.kt
+++ b/core/src/main/kotlin/live/LiveGuild.kt
@@ -125,7 +125,8 @@ fun LiveGuild.onGuildUpdate(block: suspend (GuildUpdateEvent) -> Unit) = on(cons
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)")
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    DeprecationLevel.ERROR
 )
 @KordPreview
 fun LiveGuild.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)

--- a/core/src/main/kotlin/live/LiveGuild.kt
+++ b/core/src/main/kotlin/live/LiveGuild.kt
@@ -1,6 +1,7 @@
 package dev.kord.core.live
 
 import dev.kord.common.annotation.KordPreview
+import dev.kord.common.entity.Snowflake
 import dev.kord.common.entity.optional.map
 import dev.kord.core.entity.Guild
 import dev.kord.core.entity.KordEntity
@@ -18,7 +19,6 @@ import dev.kord.core.event.user.PresenceUpdateEvent
 import dev.kord.core.event.user.VoiceStateUpdateEvent
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.job
 
 @KordPreview
 fun Guild.live(dispatcher: CoroutineDispatcher = Dispatchers.Default): LiveGuild =
@@ -125,7 +125,7 @@ fun LiveGuild.onGuildUpdate(block: suspend (GuildUpdateEvent) -> Unit) = on(cons
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("onShutDown(block)")
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)")
 )
 @KordPreview
 fun LiveGuild.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
@@ -134,7 +134,10 @@ fun LiveGuild.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(cons
 class LiveGuild(
     guild: Guild,
     dispatcher: CoroutineDispatcher = Dispatchers.Default
-) : AbstractLiveKordEntity(dispatcher, guild.kord.coroutineContext.job), KordEntity by guild {
+) : AbstractLiveKordEntity(guild.kord, dispatcher), KordEntity {
+
+    override val id: Snowflake
+        get() = guild.id
 
     var guild: Guild = guild
         private set

--- a/core/src/main/kotlin/live/LiveKordEntity.kt
+++ b/core/src/main/kotlin/live/LiveKordEntity.kt
@@ -24,7 +24,7 @@ import kotlin.coroutines.CoroutineContext
 interface LiveKordEntity : KordEntity, CoroutineScope {
     val events: Flow<Event>
 
-    fun shutDown(cause: CancellationException = CancellationException("The live entity has been shut down", null))
+    fun shutDown(cause: CancellationException = CancellationException("The live entity is shut down", null))
 }
 
 @KordPreview

--- a/core/src/main/kotlin/live/LiveKordEntity.kt
+++ b/core/src/main/kotlin/live/LiveKordEntity.kt
@@ -34,7 +34,7 @@ abstract class AbstractLiveKordEntity(dispatcher: CoroutineDispatcher, parent: J
 
     /**
      * Allows to execute behavior when the entity is shutdown.
-     * Keep in memory an empty job to continue to listen the events.
+     * Keep in memory a job without action to continue to listen events.
      */
     private var shutdownAction: Pair<(() -> Unit), Job>? = null
 

--- a/core/src/main/kotlin/live/LiveKordEntity.kt
+++ b/core/src/main/kotlin/live/LiveKordEntity.kt
@@ -32,6 +32,9 @@ abstract class AbstractLiveKordEntity(dispatcher: CoroutineDispatcher) : LiveKor
 
     override val coroutineContext: CoroutineContext = dispatcher + SupervisorJob()
 
+    var shutdownAction: (() -> Unit)? = null
+    private set
+
     private val mutex = Mutex()
 
     @Suppress("EXPERIMENTAL_API_USAGE")
@@ -44,8 +47,13 @@ abstract class AbstractLiveKordEntity(dispatcher: CoroutineDispatcher) : LiveKor
     protected abstract fun filter(event: Event): Boolean
     protected abstract fun update(event: Event)
 
+    fun onShutDown(action: (() -> Unit)?){
+        shutdownAction = action
+    }
+
     override fun shutDown() {
-        cancel("Shutdown executed")
+        shutdownAction?.invoke()
+        cancel()
     }
 }
 

--- a/core/src/main/kotlin/live/LiveKordEntity.kt
+++ b/core/src/main/kotlin/live/LiveKordEntity.kt
@@ -24,7 +24,7 @@ import kotlin.coroutines.CoroutineContext
 interface LiveKordEntity : KordEntity, CoroutineScope {
     val events: Flow<Event>
 
-    fun shutdown()
+    fun shutDown()
 }
 
 @KordPreview
@@ -62,7 +62,7 @@ abstract class AbstractLiveKordEntity(dispatcher: CoroutineDispatcher, parent: J
             }
     }
 
-    override fun shutdown() {
+    override fun shutDown() {
         if (!isActive) return
 
         cancel()

--- a/core/src/main/kotlin/live/LiveKordEntity.kt
+++ b/core/src/main/kotlin/live/LiveKordEntity.kt
@@ -24,7 +24,7 @@ import kotlin.coroutines.CoroutineContext
 interface LiveKordEntity : KordEntity, CoroutineScope {
     val events: Flow<Event>
 
-    fun shutDown()
+    fun shutDown(cause: CancellationException = CancellationException("The live entity has been shut down", null))
 }
 
 @KordPreview
@@ -48,7 +48,7 @@ abstract class AbstractLiveKordEntity(final override val kord: Kord, dispatcher:
         events.launchIn(this)
     }
 
-    override fun shutDown() = cancel()
+    override fun shutDown(cause: CancellationException) = cancel(cause)
 }
 
 /**

--- a/core/src/main/kotlin/live/LiveKordEntity.kt
+++ b/core/src/main/kotlin/live/LiveKordEntity.kt
@@ -24,16 +24,19 @@ import kotlin.coroutines.CoroutineContext
 interface LiveKordEntity : KordEntity, CoroutineScope {
     val events: Flow<Event>
 
-    fun shutDown()
+    fun shutdown()
 }
 
 @KordPreview
-abstract class AbstractLiveKordEntity(dispatcher: CoroutineDispatcher) : LiveKordEntity {
+abstract class AbstractLiveKordEntity(dispatcher: CoroutineDispatcher, parent: Job) : LiveKordEntity {
 
-    override val coroutineContext: CoroutineContext = dispatcher + SupervisorJob()
+    override val coroutineContext: CoroutineContext = dispatcher + SupervisorJob(parent)
 
-    var shutdownAction: (() -> Unit)? = null
-    private set
+    /**
+     * Allows to execute behavior when the entity is shutdown.
+     * Keep in memory an empty job to continue to listen the events.
+     */
+    private var shutdownAction: Pair<(() -> Unit), Job>? = null
 
     private val mutex = Mutex()
 
@@ -47,13 +50,23 @@ abstract class AbstractLiveKordEntity(dispatcher: CoroutineDispatcher) : LiveKor
     protected abstract fun filter(event: Event): Boolean
     protected abstract fun update(event: Event)
 
-    fun onShutDown(action: (() -> Unit)?){
-        shutdownAction = action
+    fun onShutdown(action: (() -> Unit)?) {
+        val currentAction = shutdownAction
+
+        shutdownAction =
+            if (action == null) {
+                currentAction?.second?.cancel()
+                null
+            } else {
+                action to (currentAction?.second ?: on<Event> {})
+            }
     }
 
-    override fun shutDown() {
-        shutdownAction?.invoke()
+    override fun shutdown() {
+        if (!isActive) return
+
         cancel()
+        shutdownAction?.first?.invoke()
     }
 }
 

--- a/core/src/main/kotlin/live/LiveMember.kt
+++ b/core/src/main/kotlin/live/LiveMember.kt
@@ -10,6 +10,7 @@ import dev.kord.core.event.guild.GuildDeleteEvent
 import dev.kord.core.event.guild.MemberLeaveEvent
 import dev.kord.core.event.guild.MemberUpdateEvent
 import dev.kord.core.live.channel.LiveGuildChannel
+import dev.kord.core.live.exception.LiveCancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 
@@ -80,9 +81,9 @@ class LiveMember(
     }
 
     override fun update(event: Event) = when (event) {
-        is MemberLeaveEvent -> shutDown()
-        is BanAddEvent -> shutDown()
-        is GuildDeleteEvent -> shutDown()
+        is MemberLeaveEvent -> shutDown(LiveCancellationException(event, "The member has left"))
+        is BanAddEvent -> shutDown(LiveCancellationException(event, "The member is banned"))
+        is GuildDeleteEvent -> shutDown(LiveCancellationException(event, "The guild is deleted"))
         is MemberUpdateEvent -> member = event.member
 
         else -> Unit

--- a/core/src/main/kotlin/live/LiveMember.kt
+++ b/core/src/main/kotlin/live/LiveMember.kt
@@ -25,9 +25,17 @@ fun LiveMember.onLeave(block: suspend (MemberLeaveEvent) -> Unit) = on(consumer 
 @KordPreview
 fun LiveMember.onUpdate(block: suspend (MemberUpdateEvent) -> Unit) = on(consumer = block)
 
+@Deprecated(
+    "The block is not called when the entity is deleted because the live entity is shutdown",
+    ReplaceWith("LiveMember.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 fun LiveMember.onBanAdd(block: suspend (BanAddEvent) -> Unit) = on(consumer = block)
 
+@Deprecated(
+    "The block is not called when the live entity is shutdown",
+    ReplaceWith("LiveMember.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 inline fun LiveGuildChannel.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
     if (it is MemberLeaveEvent || it is BanAddEvent || it is GuildDeleteEvent) {
@@ -35,6 +43,10 @@ inline fun LiveGuildChannel.onShutDown(crossinline block: suspend (Event) -> Uni
     }
 }
 
+@Deprecated(
+    "The block is not called when the entity is deleted because the live entity is shutdown",
+    ReplaceWith("LiveMember.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 fun LiveGuildChannel.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
 

--- a/core/src/main/kotlin/live/LiveMember.kt
+++ b/core/src/main/kotlin/live/LiveMember.kt
@@ -22,7 +22,7 @@ inline fun Member.live(dispatcher: CoroutineDispatcher = Dispatchers.Default, bl
     this.live(dispatcher).apply(block)
 
 @Deprecated(
-    "The block is not called when the entity is deleted because the live entity is shutdown",
+    "The block is not called when the entity is deleted because the live entity is shut down",
     ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
     DeprecationLevel.ERROR
 )
@@ -33,7 +33,7 @@ fun LiveMember.onLeave(block: suspend (MemberLeaveEvent) -> Unit) = on(consumer 
 fun LiveMember.onUpdate(block: suspend (MemberUpdateEvent) -> Unit) = on(consumer = block)
 
 @Deprecated(
-    "The block is not called when the entity is deleted because the live entity is shutdown",
+    "The block is not called when the entity is deleted because the live entity is shut down",
     ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
     DeprecationLevel.ERROR
 )
@@ -41,7 +41,7 @@ fun LiveMember.onUpdate(block: suspend (MemberUpdateEvent) -> Unit) = on(consume
 fun LiveMember.onBanAdd(block: suspend (BanAddEvent) -> Unit) = on(consumer = block)
 
 @Deprecated(
-    "The block is not called when the live entity is shutdown",
+    "The block is not called when the live entity is shut down",
     ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
     DeprecationLevel.ERROR
 )
@@ -53,7 +53,7 @@ inline fun LiveGuildChannel.onShutdown(crossinline block: suspend (Event) -> Uni
 }
 
 @Deprecated(
-    "The block is not called when the entity is deleted because the live entity is shutdown",
+    "The block is not called when the entity is deleted because the live entity is shut down",
     ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
     DeprecationLevel.ERROR
 )

--- a/core/src/main/kotlin/live/LiveMember.kt
+++ b/core/src/main/kotlin/live/LiveMember.kt
@@ -23,7 +23,7 @@ inline fun Member.live(dispatcher: CoroutineDispatcher = Dispatchers.Default, bl
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shut down",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)", "kotlinx.coroutines.job"),
     DeprecationLevel.ERROR
 )
 @KordPreview
@@ -34,7 +34,7 @@ fun LiveMember.onUpdate(block: suspend (MemberUpdateEvent) -> Unit) = on(consume
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shut down",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)", "kotlinx.coroutines.job"),
     DeprecationLevel.ERROR
 )
 @KordPreview
@@ -42,7 +42,7 @@ fun LiveMember.onBanAdd(block: suspend (BanAddEvent) -> Unit) = on(consumer = bl
 
 @Deprecated(
     "The block is not called when the live entity is shut down",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)", "kotlinx.coroutines.job"),
     DeprecationLevel.ERROR
 )
 @KordPreview
@@ -54,7 +54,7 @@ inline fun LiveGuildChannel.onShutdown(crossinline block: suspend (Event) -> Uni
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shut down",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)", "kotlinx.coroutines.job"),
     DeprecationLevel.ERROR
 )
 @KordPreview

--- a/core/src/main/kotlin/live/LiveMember.kt
+++ b/core/src/main/kotlin/live/LiveMember.kt
@@ -22,7 +22,8 @@ inline fun Member.live(dispatcher: CoroutineDispatcher = Dispatchers.Default, bl
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)")
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    DeprecationLevel.ERROR
 )
 @KordPreview
 fun LiveMember.onLeave(block: suspend (MemberLeaveEvent) -> Unit) = on(consumer = block)
@@ -32,14 +33,16 @@ fun LiveMember.onUpdate(block: suspend (MemberUpdateEvent) -> Unit) = on(consume
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)")
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    DeprecationLevel.ERROR
 )
 @KordPreview
 fun LiveMember.onBanAdd(block: suspend (BanAddEvent) -> Unit) = on(consumer = block)
 
 @Deprecated(
     "The block is not called when the live entity is shutdown",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)")
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    DeprecationLevel.ERROR
 )
 @KordPreview
 inline fun LiveGuildChannel.onShutdown(crossinline block: suspend (Event) -> Unit) = on<Event> {
@@ -50,7 +53,8 @@ inline fun LiveGuildChannel.onShutdown(crossinline block: suspend (Event) -> Uni
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)")
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    DeprecationLevel.ERROR
 )
 @KordPreview
 fun LiveGuildChannel.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)

--- a/core/src/main/kotlin/live/LiveMember.kt
+++ b/core/src/main/kotlin/live/LiveMember.kt
@@ -22,7 +22,7 @@ inline fun Member.live(dispatcher: CoroutineDispatcher = Dispatchers.Default, bl
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("LiveMember.onShutDown((() -> Unit)?)")
+    ReplaceWith("onShutDown(block)")
 )
 @KordPreview
 fun LiveMember.onLeave(block: suspend (MemberLeaveEvent) -> Unit) = on(consumer = block)
@@ -32,14 +32,14 @@ fun LiveMember.onUpdate(block: suspend (MemberUpdateEvent) -> Unit) = on(consume
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("LiveMember.onShutDown((() -> Unit)?)")
+    ReplaceWith("onShutDown(block)")
 )
 @KordPreview
 fun LiveMember.onBanAdd(block: suspend (BanAddEvent) -> Unit) = on(consumer = block)
 
 @Deprecated(
     "The block is not called when the live entity is shutdown",
-    ReplaceWith("LiveMember.onShutDown((() -> Unit)?)")
+    ReplaceWith("onShutDown(block)")
 )
 @KordPreview
 inline fun LiveGuildChannel.onShutdown(crossinline block: suspend (Event) -> Unit) = on<Event> {
@@ -50,7 +50,7 @@ inline fun LiveGuildChannel.onShutdown(crossinline block: suspend (Event) -> Uni
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("LiveMember.onShutDown((() -> Unit)?)")
+    ReplaceWith("onShutDown(block)")
 )
 @KordPreview
 fun LiveGuildChannel.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
@@ -72,9 +72,9 @@ class LiveMember(
     }
 
     override fun update(event: Event) = when (event) {
-        is MemberLeaveEvent -> shutdown()
-        is BanAddEvent -> shutdown()
-        is GuildDeleteEvent -> shutdown()
+        is MemberLeaveEvent -> shutDown()
+        is BanAddEvent -> shutDown()
+        is GuildDeleteEvent -> shutDown()
         is MemberUpdateEvent -> member = event.member
 
         else -> Unit

--- a/core/src/main/kotlin/live/LiveMessage.kt
+++ b/core/src/main/kotlin/live/LiveMessage.kt
@@ -59,6 +59,10 @@ fun LiveMessage.onCreate(block: suspend (MessageCreateEvent) -> Unit) = on(consu
 @KordPreview
 fun LiveMessage.onUpdate(block: suspend (MessageUpdateEvent) -> Unit) = on(consumer = block)
 
+@Deprecated(
+    "The block is not called when the live entity is shutdown",
+    ReplaceWith("LiveMessage.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 inline fun LiveMessage.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
     if (it is MessageDeleteEvent || it is MessageBulkDeleteEvent
@@ -68,15 +72,31 @@ inline fun LiveMessage.onShutDown(crossinline block: suspend (Event) -> Unit) = 
     }
 }
 
+@Deprecated(
+    "The block is not called when the entity is deleted because the live entity is shutdown",
+    ReplaceWith("LiveMessage.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 fun LiveMessage.onOnlyDelete(block: suspend (MessageDeleteEvent) -> Unit) = on(consumer = block)
 
+@Deprecated(
+    "The block is not called when the entity is deleted because the live entity is shutdown",
+    ReplaceWith("LiveMessage.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 fun LiveMessage.onBulkDelete(block: suspend (MessageBulkDeleteEvent) -> Unit) = on(consumer = block)
 
+@Deprecated(
+    "The block is not called when the entity is deleted because the live entity is shutdown",
+    ReplaceWith("LiveMessage.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 fun LiveMessage.onChannelDelete(block: suspend (ChannelDeleteEvent) -> Unit) = on(consumer = block)
 
+@Deprecated(
+    "The block is not called when the entity is deleted because the live entity is shutdown",
+    ReplaceWith("LiveMessage.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 fun LiveMessage.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
 

--- a/core/src/main/kotlin/live/LiveMessage.kt
+++ b/core/src/main/kotlin/live/LiveMessage.kt
@@ -146,7 +146,12 @@ class LiveMessage(
         is ReactionRemoveAllEvent -> message = Message(message.data.copy(reactions = Optional.Missing()), kord)
 
         is MessageUpdateEvent -> message = Message(message.data + event.new, kord)
-        is MessageDeleteEvent, is MessageBulkDeleteEvent -> shutDown(LiveCancellationException(event, "The message is deleted"))
+        is MessageDeleteEvent, is MessageBulkDeleteEvent -> shutDown(
+            LiveCancellationException(
+                event,
+                "The message is deleted"
+            )
+        )
 
         is ChannelDeleteEvent -> shutDown(LiveCancellationException(event, "The channel is deleted"))
 

--- a/core/src/main/kotlin/live/LiveMessage.kt
+++ b/core/src/main/kotlin/live/LiveMessage.kt
@@ -15,7 +15,6 @@ import dev.kord.core.event.message.*
 import dev.kord.core.supplier.EntitySupplyStrategy
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.job
 
 @KordPreview
 suspend fun Message.live(dispatcher: CoroutineDispatcher = Dispatchers.Default) =
@@ -66,7 +65,7 @@ fun LiveMessage.onUpdate(block: suspend (MessageUpdateEvent) -> Unit) = on(consu
 
 @Deprecated(
     "The block is not called when the live entity is shutdown",
-    ReplaceWith("onShutDown(block)")
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)")
 )
 @KordPreview
 inline fun LiveMessage.onShutdown(crossinline block: suspend (Event) -> Unit) = on<Event> {
@@ -79,28 +78,28 @@ inline fun LiveMessage.onShutdown(crossinline block: suspend (Event) -> Unit) = 
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("onShutDown(block)")
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)")
 )
 @KordPreview
 fun LiveMessage.onOnlyDelete(block: suspend (MessageDeleteEvent) -> Unit) = on(consumer = block)
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("onShutDown(block)")
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)")
 )
 @KordPreview
 fun LiveMessage.onBulkDelete(block: suspend (MessageBulkDeleteEvent) -> Unit) = on(consumer = block)
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("onShutDown(block)")
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)")
 )
 @KordPreview
 fun LiveMessage.onChannelDelete(block: suspend (ChannelDeleteEvent) -> Unit) = on(consumer = block)
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("onShutDown(block)")
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)")
 )
 @KordPreview
 fun LiveMessage.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
@@ -110,7 +109,10 @@ class LiveMessage(
     message: Message,
     val guildId: Snowflake?,
     dispatcher: CoroutineDispatcher = Dispatchers.Default
-) : AbstractLiveKordEntity(dispatcher, message.kord.coroutineContext.job), KordEntity by message {
+) : AbstractLiveKordEntity(message.kord, dispatcher), KordEntity {
+
+    override val id: Snowflake
+        get() = message.id
 
     var message: Message = message
         private set

--- a/core/src/main/kotlin/live/LiveMessage.kt
+++ b/core/src/main/kotlin/live/LiveMessage.kt
@@ -55,7 +55,8 @@ fun LiveMessage.onReactionRemoveAll(block: suspend (ReactionRemoveAllEvent) -> U
 
 @Deprecated(
     "The block is never called because the message is already created",
-    ReplaceWith("LiveChannel.onMessageCreate(block)")
+    ReplaceWith("LiveChannel.onMessageCreate(block)"),
+    DeprecationLevel.ERROR
 )
 @KordPreview
 fun LiveMessage.onCreate(block: suspend (MessageCreateEvent) -> Unit) = on(consumer = block)
@@ -65,7 +66,8 @@ fun LiveMessage.onUpdate(block: suspend (MessageUpdateEvent) -> Unit) = on(consu
 
 @Deprecated(
     "The block is not called when the live entity is shutdown",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)")
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    DeprecationLevel.ERROR
 )
 @KordPreview
 inline fun LiveMessage.onShutdown(crossinline block: suspend (Event) -> Unit) = on<Event> {
@@ -78,28 +80,32 @@ inline fun LiveMessage.onShutdown(crossinline block: suspend (Event) -> Unit) = 
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)")
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    DeprecationLevel.ERROR
 )
 @KordPreview
 fun LiveMessage.onOnlyDelete(block: suspend (MessageDeleteEvent) -> Unit) = on(consumer = block)
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)")
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    DeprecationLevel.ERROR
 )
 @KordPreview
 fun LiveMessage.onBulkDelete(block: suspend (MessageBulkDeleteEvent) -> Unit) = on(consumer = block)
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)")
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    DeprecationLevel.ERROR
 )
 @KordPreview
 fun LiveMessage.onChannelDelete(block: suspend (ChannelDeleteEvent) -> Unit) = on(consumer = block)
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)")
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    DeprecationLevel.ERROR
 )
 @KordPreview
 fun LiveMessage.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)

--- a/core/src/main/kotlin/live/LiveMessage.kt
+++ b/core/src/main/kotlin/live/LiveMessage.kt
@@ -66,7 +66,7 @@ fun LiveMessage.onCreate(block: suspend (MessageCreateEvent) -> Unit) = on(consu
 fun LiveMessage.onUpdate(block: suspend (MessageUpdateEvent) -> Unit) = on(consumer = block)
 
 @Deprecated(
-    "The block is not called when the live entity is shutdown",
+    "The block is not called when the live entity is shut down",
     ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
     DeprecationLevel.ERROR
 )
@@ -80,7 +80,7 @@ inline fun LiveMessage.onShutdown(crossinline block: suspend (Event) -> Unit) = 
 }
 
 @Deprecated(
-    "The block is not called when the entity is deleted because the live entity is shutdown",
+    "The block is not called when the entity is deleted because the live entity is shut down",
     ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
     DeprecationLevel.ERROR
 )
@@ -88,7 +88,7 @@ inline fun LiveMessage.onShutdown(crossinline block: suspend (Event) -> Unit) = 
 fun LiveMessage.onOnlyDelete(block: suspend (MessageDeleteEvent) -> Unit) = on(consumer = block)
 
 @Deprecated(
-    "The block is not called when the entity is deleted because the live entity is shutdown",
+    "The block is not called when the entity is deleted because the live entity is shut down",
     ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
     DeprecationLevel.ERROR
 )
@@ -96,7 +96,7 @@ fun LiveMessage.onOnlyDelete(block: suspend (MessageDeleteEvent) -> Unit) = on(c
 fun LiveMessage.onBulkDelete(block: suspend (MessageBulkDeleteEvent) -> Unit) = on(consumer = block)
 
 @Deprecated(
-    "The block is not called when the entity is deleted because the live entity is shutdown",
+    "The block is not called when the entity is deleted because the live entity is shut down",
     ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
     DeprecationLevel.ERROR
 )
@@ -104,7 +104,7 @@ fun LiveMessage.onBulkDelete(block: suspend (MessageBulkDeleteEvent) -> Unit) = 
 fun LiveMessage.onChannelDelete(block: suspend (ChannelDeleteEvent) -> Unit) = on(consumer = block)
 
 @Deprecated(
-    "The block is not called when the entity is deleted because the live entity is shutdown",
+    "The block is not called when the entity is deleted because the live entity is shut down",
     ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
     DeprecationLevel.ERROR
 )

--- a/core/src/main/kotlin/live/LiveMessage.kt
+++ b/core/src/main/kotlin/live/LiveMessage.kt
@@ -12,6 +12,7 @@ import dev.kord.core.event.Event
 import dev.kord.core.event.channel.ChannelDeleteEvent
 import dev.kord.core.event.guild.GuildDeleteEvent
 import dev.kord.core.event.message.*
+import dev.kord.core.live.exception.LiveCancellationException
 import dev.kord.core.supplier.EntitySupplyStrategy
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -145,12 +146,11 @@ class LiveMessage(
         is ReactionRemoveAllEvent -> message = Message(message.data.copy(reactions = Optional.Missing()), kord)
 
         is MessageUpdateEvent -> message = Message(message.data + event.new, kord)
-        is MessageDeleteEvent -> shutDown()
-        is MessageBulkDeleteEvent -> shutDown()
+        is MessageDeleteEvent, is MessageBulkDeleteEvent -> shutDown(LiveCancellationException(event, "The message is deleted"))
 
-        is ChannelDeleteEvent -> shutDown()
+        is ChannelDeleteEvent -> shutDown(LiveCancellationException(event, "The channel is deleted"))
 
-        is GuildDeleteEvent -> shutDown()
+        is GuildDeleteEvent -> shutDown(LiveCancellationException(event, "The guild is deleted"))
         else -> Unit
     }
 

--- a/core/src/main/kotlin/live/LiveMessage.kt
+++ b/core/src/main/kotlin/live/LiveMessage.kt
@@ -56,7 +56,7 @@ fun LiveMessage.onReactionRemoveAll(block: suspend (ReactionRemoveAllEvent) -> U
 
 @Deprecated(
     "The block is never called because the message is already created",
-    ReplaceWith("LiveChannel.onMessageCreate")
+    ReplaceWith("LiveChannel.onMessageCreate(block)")
 )
 @KordPreview
 fun LiveMessage.onCreate(block: suspend (MessageCreateEvent) -> Unit) = on(consumer = block)
@@ -66,7 +66,7 @@ fun LiveMessage.onUpdate(block: suspend (MessageUpdateEvent) -> Unit) = on(consu
 
 @Deprecated(
     "The block is not called when the live entity is shutdown",
-    ReplaceWith("LiveMessage.onShutDown((() -> Unit)?)")
+    ReplaceWith("onShutDown(block)")
 )
 @KordPreview
 inline fun LiveMessage.onShutdown(crossinline block: suspend (Event) -> Unit) = on<Event> {
@@ -79,28 +79,28 @@ inline fun LiveMessage.onShutdown(crossinline block: suspend (Event) -> Unit) = 
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("LiveMessage.onShutDown((() -> Unit)?)")
+    ReplaceWith("onShutDown(block)")
 )
 @KordPreview
 fun LiveMessage.onOnlyDelete(block: suspend (MessageDeleteEvent) -> Unit) = on(consumer = block)
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("LiveMessage.onShutDown((() -> Unit)?)")
+    ReplaceWith("onShutDown(block)")
 )
 @KordPreview
 fun LiveMessage.onBulkDelete(block: suspend (MessageBulkDeleteEvent) -> Unit) = on(consumer = block)
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("LiveMessage.onShutDown((() -> Unit)?)")
+    ReplaceWith("onShutDown(block)")
 )
 @KordPreview
 fun LiveMessage.onChannelDelete(block: suspend (ChannelDeleteEvent) -> Unit) = on(consumer = block)
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("LiveMessage.onShutDown((() -> Unit)?)")
+    ReplaceWith("onShutDown(block)")
 )
 @KordPreview
 fun LiveMessage.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
@@ -137,12 +137,12 @@ class LiveMessage(
         is ReactionRemoveAllEvent -> message = Message(message.data.copy(reactions = Optional.Missing()), kord)
 
         is MessageUpdateEvent -> message = Message(message.data + event.new, kord)
-        is MessageDeleteEvent -> shutdown()
-        is MessageBulkDeleteEvent -> shutdown()
+        is MessageDeleteEvent -> shutDown()
+        is MessageBulkDeleteEvent -> shutDown()
 
-        is ChannelDeleteEvent -> shutdown()
+        is ChannelDeleteEvent -> shutDown()
 
-        is GuildDeleteEvent -> shutdown()
+        is GuildDeleteEvent -> shutDown()
         else -> Unit
     }
 

--- a/core/src/main/kotlin/live/LiveMessage.kt
+++ b/core/src/main/kotlin/live/LiveMessage.kt
@@ -54,10 +54,10 @@ inline fun LiveMessage.onReactionRemove(
 @KordPreview
 fun LiveMessage.onReactionRemoveAll(block: suspend (ReactionRemoveAllEvent) -> Unit) = on(consumer = block)
 
+@Suppress("DeprecatedCallableAddReplaceWith")
 @Deprecated(
-    "The block is never called because the message is already created",
-    ReplaceWith("LiveChannel.onMessageCreate(block)"),
-    DeprecationLevel.ERROR
+    "The block is never called because the message is already created, use LiveChannel.onMessageCreate(block)",
+    level = DeprecationLevel.ERROR
 )
 @KordPreview
 fun LiveMessage.onCreate(block: suspend (MessageCreateEvent) -> Unit) = on(consumer = block)
@@ -67,7 +67,7 @@ fun LiveMessage.onUpdate(block: suspend (MessageUpdateEvent) -> Unit) = on(consu
 
 @Deprecated(
     "The block is not called when the live entity is shut down",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)", "kotlinx.coroutines.job"),
     DeprecationLevel.ERROR
 )
 @KordPreview
@@ -81,7 +81,7 @@ inline fun LiveMessage.onShutdown(crossinline block: suspend (Event) -> Unit) = 
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shut down",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)", "kotlinx.coroutines.job"),
     DeprecationLevel.ERROR
 )
 @KordPreview
@@ -89,7 +89,7 @@ fun LiveMessage.onOnlyDelete(block: suspend (MessageDeleteEvent) -> Unit) = on(c
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shut down",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)", "kotlinx.coroutines.job"),
     DeprecationLevel.ERROR
 )
 @KordPreview
@@ -97,7 +97,7 @@ fun LiveMessage.onBulkDelete(block: suspend (MessageBulkDeleteEvent) -> Unit) = 
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shut down",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)", "kotlinx.coroutines.job"),
     DeprecationLevel.ERROR
 )
 @KordPreview
@@ -105,7 +105,7 @@ fun LiveMessage.onChannelDelete(block: suspend (ChannelDeleteEvent) -> Unit) = o
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shut down",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)", "kotlinx.coroutines.job"),
     DeprecationLevel.ERROR
 )
 @KordPreview

--- a/core/src/main/kotlin/live/LiveRole.kt
+++ b/core/src/main/kotlin/live/LiveRole.kt
@@ -17,12 +17,20 @@ fun Role.live(dispatcher: CoroutineDispatcher = Dispatchers.Default) = LiveRole(
 inline fun Role.live(dispatcher: CoroutineDispatcher = Dispatchers.Default, block: LiveRole.() -> Unit) =
     this.live(dispatcher).apply(block)
 
+@Deprecated(
+    "The block is not called when the entity is deleted because the live entity is shutdown",
+    ReplaceWith("LiveRole.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 fun LiveRole.onDelete(block: suspend (RoleDeleteEvent) -> Unit) = on(consumer = block)
 
 @KordPreview
 fun LiveRole.onUpdate(block: suspend (RoleUpdateEvent) -> Unit) = on(consumer = block)
 
+@Deprecated(
+    "The block is not called when the live entity is shutdown",
+    ReplaceWith("LiveRole.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 inline fun LiveRole.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
     if (it is RoleDeleteEvent || it is GuildDeleteEvent) {
@@ -30,6 +38,10 @@ inline fun LiveRole.onShutDown(crossinline block: suspend (Event) -> Unit) = on<
     }
 }
 
+@Deprecated(
+    "The block is not called when the entity is deleted because the live entity is shutdown",
+    ReplaceWith("LiveRole.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 fun LiveRole.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
 

--- a/core/src/main/kotlin/live/LiveRole.kt
+++ b/core/src/main/kotlin/live/LiveRole.kt
@@ -8,6 +8,7 @@ import dev.kord.core.event.Event
 import dev.kord.core.event.guild.GuildDeleteEvent
 import dev.kord.core.event.role.RoleDeleteEvent
 import dev.kord.core.event.role.RoleUpdateEvent
+import dev.kord.core.live.exception.LiveCancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 
@@ -69,8 +70,8 @@ class LiveRole(
     }
 
     override fun update(event: Event) = when (event) {
-        is RoleDeleteEvent -> shutDown()
-        is GuildDeleteEvent -> shutDown()
+        is RoleDeleteEvent -> shutDown(LiveCancellationException(event, "The role is deleted"))
+        is GuildDeleteEvent -> shutDown(LiveCancellationException(event, "The guild is deleted"))
         is RoleUpdateEvent -> role = event.role
         else -> Unit
     }

--- a/core/src/main/kotlin/live/LiveRole.kt
+++ b/core/src/main/kotlin/live/LiveRole.kt
@@ -20,7 +20,7 @@ inline fun Role.live(dispatcher: CoroutineDispatcher = Dispatchers.Default, bloc
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("LiveRole.onShutDown((() -> Unit)?)")
+    ReplaceWith("onShutDown(block)")
 )
 @KordPreview
 fun LiveRole.onDelete(block: suspend (RoleDeleteEvent) -> Unit) = on(consumer = block)
@@ -30,7 +30,7 @@ fun LiveRole.onUpdate(block: suspend (RoleUpdateEvent) -> Unit) = on(consumer = 
 
 @Deprecated(
     "The block is not called when the live entity is shutdown",
-    ReplaceWith("LiveRole.onShutDown((() -> Unit)?)")
+    ReplaceWith("onShutDown(block)")
 )
 @KordPreview
 inline fun LiveRole.onShutdown(crossinline block: suspend (Event) -> Unit) = on<Event> {
@@ -41,7 +41,7 @@ inline fun LiveRole.onShutdown(crossinline block: suspend (Event) -> Unit) = on<
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("LiveRole.onShutDown((() -> Unit)?)")
+    ReplaceWith("onShutDown(block)")
 )
 @KordPreview
 fun LiveRole.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
@@ -62,8 +62,8 @@ class LiveRole(
     }
 
     override fun update(event: Event) = when (event) {
-        is RoleDeleteEvent -> shutdown()
-        is GuildDeleteEvent -> shutdown()
+        is RoleDeleteEvent -> shutDown()
+        is GuildDeleteEvent -> shutDown()
         is RoleUpdateEvent -> role = event.role
         else -> Unit
     }

--- a/core/src/main/kotlin/live/LiveRole.kt
+++ b/core/src/main/kotlin/live/LiveRole.kt
@@ -20,7 +20,8 @@ inline fun Role.live(dispatcher: CoroutineDispatcher = Dispatchers.Default, bloc
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)")
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    DeprecationLevel.ERROR
 )
 @KordPreview
 fun LiveRole.onDelete(block: suspend (RoleDeleteEvent) -> Unit) = on(consumer = block)
@@ -30,7 +31,8 @@ fun LiveRole.onUpdate(block: suspend (RoleUpdateEvent) -> Unit) = on(consumer = 
 
 @Deprecated(
     "The block is not called when the live entity is shutdown",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)")
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    DeprecationLevel.ERROR
 )
 @KordPreview
 inline fun LiveRole.onShutdown(crossinline block: suspend (Event) -> Unit) = on<Event> {
@@ -41,7 +43,8 @@ inline fun LiveRole.onShutdown(crossinline block: suspend (Event) -> Unit) = on<
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)")
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    DeprecationLevel.ERROR
 )
 @KordPreview
 fun LiveRole.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)

--- a/core/src/main/kotlin/live/LiveRole.kt
+++ b/core/src/main/kotlin/live/LiveRole.kt
@@ -21,7 +21,7 @@ inline fun Role.live(dispatcher: CoroutineDispatcher = Dispatchers.Default, bloc
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shut down",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)", "kotlinx.coroutines.job"),
     DeprecationLevel.ERROR
 )
 @KordPreview
@@ -32,7 +32,7 @@ fun LiveRole.onUpdate(block: suspend (RoleUpdateEvent) -> Unit) = on(consumer = 
 
 @Deprecated(
     "The block is not called when the live entity is shut down",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)", "kotlinx.coroutines.job"),
     DeprecationLevel.ERROR
 )
 @KordPreview
@@ -44,7 +44,7 @@ inline fun LiveRole.onShutdown(crossinline block: suspend (Event) -> Unit) = on<
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shut down",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)", "kotlinx.coroutines.job"),
     DeprecationLevel.ERROR
 )
 @KordPreview

--- a/core/src/main/kotlin/live/LiveRole.kt
+++ b/core/src/main/kotlin/live/LiveRole.kt
@@ -20,7 +20,7 @@ inline fun Role.live(dispatcher: CoroutineDispatcher = Dispatchers.Default, bloc
     this.live(dispatcher).apply(block)
 
 @Deprecated(
-    "The block is not called when the entity is deleted because the live entity is shutdown",
+    "The block is not called when the entity is deleted because the live entity is shut down",
     ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
     DeprecationLevel.ERROR
 )
@@ -31,7 +31,7 @@ fun LiveRole.onDelete(block: suspend (RoleDeleteEvent) -> Unit) = on(consumer = 
 fun LiveRole.onUpdate(block: suspend (RoleUpdateEvent) -> Unit) = on(consumer = block)
 
 @Deprecated(
-    "The block is not called when the live entity is shutdown",
+    "The block is not called when the live entity is shut down",
     ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
     DeprecationLevel.ERROR
 )
@@ -43,7 +43,7 @@ inline fun LiveRole.onShutdown(crossinline block: suspend (Event) -> Unit) = on<
 }
 
 @Deprecated(
-    "The block is not called when the entity is deleted because the live entity is shutdown",
+    "The block is not called when the entity is deleted because the live entity is shut down",
     ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
     DeprecationLevel.ERROR
 )

--- a/core/src/main/kotlin/live/LiveRole.kt
+++ b/core/src/main/kotlin/live/LiveRole.kt
@@ -1,6 +1,7 @@
 package dev.kord.core.live
 
 import dev.kord.common.annotation.KordPreview
+import dev.kord.common.entity.Snowflake
 import dev.kord.core.entity.KordEntity
 import dev.kord.core.entity.Role
 import dev.kord.core.event.Event
@@ -9,7 +10,6 @@ import dev.kord.core.event.role.RoleDeleteEvent
 import dev.kord.core.event.role.RoleUpdateEvent
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.job
 
 @KordPreview
 fun Role.live(dispatcher: CoroutineDispatcher = Dispatchers.Default) = LiveRole(this, dispatcher)
@@ -20,7 +20,7 @@ inline fun Role.live(dispatcher: CoroutineDispatcher = Dispatchers.Default, bloc
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("onShutDown(block)")
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)")
 )
 @KordPreview
 fun LiveRole.onDelete(block: suspend (RoleDeleteEvent) -> Unit) = on(consumer = block)
@@ -30,7 +30,7 @@ fun LiveRole.onUpdate(block: suspend (RoleUpdateEvent) -> Unit) = on(consumer = 
 
 @Deprecated(
     "The block is not called when the live entity is shutdown",
-    ReplaceWith("onShutDown(block)")
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)")
 )
 @KordPreview
 inline fun LiveRole.onShutdown(crossinline block: suspend (Event) -> Unit) = on<Event> {
@@ -41,7 +41,7 @@ inline fun LiveRole.onShutdown(crossinline block: suspend (Event) -> Unit) = on<
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("onShutDown(block)")
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)")
 )
 @KordPreview
 fun LiveRole.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
@@ -50,7 +50,11 @@ fun LiveRole.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consu
 class LiveRole(
     role: Role,
     dispatcher: CoroutineDispatcher = Dispatchers.Default
-) : AbstractLiveKordEntity(dispatcher, role.kord.coroutineContext.job), KordEntity by role {
+) : AbstractLiveKordEntity(role.kord, dispatcher), KordEntity {
+
+    override val id: Snowflake
+        get() = role.id
+
     var role = role
         private set
 

--- a/core/src/main/kotlin/live/LiveUser.kt
+++ b/core/src/main/kotlin/live/LiveUser.kt
@@ -7,6 +7,7 @@ import dev.kord.core.event.Event
 import dev.kord.core.event.user.UserUpdateEvent
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.job
 
 @KordPreview
 fun User.live(dispatcher: CoroutineDispatcher = Dispatchers.Default) = LiveUser(this, dispatcher)
@@ -24,7 +25,7 @@ fun LiveUser.onUpdate(block: suspend (UserUpdateEvent) -> Unit) = on(consumer = 
 class LiveUser(
     user: User,
     dispatcher: CoroutineDispatcher = Dispatchers.Default
-) : AbstractLiveKordEntity(dispatcher), KordEntity by user {
+) : AbstractLiveKordEntity(dispatcher, user.kord.coroutineContext.job), KordEntity by user {
 
     var user: User = user
         private set

--- a/core/src/main/kotlin/live/LiveUser.kt
+++ b/core/src/main/kotlin/live/LiveUser.kt
@@ -1,13 +1,13 @@
 package dev.kord.core.live
 
 import dev.kord.common.annotation.KordPreview
+import dev.kord.common.entity.Snowflake
 import dev.kord.core.entity.KordEntity
 import dev.kord.core.entity.User
 import dev.kord.core.event.Event
 import dev.kord.core.event.user.UserUpdateEvent
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.job
 
 @KordPreview
 fun User.live(dispatcher: CoroutineDispatcher = Dispatchers.Default) = LiveUser(this, dispatcher)
@@ -25,7 +25,10 @@ fun LiveUser.onUpdate(block: suspend (UserUpdateEvent) -> Unit) = on(consumer = 
 class LiveUser(
     user: User,
     dispatcher: CoroutineDispatcher = Dispatchers.Default
-) : AbstractLiveKordEntity(dispatcher, user.kord.coroutineContext.job), KordEntity by user {
+) : AbstractLiveKordEntity(user.kord, dispatcher), KordEntity {
+
+    override val id: Snowflake
+        get() = user.id
 
     var user: User = user
         private set

--- a/core/src/main/kotlin/live/channel/LiveCategory.kt
+++ b/core/src/main/kotlin/live/channel/LiveCategory.kt
@@ -24,10 +24,10 @@ inline fun Category.live(
     block: LiveCategory.() -> Unit
 ) = this.live(dispatcher).apply(block)
 
+@Suppress("DeprecatedCallableAddReplaceWith")
 @Deprecated(
-    "The block is never called because the channel is already created",
-    ReplaceWith("LiveGuild.onChannelCreate(block)", "dev.kord.core.live"),
-    DeprecationLevel.ERROR
+    "The block is never called because the channel is already created, use LiveGuild.onChannelCreate(block)",
+    level = DeprecationLevel.ERROR
 )
 @KordPreview
 fun LiveCategory.onCreate(block: suspend (CategoryCreateEvent) -> Unit) = on(consumer = block)

--- a/core/src/main/kotlin/live/channel/LiveCategory.kt
+++ b/core/src/main/kotlin/live/channel/LiveCategory.kt
@@ -1,6 +1,7 @@
 package dev.kord.core.live.channel
 
 import dev.kord.common.annotation.KordPreview
+import dev.kord.common.entity.Snowflake
 import dev.kord.core.entity.KordEntity
 import dev.kord.core.entity.channel.Category
 import dev.kord.core.event.Event
@@ -11,7 +12,6 @@ import dev.kord.core.event.guild.GuildDeleteEvent
 import dev.kord.core.live.on
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.job
 
 @KordPreview
 fun Category.live(dispatcher: CoroutineDispatcher = Dispatchers.Default) =
@@ -35,7 +35,7 @@ fun LiveCategory.onUpdate(block: suspend (CategoryUpdateEvent) -> Unit) = on(con
 
 @Deprecated(
     "The block is not called when the live entity is shutdown",
-    ReplaceWith("onShutDown(block)")
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)")
 )
 @KordPreview
 inline fun LiveCategory.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
@@ -46,14 +46,14 @@ inline fun LiveCategory.onShutDown(crossinline block: suspend (Event) -> Unit) =
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("onShutDown(block)")
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)")
 )
 @KordPreview
 fun LiveCategory.onDelete(block: suspend (CategoryDeleteEvent) -> Unit) = on(consumer = block)
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("onShutDown(block)")
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)")
 )
 @KordPreview
 fun LiveCategory.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
@@ -62,7 +62,10 @@ fun LiveCategory.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(c
 class LiveCategory(
     channel: Category,
     dispatcher: CoroutineDispatcher = Dispatchers.Default
-) : LiveChannel(dispatcher, channel.kord.coroutineContext.job), KordEntity by channel {
+) : LiveChannel(channel.kord, dispatcher), KordEntity {
+
+    override val id: Snowflake
+        get() = channel.id
 
     override var channel: Category = channel
         private set

--- a/core/src/main/kotlin/live/channel/LiveCategory.kt
+++ b/core/src/main/kotlin/live/channel/LiveCategory.kt
@@ -25,7 +25,7 @@ inline fun Category.live(
 
 @Deprecated(
     "The block is never called because the channel is already created",
-    ReplaceWith("LiveGuild.onChannelCreate")
+    ReplaceWith("LiveGuild.onChannelCreate(block)")
 )
 @KordPreview
 fun LiveCategory.onCreate(block: suspend (CategoryCreateEvent) -> Unit) = on(consumer = block)
@@ -35,7 +35,7 @@ fun LiveCategory.onUpdate(block: suspend (CategoryUpdateEvent) -> Unit) = on(con
 
 @Deprecated(
     "The block is not called when the live entity is shutdown",
-    ReplaceWith("LiveCategory.onShutDown((() -> Unit)?)")
+    ReplaceWith("onShutDown(block)")
 )
 @KordPreview
 inline fun LiveCategory.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
@@ -46,14 +46,14 @@ inline fun LiveCategory.onShutDown(crossinline block: suspend (Event) -> Unit) =
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("LiveCategory.onShutDown((() -> Unit)?)")
+    ReplaceWith("onShutDown(block)")
 )
 @KordPreview
 fun LiveCategory.onDelete(block: suspend (CategoryDeleteEvent) -> Unit) = on(consumer = block)
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("LiveCategory.onShutDown((() -> Unit)?)")
+    ReplaceWith("onShutDown(block)")
 )
 @KordPreview
 fun LiveCategory.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
@@ -70,9 +70,9 @@ class LiveCategory(
     override fun update(event: Event) = when (event) {
         is CategoryCreateEvent -> channel = event.channel
         is CategoryUpdateEvent -> channel = event.channel
-        is CategoryDeleteEvent -> shutdown()
+        is CategoryDeleteEvent -> shutDown()
 
-        is GuildDeleteEvent -> shutdown()
+        is GuildDeleteEvent -> shutDown()
 
         else -> Unit
     }

--- a/core/src/main/kotlin/live/channel/LiveCategory.kt
+++ b/core/src/main/kotlin/live/channel/LiveCategory.kt
@@ -28,6 +28,10 @@ fun LiveCategory.onCreate(block: suspend (CategoryCreateEvent) -> Unit) = on(con
 @KordPreview
 fun LiveCategory.onUpdate(block: suspend (CategoryUpdateEvent) -> Unit) = on(consumer = block)
 
+@Deprecated(
+    "The block is not called when the live entity is shutdown",
+    ReplaceWith("LiveCategory.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 inline fun LiveCategory.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
     if (it is CategoryDeleteEvent || it is GuildDeleteEvent) {
@@ -35,9 +39,17 @@ inline fun LiveCategory.onShutDown(crossinline block: suspend (Event) -> Unit) =
     }
 }
 
+@Deprecated(
+    "The block is not called when the entity is deleted because the live entity is shutdown",
+    ReplaceWith("LiveCategory.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 fun LiveCategory.onDelete(block: suspend (CategoryDeleteEvent) -> Unit) = on(consumer = block)
 
+@Deprecated(
+    "The block is not called when the entity is deleted because the live entity is shutdown",
+    ReplaceWith("LiveCategory.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 fun LiveCategory.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
 

--- a/core/src/main/kotlin/live/channel/LiveCategory.kt
+++ b/core/src/main/kotlin/live/channel/LiveCategory.kt
@@ -25,7 +25,8 @@ inline fun Category.live(
 
 @Deprecated(
     "The block is never called because the channel is already created",
-    ReplaceWith("LiveGuild.onChannelCreate(block)")
+    ReplaceWith("LiveGuild.onChannelCreate(block)"),
+    DeprecationLevel.ERROR
 )
 @KordPreview
 fun LiveCategory.onCreate(block: suspend (CategoryCreateEvent) -> Unit) = on(consumer = block)
@@ -35,7 +36,8 @@ fun LiveCategory.onUpdate(block: suspend (CategoryUpdateEvent) -> Unit) = on(con
 
 @Deprecated(
     "The block is not called when the live entity is shutdown",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)")
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    DeprecationLevel.ERROR
 )
 @KordPreview
 inline fun LiveCategory.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
@@ -46,14 +48,16 @@ inline fun LiveCategory.onShutDown(crossinline block: suspend (Event) -> Unit) =
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)")
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    DeprecationLevel.ERROR
 )
 @KordPreview
 fun LiveCategory.onDelete(block: suspend (CategoryDeleteEvent) -> Unit) = on(consumer = block)
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)")
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    DeprecationLevel.ERROR
 )
 @KordPreview
 fun LiveCategory.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)

--- a/core/src/main/kotlin/live/channel/LiveCategory.kt
+++ b/core/src/main/kotlin/live/channel/LiveCategory.kt
@@ -26,7 +26,7 @@ inline fun Category.live(
 
 @Deprecated(
     "The block is never called because the channel is already created",
-    ReplaceWith("LiveGuild.onChannelCreate(block)"),
+    ReplaceWith("LiveGuild.onChannelCreate(block)", "dev.kord.core.live"),
     DeprecationLevel.ERROR
 )
 @KordPreview
@@ -36,7 +36,7 @@ fun LiveCategory.onCreate(block: suspend (CategoryCreateEvent) -> Unit) = on(con
 fun LiveCategory.onUpdate(block: suspend (CategoryUpdateEvent) -> Unit) = on(consumer = block)
 
 @Deprecated(
-    "The block is not called when the live entity is shutdown",
+    "The block is not called when the live entity is shut down",
     ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
     DeprecationLevel.ERROR
 )
@@ -48,7 +48,7 @@ inline fun LiveCategory.onShutDown(crossinline block: suspend (Event) -> Unit) =
 }
 
 @Deprecated(
-    "The block is not called when the entity is deleted because the live entity is shutdown",
+    "The block is not called when the entity is deleted because the live entity is shut down",
     ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
     DeprecationLevel.ERROR
 )
@@ -56,7 +56,7 @@ inline fun LiveCategory.onShutDown(crossinline block: suspend (Event) -> Unit) =
 fun LiveCategory.onDelete(block: suspend (CategoryDeleteEvent) -> Unit) = on(consumer = block)
 
 @Deprecated(
-    "The block is not called when the entity is deleted because the live entity is shutdown",
+    "The block is not called when the entity is deleted because the live entity is shut down",
     ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
     DeprecationLevel.ERROR
 )

--- a/core/src/main/kotlin/live/channel/LiveCategory.kt
+++ b/core/src/main/kotlin/live/channel/LiveCategory.kt
@@ -37,7 +37,7 @@ fun LiveCategory.onUpdate(block: suspend (CategoryUpdateEvent) -> Unit) = on(con
 
 @Deprecated(
     "The block is not called when the live entity is shut down",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)", "kotlinx.coroutines.job"),
     DeprecationLevel.ERROR
 )
 @KordPreview
@@ -49,7 +49,7 @@ inline fun LiveCategory.onShutDown(crossinline block: suspend (Event) -> Unit) =
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shut down",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)", "kotlinx.coroutines.job"),
     DeprecationLevel.ERROR
 )
 @KordPreview
@@ -57,7 +57,7 @@ fun LiveCategory.onDelete(block: suspend (CategoryDeleteEvent) -> Unit) = on(con
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shut down",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)", "kotlinx.coroutines.job"),
     DeprecationLevel.ERROR
 )
 @KordPreview

--- a/core/src/main/kotlin/live/channel/LiveCategory.kt
+++ b/core/src/main/kotlin/live/channel/LiveCategory.kt
@@ -9,6 +9,7 @@ import dev.kord.core.event.channel.CategoryCreateEvent
 import dev.kord.core.event.channel.CategoryDeleteEvent
 import dev.kord.core.event.channel.CategoryUpdateEvent
 import dev.kord.core.event.guild.GuildDeleteEvent
+import dev.kord.core.live.exception.LiveCancellationException
 import dev.kord.core.live.on
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -77,9 +78,9 @@ class LiveCategory(
     override fun update(event: Event) = when (event) {
         is CategoryCreateEvent -> channel = event.channel
         is CategoryUpdateEvent -> channel = event.channel
-        is CategoryDeleteEvent -> shutDown()
+        is CategoryDeleteEvent -> shutDown(LiveCancellationException(event, "The category is deleted"))
 
-        is GuildDeleteEvent -> shutDown()
+        is GuildDeleteEvent -> shutDown(LiveCancellationException(event, "The guild is deleted"))
 
         else -> Unit
     }

--- a/core/src/main/kotlin/live/channel/LiveChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveChannel.kt
@@ -16,6 +16,7 @@ import dev.kord.core.live.AbstractLiveKordEntity
 import dev.kord.core.live.on
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 
 @KordPreview
 fun Channel.live(dispatcher: CoroutineDispatcher = Dispatchers.Default) = when (this) {
@@ -72,15 +73,27 @@ fun LiveChannel.onMessageUpdate(block: suspend (MessageUpdateEvent) -> Unit) = o
 @KordPreview
 fun LiveChannel.onMessageDelete(block: suspend (MessageDeleteEvent) -> Unit) = on(consumer = block)
 
+@Deprecated(
+    "The block is never called because the channel is already created",
+    ReplaceWith("LiveGuild.onChannelCreate")
+)
 @KordPreview
 fun LiveChannel.onChannelCreate(block: suspend (ChannelCreateEvent) -> Unit) = on(consumer = block)
 
 @KordPreview
 fun LiveChannel.onChannelUpdate(block: suspend (ChannelUpdateEvent) -> Unit) = on(consumer = block)
 
+@Deprecated(
+    "The block is not called when the entity is deleted because the live entity is shutdown",
+    ReplaceWith("LiveChannel.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 fun LiveChannel.onChannelDelete(block: suspend (ChannelDeleteEvent) -> Unit) = on(consumer = block)
 
+@Deprecated(
+    "The block is never called because the guild where the channel is located is already created",
+    ReplaceWith("Kord.on<GuildCreateEvent>")
+)
 @KordPreview
 fun LiveChannel.onGuildCreate(block: suspend (GuildCreateEvent) -> Unit) = on(consumer = block)
 
@@ -88,7 +101,7 @@ fun LiveChannel.onGuildCreate(block: suspend (GuildCreateEvent) -> Unit) = on(co
 fun LiveChannel.onGuildUpdate(block: suspend (GuildUpdateEvent) -> Unit) = on(consumer = block)
 
 @KordPreview
-abstract class LiveChannel(dispatcher: CoroutineDispatcher = Dispatchers.Default) : AbstractLiveKordEntity(dispatcher) {
+abstract class LiveChannel(dispatcher: CoroutineDispatcher = Dispatchers.Default, parent: Job) : AbstractLiveKordEntity(dispatcher, parent) {
 
     abstract val channel: Channel
 

--- a/core/src/main/kotlin/live/channel/LiveChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveChannel.kt
@@ -86,7 +86,7 @@ fun LiveChannel.onChannelUpdate(block: suspend (ChannelUpdateEvent) -> Unit) = o
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shut down",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)", "kotlinx.coroutines.job"),
     DeprecationLevel.ERROR
 )
 @KordPreview

--- a/core/src/main/kotlin/live/channel/LiveChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveChannel.kt
@@ -75,7 +75,8 @@ fun LiveChannel.onMessageDelete(block: suspend (MessageDeleteEvent) -> Unit) = o
 
 @Deprecated(
     "The block is never called because the channel is already created",
-    ReplaceWith("LiveGuild.onChannelCreate(block)")
+    ReplaceWith("LiveGuild.onChannelCreate(block)"),
+    DeprecationLevel.ERROR
 )
 @KordPreview
 fun LiveChannel.onChannelCreate(block: suspend (ChannelCreateEvent) -> Unit) = on(consumer = block)
@@ -85,14 +86,16 @@ fun LiveChannel.onChannelUpdate(block: suspend (ChannelUpdateEvent) -> Unit) = o
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)")
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    DeprecationLevel.ERROR
 )
 @KordPreview
 fun LiveChannel.onChannelDelete(block: suspend (ChannelDeleteEvent) -> Unit) = on(consumer = block)
 
 @Deprecated(
     "The block is never called because the guild where the channel is located is already created",
-    ReplaceWith("Kord.on<GuildCreateEvent>(block)")
+    ReplaceWith("Kord.on<GuildCreateEvent>(block)"),
+    DeprecationLevel.ERROR
 )
 @KordPreview
 fun LiveChannel.onGuildCreate(block: suspend (GuildCreateEvent) -> Unit) = on(consumer = block)

--- a/core/src/main/kotlin/live/channel/LiveChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveChannel.kt
@@ -75,7 +75,7 @@ fun LiveChannel.onMessageDelete(block: suspend (MessageDeleteEvent) -> Unit) = o
 
 @Deprecated(
     "The block is never called because the channel is already created",
-    ReplaceWith("LiveGuild.onChannelCreate")
+    ReplaceWith("LiveGuild.onChannelCreate(block)")
 )
 @KordPreview
 fun LiveChannel.onChannelCreate(block: suspend (ChannelCreateEvent) -> Unit) = on(consumer = block)
@@ -85,14 +85,14 @@ fun LiveChannel.onChannelUpdate(block: suspend (ChannelUpdateEvent) -> Unit) = o
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("LiveChannel.onShutDown((() -> Unit)?)")
+    ReplaceWith("onShutDown(block)")
 )
 @KordPreview
 fun LiveChannel.onChannelDelete(block: suspend (ChannelDeleteEvent) -> Unit) = on(consumer = block)
 
 @Deprecated(
     "The block is never called because the guild where the channel is located is already created",
-    ReplaceWith("Kord.on<GuildCreateEvent>")
+    ReplaceWith("Kord.on<GuildCreateEvent>(block)")
 )
 @KordPreview
 fun LiveChannel.onGuildCreate(block: suspend (GuildCreateEvent) -> Unit) = on(consumer = block)

--- a/core/src/main/kotlin/live/channel/LiveChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveChannel.kt
@@ -1,6 +1,7 @@
 package dev.kord.core.live.channel
 
 import dev.kord.common.annotation.KordPreview
+import dev.kord.core.Kord
 import dev.kord.core.entity.ReactionEmoji
 import dev.kord.core.entity.channel.*
 import dev.kord.core.event.Event
@@ -16,7 +17,6 @@ import dev.kord.core.live.AbstractLiveKordEntity
 import dev.kord.core.live.on
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 
 @KordPreview
 fun Channel.live(dispatcher: CoroutineDispatcher = Dispatchers.Default) = when (this) {
@@ -85,7 +85,7 @@ fun LiveChannel.onChannelUpdate(block: suspend (ChannelUpdateEvent) -> Unit) = o
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("onShutDown(block)")
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)")
 )
 @KordPreview
 fun LiveChannel.onChannelDelete(block: suspend (ChannelDeleteEvent) -> Unit) = on(consumer = block)
@@ -101,7 +101,8 @@ fun LiveChannel.onGuildCreate(block: suspend (GuildCreateEvent) -> Unit) = on(co
 fun LiveChannel.onGuildUpdate(block: suspend (GuildUpdateEvent) -> Unit) = on(consumer = block)
 
 @KordPreview
-abstract class LiveChannel(dispatcher: CoroutineDispatcher = Dispatchers.Default, parent: Job) : AbstractLiveKordEntity(dispatcher, parent) {
+abstract class LiveChannel(kord: Kord, dispatcher: CoroutineDispatcher = Dispatchers.Default) :
+    AbstractLiveKordEntity(kord, dispatcher) {
 
     abstract val channel: Channel
 

--- a/core/src/main/kotlin/live/channel/LiveChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveChannel.kt
@@ -85,7 +85,7 @@ fun LiveChannel.onChannelCreate(block: suspend (ChannelCreateEvent) -> Unit) = o
 fun LiveChannel.onChannelUpdate(block: suspend (ChannelUpdateEvent) -> Unit) = on(consumer = block)
 
 @Deprecated(
-    "The block is not called when the entity is deleted because the live entity is shutdown",
+    "The block is not called when the entity is deleted because the live entity is shut down",
     ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
     DeprecationLevel.ERROR
 )

--- a/core/src/main/kotlin/live/channel/LiveChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveChannel.kt
@@ -73,10 +73,10 @@ fun LiveChannel.onMessageUpdate(block: suspend (MessageUpdateEvent) -> Unit) = o
 @KordPreview
 fun LiveChannel.onMessageDelete(block: suspend (MessageDeleteEvent) -> Unit) = on(consumer = block)
 
+@Suppress("DeprecatedCallableAddReplaceWith")
 @Deprecated(
-    "The block is never called because the channel is already created",
-    ReplaceWith("LiveGuild.onChannelCreate(block)"),
-    DeprecationLevel.ERROR
+    "The block is never called because the channel is already created, use LiveGuild.onChannelCreate(block)",
+    level = DeprecationLevel.ERROR
 )
 @KordPreview
 fun LiveChannel.onChannelCreate(block: suspend (ChannelCreateEvent) -> Unit) = on(consumer = block)

--- a/core/src/main/kotlin/live/channel/LiveDmChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveDmChannel.kt
@@ -9,6 +9,7 @@ import dev.kord.core.event.channel.DMChannelCreateEvent
 import dev.kord.core.event.channel.DMChannelDeleteEvent
 import dev.kord.core.event.channel.DMChannelUpdateEvent
 import dev.kord.core.event.guild.GuildDeleteEvent
+import dev.kord.core.live.exception.LiveCancellationException
 import dev.kord.core.live.on
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -76,9 +77,9 @@ class LiveDmChannel(
     override fun update(event: Event) = when (event) {
         is DMChannelCreateEvent -> channel = event.channel
         is DMChannelUpdateEvent -> channel = event.channel
-        is DMChannelDeleteEvent -> shutDown()
+        is DMChannelDeleteEvent -> shutDown(LiveCancellationException(event, "The channel is deleted"))
 
-        is GuildDeleteEvent -> shutDown()
+        is GuildDeleteEvent -> shutDown(LiveCancellationException(event, "The guild is deleted"))
 
         else -> Unit
     }

--- a/core/src/main/kotlin/live/channel/LiveDmChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveDmChannel.kt
@@ -24,7 +24,8 @@ inline fun DmChannel.live(
 
 @Deprecated(
     "The block is never called because the channel is already created",
-    ReplaceWith("LiveGuild.onChannelCreate(block)")
+    ReplaceWith("LiveGuild.onChannelCreate(block)"),
+    DeprecationLevel.ERROR
 )
 @KordPreview
 fun LiveDmChannel.onCreate(block: suspend (DMChannelCreateEvent) -> Unit) = on(consumer = block)
@@ -34,7 +35,8 @@ fun LiveDmChannel.onUpdate(block: suspend (DMChannelUpdateEvent) -> Unit) = on(c
 
 @Deprecated(
     "The block is not called when the live entity is shutdown",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)")
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    DeprecationLevel.ERROR
 )
 @KordPreview
 inline fun LiveDmChannel.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
@@ -45,14 +47,16 @@ inline fun LiveDmChannel.onShutDown(crossinline block: suspend (Event) -> Unit) 
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)")
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    DeprecationLevel.ERROR
 )
 @KordPreview
 fun LiveDmChannel.onDelete(block: suspend (DMChannelDeleteEvent) -> Unit) = on(consumer = block)
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)")
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    DeprecationLevel.ERROR
 )
 @KordPreview
 fun LiveDmChannel.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)

--- a/core/src/main/kotlin/live/channel/LiveDmChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveDmChannel.kt
@@ -35,7 +35,7 @@ fun LiveDmChannel.onCreate(block: suspend (DMChannelCreateEvent) -> Unit) = on(c
 fun LiveDmChannel.onUpdate(block: suspend (DMChannelUpdateEvent) -> Unit) = on(consumer = block)
 
 @Deprecated(
-    "The block is not called when the live entity is shutdown",
+    "The block is not called when the live entity is shut down",
     ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
     DeprecationLevel.ERROR
 )
@@ -47,7 +47,7 @@ inline fun LiveDmChannel.onShutDown(crossinline block: suspend (Event) -> Unit) 
 }
 
 @Deprecated(
-    "The block is not called when the entity is deleted because the live entity is shutdown",
+    "The block is not called when the entity is deleted because the live entity is shut down",
     ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
     DeprecationLevel.ERROR
 )
@@ -55,7 +55,7 @@ inline fun LiveDmChannel.onShutDown(crossinline block: suspend (Event) -> Unit) 
 fun LiveDmChannel.onDelete(block: suspend (DMChannelDeleteEvent) -> Unit) = on(consumer = block)
 
 @Deprecated(
-    "The block is not called when the entity is deleted because the live entity is shutdown",
+    "The block is not called when the entity is deleted because the live entity is shut down",
     ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
     DeprecationLevel.ERROR
 )

--- a/core/src/main/kotlin/live/channel/LiveDmChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveDmChannel.kt
@@ -24,7 +24,7 @@ inline fun DmChannel.live(
 
 @Deprecated(
     "The block is never called because the channel is already created",
-    ReplaceWith("LiveGuild.onChannelCreate")
+    ReplaceWith("LiveGuild.onChannelCreate(block)")
 )
 @KordPreview
 fun LiveDmChannel.onCreate(block: suspend (DMChannelCreateEvent) -> Unit) = on(consumer = block)
@@ -34,7 +34,7 @@ fun LiveDmChannel.onUpdate(block: suspend (DMChannelUpdateEvent) -> Unit) = on(c
 
 @Deprecated(
     "The block is not called when the live entity is shutdown",
-    ReplaceWith("LiveDmChannel.onShutDown((() -> Unit)?)")
+    ReplaceWith("onShutDown(block)")
 )
 @KordPreview
 inline fun LiveDmChannel.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
@@ -45,14 +45,14 @@ inline fun LiveDmChannel.onShutDown(crossinline block: suspend (Event) -> Unit) 
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("LiveDmChannel.onShutDown((() -> Unit)?)")
+    ReplaceWith("onShutDown(block)")
 )
 @KordPreview
 fun LiveDmChannel.onDelete(block: suspend (DMChannelDeleteEvent) -> Unit) = on(consumer = block)
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("LiveDmChannel.onShutDown((() -> Unit)?)")
+    ReplaceWith("onShutDown(block)")
 )
 @KordPreview
 fun LiveDmChannel.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
@@ -69,9 +69,9 @@ class LiveDmChannel(
     override fun update(event: Event) = when (event) {
         is DMChannelCreateEvent -> channel = event.channel
         is DMChannelUpdateEvent -> channel = event.channel
-        is DMChannelDeleteEvent -> shutdown()
+        is DMChannelDeleteEvent -> shutDown()
 
-        is GuildDeleteEvent -> shutdown()
+        is GuildDeleteEvent -> shutDown()
 
         else -> Unit
     }

--- a/core/src/main/kotlin/live/channel/LiveDmChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveDmChannel.kt
@@ -23,10 +23,10 @@ inline fun DmChannel.live(
     block: LiveDmChannel.() -> Unit
 ) = this.live(dispatcher).apply(block)
 
+@Suppress("DeprecatedCallableAddReplaceWith")
 @Deprecated(
-    "The block is never called because the channel is already created",
-    ReplaceWith("LiveGuild.onChannelCreate(block)"),
-    DeprecationLevel.ERROR
+    "The block is never called because the channel is already created, use LiveGuild.onChannelCreate(block)",
+    level = DeprecationLevel.ERROR
 )
 @KordPreview
 fun LiveDmChannel.onCreate(block: suspend (DMChannelCreateEvent) -> Unit) = on(consumer = block)
@@ -36,7 +36,7 @@ fun LiveDmChannel.onUpdate(block: suspend (DMChannelUpdateEvent) -> Unit) = on(c
 
 @Deprecated(
     "The block is not called when the live entity is shut down",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)", "kotlinx.coroutines.job"),
     DeprecationLevel.ERROR
 )
 @KordPreview
@@ -48,7 +48,7 @@ inline fun LiveDmChannel.onShutDown(crossinline block: suspend (Event) -> Unit) 
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shut down",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)", "kotlinx.coroutines.job"),
     DeprecationLevel.ERROR
 )
 @KordPreview
@@ -56,7 +56,7 @@ fun LiveDmChannel.onDelete(block: suspend (DMChannelDeleteEvent) -> Unit) = on(c
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shut down",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)", "kotlinx.coroutines.job"),
     DeprecationLevel.ERROR
 )
 @KordPreview

--- a/core/src/main/kotlin/live/channel/LiveDmChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveDmChannel.kt
@@ -27,6 +27,10 @@ fun LiveDmChannel.onCreate(block: suspend (DMChannelCreateEvent) -> Unit) = on(c
 @KordPreview
 fun LiveDmChannel.onUpdate(block: suspend (DMChannelUpdateEvent) -> Unit) = on(consumer = block)
 
+@Deprecated(
+    "The block is not called when the live entity is shutdown",
+    ReplaceWith("LiveDmChannel.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 inline fun LiveDmChannel.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
     if (it is DMChannelDeleteEvent || it is GuildDeleteEvent) {
@@ -34,9 +38,17 @@ inline fun LiveDmChannel.onShutDown(crossinline block: suspend (Event) -> Unit) 
     }
 }
 
+@Deprecated(
+    "The block is not called when the entity is deleted because the live entity is shutdown",
+    ReplaceWith("LiveDmChannel.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 fun LiveDmChannel.onDelete(block: suspend (DMChannelDeleteEvent) -> Unit) = on(consumer = block)
 
+@Deprecated(
+    "The block is not called when the entity is deleted because the live entity is shutdown",
+    ReplaceWith("LiveDmChannel.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 fun LiveDmChannel.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
 

--- a/core/src/main/kotlin/live/channel/LiveGuildChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveGuildChannel.kt
@@ -29,6 +29,10 @@ fun LiveGuildChannel.onCreate(block: suspend (ChannelCreateEvent) -> Unit) = on(
 @KordPreview
 fun LiveGuildChannel.onUpdate(block: suspend (ChannelUpdateEvent) -> Unit) = on(consumer = block)
 
+@Deprecated(
+    "The block is not called when the live entity is shutdown",
+    ReplaceWith("LiveGuildChannel.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 inline fun LiveGuildChannel.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
     if (it is ChannelDeleteEvent || it is GuildDeleteEvent) {
@@ -36,9 +40,17 @@ inline fun LiveGuildChannel.onShutDown(crossinline block: suspend (Event) -> Uni
     }
 }
 
+@Deprecated(
+    "The block is not called when the entity is deleted because the live entity is shutdown",
+    ReplaceWith("LiveGuildChannel.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 fun LiveGuildChannel.onDelete(block: suspend (ChannelDeleteEvent) -> Unit) = on(consumer = block)
 
+@Deprecated(
+    "The block is not called when the entity is deleted because the live entity is shutdown",
+    ReplaceWith("LiveGuildChannel.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 fun LiveGuildChannel.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
 

--- a/core/src/main/kotlin/live/channel/LiveGuildChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveGuildChannel.kt
@@ -37,7 +37,7 @@ fun LiveGuildChannel.onCreate(block: suspend (ChannelCreateEvent) -> Unit) = on(
 fun LiveGuildChannel.onUpdate(block: suspend (ChannelUpdateEvent) -> Unit) = on(consumer = block)
 
 @Deprecated(
-    "The block is not called when the live entity is shutdown",
+    "The block is not called when the live entity is shut down",
     ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
     DeprecationLevel.ERROR
 )
@@ -49,7 +49,7 @@ inline fun LiveGuildChannel.onShutDown(crossinline block: suspend (Event) -> Uni
 }
 
 @Deprecated(
-    "The block is not called when the entity is deleted because the live entity is shutdown",
+    "The block is not called when the entity is deleted because the live entity is shut down",
     ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
     DeprecationLevel.ERROR
 )
@@ -57,7 +57,7 @@ inline fun LiveGuildChannel.onShutDown(crossinline block: suspend (Event) -> Uni
 fun LiveGuildChannel.onDelete(block: suspend (ChannelDeleteEvent) -> Unit) = on(consumer = block)
 
 @Deprecated(
-    "The block is not called when the entity is deleted because the live entity is shutdown",
+    "The block is not called when the entity is deleted because the live entity is shut down",
     ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
     DeprecationLevel.ERROR
 )

--- a/core/src/main/kotlin/live/channel/LiveGuildChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveGuildChannel.kt
@@ -10,6 +10,7 @@ import dev.kord.core.event.channel.ChannelCreateEvent
 import dev.kord.core.event.channel.ChannelDeleteEvent
 import dev.kord.core.event.channel.ChannelUpdateEvent
 import dev.kord.core.event.guild.GuildDeleteEvent
+import dev.kord.core.live.exception.LiveCancellationException
 import dev.kord.core.live.on
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -78,9 +79,9 @@ class LiveGuildChannel(
     override fun update(event: Event) = when (event) {
         is ChannelCreateEvent -> channel = event.channel as GuildMessageChannel
         is ChannelUpdateEvent -> channel = event.channel as GuildMessageChannel
-        is ChannelDeleteEvent -> shutDown()
+        is ChannelDeleteEvent -> shutDown(LiveCancellationException(event, "The channel is deleted"))
 
-        is GuildDeleteEvent -> shutDown()
+        is GuildDeleteEvent -> shutDown(LiveCancellationException(event, "The guild is deleted"))
 
         else -> Unit
     }

--- a/core/src/main/kotlin/live/channel/LiveGuildChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveGuildChannel.kt
@@ -25,10 +25,10 @@ inline fun GuildChannel.live(
     block: LiveGuildChannel.() -> Unit
 ) = this.live(dispatcher).apply(block)
 
+@Suppress("DeprecatedCallableAddReplaceWith")
 @Deprecated(
-    "The block is never called because the channel is already created",
-    ReplaceWith("LiveGuild.onChannelCreate(block)"),
-    DeprecationLevel.ERROR
+    "The block is never called because the channel is already created, use LiveGuild.onChannelCreate(block)",
+    level = DeprecationLevel.ERROR
 )
 @KordPreview
 fun LiveGuildChannel.onCreate(block: suspend (ChannelCreateEvent) -> Unit) = on(consumer = block)
@@ -38,7 +38,7 @@ fun LiveGuildChannel.onUpdate(block: suspend (ChannelUpdateEvent) -> Unit) = on(
 
 @Deprecated(
     "The block is not called when the live entity is shut down",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)", "kotlinx.coroutines.job"),
     DeprecationLevel.ERROR
 )
 @KordPreview
@@ -50,7 +50,7 @@ inline fun LiveGuildChannel.onShutDown(crossinline block: suspend (Event) -> Uni
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shut down",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)", "kotlinx.coroutines.job"),
     DeprecationLevel.ERROR
 )
 @KordPreview
@@ -58,7 +58,7 @@ fun LiveGuildChannel.onDelete(block: suspend (ChannelDeleteEvent) -> Unit) = on(
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shut down",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)", "kotlinx.coroutines.job"),
     DeprecationLevel.ERROR
 )
 @KordPreview

--- a/core/src/main/kotlin/live/channel/LiveGuildChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveGuildChannel.kt
@@ -26,7 +26,7 @@ inline fun GuildChannel.live(
 
 @Deprecated(
     "The block is never called because the channel is already created",
-    ReplaceWith("LiveGuild.onChannelCreate")
+    ReplaceWith("LiveGuild.onChannelCreate(block)")
 )
 @KordPreview
 fun LiveGuildChannel.onCreate(block: suspend (ChannelCreateEvent) -> Unit) = on(consumer = block)
@@ -36,7 +36,7 @@ fun LiveGuildChannel.onUpdate(block: suspend (ChannelUpdateEvent) -> Unit) = on(
 
 @Deprecated(
     "The block is not called when the live entity is shutdown",
-    ReplaceWith("LiveGuildChannel.onShutDown((() -> Unit)?)")
+    ReplaceWith("onShutDown(block)")
 )
 @KordPreview
 inline fun LiveGuildChannel.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
@@ -47,14 +47,14 @@ inline fun LiveGuildChannel.onShutDown(crossinline block: suspend (Event) -> Uni
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("LiveGuildChannel.onShutDown((() -> Unit)?)")
+    ReplaceWith("onShutDown(block)")
 )
 @KordPreview
 fun LiveGuildChannel.onDelete(block: suspend (ChannelDeleteEvent) -> Unit) = on(consumer = block)
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("LiveGuildChannel.onShutDown((() -> Unit)?)")
+    ReplaceWith("onShutDown(block)")
 )
 @KordPreview
 fun LiveGuildChannel.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
@@ -71,9 +71,9 @@ class LiveGuildChannel(
     override fun update(event: Event) = when (event) {
         is ChannelCreateEvent -> channel = event.channel as GuildMessageChannel
         is ChannelUpdateEvent -> channel = event.channel as GuildMessageChannel
-        is ChannelDeleteEvent -> shutdown()
+        is ChannelDeleteEvent -> shutDown()
 
-        is GuildDeleteEvent -> shutdown()
+        is GuildDeleteEvent -> shutDown()
 
         else -> Unit
     }

--- a/core/src/main/kotlin/live/channel/LiveGuildChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveGuildChannel.kt
@@ -26,7 +26,8 @@ inline fun GuildChannel.live(
 
 @Deprecated(
     "The block is never called because the channel is already created",
-    ReplaceWith("LiveGuild.onChannelCreate(block)")
+    ReplaceWith("LiveGuild.onChannelCreate(block)"),
+    DeprecationLevel.ERROR
 )
 @KordPreview
 fun LiveGuildChannel.onCreate(block: suspend (ChannelCreateEvent) -> Unit) = on(consumer = block)
@@ -36,7 +37,8 @@ fun LiveGuildChannel.onUpdate(block: suspend (ChannelUpdateEvent) -> Unit) = on(
 
 @Deprecated(
     "The block is not called when the live entity is shutdown",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)")
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    DeprecationLevel.ERROR
 )
 @KordPreview
 inline fun LiveGuildChannel.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
@@ -47,14 +49,16 @@ inline fun LiveGuildChannel.onShutDown(crossinline block: suspend (Event) -> Uni
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)")
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    DeprecationLevel.ERROR
 )
 @KordPreview
 fun LiveGuildChannel.onDelete(block: suspend (ChannelDeleteEvent) -> Unit) = on(consumer = block)
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)")
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    DeprecationLevel.ERROR
 )
 @KordPreview
 fun LiveGuildChannel.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)

--- a/core/src/main/kotlin/live/channel/LiveGuildMessageChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveGuildMessageChannel.kt
@@ -25,7 +25,8 @@ inline fun GuildMessageChannel.live(
 
 @Deprecated(
     "The block is never called because the channel is already created",
-    ReplaceWith("LiveGuild.onChannelCreate(block)")
+    ReplaceWith("LiveGuild.onChannelCreate(block)"),
+    DeprecationLevel.ERROR
 )
 @KordPreview
 fun LiveGuildMessageChannel.onCreate(block: suspend (ChannelCreateEvent) -> Unit) = on(consumer = block)
@@ -35,7 +36,8 @@ fun LiveGuildMessageChannel.onUpdate(block: suspend (ChannelUpdateEvent) -> Unit
 
 @Deprecated(
     "The block is not called when the live entity is shutdown",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)")
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    DeprecationLevel.ERROR
 )
 @KordPreview
 inline fun LiveGuildMessageChannel.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
@@ -46,14 +48,16 @@ inline fun LiveGuildMessageChannel.onShutDown(crossinline block: suspend (Event)
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)")
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    DeprecationLevel.ERROR
 )
 @KordPreview
 fun LiveGuildMessageChannel.onChannelDelete(block: suspend (ChannelDeleteEvent) -> Unit) = on(consumer = block)
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)")
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    DeprecationLevel.ERROR
 )
 @KordPreview
 fun LiveGuildMessageChannel.onDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)

--- a/core/src/main/kotlin/live/channel/LiveGuildMessageChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveGuildMessageChannel.kt
@@ -9,6 +9,7 @@ import dev.kord.core.event.channel.ChannelCreateEvent
 import dev.kord.core.event.channel.ChannelDeleteEvent
 import dev.kord.core.event.channel.ChannelUpdateEvent
 import dev.kord.core.event.guild.GuildDeleteEvent
+import dev.kord.core.live.exception.LiveCancellationException
 import dev.kord.core.live.on
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -77,9 +78,9 @@ class LiveGuildMessageChannel(
     override fun update(event: Event) = when (event) {
         is ChannelCreateEvent -> channel = event.channel as GuildMessageChannel
         is ChannelUpdateEvent -> channel = event.channel as GuildMessageChannel
-        is ChannelDeleteEvent -> shutDown()
+        is ChannelDeleteEvent -> shutDown(LiveCancellationException(event, "The channel is deleted"))
 
-        is GuildDeleteEvent -> shutDown()
+        is GuildDeleteEvent -> shutDown(LiveCancellationException(event, "The guild is deleted"))
 
         else -> Unit
     }

--- a/core/src/main/kotlin/live/channel/LiveGuildMessageChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveGuildMessageChannel.kt
@@ -25,7 +25,7 @@ inline fun GuildMessageChannel.live(
 
 @Deprecated(
     "The block is never called because the channel is already created",
-    ReplaceWith("LiveGuild.onChannelCreate")
+    ReplaceWith("LiveGuild.onChannelCreate(block)")
 )
 @KordPreview
 fun LiveGuildMessageChannel.onCreate(block: suspend (ChannelCreateEvent) -> Unit) = on(consumer = block)
@@ -35,7 +35,7 @@ fun LiveGuildMessageChannel.onUpdate(block: suspend (ChannelUpdateEvent) -> Unit
 
 @Deprecated(
     "The block is not called when the live entity is shutdown",
-    ReplaceWith("LiveGuildMessageChannel.onShutDown((() -> Unit)?)")
+    ReplaceWith("onShutDown(block)")
 )
 @KordPreview
 inline fun LiveGuildMessageChannel.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
@@ -46,14 +46,14 @@ inline fun LiveGuildMessageChannel.onShutDown(crossinline block: suspend (Event)
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("LiveGuildMessageChannel.onShutDown((() -> Unit)?)")
+    ReplaceWith("onShutDown(block)")
 )
 @KordPreview
 fun LiveGuildMessageChannel.onChannelDelete(block: suspend (ChannelDeleteEvent) -> Unit) = on(consumer = block)
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("LiveGuildMessageChannel.onShutDown((() -> Unit)?)")
+    ReplaceWith("onShutDown(block)")
 )
 @KordPreview
 fun LiveGuildMessageChannel.onDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
@@ -70,9 +70,9 @@ class LiveGuildMessageChannel(
     override fun update(event: Event) = when (event) {
         is ChannelCreateEvent -> channel = event.channel as GuildMessageChannel
         is ChannelUpdateEvent -> channel = event.channel as GuildMessageChannel
-        is ChannelDeleteEvent -> shutdown()
+        is ChannelDeleteEvent -> shutDown()
 
-        is GuildDeleteEvent -> shutdown()
+        is GuildDeleteEvent -> shutDown()
 
         else -> Unit
     }

--- a/core/src/main/kotlin/live/channel/LiveGuildMessageChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveGuildMessageChannel.kt
@@ -24,10 +24,10 @@ inline fun GuildMessageChannel.live(
     block: LiveGuildMessageChannel.() -> Unit
 ) = this.live(dispatcher).apply(block)
 
+@Suppress("DeprecatedCallableAddReplaceWith")
 @Deprecated(
-    "The block is never called because the channel is already created",
-    ReplaceWith("LiveGuild.onChannelCreate(block)"),
-    DeprecationLevel.ERROR
+    "The block is never called because the channel is already created, use LiveGuild.onChannelCreate(block)",
+    level = DeprecationLevel.ERROR
 )
 @KordPreview
 fun LiveGuildMessageChannel.onCreate(block: suspend (ChannelCreateEvent) -> Unit) = on(consumer = block)
@@ -37,7 +37,7 @@ fun LiveGuildMessageChannel.onUpdate(block: suspend (ChannelUpdateEvent) -> Unit
 
 @Deprecated(
     "The block is not called when the live entity is shut down",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)", "kotlinx.coroutines.job"),
     DeprecationLevel.ERROR
 )
 @KordPreview
@@ -49,7 +49,7 @@ inline fun LiveGuildMessageChannel.onShutDown(crossinline block: suspend (Event)
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shut down",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)", "kotlinx.coroutines.job"),
     DeprecationLevel.ERROR
 )
 @KordPreview
@@ -57,7 +57,7 @@ fun LiveGuildMessageChannel.onChannelDelete(block: suspend (ChannelDeleteEvent) 
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shut down",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)", "kotlinx.coroutines.job"),
     DeprecationLevel.ERROR
 )
 @KordPreview

--- a/core/src/main/kotlin/live/channel/LiveGuildMessageChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveGuildMessageChannel.kt
@@ -36,7 +36,7 @@ fun LiveGuildMessageChannel.onCreate(block: suspend (ChannelCreateEvent) -> Unit
 fun LiveGuildMessageChannel.onUpdate(block: suspend (ChannelUpdateEvent) -> Unit) = on(consumer = block)
 
 @Deprecated(
-    "The block is not called when the live entity is shutdown",
+    "The block is not called when the live entity is shut down",
     ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
     DeprecationLevel.ERROR
 )
@@ -48,7 +48,7 @@ inline fun LiveGuildMessageChannel.onShutDown(crossinline block: suspend (Event)
 }
 
 @Deprecated(
-    "The block is not called when the entity is deleted because the live entity is shutdown",
+    "The block is not called when the entity is deleted because the live entity is shut down",
     ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
     DeprecationLevel.ERROR
 )
@@ -56,7 +56,7 @@ inline fun LiveGuildMessageChannel.onShutDown(crossinline block: suspend (Event)
 fun LiveGuildMessageChannel.onChannelDelete(block: suspend (ChannelDeleteEvent) -> Unit) = on(consumer = block)
 
 @Deprecated(
-    "The block is not called when the entity is deleted because the live entity is shutdown",
+    "The block is not called when the entity is deleted because the live entity is shut down",
     ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
     DeprecationLevel.ERROR
 )

--- a/core/src/main/kotlin/live/channel/LiveGuildMessageChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveGuildMessageChannel.kt
@@ -28,6 +28,10 @@ fun LiveGuildMessageChannel.onCreate(block: suspend (ChannelCreateEvent) -> Unit
 @KordPreview
 fun LiveGuildMessageChannel.onUpdate(block: suspend (ChannelUpdateEvent) -> Unit) = on(consumer = block)
 
+@Deprecated(
+    "The block is not called when the live entity is shutdown",
+    ReplaceWith("LiveGuildMessageChannel.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 inline fun LiveGuildMessageChannel.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
     if (it is ChannelDeleteEvent || it is GuildDeleteEvent) {
@@ -35,9 +39,17 @@ inline fun LiveGuildMessageChannel.onShutDown(crossinline block: suspend (Event)
     }
 }
 
+@Deprecated(
+    "The block is not called when the entity is deleted because the live entity is shutdown",
+    ReplaceWith("LiveGuildMessageChannel.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 fun LiveGuildMessageChannel.onChannelDelete(block: suspend (ChannelDeleteEvent) -> Unit) = on(consumer = block)
 
+@Deprecated(
+    "The block is not called when the entity is deleted because the live entity is shutdown",
+    ReplaceWith("LiveGuildMessageChannel.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 fun LiveGuildMessageChannel.onDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
 

--- a/core/src/main/kotlin/live/channel/LiveVoiceChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveVoiceChannel.kt
@@ -9,6 +9,7 @@ import dev.kord.core.event.channel.VoiceChannelCreateEvent
 import dev.kord.core.event.channel.VoiceChannelDeleteEvent
 import dev.kord.core.event.channel.VoiceChannelUpdateEvent
 import dev.kord.core.event.guild.GuildDeleteEvent
+import dev.kord.core.live.exception.LiveCancellationException
 import dev.kord.core.live.on
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -77,9 +78,9 @@ class LiveVoiceChannel(
     override fun update(event: Event) = when (event) {
         is VoiceChannelCreateEvent -> channel = event.channel
         is VoiceChannelUpdateEvent -> channel = event.channel
-        is VoiceChannelDeleteEvent -> shutDown()
+        is VoiceChannelDeleteEvent -> shutDown(LiveCancellationException(event, "The channel is deleted"))
 
-        is GuildDeleteEvent -> shutDown()
+        is GuildDeleteEvent -> shutDown(LiveCancellationException(event, "The guild is deleted"))
 
         else -> Unit
     }

--- a/core/src/main/kotlin/live/channel/LiveVoiceChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveVoiceChannel.kt
@@ -36,7 +36,7 @@ fun LiveVoiceChannel.onCreate(block: suspend (VoiceChannelCreateEvent) -> Unit) 
 fun LiveVoiceChannel.onUpdate(block: suspend (VoiceChannelUpdateEvent) -> Unit) = on(consumer = block)
 
 @Deprecated(
-    "The block is not called when the live entity is shutdown",
+    "The block is not called when the live entity is shut down",
     ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
     DeprecationLevel.ERROR
 )
@@ -48,7 +48,7 @@ inline fun LiveVoiceChannel.onShutDown(crossinline block: suspend (Event) -> Uni
 }
 
 @Deprecated(
-    "The block is not called when the entity is deleted because the live entity is shutdown",
+    "The block is not called when the entity is deleted because the live entity is shut down",
     ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
     DeprecationLevel.ERROR
 )
@@ -56,7 +56,7 @@ inline fun LiveVoiceChannel.onShutDown(crossinline block: suspend (Event) -> Uni
 fun LiveVoiceChannel.onDelete(block: suspend (VoiceChannelDeleteEvent) -> Unit) = on(consumer = block)
 
 @Deprecated(
-    "The block is not called when the entity is deleted because the live entity is shutdown",
+    "The block is not called when the entity is deleted because the live entity is shut down",
     ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
     DeprecationLevel.ERROR
 )

--- a/core/src/main/kotlin/live/channel/LiveVoiceChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveVoiceChannel.kt
@@ -28,6 +28,10 @@ fun LiveVoiceChannel.onCreate(block: suspend (VoiceChannelCreateEvent) -> Unit) 
 @KordPreview
 fun LiveVoiceChannel.onUpdate(block: suspend (VoiceChannelUpdateEvent) -> Unit) = on(consumer = block)
 
+@Deprecated(
+    "The block is not called when the live entity is shutdown",
+    ReplaceWith("LiveVoiceChannel.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 inline fun LiveVoiceChannel.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
     if (it is VoiceChannelDeleteEvent || it is GuildDeleteEvent) {
@@ -35,9 +39,17 @@ inline fun LiveVoiceChannel.onShutDown(crossinline block: suspend (Event) -> Uni
     }
 }
 
+@Deprecated(
+    "The block is not called when the entity is deleted because the live entity is shutdown",
+    ReplaceWith("LiveVoiceChannel.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 fun LiveVoiceChannel.onDelete(block: suspend (VoiceChannelDeleteEvent) -> Unit) = on(consumer = block)
 
+@Deprecated(
+    "The block is not called when the entity is deleted because the live entity is shutdown",
+    ReplaceWith("LiveVoiceChannel.onShutDown((() -> Unit)?)")
+)
 @KordPreview
 fun LiveVoiceChannel.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
 

--- a/core/src/main/kotlin/live/channel/LiveVoiceChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveVoiceChannel.kt
@@ -24,10 +24,10 @@ inline fun VoiceChannel.live(
     block: LiveVoiceChannel.() -> Unit
 ) = this.live(dispatcher).apply(block)
 
+@Suppress("DeprecatedCallableAddReplaceWith")
 @Deprecated(
-    "The block is never called because the channel is already created",
-    ReplaceWith("LiveGuild.onChannelCreate(block)"),
-    DeprecationLevel.ERROR
+    "The block is never called because the channel is already created, use LiveGuild.onChannelCreate(block)",
+    level = DeprecationLevel.ERROR
 )
 @KordPreview
 fun LiveVoiceChannel.onCreate(block: suspend (VoiceChannelCreateEvent) -> Unit) = on(consumer = block)

--- a/core/src/main/kotlin/live/channel/LiveVoiceChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveVoiceChannel.kt
@@ -1,6 +1,7 @@
 package dev.kord.core.live.channel
 
 import dev.kord.common.annotation.KordPreview
+import dev.kord.common.entity.Snowflake
 import dev.kord.core.entity.KordEntity
 import dev.kord.core.entity.channel.VoiceChannel
 import dev.kord.core.event.Event
@@ -11,7 +12,6 @@ import dev.kord.core.event.guild.GuildDeleteEvent
 import dev.kord.core.live.on
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.job
 
 @KordPreview
 fun VoiceChannel.live(dispatcher: CoroutineDispatcher = Dispatchers.Default) =
@@ -35,7 +35,7 @@ fun LiveVoiceChannel.onUpdate(block: suspend (VoiceChannelUpdateEvent) -> Unit) 
 
 @Deprecated(
     "The block is not called when the live entity is shutdown",
-    ReplaceWith("onShutDown(block)")
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)")
 )
 @KordPreview
 inline fun LiveVoiceChannel.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
@@ -46,14 +46,14 @@ inline fun LiveVoiceChannel.onShutDown(crossinline block: suspend (Event) -> Uni
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("onShutDown(block)")
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)")
 )
 @KordPreview
 fun LiveVoiceChannel.onDelete(block: suspend (VoiceChannelDeleteEvent) -> Unit) = on(consumer = block)
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("onShutDown(block)")
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)")
 )
 @KordPreview
 fun LiveVoiceChannel.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
@@ -62,7 +62,10 @@ fun LiveVoiceChannel.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = 
 class LiveVoiceChannel(
     channel: VoiceChannel,
     dispatcher: CoroutineDispatcher = Dispatchers.Default
-) : LiveChannel(dispatcher, channel.kord.coroutineContext.job), KordEntity by channel {
+) : LiveChannel(channel.kord, dispatcher), KordEntity {
+
+    override val id: Snowflake
+        get() = channel.id
 
     override var channel: VoiceChannel = channel
         private set

--- a/core/src/main/kotlin/live/channel/LiveVoiceChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveVoiceChannel.kt
@@ -25,7 +25,7 @@ inline fun VoiceChannel.live(
 
 @Deprecated(
     "The block is never called because the channel is already created",
-    ReplaceWith("LiveGuild.onChannelCreate")
+    ReplaceWith("LiveGuild.onChannelCreate(block)")
 )
 @KordPreview
 fun LiveVoiceChannel.onCreate(block: suspend (VoiceChannelCreateEvent) -> Unit) = on(consumer = block)
@@ -35,7 +35,7 @@ fun LiveVoiceChannel.onUpdate(block: suspend (VoiceChannelUpdateEvent) -> Unit) 
 
 @Deprecated(
     "The block is not called when the live entity is shutdown",
-    ReplaceWith("LiveVoiceChannel.onShutDown((() -> Unit)?)")
+    ReplaceWith("onShutDown(block)")
 )
 @KordPreview
 inline fun LiveVoiceChannel.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
@@ -46,14 +46,14 @@ inline fun LiveVoiceChannel.onShutDown(crossinline block: suspend (Event) -> Uni
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("LiveVoiceChannel.onShutDown((() -> Unit)?)")
+    ReplaceWith("onShutDown(block)")
 )
 @KordPreview
 fun LiveVoiceChannel.onDelete(block: suspend (VoiceChannelDeleteEvent) -> Unit) = on(consumer = block)
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("LiveVoiceChannel.onShutDown((() -> Unit)?)")
+    ReplaceWith("onShutDown(block)")
 )
 @KordPreview
 fun LiveVoiceChannel.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
@@ -70,9 +70,9 @@ class LiveVoiceChannel(
     override fun update(event: Event) = when (event) {
         is VoiceChannelCreateEvent -> channel = event.channel
         is VoiceChannelUpdateEvent -> channel = event.channel
-        is VoiceChannelDeleteEvent -> shutdown()
+        is VoiceChannelDeleteEvent -> shutDown()
 
-        is GuildDeleteEvent -> shutdown()
+        is GuildDeleteEvent -> shutDown()
 
         else -> Unit
     }

--- a/core/src/main/kotlin/live/channel/LiveVoiceChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveVoiceChannel.kt
@@ -25,7 +25,8 @@ inline fun VoiceChannel.live(
 
 @Deprecated(
     "The block is never called because the channel is already created",
-    ReplaceWith("LiveGuild.onChannelCreate(block)")
+    ReplaceWith("LiveGuild.onChannelCreate(block)"),
+    DeprecationLevel.ERROR
 )
 @KordPreview
 fun LiveVoiceChannel.onCreate(block: suspend (VoiceChannelCreateEvent) -> Unit) = on(consumer = block)
@@ -35,7 +36,8 @@ fun LiveVoiceChannel.onUpdate(block: suspend (VoiceChannelUpdateEvent) -> Unit) 
 
 @Deprecated(
     "The block is not called when the live entity is shutdown",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)")
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    DeprecationLevel.ERROR
 )
 @KordPreview
 inline fun LiveVoiceChannel.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
@@ -46,14 +48,16 @@ inline fun LiveVoiceChannel.onShutDown(crossinline block: suspend (Event) -> Uni
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)")
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    DeprecationLevel.ERROR
 )
 @KordPreview
 fun LiveVoiceChannel.onDelete(block: suspend (VoiceChannelDeleteEvent) -> Unit) = on(consumer = block)
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shutdown",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)")
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    DeprecationLevel.ERROR
 )
 @KordPreview
 fun LiveVoiceChannel.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)

--- a/core/src/main/kotlin/live/channel/LiveVoiceChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveVoiceChannel.kt
@@ -37,7 +37,7 @@ fun LiveVoiceChannel.onUpdate(block: suspend (VoiceChannelUpdateEvent) -> Unit) 
 
 @Deprecated(
     "The block is not called when the live entity is shut down",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)", "kotlinx.coroutines.job"),
     DeprecationLevel.ERROR
 )
 @KordPreview
@@ -49,7 +49,7 @@ inline fun LiveVoiceChannel.onShutDown(crossinline block: suspend (Event) -> Uni
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shut down",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)", "kotlinx.coroutines.job"),
     DeprecationLevel.ERROR
 )
 @KordPreview
@@ -57,7 +57,7 @@ fun LiveVoiceChannel.onDelete(block: suspend (VoiceChannelDeleteEvent) -> Unit) 
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shut down",
-    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)"),
+    ReplaceWith("coroutineContext.job.invokeOnCompletion(block)", "kotlinx.coroutines.job"),
     DeprecationLevel.ERROR
 )
 @KordPreview

--- a/core/src/main/kotlin/live/exception/LiveCancellationException.kt
+++ b/core/src/main/kotlin/live/exception/LiveCancellationException.kt
@@ -1,0 +1,6 @@
+package dev.kord.core.live.exception
+
+import dev.kord.core.event.Event
+import java.util.concurrent.CancellationException
+
+class LiveCancellationException(val event: Event, reason: String? = null) : CancellationException(reason)

--- a/core/src/main/kotlin/live/exception/LiveCancellationException.kt
+++ b/core/src/main/kotlin/live/exception/LiveCancellationException.kt
@@ -3,4 +3,4 @@ package dev.kord.core.live.exception
 import dev.kord.core.event.Event
 import java.util.concurrent.CancellationException
 
-class LiveCancellationException(val event: Event, reason: String? = null) : CancellationException(reason)
+class LiveCancellationException(val event: Event, message: String? = null) : CancellationException(message)

--- a/core/src/test/kotlin/live/AbstractLiveEntityTest.kt
+++ b/core/src/test/kotlin/live/AbstractLiveEntityTest.kt
@@ -1,0 +1,149 @@
+package live
+
+import dev.kord.cache.api.DataCache
+import dev.kord.common.annotation.KordPreview
+import dev.kord.common.entity.Snowflake
+import dev.kord.core.ClientResources
+import dev.kord.core.Kord
+import dev.kord.core.builder.kord.Shards
+import dev.kord.core.gateway.MasterGateway
+import dev.kord.core.live.AbstractLiveKordEntity
+import dev.kord.core.supplier.EntitySupplyStrategy
+import dev.kord.gateway.*
+import dev.kord.rest.request.KtorRequestHandler
+import dev.kord.rest.service.RestClient
+import equality.randomId
+import io.ktor.client.*
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import java.time.Clock
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.test.AfterTest
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Duration
+
+@OptIn(KordPreview::class)
+abstract class AbstractLiveEntityTest<LIVE : AbstractLiveKordEntity> {
+
+    class GatewayMock : Gateway {
+        override val coroutineContext: CoroutineContext = EmptyCoroutineContext + SupervisorJob()
+
+        @OptIn(FlowPreview::class)
+        override val events: MutableSharedFlow<Event> = MutableSharedFlow()
+
+        override val ping: StateFlow<Duration?> = MutableStateFlow(null)
+
+        override suspend fun detach() {}
+
+        override suspend fun send(command: Command) {}
+
+        override suspend fun start(configuration: GatewayConfiguration) {}
+
+        override suspend fun stop() {}
+    }
+
+    class CounterAtomicLatch(count: Int) {
+
+        private val countdown = CountDownLatch(count)
+        val latchCount get() = countdown.count
+
+        private val counter = AtomicInteger(0)
+        val atomicCount get() = counter.get()
+
+        fun count() {
+            counter.incrementAndGet()
+            countdown.countDown()
+        }
+
+        fun await(timeout: Long, unit: TimeUnit) = countdown.await(timeout, unit)
+    }
+
+    private lateinit var gateway: GatewayMock
+
+    protected lateinit var kord: Kord
+
+    protected lateinit var guildId: Snowflake
+
+    lateinit var live: LIVE
+
+    @BeforeAll
+    open fun onBeforeAll() = runBlocking {
+        kord = createKord()
+        guildId = randomId()
+    }
+
+    @AfterAll
+    open fun onAfterAll() = runBlocking {
+        if (kord.isActive) {
+            kord.logout()
+            kord.shutdown()
+        }
+    }
+
+    @AfterTest
+    open fun onAfter() {
+        if (this::live.isInitialized && live.isActive) {
+            live.shutdown()
+        }
+    }
+
+    protected open fun createKord(): Kord {
+        gateway = GatewayMock()
+        return Kord(
+            resources = ClientResources("token", Shards(1), HttpClient(), EntitySupplyStrategy.cache, Intents.none),
+            cache = DataCache.none(),
+            MasterGateway(mapOf(0 to gateway)),
+            RestClient(KtorRequestHandler("token", clock = Clock.systemUTC())),
+            randomId(),
+            MutableSharedFlow(extraBufferCapacity = Int.MAX_VALUE),
+            Dispatchers.Default
+        )
+    }
+
+    protected inline fun countdownContext(
+        expectedCount: Int,
+        waitMs: Long = 5000,
+        crossinline action: suspend CounterAtomicLatch.() -> Unit
+    ) = runBlocking {
+        val counter = CounterAtomicLatch(expectedCount)
+
+        action(counter)
+
+        counter.await(waitMs, TimeUnit.MILLISECONDS)
+        assertEquals(0, counter.latchCount)
+        assertEquals(expectedCount, counter.atomicCount)
+    }
+
+    suspend inline fun sendEventValidAndRandomId(validId: Snowflake, builderEvent: (Snowflake) -> Event) {
+        sendEventAndWait(builderEvent(randomId()))
+        sendEvent(builderEvent(validId))
+    }
+
+    suspend inline fun sendEventValidAndRandomIdCheckLiveActive(
+        validId: Snowflake,
+        builderEvent: (Snowflake) -> Event
+    ) {
+        sendEventAndWait(builderEvent(randomId()))
+        assertTrue { live.isActive }
+        sendEventAndWait(builderEvent(validId))
+        assertFalse { live.isActive }
+    }
+
+    suspend fun sendEventAndWait(event: Event, delayMs: Long = 50) {
+        sendEvent(event)
+        // Let time to receive event from the flow before the next action.
+        delay(delayMs)
+    }
+
+    suspend fun sendEvent(event: Event) = gateway.events.emit(event)
+}

--- a/core/src/test/kotlin/live/AbstractLiveEntityTest.kt
+++ b/core/src/test/kotlin/live/AbstractLiveEntityTest.kt
@@ -93,7 +93,7 @@ abstract class AbstractLiveEntityTest<LIVE : AbstractLiveKordEntity> {
     @AfterTest
     open fun onAfter() {
         if (this::live.isInitialized && live.isActive) {
-            live.shutdown()
+            live.shutDown()
         }
     }
 

--- a/core/src/test/kotlin/live/AbstractLiveEntityTest.kt
+++ b/core/src/test/kotlin/live/AbstractLiveEntityTest.kt
@@ -35,6 +35,10 @@ import kotlin.time.Duration
 @OptIn(KordPreview::class)
 abstract class AbstractLiveEntityTest<LIVE : AbstractLiveKordEntity> {
 
+    companion object {
+        const val DELAY_TIME = 400L
+    }
+
     class GatewayMock : Gateway {
         override val coroutineContext: CoroutineContext = EmptyCoroutineContext + SupervisorJob()
 
@@ -139,7 +143,7 @@ abstract class AbstractLiveEntityTest<LIVE : AbstractLiveKordEntity> {
         assertFalse { live.isActive }
     }
 
-    suspend fun sendEventAndWait(event: Event, delayMs: Long = 50) {
+    suspend fun sendEventAndWait(event: Event, delayMs: Long = DELAY_TIME) {
         sendEvent(event)
         // Let time to receive event from the flow before the next action.
         delay(delayMs)

--- a/core/src/test/kotlin/live/LiveGuildTest.kt
+++ b/core/src/test/kotlin/live/LiveGuildTest.kt
@@ -678,6 +678,48 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
     }
 
     @Test
+    fun `Check onGuildCreate is called when event is received`() {
+        countdownContext(1) {
+            live.onGuildCreate {
+                assertEquals(guildId, it.guild.id)
+                count()
+            }
+
+            sendEventValidAndRandomId(guildId) {
+                GuildCreate(
+                    DiscordGuild(
+                        id = it,
+                        name = "",
+                        icon = null,
+                        ownerId = randomId(),
+                        region = "",
+                        afkChannelId = null,
+                        afkTimeout = 0,
+                        verificationLevel = VerificationLevel.None,
+                        defaultMessageNotifications = DefaultMessageNotificationLevel.AllMessages,
+                        explicitContentFilter = ExplicitContentFilter.Disabled,
+                        roles = emptyList(),
+                        emojis = emptyList(),
+                        features = emptyList(),
+                        mfaLevel = MFALevel.None,
+                        applicationId = null,
+                        systemChannelId = null,
+                        systemChannelFlags = SystemChannelFlags(0),
+                        rulesChannelId = null,
+                        vanityUrlCode = null,
+                        description = null,
+                        banner = null,
+                        premiumTier = PremiumTier.None,
+                        preferredLocale = "",
+                        publicUpdatesChannelId = null
+                    ),
+                    0
+                )
+            }
+        }
+    }
+
+    @Test
     fun `Check onGuildUpdate is called when event is received`() {
         countdownContext(1) {
             live.onGuildUpdate {

--- a/core/src/test/kotlin/live/LiveGuildTest.kt
+++ b/core/src/test/kotlin/live/LiveGuildTest.kt
@@ -445,18 +445,9 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
                 0
             )
 
-            EventQueueManager(kord).apply {
-                add {
-                    sendEvent(createEvent(randomId(), emojiExpected))
-                }
-                add {
-                    sendEvent(createEvent(guildId, emojiOther))
-                }
-                add {
-                    sendEvent(createEvent(guildId, emojiExpected))
-                }
-                start()
-            }
+            sendEventAndWait(createEvent(randomId(), emojiExpected))
+            sendEventAndWait(createEvent(guildId, emojiOther))
+            sendEvent(createEvent(guildId, emojiExpected))
         }
     }
 
@@ -509,18 +500,9 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
                 0
             )
 
-            EventQueueManager(kord).apply {
-                add {
-                    sendEvent(createEvent(randomId(), emojiExpected))
-                }
-                add {
-                    sendEvent(createEvent(guildId, emojiOther))
-                }
-                add {
-                    sendEvent(createEvent(guildId, emojiExpected))
-                }
-                start()
-            }
+            sendEventAndWait(createEvent(randomId(), emojiExpected))
+            sendEventAndWait(createEvent(guildId, emojiOther))
+            sendEvent(createEvent(guildId, emojiExpected))
         }
     }
 

--- a/core/src/test/kotlin/live/LiveGuildTest.kt
+++ b/core/src/test/kotlin/live/LiveGuildTest.kt
@@ -14,12 +14,15 @@ import kotlinx.coroutines.job
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.JsonObject
 import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.Timeout
+import java.util.concurrent.TimeUnit
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @OptIn(KordPreview::class)
+@Timeout(value = 5, unit = TimeUnit.SECONDS)
 class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
 
     @BeforeTest
@@ -442,14 +445,18 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
                 0
             )
 
-            val eventRandomId = createEvent(randomId(), emojiExpected)
-            sendEventAndWait(eventRandomId)
-
-            val eventOtherReaction = createEvent(guildId, emojiOther)
-            sendEventAndWait(eventOtherReaction)
-
-            val event = createEvent(guildId, emojiExpected)
-            sendEvent(event)
+            EventQueueManager(kord).apply {
+                add {
+                    sendEvent(createEvent(randomId(), emojiExpected))
+                }
+                add {
+                    sendEvent(createEvent(guildId, emojiOther))
+                }
+                add {
+                    sendEvent(createEvent(guildId, emojiExpected))
+                }
+                start()
+            }
         }
     }
 
@@ -502,14 +509,18 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
                 0
             )
 
-            val eventRandomId = createEvent(randomId(), emojiExpected)
-            sendEventAndWait(eventRandomId)
-
-            val eventOtherReaction = createEvent(guildId, emojiOther)
-            sendEventAndWait(eventOtherReaction)
-
-            val event = createEvent(guildId, emojiExpected)
-            sendEvent(event)
+            EventQueueManager(kord).apply {
+                add {
+                    sendEvent(createEvent(randomId(), emojiExpected))
+                }
+                add {
+                    sendEvent(createEvent(guildId, emojiOther))
+                }
+                add {
+                    sendEvent(createEvent(guildId, emojiExpected))
+                }
+                start()
+            }
         }
     }
 

--- a/core/src/test/kotlin/live/LiveGuildTest.kt
+++ b/core/src/test/kotlin/live/LiveGuildTest.kt
@@ -1,0 +1,738 @@
+package live
+
+import dev.kord.common.annotation.KordPreview
+import dev.kord.common.entity.*
+import dev.kord.common.entity.optional.Optional
+import dev.kord.common.entity.optional.optionalSnowflake
+import dev.kord.core.cache.data.GuildData
+import dev.kord.core.entity.Guild
+import dev.kord.core.entity.ReactionEmoji
+import dev.kord.core.live.*
+import dev.kord.gateway.*
+import equality.randomId
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonObject
+import org.junit.jupiter.api.TestInstance
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@OptIn(KordPreview::class)
+class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
+
+    @BeforeTest
+    fun onBefore() = runBlocking {
+        live = LiveGuild(
+            Guild(
+                kord = kord,
+                data = GuildData(
+                    id = guildId,
+                    name = "",
+                    ownerId = randomId(),
+                    region = "",
+                    afkTimeout = 0,
+                    verificationLevel = VerificationLevel.None,
+                    defaultMessageNotifications = DefaultMessageNotificationLevel.AllMessages,
+                    explicitContentFilter = ExplicitContentFilter.Disabled,
+                    roles = emptyList(),
+                    emojis = emptyList(),
+                    features = emptyList(),
+                    mfaLevel = MFALevel.None,
+                    premiumTier = PremiumTier.None,
+                    preferredLocale = "",
+                    systemChannelFlags = SystemChannelFlags(0)
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `Check onEmojisUpdate is called when event is received`() {
+        countdownContext(1) {
+            live.onEmojisUpdate {
+                assertEquals(guildId, it.guildId)
+                count()
+            }
+
+            sendEventValidAndRandomId(guildId) {
+                GuildEmojisUpdate(
+                    DiscordUpdatedEmojis(
+                        guildId = it,
+                        emojis = emptyList()
+                    ),
+                    0
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `Check onIntegrationsUpdate is called when event is received`() {
+        countdownContext(1) {
+            live.onIntegrationsUpdate {
+                assertEquals(guildId, it.guildId)
+                count()
+            }
+
+            sendEventValidAndRandomId(guildId) {
+                GuildIntegrationsUpdate(
+                    DiscordGuildIntegrations(
+                        guildId = it
+                    ),
+                    0
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `Check onBanAdd is called when event is received`() {
+        countdownContext(1) {
+            live.onBanAdd {
+                assertEquals(guildId, it.guildId)
+                count()
+            }
+
+            sendEventValidAndRandomId(guildId) {
+                GuildBanAdd(
+                    DiscordGuildBan(
+                        guildId = it.asString,
+                        user = DiscordUser(
+                            id = randomId(),
+                            username = "",
+                            discriminator = "",
+                            avatar = null
+                        )
+                    ),
+                    0
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `Check onBanRemove is called when event is received`() {
+        countdownContext(1) {
+            live.onBanRemove {
+                assertEquals(guildId, it.guildId)
+                count()
+            }
+
+            sendEventValidAndRandomId(guildId) {
+                GuildBanRemove(
+                    DiscordGuildBan(
+                        guildId = it.asString,
+                        user = DiscordUser(
+                            id = randomId(),
+                            username = "",
+                            discriminator = "",
+                            avatar = null
+                        )
+                    ),
+                    0
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `Check onPresenceUpdate is called when event is received`() {
+        countdownContext(1) {
+            live.onPresenceUpdate {
+                assertEquals(guildId, it.guildId)
+                count()
+            }
+
+            sendEventValidAndRandomId(guildId) {
+                PresenceUpdate(
+                    DiscordPresenceUpdate(
+                        user = DiscordPresenceUser(
+                            id = randomId(),
+                            details = JsonObject(emptyMap())
+                        ),
+                        guildId = it.optionalSnowflake(),
+                        status = PresenceStatus.DoNotDisturb,
+                        activities = emptyList(),
+                        clientStatus = DiscordClientStatus()
+                    ),
+                    0
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `Check onVoiceServerUpdate is called when event is received`() {
+        countdownContext(1) {
+            live.onVoiceServerUpdate {
+                assertEquals(guildId, it.guildId)
+                count()
+            }
+
+            sendEventValidAndRandomId(guildId) {
+                VoiceServerUpdate(
+                    DiscordVoiceServerUpdateData(
+                        guildId = it,
+                        token = "",
+                        endpoint = null
+                    ),
+                    0
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `Check onVoiceStateUpdate is called when event is received`() {
+        countdownContext(1) {
+            live.onVoiceStateUpdate {
+                assertEquals(guildId, it.state.guildId)
+                count()
+            }
+
+            sendEventValidAndRandomId(guildId) {
+                VoiceStateUpdate(
+                    DiscordVoiceState(
+                        guildId = it.optionalSnowflake(),
+                        channelId = null,
+                        userId = randomId(),
+                        sessionId = "",
+                        deaf = false,
+                        mute = false,
+                        selfDeaf = false,
+                        selfMute = false,
+                        selfVideo = false,
+                        suppress = false,
+                        requestToSpeakTimestamp = null
+                    ),
+                    0
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `Check onWebhookUpdate is called when event is received`() {
+        countdownContext(1) {
+            live.onWebhookUpdate {
+                assertEquals(guildId, it.guildId)
+                count()
+            }
+
+            sendEventValidAndRandomId(guildId) {
+                WebhooksUpdate(
+                    DiscordWebhooksUpdateData(
+                        guildId = it,
+                        channelId = randomId(),
+                    ),
+                    0
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `Check onRoleCreate is called when event is received`() {
+        countdownContext(1) {
+            live.onRoleCreate {
+                assertEquals(guildId, it.guildId)
+                count()
+            }
+
+            sendEventValidAndRandomId(guildId) {
+                GuildRoleCreate(
+                    DiscordGuildRole(
+                        guildId = it,
+                        role = DiscordRole(
+                            id = randomId(),
+                            name = "",
+                            color = 0,
+                            hoist = false,
+                            position = 0,
+                            permissions = Permissions(Permission.BanMembers),
+                            managed = false,
+                            mentionable = false
+                        )
+                    ),
+                    0
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `Check onRoleUpdate is called when event is received`() {
+        countdownContext(1) {
+            live.onRoleUpdate {
+                assertEquals(guildId, it.guildId)
+                count()
+            }
+
+            sendEventValidAndRandomId(guildId) {
+                GuildRoleUpdate(
+                    DiscordGuildRole(
+                        guildId = it,
+                        role = DiscordRole(
+                            id = randomId(),
+                            name = "",
+                            color = 0,
+                            hoist = false,
+                            position = 0,
+                            permissions = Permissions(Permission.BanMembers),
+                            managed = false,
+                            mentionable = false
+                        )
+                    ),
+                    0
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `Check onRoleDelete is called when event is received`() {
+        countdownContext(1) {
+            live.onRoleDelete {
+                assertEquals(guildId, it.guildId)
+                count()
+            }
+
+            sendEventValidAndRandomId(guildId) {
+                GuildRoleDelete(
+                    DiscordDeletedGuildRole(
+                        guildId = it,
+                        id = randomId()
+                    ),
+                    0
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `Check onMemberJoin is called when event is received`() {
+        countdownContext(1) {
+            live.onMemberJoin {
+                assertEquals(guildId, it.guildId)
+                count()
+            }
+
+            sendEventValidAndRandomId(guildId) {
+                GuildMemberAdd(
+                    DiscordAddedGuildMember(
+                        guildId = it,
+                        user = Optional.invoke(
+                            DiscordUser(
+                                id = randomId(),
+                                username = "",
+                                discriminator = "",
+                                avatar = null
+                            )
+                        ),
+                        roles = emptyList(),
+                        deaf = false,
+                        mute = false,
+                        joinedAt = ""
+                    ),
+                    0
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `Check onMemberUpdate is called when event is received`() {
+        countdownContext(1) {
+            live.onMemberUpdate {
+                assertEquals(guildId, it.guildId)
+                count()
+            }
+
+            sendEventValidAndRandomId(guildId) {
+                GuildMemberUpdate(
+                    DiscordUpdatedGuildMember(
+                        guildId = it,
+                        roles = emptyList(),
+                        user = DiscordUser(
+                            id = randomId(),
+                            username = "",
+                            discriminator = "",
+                            avatar = null
+                        ),
+                        joinedAt = ""
+                    ),
+                    0
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `Check onMemberLeave is called when event is received`() {
+        countdownContext(1) {
+            live.onMemberLeave {
+                assertEquals(guildId, it.guildId)
+                count()
+            }
+
+            sendEventValidAndRandomId(guildId) {
+                GuildMemberRemove(
+                    DiscordRemovedGuildMember(
+                        guildId = it,
+                        user = DiscordUser(
+                            id = randomId(),
+                            username = "",
+                            discriminator = "",
+                            avatar = null
+                        )
+                    ),
+                    0
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `Check onReactionAdd is called when event is received`() {
+        countdownContext(1) {
+            val emojiExpected = ReactionEmoji.Unicode("\uD83D\uDC28")
+
+            live.onReactionAdd {
+                assertEquals(guildId, it.guildId)
+                count()
+            }
+
+            sendEventValidAndRandomId(guildId) {
+                MessageReactionAdd(
+                    MessageReactionAddData(
+                        messageId = randomId(),
+                        channelId = randomId(),
+                        guildId = it.optionalSnowflake(),
+                        userId = randomId(),
+                        emoji = DiscordPartialEmoji(null, emojiExpected.name)
+                    ),
+                    0
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `Check onReactionAdd with specific reaction is called when event is received`() {
+        countdownContext(1) {
+            val emojiExpected = ReactionEmoji.Unicode("\uD83D\uDC28")
+            val emojiOther = ReactionEmoji.Unicode("\uD83D\uDC3B")
+
+            live.onReactionAdd(emojiExpected) {
+                assertEquals(guildId, it.guildId)
+                assertEquals(emojiExpected, it.emoji)
+                count()
+            }
+
+            fun createEvent(guildId: Snowflake, emoji: ReactionEmoji) = MessageReactionAdd(
+                MessageReactionAddData(
+                    messageId = randomId(),
+                    channelId = randomId(),
+                    guildId = guildId.optionalSnowflake(),
+                    userId = randomId(),
+                    emoji = DiscordPartialEmoji(null, emoji.name)
+                ),
+                0
+            )
+
+            val eventRandomId = createEvent(randomId(), emojiExpected)
+            sendEventAndWait(eventRandomId)
+
+            val eventOtherReaction = createEvent(guildId, emojiOther)
+            sendEventAndWait(eventOtherReaction)
+
+            val event = createEvent(guildId, emojiExpected)
+            sendEvent(event)
+        }
+    }
+
+    @Test
+    fun `Check onReactionRemove is called when event is received`() {
+        countdownContext(1) {
+            val emojiExpected = ReactionEmoji.Unicode("\uD83D\uDC28")
+
+            live.onReactionRemove {
+                assertEquals(guildId, it.guildId)
+                assertEquals(emojiExpected, it.emoji)
+                count()
+            }
+
+            sendEventValidAndRandomId(guildId) {
+                MessageReactionRemove(
+                    MessageReactionRemoveData(
+                        messageId = randomId(),
+                        channelId = randomId(),
+                        guildId = it.optionalSnowflake(),
+                        userId = randomId(),
+                        emoji = DiscordPartialEmoji(null, emojiExpected.name)
+                    ),
+                    0
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `Check onReactionRemove with specific reaction is called when event is received`() {
+        countdownContext(1) {
+            val emojiExpected = ReactionEmoji.Unicode("\uD83D\uDC28")
+            val emojiOther = ReactionEmoji.Unicode("\uD83D\uDC3B")
+
+            live.onReactionRemove(emojiExpected) {
+                assertEquals(guildId, it.guildId)
+                assertEquals(emojiExpected, it.emoji)
+                count()
+            }
+
+            fun createEvent(guildId: Snowflake, emoji: ReactionEmoji) = MessageReactionRemove(
+                MessageReactionRemoveData(
+                    messageId = randomId(),
+                    channelId = randomId(),
+                    guildId = guildId.optionalSnowflake(),
+                    userId = randomId(),
+                    emoji = DiscordPartialEmoji(null, emoji.name)
+                ),
+                0
+            )
+
+            val eventRandomId = createEvent(randomId(), emojiExpected)
+            sendEventAndWait(eventRandomId)
+
+            val eventOtherReaction = createEvent(guildId, emojiOther)
+            sendEventAndWait(eventOtherReaction)
+
+            val event = createEvent(guildId, emojiExpected)
+            sendEvent(event)
+        }
+    }
+
+    @Test
+    fun `Check onReactionRemoveAll is called when event is received`() {
+        countdownContext(1) {
+            live.onReactionRemoveAll {
+                assertEquals(guildId, it.guildId)
+                count()
+            }
+
+            sendEventValidAndRandomId(guildId) {
+                MessageReactionRemoveAll(
+                    AllRemovedMessageReactions(
+                        channelId = randomId(),
+                        messageId = randomId(),
+                        guildId = it.optionalSnowflake()
+                    ),
+                    0
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `Check onMessageCreate is called when event is received`() {
+        countdownContext(1) {
+            live.onMessageCreate {
+                assertEquals(guildId, it.guildId)
+                count()
+            }
+
+            sendEventValidAndRandomId(guildId) {
+                MessageCreate(
+                    DiscordMessage(
+                        id = randomId(),
+                        channelId = randomId(),
+                        guildId = it.optionalSnowflake(),
+                        author = DiscordUser(
+                            id = randomId(),
+                            username = "",
+                            discriminator = "",
+                            avatar = null
+                        ),
+                        content = "",
+                        timestamp = "",
+                        editedTimestamp = null,
+                        tts = false,
+                        mentionEveryone = false,
+                        mentions = emptyList(),
+                        mentionRoles = emptyList(),
+                        attachments = emptyList(),
+                        embeds = emptyList(),
+                        pinned = false,
+                        type = MessageType.Default
+                    ),
+                    0
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `Check onMessageUpdate is called when event is received`() {
+        countdownContext(1) {
+            live.onMessageUpdate {
+                assertEquals(guildId, it.new.guildId.value)
+                count()
+            }
+
+            sendEventValidAndRandomId(guildId) {
+                MessageUpdate(
+                    DiscordPartialMessage(
+                        id = randomId(),
+                        channelId = randomId(),
+                        guildId = it.optionalSnowflake(),
+                    ),
+                    0
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `Check onMessageDelete is called when event is received`() {
+        countdownContext(1) {
+            live.onMessageDelete {
+                assertEquals(guildId, it.guildId)
+                count()
+            }
+
+            sendEventValidAndRandomId(guildId) {
+                MessageDelete(
+                    DeletedMessage(
+                        id = randomId(),
+                        channelId = randomId(),
+                        guildId = it.optionalSnowflake(),
+                    ),
+                    0
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `Check onChannelCreate is called when event is received`() {
+        countdownContext(1) {
+            live.onChannelCreate {
+                assertEquals(guildId, it.channel.data.guildId.value)
+                count()
+            }
+
+            sendEventValidAndRandomId(guildId) {
+                ChannelCreate(
+                    DiscordChannel(
+                        id = randomId(),
+                        type = ChannelType.GuildText,
+                        guildId = it.optionalSnowflake(),
+                    ),
+                    0
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `Check onChannelUpdate is called when event is received`() {
+        countdownContext(1) {
+            live.onChannelUpdate {
+                assertEquals(guildId, it.channel.data.guildId.value)
+                count()
+            }
+
+            sendEventValidAndRandomId(guildId) {
+                ChannelUpdate(
+                    DiscordChannel(
+                        id = randomId(),
+                        type = ChannelType.GuildText,
+                        guildId = it.optionalSnowflake(),
+                    ),
+                    0
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `Check onChannelDelete is called when event is received`() {
+        countdownContext(1) {
+            live.onChannelDelete {
+                assertEquals(guildId, it.channel.data.guildId.value)
+                count()
+            }
+
+            sendEventValidAndRandomId(guildId) {
+                ChannelDelete(
+                    DiscordChannel(
+                        id = randomId(),
+                        type = ChannelType.GuildText,
+                        guildId = it.optionalSnowflake(),
+                    ),
+                    0
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `Check onGuildUpdate is called when event is received`() {
+        countdownContext(1) {
+            live.onGuildUpdate {
+                assertEquals(guildId, it.guild.id)
+                count()
+            }
+
+            sendEventValidAndRandomId(guildId) {
+                GuildUpdate(
+                    DiscordGuild(
+                        id = it,
+                        name = "",
+                        icon = null,
+                        ownerId = randomId(),
+                        region = "",
+                        afkChannelId = null,
+                        afkTimeout = 0,
+                        verificationLevel = VerificationLevel.None,
+                        defaultMessageNotifications = DefaultMessageNotificationLevel.AllMessages,
+                        explicitContentFilter = ExplicitContentFilter.Disabled,
+                        roles = emptyList(),
+                        emojis = emptyList(),
+                        features = emptyList(),
+                        mfaLevel = MFALevel.None,
+                        applicationId = null,
+                        systemChannelId = null,
+                        systemChannelFlags = SystemChannelFlags(0),
+                        rulesChannelId = null,
+                        vanityUrlCode = null,
+                        description = null,
+                        banner = null,
+                        premiumTier = PremiumTier.None,
+                        preferredLocale = "",
+                        publicUpdatesChannelId = null
+                    ),
+                    0
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `Check onShutdown is called when event the guild delete event is received`() {
+        countdownContext(1) {
+            live.onShutdown {
+                count()
+            }
+
+            sendEventValidAndRandomIdCheckLiveActive(guildId) {
+                GuildDelete(
+                    DiscordUnavailableGuild(
+                        id = it,
+                    ),
+                    0
+                )
+            }
+        }
+    }
+}

--- a/core/src/test/kotlin/live/LiveGuildTest.kt
+++ b/core/src/test/kotlin/live/LiveGuildTest.kt
@@ -762,7 +762,7 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
     }
 
     @Test
-    fun `Check onShutdown is called when event the guild delete event is received`() {
+    fun `Check if live entity is completed when event the guild delete event is received`() {
         countdownContext(1) {
             live.coroutineContext.job.invokeOnCompletion {
                 count()

--- a/core/src/test/kotlin/live/LiveGuildTest.kt
+++ b/core/src/test/kotlin/live/LiveGuildTest.kt
@@ -7,7 +7,9 @@ import dev.kord.common.entity.optional.optionalSnowflake
 import dev.kord.core.cache.data.GuildData
 import dev.kord.core.entity.Guild
 import dev.kord.core.entity.ReactionEmoji
+import dev.kord.core.event.guild.GuildDeleteEvent
 import dev.kord.core.live.*
+import dev.kord.core.live.exception.LiveCancellationException
 import dev.kord.gateway.*
 import equality.randomId
 import kotlinx.coroutines.job
@@ -758,6 +760,9 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
     fun `Check if live entity is completed when event the guild delete event is received`() {
         countdownContext(1) {
             live.coroutineContext.job.invokeOnCompletion {
+                it as LiveCancellationException
+                val event = it.event as GuildDeleteEvent
+                assertEquals(guildId, event.guildId)
                 count()
             }
 

--- a/core/src/test/kotlin/live/LiveGuildTest.kt
+++ b/core/src/test/kotlin/live/LiveGuildTest.kt
@@ -10,6 +10,7 @@ import dev.kord.core.entity.ReactionEmoji
 import dev.kord.core.live.*
 import dev.kord.gateway.*
 import equality.randomId
+import kotlinx.coroutines.job
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.JsonObject
 import org.junit.jupiter.api.TestInstance
@@ -721,7 +722,7 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
     @Test
     fun `Check onShutdown is called when event the guild delete event is received`() {
         countdownContext(1) {
-            live.onShutdown {
+            live.coroutineContext.job.invokeOnCompletion {
                 count()
             }
 

--- a/core/src/test/kotlin/live/LiveKordEntityTest.kt
+++ b/core/src/test/kotlin/live/LiveKordEntityTest.kt
@@ -132,36 +132,28 @@ class LiveKordEntityTest : AbstractLiveEntityTest<LiveKordEntityTest.LiveEntityM
             // Without the delay, the success of the test is uncertain.
             delay(DELAY_TIME)
 
-            EventQueueManager(kord).apply {
-                add {
-                    val eventGuildBan = GuildBanAdd(
-                        DiscordGuildBan(
-                            guildId = guildId.asString,
-                            user = DiscordUser(
-                                id = randomId(),
-                                username = "",
-                                discriminator = "",
-                                avatar = null
-                            )
-                        ),
-                        0
+            val eventGuildBan = GuildBanAdd(
+                DiscordGuildBan(
+                    guildId = guildId.asString,
+                    user = DiscordUser(
+                        id = randomId(),
+                        username = "",
+                        discriminator = "",
+                        avatar = null
                     )
-                    sendEvent(eventGuildBan)
-                }
+                ),
+                0
+            )
+            sendEventAndWait(eventGuildBan)
 
-                add {
-                    val eventGuildDelete = GuildDelete(
-                        DiscordUnavailableGuild(
-                            id = guildId
-                        ),
-                        0
-                    )
+            val eventGuildDelete = GuildDelete(
+                DiscordUnavailableGuild(
+                    id = guildId
+                ),
+                0
+            )
 
-                    sendEvent(eventGuildDelete)
-                }
-
-                start()
-            }
+            sendEvent(eventGuildDelete)
         }
     }
 

--- a/core/src/test/kotlin/live/LiveKordEntityTest.kt
+++ b/core/src/test/kotlin/live/LiveKordEntityTest.kt
@@ -127,7 +127,7 @@ class LiveKordEntityTest : AbstractLiveEntityTest<LiveKordEntityTest.LiveEntityM
 
             // Wait that the 2 jobs are ready to listen the next events.
             // Without the delay, the success of the test is uncertain.
-            delay(50)
+            delay(DELAY_TIME)
 
             val eventGuildBan = GuildBanAdd(
                 DiscordGuildBan(

--- a/core/src/test/kotlin/live/LiveKordEntityTest.kt
+++ b/core/src/test/kotlin/live/LiveKordEntityTest.kt
@@ -51,7 +51,7 @@ class LiveKordEntityTest : AbstractLiveEntityTest<LiveKordEntityTest.LiveEntityM
     @Test
     fun `Shutdown entity cancel the lifecycle`() {
         assertTrue(live.isActive)
-        live.shutdown()
+        live.shutDown()
         assertFalse(live.isActive)
     }
 
@@ -60,7 +60,7 @@ class LiveKordEntityTest : AbstractLiveEntityTest<LiveKordEntityTest.LiveEntityM
         val job = live.on<Event> { }
         assertTrue(job.isActive)
 
-        live.shutdown()
+        live.shutDown()
         assertTrue(job.isCancelled)
         assertFalse(live.isActive)
     }
@@ -71,7 +71,7 @@ class LiveKordEntityTest : AbstractLiveEntityTest<LiveKordEntityTest.LiveEntityM
             live.onShutdown {
                 count()
             }
-            live.shutdown()
+            live.shutDown()
         }
     }
 
@@ -81,7 +81,7 @@ class LiveKordEntityTest : AbstractLiveEntityTest<LiveKordEntityTest.LiveEntityM
             error("Must not be executed")
         }
         live.onShutdown(null)
-        live.shutdown()
+        live.shutDown()
     }
 
     @Test
@@ -93,7 +93,7 @@ class LiveKordEntityTest : AbstractLiveEntityTest<LiveKordEntityTest.LiveEntityM
             live.onShutdown {
                 count()
             }
-            live.shutdown()
+            live.shutDown()
         }
     }
 
@@ -107,7 +107,7 @@ class LiveKordEntityTest : AbstractLiveEntityTest<LiveKordEntityTest.LiveEntityM
             live.onShutdown {
                 count()
             }
-            live.shutdown()
+            live.shutDown()
         }
     }
 

--- a/core/src/test/kotlin/live/LiveKordEntityTest.kt
+++ b/core/src/test/kotlin/live/LiveKordEntityTest.kt
@@ -66,7 +66,7 @@ class LiveKordEntityTest : AbstractLiveEntityTest<LiveKordEntityTest.LiveEntityM
     }
 
     @Test
-    fun `Children job are cancelled when the live entity is shutdown`() {
+    fun `Children job are cancelled when the live entity is shut down`() {
         val job = live.on<Event> { }
         assertTrue(job.isActive)
 

--- a/core/src/test/kotlin/live/LiveKordEntityTest.kt
+++ b/core/src/test/kotlin/live/LiveKordEntityTest.kt
@@ -1,0 +1,182 @@
+package live
+
+import dev.kord.common.annotation.KordPreview
+import dev.kord.common.entity.DiscordGuildBan
+import dev.kord.common.entity.DiscordUnavailableGuild
+import dev.kord.common.entity.DiscordUser
+import dev.kord.common.entity.Snowflake
+import dev.kord.core.Kord
+import dev.kord.core.event.Event
+import dev.kord.core.event.guild.BanAddEvent
+import dev.kord.core.event.guild.GuildDeleteEvent
+import dev.kord.core.live.AbstractLiveKordEntity
+import dev.kord.core.live.on
+import dev.kord.gateway.GuildBanAdd
+import dev.kord.gateway.GuildDelete
+import equality.randomId
+import kotlinx.coroutines.*
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.TestInstance
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@OptIn(KordPreview::class)
+class LiveKordEntityTest : AbstractLiveEntityTest<LiveKordEntityTest.LiveEntityMock>() {
+
+    @Disabled
+    inner class LiveEntityMock(override val kord: Kord) :
+        AbstractLiveKordEntity(Dispatchers.Default, kord.coroutineContext.job) {
+
+        var counter: CounterAtomicLatch? = null
+
+        override val id: Snowflake = randomId()
+
+        override fun filter(event: Event): Boolean = event is BanAddEvent
+
+        override fun update(event: Event) {
+            if (event is BanAddEvent) {
+                counter?.count()
+            }
+        }
+    }
+
+    @BeforeTest
+    fun onBefore() {
+        live = LiveEntityMock(kord)
+    }
+
+    @Test
+    fun `Shutdown entity cancel the lifecycle`() {
+        assertTrue(live.isActive)
+        live.shutdown()
+        assertFalse(live.isActive)
+    }
+
+    @Test
+    fun `Children job are cancelled when the live entity is shutdown`() {
+        val job = live.on<Event> { }
+        assertTrue(job.isActive)
+
+        live.shutdown()
+        assertTrue(job.isCancelled)
+        assertFalse(live.isActive)
+    }
+
+    @Test
+    fun `Shutdown entity without listening events`() {
+        countdownContext(1) {
+            live.onShutdown {
+                count()
+            }
+            live.shutdown()
+        }
+    }
+
+    @Test
+    fun `Replace the shutdown action with null value`() {
+        live.onShutdown {
+            error("Must not be executed")
+        }
+        live.onShutdown(null)
+        live.shutdown()
+    }
+
+    @Test
+    fun `Replace the shutdown action with another action`() {
+        live.onShutdown {
+            error("Must not be executed")
+        }
+        countdownContext(1) {
+            live.onShutdown {
+                count()
+            }
+            live.shutdown()
+        }
+    }
+
+    @Test
+    fun `Replace the shutdown action with null value and another action`() {
+        live.onShutdown {
+            error("Must not be executed")
+        }
+        live.onShutdown(null)
+        countdownContext(1) {
+            live.onShutdown {
+                count()
+            }
+            live.shutdown()
+        }
+    }
+
+    @Test
+    fun `Check if the filter and update are executed`() {
+        // Second countdown in the live entity to check
+        // if the method update is called
+        countdownContext(3) {
+            live.counter = this
+
+            live.on<BanAddEvent> {
+                count()
+            }
+
+            live.on<GuildDeleteEvent> {
+                error("Must not be executed")
+            }
+
+            // Wait that the 2 jobs are ready to listen the next events.
+            // Without the delay, the success of the test is uncertain.
+            delay(50)
+
+            val eventGuildBan = GuildBanAdd(
+                DiscordGuildBan(
+                    guildId = guildId.asString,
+                    user = DiscordUser(
+                        id = randomId(),
+                        username = "",
+                        discriminator = "",
+                        avatar = null
+                    )
+                ),
+                0
+            )
+
+            sendEventAndWait(eventGuildBan)
+
+            val eventGuildDelete = GuildDelete(
+                DiscordUnavailableGuild(
+                    id = guildId
+                ),
+                0
+            )
+
+            sendEvent(eventGuildDelete)
+        }
+    }
+
+    @Test
+    fun `Check the entity is cancelled when kord is cancelled`() = runBlocking {
+        val job = live.on<BanAddEvent> {
+            error("Never called")
+        }
+
+        live.onShutdown {
+            error("Never called")
+        }
+
+        assertTrue(kord.isActive)
+        assertTrue(live.isActive)
+        assertTrue(job.isActive)
+
+        kord.logout()
+        kord.shutdown()
+
+        assertFalse(kord.isActive)
+        assertFalse(live.isActive)
+        assertFalse(job.isActive)
+
+        kord = createKord()
+    }
+}

--- a/core/src/test/kotlin/live/LiveMemberTest.kt
+++ b/core/src/test/kotlin/live/LiveMemberTest.kt
@@ -106,7 +106,7 @@ class LiveMemberTest : AbstractLiveEntityTest<LiveMember>() {
     }
 
     @Test
-    fun `Check onShutdown is called when the member is banned`() {
+    fun `Check if live entity is completed when the member is banned`() {
         countdownContext(1) {
             live.coroutineContext.job.invokeOnCompletion {
                 count()
@@ -130,7 +130,7 @@ class LiveMemberTest : AbstractLiveEntityTest<LiveMember>() {
     }
 
     @Test
-    fun `Check onShutdown is called when the guild is deleted`() {
+    fun `Check if live entity is completed when the guild is deleted`() {
         countdownContext(1) {
             live.coroutineContext.job.invokeOnCompletion {
                 count()

--- a/core/src/test/kotlin/live/LiveMemberTest.kt
+++ b/core/src/test/kotlin/live/LiveMemberTest.kt
@@ -6,7 +6,11 @@ import dev.kord.common.entity.optional.Optional
 import dev.kord.core.cache.data.MemberData
 import dev.kord.core.cache.data.UserData
 import dev.kord.core.entity.Member
+import dev.kord.core.event.guild.BanAddEvent
+import dev.kord.core.event.guild.GuildDeleteEvent
+import dev.kord.core.event.guild.MemberLeaveEvent
 import dev.kord.core.live.LiveMember
+import dev.kord.core.live.exception.LiveCancellationException
 import dev.kord.core.live.onUpdate
 import dev.kord.gateway.GuildBanAdd
 import dev.kord.gateway.GuildDelete
@@ -88,6 +92,9 @@ class LiveMemberTest : AbstractLiveEntityTest<LiveMember>() {
     fun `Check onLeave is called when event is received`() {
         countdownContext(1) {
             live.coroutineContext.job.invokeOnCompletion {
+                it as LiveCancellationException
+                val event = it.event as MemberLeaveEvent
+                assertEquals(userId, event.user.id)
                 count()
             }
 
@@ -112,6 +119,9 @@ class LiveMemberTest : AbstractLiveEntityTest<LiveMember>() {
     fun `Check if live entity is completed when the member is banned`() {
         countdownContext(1) {
             live.coroutineContext.job.invokeOnCompletion {
+                it as LiveCancellationException
+                val event = it.event as BanAddEvent
+                assertEquals(userId, event.user.id)
                 count()
             }
 
@@ -136,6 +146,9 @@ class LiveMemberTest : AbstractLiveEntityTest<LiveMember>() {
     fun `Check if live entity is completed when the guild is deleted`() {
         countdownContext(1) {
             live.coroutineContext.job.invokeOnCompletion {
+                it as LiveCancellationException
+                val event = it.event as GuildDeleteEvent
+                assertEquals(guildId, event.guildId)
                 count()
             }
 

--- a/core/src/test/kotlin/live/LiveMemberTest.kt
+++ b/core/src/test/kotlin/live/LiveMemberTest.kt
@@ -17,12 +17,15 @@ import kotlinx.coroutines.job
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.Timeout
+import java.util.concurrent.TimeUnit
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @OptIn(KordPreview::class)
+@Timeout(value = 5, unit = TimeUnit.SECONDS)
 class LiveMemberTest : AbstractLiveEntityTest<LiveMember>() {
 
     private lateinit var userId: Snowflake

--- a/core/src/test/kotlin/live/LiveMemberTest.kt
+++ b/core/src/test/kotlin/live/LiveMemberTest.kt
@@ -13,6 +13,7 @@ import dev.kord.gateway.GuildDelete
 import dev.kord.gateway.GuildMemberRemove
 import dev.kord.gateway.GuildMemberUpdate
 import equality.randomId
+import kotlinx.coroutines.job
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.TestInstance
@@ -83,7 +84,7 @@ class LiveMemberTest : AbstractLiveEntityTest<LiveMember>() {
     @Test
     fun `Check onLeave is called when event is received`() {
         countdownContext(1) {
-            live.onShutdown {
+            live.coroutineContext.job.invokeOnCompletion {
                 count()
             }
 
@@ -107,7 +108,7 @@ class LiveMemberTest : AbstractLiveEntityTest<LiveMember>() {
     @Test
     fun `Check onShutdown is called when the member is banned`() {
         countdownContext(1) {
-            live.onShutdown {
+            live.coroutineContext.job.invokeOnCompletion {
                 count()
             }
 
@@ -131,7 +132,7 @@ class LiveMemberTest : AbstractLiveEntityTest<LiveMember>() {
     @Test
     fun `Check onShutdown is called when the guild is deleted`() {
         countdownContext(1) {
-            live.onShutdown {
+            live.coroutineContext.job.invokeOnCompletion {
                 count()
             }
 

--- a/core/src/test/kotlin/live/LiveMemberTest.kt
+++ b/core/src/test/kotlin/live/LiveMemberTest.kt
@@ -1,0 +1,148 @@
+package live
+
+import dev.kord.common.annotation.KordPreview
+import dev.kord.common.entity.*
+import dev.kord.common.entity.optional.Optional
+import dev.kord.core.cache.data.MemberData
+import dev.kord.core.cache.data.UserData
+import dev.kord.core.entity.Member
+import dev.kord.core.live.LiveMember
+import dev.kord.core.live.onUpdate
+import dev.kord.gateway.GuildBanAdd
+import dev.kord.gateway.GuildDelete
+import dev.kord.gateway.GuildMemberRemove
+import dev.kord.gateway.GuildMemberUpdate
+import equality.randomId
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@OptIn(KordPreview::class)
+class LiveMemberTest : AbstractLiveEntityTest<LiveMember>() {
+
+    private lateinit var userId: Snowflake
+
+    @BeforeAll
+    override fun onBeforeAll() {
+        super.onBeforeAll()
+        userId = randomId()
+    }
+
+    @BeforeTest
+    fun onBefore() = runBlocking {
+        live = LiveMember(
+            Member(
+                kord = kord,
+                memberData = MemberData(
+                    userId = userId,
+                    guildId = guildId,
+                    roles = emptyList(),
+                    joinedAt = "",
+                    premiumSince = Optional.Missing()
+                ),
+                userData = UserData(
+                    id = userId,
+                    username = "",
+                    discriminator = ""
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `Check onUpdate is called when event is received`() {
+        countdownContext(1) {
+            live.onUpdate {
+                assertEquals(userId, it.member.id)
+                count()
+            }
+
+            sendEventValidAndRandomId(userId) {
+                GuildMemberUpdate(
+                    DiscordUpdatedGuildMember(
+                        guildId = randomId(),
+                        roles = emptyList(),
+                        user = DiscordUser(
+                            id = it,
+                            username = "",
+                            discriminator = "",
+                            avatar = null
+                        ),
+                        joinedAt = ""
+                    ),
+                    0
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `Check onLeave is called when event is received`() {
+        countdownContext(1) {
+            live.onShutdown {
+                count()
+            }
+
+            sendEventValidAndRandomIdCheckLiveActive(userId) {
+                GuildMemberRemove(
+                    DiscordRemovedGuildMember(
+                        guildId = randomId(),
+                        user = DiscordUser(
+                            id = it,
+                            username = "",
+                            discriminator = "",
+                            avatar = null
+                        )
+                    ),
+                    0
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `Check onShutdown is called when the member is banned`() {
+        countdownContext(1) {
+            live.onShutdown {
+                count()
+            }
+
+            sendEventValidAndRandomIdCheckLiveActive(userId) {
+                GuildBanAdd(
+                    DiscordGuildBan(
+                        guildId = randomId().asString,
+                        user = DiscordUser(
+                            id = it,
+                            username = "",
+                            discriminator = "",
+                            avatar = null
+                        )
+                    ),
+                    0
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `Check onShutdown is called when the guild is deleted`() {
+        countdownContext(1) {
+            live.onShutdown {
+                count()
+            }
+
+            sendEventValidAndRandomIdCheckLiveActive(guildId) {
+                GuildDelete(
+                    DiscordUnavailableGuild(
+                        id = it
+                    ),
+                    0
+                )
+            }
+        }
+    }
+}

--- a/core/src/test/kotlin/live/LiveMessageTest.kt
+++ b/core/src/test/kotlin/live/LiveMessageTest.kt
@@ -111,18 +111,9 @@ class LiveMessageTest : AbstractLiveEntityTest<LiveMessage>() {
                 0
             )
 
-            EventQueueManager(kord).apply {
-                add {
-                    sendEvent(createEvent(randomId(), emojiExpected))
-                }
-                add {
-                    sendEvent(createEvent(messageId, emojiOther))
-                }
-                add {
-                    sendEvent(createEvent(messageId, emojiExpected))
-                }
-                start()
-            }
+            sendEventAndWait(createEvent(randomId(), emojiExpected))
+            sendEventAndWait(createEvent(messageId, emojiOther))
+            sendEvent(createEvent(messageId, emojiExpected))
         }
     }
 
@@ -173,18 +164,9 @@ class LiveMessageTest : AbstractLiveEntityTest<LiveMessage>() {
                 0
             )
 
-            EventQueueManager(kord).apply {
-                add {
-                    sendEvent(createEvent(randomId(), emojiExpected))
-                }
-                add {
-                    sendEvent(createEvent(messageId, emojiOther))
-                }
-                add {
-                    sendEvent(createEvent(messageId, emojiExpected))
-                }
-                start()
-            }
+            sendEvent(createEvent(randomId(), emojiExpected))
+            sendEvent(createEvent(messageId, emojiOther))
+            sendEvent(createEvent(messageId, emojiExpected))
         }
     }
 

--- a/core/src/test/kotlin/live/LiveMessageTest.kt
+++ b/core/src/test/kotlin/live/LiveMessageTest.kt
@@ -13,12 +13,15 @@ import kotlinx.coroutines.job
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.Timeout
+import java.util.concurrent.TimeUnit
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @OptIn(KordPreview::class)
+@Timeout(value = 5, unit = TimeUnit.SECONDS)
 class LiveMessageTest : AbstractLiveEntityTest<LiveMessage>() {
 
     private lateinit var messageId: Snowflake
@@ -108,14 +111,18 @@ class LiveMessageTest : AbstractLiveEntityTest<LiveMessage>() {
                 0
             )
 
-            val eventRandomId = createEvent(randomId(), emojiExpected)
-            sendEventAndWait(eventRandomId)
-
-            val eventOtherReaction = createEvent(messageId, emojiOther)
-            sendEventAndWait(eventOtherReaction)
-
-            val event = createEvent(messageId, emojiExpected)
-            sendEvent(event)
+            EventQueueManager(kord).apply {
+                add {
+                    sendEvent(createEvent(randomId(), emojiExpected))
+                }
+                add {
+                    sendEvent(createEvent(messageId, emojiOther))
+                }
+                add {
+                    sendEvent(createEvent(messageId, emojiExpected))
+                }
+                start()
+            }
         }
     }
 
@@ -166,14 +173,18 @@ class LiveMessageTest : AbstractLiveEntityTest<LiveMessage>() {
                 0
             )
 
-            val eventRandomId = createEvent(randomId(), emojiExpected)
-            sendEventAndWait(eventRandomId)
-
-            val eventOtherReaction = createEvent(messageId, emojiOther)
-            sendEventAndWait(eventOtherReaction)
-
-            val event = createEvent(messageId, emojiExpected)
-            sendEvent(event)
+            EventQueueManager(kord).apply {
+                add {
+                    sendEvent(createEvent(randomId(), emojiExpected))
+                }
+                add {
+                    sendEvent(createEvent(messageId, emojiOther))
+                }
+                add {
+                    sendEvent(createEvent(messageId, emojiExpected))
+                }
+                start()
+            }
         }
     }
 

--- a/core/src/test/kotlin/live/LiveMessageTest.kt
+++ b/core/src/test/kotlin/live/LiveMessageTest.kt
@@ -6,7 +6,13 @@ import dev.kord.core.cache.data.MessageData
 import dev.kord.core.cache.data.UserData
 import dev.kord.core.entity.Message
 import dev.kord.core.entity.ReactionEmoji
+import dev.kord.core.event.channel.ChannelDeleteEvent
+import dev.kord.core.event.guild.GuildDeleteEvent
+import dev.kord.core.event.message.MessageBulkDeleteEvent
+import dev.kord.core.event.message.MessageDeleteEvent
+import dev.kord.core.event.role.RoleDeleteEvent
 import dev.kord.core.live.*
+import dev.kord.core.live.exception.LiveCancellationException
 import dev.kord.gateway.*
 import equality.randomId
 import kotlinx.coroutines.job
@@ -18,6 +24,7 @@ import java.util.concurrent.TimeUnit
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @OptIn(KordPreview::class)
@@ -214,6 +221,9 @@ class LiveMessageTest : AbstractLiveEntityTest<LiveMessage>() {
     fun `Check if live entity is completed when event the message delete event is received`() {
         countdownContext(1) {
             live.coroutineContext.job.invokeOnCompletion {
+                it as LiveCancellationException
+                val event = it.event as MessageDeleteEvent
+                assertEquals(messageId, event.messageId)
                 count()
             }
 
@@ -233,6 +243,9 @@ class LiveMessageTest : AbstractLiveEntityTest<LiveMessage>() {
     fun `Check if live entity is completed when event the bulk delete event is received`() {
         countdownContext(1) {
             live.coroutineContext.job.invokeOnCompletion {
+                it as LiveCancellationException
+                val event = it.event as MessageBulkDeleteEvent
+                assertTrue { messageId in event.messageIds }
                 count()
             }
 
@@ -252,6 +265,9 @@ class LiveMessageTest : AbstractLiveEntityTest<LiveMessage>() {
     fun `Check if live entity is completed when event the channel delete event is received`() {
         countdownContext(1) {
             live.coroutineContext.job.invokeOnCompletion {
+                it as LiveCancellationException
+                val event = it.event as ChannelDeleteEvent
+                assertEquals(channelId, event.channel.id)
                 count()
             }
 
@@ -271,6 +287,9 @@ class LiveMessageTest : AbstractLiveEntityTest<LiveMessage>() {
     fun `Check if live entity is completed when event the guild delete event is received`() {
         countdownContext(1) {
             live.coroutineContext.job.invokeOnCompletion {
+                it as LiveCancellationException
+                val event = it.event as GuildDeleteEvent
+                assertEquals(guildId, event.guildId)
                 count()
             }
 

--- a/core/src/test/kotlin/live/LiveMessageTest.kt
+++ b/core/src/test/kotlin/live/LiveMessageTest.kt
@@ -9,6 +9,7 @@ import dev.kord.core.entity.ReactionEmoji
 import dev.kord.core.live.*
 import dev.kord.gateway.*
 import equality.randomId
+import kotlinx.coroutines.job
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.TestInstance
@@ -219,7 +220,7 @@ class LiveMessageTest : AbstractLiveEntityTest<LiveMessage>() {
     @Test
     fun `Check onShutdown is called when event the message delete event is received`() {
         countdownContext(1) {
-            live.onShutdown {
+            live.coroutineContext.job.invokeOnCompletion {
                 count()
             }
 
@@ -238,7 +239,7 @@ class LiveMessageTest : AbstractLiveEntityTest<LiveMessage>() {
     @Test
     fun `Check onShutdown is called when event the bulk delete event is received`() {
         countdownContext(1) {
-            live.onShutdown {
+            live.coroutineContext.job.invokeOnCompletion {
                 count()
             }
 
@@ -257,7 +258,7 @@ class LiveMessageTest : AbstractLiveEntityTest<LiveMessage>() {
     @Test
     fun `Check onShutdown is called when event the channel delete event is received`() {
         countdownContext(1) {
-            live.onShutdown {
+            live.coroutineContext.job.invokeOnCompletion {
                 count()
             }
 
@@ -276,7 +277,7 @@ class LiveMessageTest : AbstractLiveEntityTest<LiveMessage>() {
     @Test
     fun `Check onShutdown is called when event the guild delete event is received`() {
         countdownContext(1) {
-            live.onShutdown {
+            live.coroutineContext.job.invokeOnCompletion {
                 count()
             }
 

--- a/core/src/test/kotlin/live/LiveMessageTest.kt
+++ b/core/src/test/kotlin/live/LiveMessageTest.kt
@@ -218,7 +218,7 @@ class LiveMessageTest : AbstractLiveEntityTest<LiveMessage>() {
     }
 
     @Test
-    fun `Check onShutdown is called when event the message delete event is received`() {
+    fun `Check if live entity is completed when event the message delete event is received`() {
         countdownContext(1) {
             live.coroutineContext.job.invokeOnCompletion {
                 count()
@@ -237,7 +237,7 @@ class LiveMessageTest : AbstractLiveEntityTest<LiveMessage>() {
     }
 
     @Test
-    fun `Check onShutdown is called when event the bulk delete event is received`() {
+    fun `Check if live entity is completed when event the bulk delete event is received`() {
         countdownContext(1) {
             live.coroutineContext.job.invokeOnCompletion {
                 count()
@@ -256,7 +256,7 @@ class LiveMessageTest : AbstractLiveEntityTest<LiveMessage>() {
     }
 
     @Test
-    fun `Check onShutdown is called when event the channel delete event is received`() {
+    fun `Check if live entity is completed when event the channel delete event is received`() {
         countdownContext(1) {
             live.coroutineContext.job.invokeOnCompletion {
                 count()
@@ -275,7 +275,7 @@ class LiveMessageTest : AbstractLiveEntityTest<LiveMessage>() {
     }
 
     @Test
-    fun `Check onShutdown is called when event the guild delete event is received`() {
+    fun `Check if live entity is completed when event the guild delete event is received`() {
         countdownContext(1) {
             live.coroutineContext.job.invokeOnCompletion {
                 count()

--- a/core/src/test/kotlin/live/LiveMessageTest.kt
+++ b/core/src/test/kotlin/live/LiveMessageTest.kt
@@ -1,0 +1,293 @@
+package live
+
+import dev.kord.common.annotation.KordPreview
+import dev.kord.common.entity.*
+import dev.kord.core.cache.data.MessageData
+import dev.kord.core.cache.data.UserData
+import dev.kord.core.entity.Message
+import dev.kord.core.entity.ReactionEmoji
+import dev.kord.core.live.*
+import dev.kord.gateway.*
+import equality.randomId
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@OptIn(KordPreview::class)
+class LiveMessageTest : AbstractLiveEntityTest<LiveMessage>() {
+
+    private lateinit var messageId: Snowflake
+
+    private lateinit var channelId: Snowflake
+
+    @BeforeAll
+    override fun onBeforeAll() {
+        super.onBeforeAll()
+        messageId = randomId()
+        channelId = randomId()
+    }
+
+    @BeforeTest
+    fun onBefore() = runBlocking {
+        live = LiveMessage(
+            guildId = guildId,
+            message = Message(
+                kord = kord,
+                data = MessageData(
+                    id = messageId,
+                    channelId = channelId,
+                    author = UserData(
+                        id = randomId(),
+                        username = "",
+                        discriminator = ""
+                    ),
+                    content = "",
+                    timestamp = "",
+                    tts = false,
+                    mentionEveryone = false,
+                    mentions = emptyList(),
+                    mentionRoles = emptyList(),
+                    attachments = emptyList(),
+                    embeds = emptyList(),
+                    pinned = false,
+                    type = MessageType.Default
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `Check onReactionAdd is called when event is received`() {
+        countdownContext(1) {
+            val emojiExpected = ReactionEmoji.Unicode("\uD83D\uDC28")
+
+            live.onReactionAdd {
+                assertEquals(messageId, it.messageId)
+                assertEquals(emojiExpected, it.emoji)
+                count()
+            }
+
+            sendEventValidAndRandomId(messageId) {
+                MessageReactionAdd(
+                    MessageReactionAddData(
+                        messageId = it,
+                        channelId = randomId(),
+                        userId = randomId(),
+                        emoji = DiscordPartialEmoji(null, emojiExpected.name)
+                    ),
+                    0
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `Check onReactionAdd with specific reaction is called when event is received`() {
+        countdownContext(1) {
+            val emojiExpected = ReactionEmoji.Unicode("\uD83D\uDC28")
+            val emojiOther = ReactionEmoji.Unicode("\uD83D\uDC3B")
+
+            live.onReactionAdd(emojiExpected) {
+                assertEquals(messageId, it.messageId)
+                assertEquals(emojiExpected, it.emoji)
+                count()
+            }
+
+            fun createEvent(messageId: Snowflake, emoji: ReactionEmoji) = MessageReactionAdd(
+                MessageReactionAddData(
+                    messageId = messageId,
+                    channelId = randomId(),
+                    userId = randomId(),
+                    emoji = DiscordPartialEmoji(null, emoji.name)
+                ),
+                0
+            )
+
+            val eventRandomId = createEvent(randomId(), emojiExpected)
+            sendEventAndWait(eventRandomId)
+
+            val eventOtherReaction = createEvent(messageId, emojiOther)
+            sendEventAndWait(eventOtherReaction)
+
+            val event = createEvent(messageId, emojiExpected)
+            sendEvent(event)
+        }
+    }
+
+    @Test
+    fun `Check onReactionRemove is called when event is received`() {
+        countdownContext(1) {
+            val emojiExpected = ReactionEmoji.Unicode("\uD83D\uDC28")
+
+            live.onReactionRemove {
+                assertEquals(messageId, it.messageId)
+                assertEquals(emojiExpected, it.emoji)
+                count()
+            }
+
+            sendEventValidAndRandomId(messageId) {
+                MessageReactionRemove(
+                    MessageReactionRemoveData(
+                        messageId = it,
+                        channelId = randomId(),
+                        userId = randomId(),
+                        emoji = DiscordPartialEmoji(null, emojiExpected.name)
+                    ),
+                    0
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `Check onReactionRemove with specific reaction is called when event is received`() {
+        countdownContext(1) {
+            val emojiExpected = ReactionEmoji.Unicode("\uD83D\uDC28")
+            val emojiOther = ReactionEmoji.Unicode("\uD83D\uDC3B")
+
+            live.onReactionRemove(emojiExpected) {
+                assertEquals(messageId, it.messageId)
+                assertEquals(emojiExpected, it.emoji)
+                count()
+            }
+
+            fun createEvent(messageId: Snowflake, emoji: ReactionEmoji) = MessageReactionRemove(
+                MessageReactionRemoveData(
+                    messageId = messageId,
+                    channelId = randomId(),
+                    userId = randomId(),
+                    emoji = DiscordPartialEmoji(null, emoji.name)
+                ),
+                0
+            )
+
+            val eventRandomId = createEvent(randomId(), emojiExpected)
+            sendEventAndWait(eventRandomId)
+
+            val eventOtherReaction = createEvent(messageId, emojiOther)
+            sendEventAndWait(eventOtherReaction)
+
+            val event = createEvent(messageId, emojiExpected)
+            sendEvent(event)
+        }
+    }
+
+    @Test
+    fun `Check onReactionRemoveAll is called when event is received`() {
+        countdownContext(1) {
+            live.onReactionRemoveAll {
+                assertEquals(messageId, it.messageId)
+                count()
+            }
+
+            sendEventValidAndRandomId(messageId) {
+                MessageReactionRemoveAll(
+                    AllRemovedMessageReactions(
+                        channelId = randomId(),
+                        messageId = it,
+                    ),
+                    0
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `Check onUpdate is called when event is received`() {
+        countdownContext(1) {
+            live.onUpdate {
+                assertEquals(messageId, it.messageId)
+                count()
+            }
+
+            sendEventValidAndRandomId(messageId) {
+                MessageUpdate(
+                    DiscordPartialMessage(
+                        id = it,
+                        channelId = randomId()
+                    ),
+                    0
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `Check onShutdown is called when event the message delete event is received`() {
+        countdownContext(1) {
+            live.onShutdown {
+                count()
+            }
+
+            sendEventValidAndRandomIdCheckLiveActive(messageId) {
+                MessageDelete(
+                    DeletedMessage(
+                        id = it,
+                        channelId = randomId()
+                    ),
+                    0
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `Check onShutdown is called when event the bulk delete event is received`() {
+        countdownContext(1) {
+            live.onShutdown {
+                count()
+            }
+
+            sendEventValidAndRandomIdCheckLiveActive(messageId) {
+                MessageDeleteBulk(
+                    BulkDeleteData(
+                        ids = mutableListOf(it),
+                        channelId = randomId()
+                    ),
+                    0
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `Check onShutdown is called when event the channel delete event is received`() {
+        countdownContext(1) {
+            live.onShutdown {
+                count()
+            }
+
+            sendEventValidAndRandomIdCheckLiveActive(channelId) {
+                ChannelDelete(
+                    DiscordChannel(
+                        id = it,
+                        type = ChannelType.GuildText
+                    ),
+                    0
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `Check onShutdown is called when event the guild delete event is received`() {
+        countdownContext(1) {
+            live.onShutdown {
+                count()
+            }
+
+            sendEventValidAndRandomIdCheckLiveActive(guildId) {
+                GuildDelete(
+                    DiscordUnavailableGuild(
+                        id = it
+                    ),
+                    0
+                )
+            }
+        }
+    }
+}

--- a/core/src/test/kotlin/live/LiveRoleTest.kt
+++ b/core/src/test/kotlin/live/LiveRoleTest.kt
@@ -10,6 +10,7 @@ import dev.kord.gateway.GuildDelete
 import dev.kord.gateway.GuildRoleDelete
 import dev.kord.gateway.GuildRoleUpdate
 import equality.randomId
+import kotlinx.coroutines.job
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.TestInstance
 import kotlin.test.BeforeTest
@@ -80,7 +81,7 @@ class LiveRoleTest : AbstractLiveEntityTest<LiveRole>() {
     @Test
     fun `Check onShutdown is called when the role is deleted`() {
         countdownContext(1) {
-            live.onShutdown {
+            live.coroutineContext.job.invokeOnCompletion {
                 count()
             }
 
@@ -99,7 +100,7 @@ class LiveRoleTest : AbstractLiveEntityTest<LiveRole>() {
     @Test
     fun `Check onShutdown is called when the guild is deleted`() {
         countdownContext(1) {
-            live.onShutdown {
+            live.coroutineContext.job.invokeOnCompletion {
                 count()
             }
 

--- a/core/src/test/kotlin/live/LiveRoleTest.kt
+++ b/core/src/test/kotlin/live/LiveRoleTest.kt
@@ -1,0 +1,116 @@
+package live
+
+import dev.kord.common.annotation.KordPreview
+import dev.kord.common.entity.*
+import dev.kord.core.cache.data.RoleData
+import dev.kord.core.entity.Role
+import dev.kord.core.live.LiveRole
+import dev.kord.core.live.onUpdate
+import dev.kord.gateway.GuildDelete
+import dev.kord.gateway.GuildRoleDelete
+import dev.kord.gateway.GuildRoleUpdate
+import equality.randomId
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@OptIn(KordPreview::class)
+class LiveRoleTest : AbstractLiveEntityTest<LiveRole>() {
+
+    private lateinit var roleId: Snowflake
+
+    @BeforeAll
+    override fun onBeforeAll() {
+        super.onBeforeAll()
+        roleId = randomId()
+    }
+
+    @BeforeTest
+    fun onBefore() {
+        live = LiveRole(
+            Role(
+                kord = kord,
+                data = RoleData(
+                    id = roleId,
+                    guildId = guildId,
+                    name = "test",
+                    color = 0,
+                    hoisted = false,
+                    position = 0,
+                    permissions = Permissions(Permission.CreateInstantInvite),
+                    managed = false,
+                    mentionable = false
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `Check onUpdate is called when event is received`() {
+        countdownContext(1) {
+            live.onUpdate {
+                assertEquals(roleId, it.role.id)
+                count()
+            }
+
+            sendEventValidAndRandomId(roleId) {
+                GuildRoleUpdate(
+                    DiscordGuildRole(
+                        guildId = randomId(),
+                        role = DiscordRole(
+                            id = it,
+                            name = "",
+                            color = 0,
+                            hoist = false,
+                            position = 0,
+                            permissions = Permissions(Permission.BanMembers),
+                            managed = false,
+                            mentionable = false
+                        )
+                    ),
+                    0
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `Check onShutdown is called when the role is deleted`() {
+        countdownContext(1) {
+            live.onShutdown {
+                count()
+            }
+
+            sendEventValidAndRandomIdCheckLiveActive(roleId) {
+                GuildRoleDelete(
+                    DiscordDeletedGuildRole(
+                        guildId = randomId(),
+                        id = it
+                    ),
+                    0
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `Check onShutdown is called when the guild is deleted`() {
+        countdownContext(1) {
+            live.onShutdown {
+                count()
+            }
+
+            sendEventValidAndRandomIdCheckLiveActive(guildId) {
+                GuildDelete(
+                    DiscordUnavailableGuild(
+                        id = it
+                    ),
+                    0
+                )
+            }
+        }
+    }
+}

--- a/core/src/test/kotlin/live/LiveRoleTest.kt
+++ b/core/src/test/kotlin/live/LiveRoleTest.kt
@@ -79,7 +79,7 @@ class LiveRoleTest : AbstractLiveEntityTest<LiveRole>() {
     }
 
     @Test
-    fun `Check onShutdown is called when the role is deleted`() {
+    fun `Check if live entity is completed when the role is deleted`() {
         countdownContext(1) {
             live.coroutineContext.job.invokeOnCompletion {
                 count()
@@ -98,7 +98,7 @@ class LiveRoleTest : AbstractLiveEntityTest<LiveRole>() {
     }
 
     @Test
-    fun `Check onShutdown is called when the guild is deleted`() {
+    fun `Check if live entity is completed when the guild is deleted`() {
         countdownContext(1) {
             live.coroutineContext.job.invokeOnCompletion {
                 count()

--- a/core/src/test/kotlin/live/LiveRoleTest.kt
+++ b/core/src/test/kotlin/live/LiveRoleTest.kt
@@ -4,7 +4,10 @@ import dev.kord.common.annotation.KordPreview
 import dev.kord.common.entity.*
 import dev.kord.core.cache.data.RoleData
 import dev.kord.core.entity.Role
+import dev.kord.core.event.guild.GuildDeleteEvent
+import dev.kord.core.event.role.RoleDeleteEvent
 import dev.kord.core.live.LiveRole
+import dev.kord.core.live.exception.LiveCancellationException
 import dev.kord.core.live.onUpdate
 import dev.kord.gateway.GuildDelete
 import dev.kord.gateway.GuildRoleDelete
@@ -85,6 +88,9 @@ class LiveRoleTest : AbstractLiveEntityTest<LiveRole>() {
     fun `Check if live entity is completed when the role is deleted`() {
         countdownContext(1) {
             live.coroutineContext.job.invokeOnCompletion {
+                it as LiveCancellationException
+                val event = it.event as RoleDeleteEvent
+                assertEquals(roleId, event.roleId)
                 count()
             }
 
@@ -104,6 +110,9 @@ class LiveRoleTest : AbstractLiveEntityTest<LiveRole>() {
     fun `Check if live entity is completed when the guild is deleted`() {
         countdownContext(1) {
             live.coroutineContext.job.invokeOnCompletion {
+                it as LiveCancellationException
+                val event = it.event as GuildDeleteEvent
+                assertEquals(guildId, event.guildId)
                 count()
             }
 

--- a/core/src/test/kotlin/live/LiveRoleTest.kt
+++ b/core/src/test/kotlin/live/LiveRoleTest.kt
@@ -13,12 +13,15 @@ import equality.randomId
 import kotlinx.coroutines.job
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.Timeout
+import java.util.concurrent.TimeUnit
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @OptIn(KordPreview::class)
+@Timeout(value = 5, unit = TimeUnit.SECONDS)
 class LiveRoleTest : AbstractLiveEntityTest<LiveRole>() {
 
     private lateinit var roleId: Snowflake

--- a/core/src/test/kotlin/live/LiveUserTest.kt
+++ b/core/src/test/kotlin/live/LiveUserTest.kt
@@ -12,12 +12,15 @@ import equality.randomId
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.Timeout
+import java.util.concurrent.TimeUnit
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @OptIn(KordPreview::class)
+@Timeout(value = 5, unit = TimeUnit.SECONDS)
 class LiveUserTest : AbstractLiveEntityTest<LiveUser>() {
 
     private lateinit var userId: Snowflake

--- a/core/src/test/kotlin/live/LiveUserTest.kt
+++ b/core/src/test/kotlin/live/LiveUserTest.kt
@@ -1,0 +1,66 @@
+package live
+
+import dev.kord.common.annotation.KordPreview
+import dev.kord.common.entity.DiscordUser
+import dev.kord.common.entity.Snowflake
+import dev.kord.core.cache.data.UserData
+import dev.kord.core.entity.User
+import dev.kord.core.live.LiveUser
+import dev.kord.core.live.onUpdate
+import dev.kord.gateway.UserUpdate
+import equality.randomId
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@OptIn(KordPreview::class)
+class LiveUserTest : AbstractLiveEntityTest<LiveUser>() {
+
+    private lateinit var userId: Snowflake
+
+    @BeforeAll
+    override fun onBeforeAll() {
+        super.onBeforeAll()
+        userId = randomId()
+    }
+
+    @BeforeTest
+    fun onBefore() = runBlocking {
+        live = LiveUser(
+            user = User(
+                kord = kord,
+                data = UserData(
+                    id = userId,
+                    username = "",
+                    discriminator = ""
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `Check onUpdate is called when event is received`() {
+        countdownContext(1) {
+            live.onUpdate {
+                assertEquals(it.user.id, userId)
+                count()
+            }
+
+            sendEventValidAndRandomId(userId) {
+                UserUpdate(
+                    DiscordUser(
+                        id = it,
+                        username = "",
+                        discriminator = "",
+                        avatar = null
+                    ),
+                    0
+                )
+            }
+        }
+    }
+}

--- a/core/src/test/kotlin/live/channel/LiveCategoryTest.kt
+++ b/core/src/test/kotlin/live/channel/LiveCategoryTest.kt
@@ -1,0 +1,66 @@
+package live.channel
+
+import dev.kord.common.annotation.KordPreview
+import dev.kord.common.entity.ChannelType
+import dev.kord.common.entity.DiscordChannel
+import dev.kord.common.entity.Snowflake
+import dev.kord.common.entity.optional.optionalSnowflake
+import dev.kord.core.cache.data.ChannelData
+import dev.kord.core.entity.channel.Category
+import dev.kord.core.live.channel.LiveCategory
+import dev.kord.core.live.channel.onUpdate
+import dev.kord.gateway.ChannelUpdate
+import equality.randomId
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@OptIn(KordPreview::class)
+class LiveCategoryTest : LiveChannelTest<LiveCategory>() {
+
+    override lateinit var channelId: Snowflake
+
+    @BeforeAll
+    override fun onBeforeAll() {
+        super.onBeforeAll()
+        channelId = randomId()
+    }
+
+    @BeforeTest
+    fun onBefore() = runBlocking {
+        live = LiveCategory(
+            Category(
+                kord = kord,
+                data = ChannelData(
+                    id = channelId,
+                    type = ChannelType.GuildCategory,
+                    guildId = guildId.optionalSnowflake()
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `Check onUpdate is called when event is received`() {
+        countdownContext(1) {
+            live.onUpdate {
+                assertEquals(it.channel.id, channelId)
+                count()
+            }
+
+            sendEventValidAndRandomId(channelId) {
+                ChannelUpdate(
+                    DiscordChannel(
+                        id = it,
+                        type = ChannelType.GuildCategory,
+                    ),
+                    0
+                )
+            }
+        }
+    }
+}

--- a/core/src/test/kotlin/live/channel/LiveCategoryTest.kt
+++ b/core/src/test/kotlin/live/channel/LiveCategoryTest.kt
@@ -14,12 +14,15 @@ import equality.randomId
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.Timeout
+import java.util.concurrent.TimeUnit
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @OptIn(KordPreview::class)
+@Timeout(value = 5, unit = TimeUnit.SECONDS)
 class LiveCategoryTest : LiveChannelTest<LiveCategory>() {
 
     override lateinit var channelId: Snowflake

--- a/core/src/test/kotlin/live/channel/LiveChannelTest.kt
+++ b/core/src/test/kotlin/live/channel/LiveChannelTest.kt
@@ -11,6 +11,7 @@ import dev.kord.core.live.channel.*
 import dev.kord.gateway.ChannelDelete
 import dev.kord.gateway.GuildDelete
 import equality.randomId
+import kotlinx.coroutines.job
 import kotlinx.coroutines.runBlocking
 import live.AbstractLiveEntityTest
 import org.junit.jupiter.api.TestInstance
@@ -45,7 +46,7 @@ abstract class LiveChannelTest<LIVE : LiveChannel> : AbstractLiveEntityTest<LIVE
     @Test
     fun `Check onShutdown is called when event the category delete event is received`() {
         countdownContext(1) {
-            live.onShutdown {
+            live.coroutineContext.job.invokeOnCompletion {
                 count()
             }
 
@@ -64,7 +65,7 @@ abstract class LiveChannelTest<LIVE : LiveChannel> : AbstractLiveEntityTest<LIVE
     @Test
     fun `Check onShutdown is called when event the guild delete event is received`() {
         countdownContext(1) {
-            live.onShutdown {
+            live.coroutineContext.job.invokeOnCompletion {
                 count()
             }
 

--- a/core/src/test/kotlin/live/channel/LiveChannelTest.kt
+++ b/core/src/test/kotlin/live/channel/LiveChannelTest.kt
@@ -1,0 +1,81 @@
+package live.channel
+
+import dev.kord.common.annotation.KordPreview
+import dev.kord.common.entity.ChannelType
+import dev.kord.common.entity.DiscordChannel
+import dev.kord.common.entity.DiscordUnavailableGuild
+import dev.kord.common.entity.Snowflake
+import dev.kord.core.cache.data.ChannelData
+import dev.kord.core.entity.channel.*
+import dev.kord.core.live.channel.*
+import dev.kord.gateway.ChannelDelete
+import dev.kord.gateway.GuildDelete
+import equality.randomId
+import kotlinx.coroutines.runBlocking
+import live.AbstractLiveEntityTest
+import org.junit.jupiter.api.TestInstance
+import kotlin.reflect.KClass
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@OptIn(KordPreview::class)
+abstract class LiveChannelTest<LIVE : LiveChannel> : AbstractLiveEntityTest<LIVE>() {
+
+    protected abstract val channelId: Snowflake
+
+    @Test
+    fun `Check type of live entity corresponds to the channel type`() = runBlocking {
+        val data = ChannelData(
+            id = randomId(),
+            type = ChannelType.DM
+        )
+
+        fun checkLiveEntityType(expectedType: KClass<*>, channel: Channel) {
+            assertEquals(expectedType, channel.live()::class)
+        }
+
+        checkLiveEntityType(LiveDmChannel::class, DmChannel(kord = kord, data = data))
+        checkLiveEntityType(LiveGuildMessageChannel::class, NewsChannel(kord = kord, data = data))
+        checkLiveEntityType(LiveGuildChannel::class, StoreChannel(kord = kord, data = data))
+        checkLiveEntityType(LiveGuildMessageChannel::class, TextChannel(kord = kord, data = data))
+        checkLiveEntityType(LiveVoiceChannel::class, VoiceChannel(kord = kord, data = data))
+    }
+
+    @Test
+    fun `Check onShutdown is called when event the category delete event is received`() {
+        countdownContext(1) {
+            live.onShutdown {
+                count()
+            }
+
+            sendEventValidAndRandomId(channelId) {
+                ChannelDelete(
+                    DiscordChannel(
+                        id = it,
+                        type = live.channel.type,
+                    ),
+                    0
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `Check onShutdown is called when event the guild delete event is received`() {
+        countdownContext(1) {
+            live.onShutdown {
+                count()
+            }
+
+            sendEventValidAndRandomIdCheckLiveActive(guildId) {
+                GuildDelete(
+                    DiscordUnavailableGuild(
+                        id = it
+                    ),
+                    0
+                )
+            }
+        }
+    }
+}

--- a/core/src/test/kotlin/live/channel/LiveChannelTest.kt
+++ b/core/src/test/kotlin/live/channel/LiveChannelTest.kt
@@ -7,7 +7,10 @@ import dev.kord.common.entity.DiscordUnavailableGuild
 import dev.kord.common.entity.Snowflake
 import dev.kord.core.cache.data.ChannelData
 import dev.kord.core.entity.channel.*
+import dev.kord.core.event.channel.ChannelDeleteEvent
+import dev.kord.core.event.guild.GuildDeleteEvent
 import dev.kord.core.live.channel.*
+import dev.kord.core.live.exception.LiveCancellationException
 import dev.kord.gateway.ChannelDelete
 import dev.kord.gateway.GuildDelete
 import equality.randomId
@@ -50,6 +53,9 @@ abstract class LiveChannelTest<LIVE : LiveChannel> : AbstractLiveEntityTest<LIVE
     fun `Check if live entity is completed when event the category delete event is received`() {
         countdownContext(1) {
             live.coroutineContext.job.invokeOnCompletion {
+                it as LiveCancellationException
+                val event = it.event as ChannelDeleteEvent
+                assertEquals(channelId, event.channel.id)
                 count()
             }
 
@@ -69,6 +75,9 @@ abstract class LiveChannelTest<LIVE : LiveChannel> : AbstractLiveEntityTest<LIVE
     fun `Check if live entity is completed when event the guild delete event is received`() {
         countdownContext(1) {
             live.coroutineContext.job.invokeOnCompletion {
+                it as LiveCancellationException
+                val event = it.event as GuildDeleteEvent
+                assertEquals(guildId, event.guildId)
                 count()
             }
 

--- a/core/src/test/kotlin/live/channel/LiveChannelTest.kt
+++ b/core/src/test/kotlin/live/channel/LiveChannelTest.kt
@@ -15,12 +15,15 @@ import kotlinx.coroutines.job
 import kotlinx.coroutines.runBlocking
 import live.AbstractLiveEntityTest
 import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.Timeout
+import java.util.concurrent.TimeUnit
 import kotlin.reflect.KClass
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @OptIn(KordPreview::class)
+@Timeout(value = 5, unit = TimeUnit.SECONDS)
 abstract class LiveChannelTest<LIVE : LiveChannel> : AbstractLiveEntityTest<LIVE>() {
 
     protected abstract val channelId: Snowflake

--- a/core/src/test/kotlin/live/channel/LiveChannelTest.kt
+++ b/core/src/test/kotlin/live/channel/LiveChannelTest.kt
@@ -44,7 +44,7 @@ abstract class LiveChannelTest<LIVE : LiveChannel> : AbstractLiveEntityTest<LIVE
     }
 
     @Test
-    fun `Check onShutdown is called when event the category delete event is received`() {
+    fun `Check if live entity is completed when event the category delete event is received`() {
         countdownContext(1) {
             live.coroutineContext.job.invokeOnCompletion {
                 count()
@@ -63,7 +63,7 @@ abstract class LiveChannelTest<LIVE : LiveChannel> : AbstractLiveEntityTest<LIVE
     }
 
     @Test
-    fun `Check onShutdown is called when event the guild delete event is received`() {
+    fun `Check if live entity is completed when event the guild delete event is received`() {
         countdownContext(1) {
             live.coroutineContext.job.invokeOnCompletion {
                 count()

--- a/core/src/test/kotlin/live/channel/LiveDmChannelTest.kt
+++ b/core/src/test/kotlin/live/channel/LiveDmChannelTest.kt
@@ -14,12 +14,15 @@ import equality.randomId
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.Timeout
+import java.util.concurrent.TimeUnit
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @OptIn(KordPreview::class)
+@Timeout(value = 5, unit = TimeUnit.SECONDS)
 class LiveDmChannelTest : LiveChannelTest<LiveDmChannel>() {
 
     override lateinit var channelId: Snowflake

--- a/core/src/test/kotlin/live/channel/LiveDmChannelTest.kt
+++ b/core/src/test/kotlin/live/channel/LiveDmChannelTest.kt
@@ -1,0 +1,66 @@
+package live.channel
+
+import dev.kord.common.annotation.KordPreview
+import dev.kord.common.entity.ChannelType
+import dev.kord.common.entity.DiscordChannel
+import dev.kord.common.entity.Snowflake
+import dev.kord.common.entity.optional.optionalSnowflake
+import dev.kord.core.cache.data.ChannelData
+import dev.kord.core.entity.channel.DmChannel
+import dev.kord.core.live.channel.LiveDmChannel
+import dev.kord.core.live.channel.onUpdate
+import dev.kord.gateway.ChannelUpdate
+import equality.randomId
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@OptIn(KordPreview::class)
+class LiveDmChannelTest : LiveChannelTest<LiveDmChannel>() {
+
+    override lateinit var channelId: Snowflake
+
+    @BeforeAll
+    override fun onBeforeAll() {
+        super.onBeforeAll()
+        channelId = randomId()
+    }
+
+    @BeforeTest
+    fun onBefore() = runBlocking {
+        live = LiveDmChannel(
+            DmChannel(
+                kord = kord,
+                data = ChannelData(
+                    id = channelId,
+                    type = ChannelType.DM,
+                    guildId = guildId.optionalSnowflake()
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `Check onUpdate is called when event is received`() {
+        countdownContext(1) {
+            live.onUpdate {
+                assertEquals(it.channel.id, channelId)
+                count()
+            }
+
+            sendEventValidAndRandomId(channelId) {
+                ChannelUpdate(
+                    DiscordChannel(
+                        id = it,
+                        type = ChannelType.DM,
+                    ),
+                    0
+                )
+            }
+        }
+    }
+}

--- a/core/src/test/kotlin/live/channel/LiveGuildChannelTest.kt
+++ b/core/src/test/kotlin/live/channel/LiveGuildChannelTest.kt
@@ -1,0 +1,79 @@
+package live.channel
+
+import dev.kord.common.annotation.KordPreview
+import dev.kord.common.entity.ChannelType
+import dev.kord.common.entity.DiscordChannel
+import dev.kord.common.entity.Snowflake
+import dev.kord.common.entity.optional.optionalSnowflake
+import dev.kord.core.Kord
+import dev.kord.core.cache.data.ChannelData
+import dev.kord.core.entity.channel.GuildMessageChannel
+import dev.kord.core.live.channel.LiveGuildChannel
+import dev.kord.core.live.channel.onUpdate
+import dev.kord.core.supplier.EntitySupplier
+import dev.kord.core.supplier.EntitySupplyStrategy
+import dev.kord.gateway.ChannelUpdate
+import equality.randomId
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@OptIn(KordPreview::class)
+class LiveGuildChannelTest : LiveChannelTest<LiveGuildChannel>() {
+
+    inner class GuildChannelMock(
+        override val kord: Kord,
+        override val data: ChannelData,
+        override val supplier: EntitySupplier = kord.defaultSupplier
+    ) : GuildMessageChannel {
+        override fun withStrategy(strategy: EntitySupplyStrategy<*>): GuildMessageChannel {
+            error("Not invoked in test")
+        }
+    }
+
+    override lateinit var channelId: Snowflake
+
+    @BeforeAll
+    override fun onBeforeAll() {
+        super.onBeforeAll()
+        channelId = randomId()
+    }
+
+    @BeforeTest
+    fun onBefore() = runBlocking {
+        live = LiveGuildChannel(
+            GuildChannelMock(
+                kord = kord,
+                data = ChannelData(
+                    id = channelId,
+                    type = ChannelType.GuildText,
+                    guildId = guildId.optionalSnowflake()
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `Check onUpdate is called when event is received`() {
+        countdownContext(1) {
+            live.onUpdate {
+                assertEquals(it.channel.id, channelId)
+                count()
+            }
+
+            sendEventValidAndRandomId(channelId) {
+                ChannelUpdate(
+                    DiscordChannel(
+                        id = it,
+                        type = ChannelType.GuildText,
+                    ),
+                    0
+                )
+            }
+        }
+    }
+}

--- a/core/src/test/kotlin/live/channel/LiveGuildChannelTest.kt
+++ b/core/src/test/kotlin/live/channel/LiveGuildChannelTest.kt
@@ -17,12 +17,15 @@ import equality.randomId
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.Timeout
+import java.util.concurrent.TimeUnit
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @OptIn(KordPreview::class)
+@Timeout(value = 5, unit = TimeUnit.SECONDS)
 class LiveGuildChannelTest : LiveChannelTest<LiveGuildChannel>() {
 
     inner class GuildChannelMock(

--- a/core/src/test/kotlin/live/channel/LiveGuildTextTest.kt
+++ b/core/src/test/kotlin/live/channel/LiveGuildTextTest.kt
@@ -17,12 +17,15 @@ import equality.randomId
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.Timeout
+import java.util.concurrent.TimeUnit
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @OptIn(KordPreview::class)
+@Timeout(value = 5, unit = TimeUnit.SECONDS)
 class LiveGuildTextTest : LiveChannelTest<LiveGuildChannel>() {
 
     inner class GuildChannelMock(

--- a/core/src/test/kotlin/live/channel/LiveGuildTextTest.kt
+++ b/core/src/test/kotlin/live/channel/LiveGuildTextTest.kt
@@ -1,0 +1,79 @@
+package live.channel
+
+import dev.kord.common.annotation.KordPreview
+import dev.kord.common.entity.ChannelType
+import dev.kord.common.entity.DiscordChannel
+import dev.kord.common.entity.Snowflake
+import dev.kord.common.entity.optional.optionalSnowflake
+import dev.kord.core.Kord
+import dev.kord.core.cache.data.ChannelData
+import dev.kord.core.entity.channel.GuildChannel
+import dev.kord.core.live.channel.LiveGuildChannel
+import dev.kord.core.live.channel.onUpdate
+import dev.kord.core.supplier.EntitySupplier
+import dev.kord.core.supplier.EntitySupplyStrategy
+import dev.kord.gateway.ChannelUpdate
+import equality.randomId
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@OptIn(KordPreview::class)
+class LiveGuildTextTest : LiveChannelTest<LiveGuildChannel>() {
+
+    inner class GuildChannelMock(
+        override val kord: Kord,
+        override val data: ChannelData,
+        override val supplier: EntitySupplier = kord.defaultSupplier
+    ) : GuildChannel {
+        override fun withStrategy(strategy: EntitySupplyStrategy<*>): GuildChannel {
+            error("Not invoked in test")
+        }
+    }
+
+    override lateinit var channelId: Snowflake
+
+    @BeforeAll
+    override fun onBeforeAll() {
+        super.onBeforeAll()
+        channelId = randomId()
+    }
+
+    @BeforeTest
+    fun onBefore() = runBlocking {
+        live = LiveGuildChannel(
+            GuildChannelMock(
+                kord = kord,
+                data = ChannelData(
+                    id = channelId,
+                    type = ChannelType.GuildText,
+                    guildId = guildId.optionalSnowflake()
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `Check onUpdate is called when event is received`() {
+        countdownContext(1) {
+            live.onUpdate {
+                assertEquals(it.channel.id, channelId)
+                count()
+            }
+
+            sendEventValidAndRandomId(channelId) {
+                ChannelUpdate(
+                    DiscordChannel(
+                        id = it,
+                        type = ChannelType.GuildText,
+                    ),
+                    0
+                )
+            }
+        }
+    }
+}

--- a/core/src/test/kotlin/live/channel/LiveVoiceChannelTest.kt
+++ b/core/src/test/kotlin/live/channel/LiveVoiceChannelTest.kt
@@ -14,12 +14,15 @@ import equality.randomId
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.Timeout
+import java.util.concurrent.TimeUnit
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @OptIn(KordPreview::class)
+@Timeout(value = 5, unit = TimeUnit.SECONDS)
 class LiveVoiceChannelTest : LiveChannelTest<LiveVoiceChannel>() {
 
     override lateinit var channelId: Snowflake

--- a/core/src/test/kotlin/live/channel/LiveVoiceChannelTest.kt
+++ b/core/src/test/kotlin/live/channel/LiveVoiceChannelTest.kt
@@ -1,0 +1,66 @@
+package live.channel
+
+import dev.kord.common.annotation.KordPreview
+import dev.kord.common.entity.ChannelType
+import dev.kord.common.entity.DiscordChannel
+import dev.kord.common.entity.Snowflake
+import dev.kord.common.entity.optional.optionalSnowflake
+import dev.kord.core.cache.data.ChannelData
+import dev.kord.core.entity.channel.VoiceChannel
+import dev.kord.core.live.channel.LiveVoiceChannel
+import dev.kord.core.live.channel.onUpdate
+import dev.kord.gateway.ChannelUpdate
+import equality.randomId
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@OptIn(KordPreview::class)
+class LiveVoiceChannelTest : LiveChannelTest<LiveVoiceChannel>() {
+
+    override lateinit var channelId: Snowflake
+
+    @BeforeAll
+    override fun onBeforeAll() {
+        super.onBeforeAll()
+        channelId = randomId()
+    }
+
+    @BeforeTest
+    fun onBefore() = runBlocking {
+        live = LiveVoiceChannel(
+            VoiceChannel(
+                kord = kord,
+                data = ChannelData(
+                    id = channelId,
+                    type = ChannelType.GuildVoice,
+                    guildId = guildId.optionalSnowflake()
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `Check onUpdate is called when event is received`() {
+        countdownContext(1) {
+            live.onUpdate {
+                assertEquals(it.channel.id, channelId)
+                count()
+            }
+
+            sendEventValidAndRandomId(channelId) {
+                ChannelUpdate(
+                    DiscordChannel(
+                        id = it,
+                        type = ChannelType.GuildVoice,
+                    ),
+                    0
+                )
+            }
+        }
+    }
+}

--- a/core/src/test/kotlin/live/exception/LiveCancellationExceptionTest.kt
+++ b/core/src/test/kotlin/live/exception/LiveCancellationExceptionTest.kt
@@ -1,0 +1,32 @@
+package live.exception
+
+import dev.kord.core.Kord
+import dev.kord.core.event.Event
+import dev.kord.core.live.exception.LiveCancellationException
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+class LiveCancellationExceptionTest {
+
+    inner class EventMock : Event {
+        override val kord: Kord
+            get() = error("Never called")
+        override val shard: Int
+            get() = error("Never called")
+    }
+
+    @Test
+    fun `Throw exception without message`() {
+        assertFailsWith<LiveCancellationException> {
+            throw LiveCancellationException(EventMock(), null)
+        }
+    }
+
+    @Test
+    @Throws(LiveCancellationException::class)
+    fun `Throw exception with message`() {
+        assertFailsWith<LiveCancellationException> {
+            throw LiveCancellationException(EventMock(), "A reason")
+        }
+    }
+}


### PR DESCRIPTION
# Context

- Currently, when a live entity is shutdown, its children still alive.
- When kord instance is shutdown, the job from the method `LiveEntity.on` still alive.
- The live entities don't have a tests.
- Some extension methods for Live entities are never invoked.

# Features

- Define a live entity as `CoroutineScope`.
- Add shutdown action property in `AbstractLiveKordEntity` to apply action when the entity is shutdown.
- Add tests about live entities.
- Add `@Deprecated` annotation in event cannot be invoked.