### PR TITLE
 Properly decode null in gateway events

### DIFF
--- a/gateway/src/main/kotlin/Event.kt
+++ b/gateway/src/main/kotlin/Event.kt
@@ -8,10 +8,7 @@ import dev.kord.common.entity.optional.OptionalSnowflake
 import kotlinx.serialization.*
 import kotlinx.serialization.builtins.nullable
 import kotlinx.serialization.builtins.serializer
-import kotlinx.serialization.descriptors.PrimitiveKind
-import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
-import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.CompositeDecoder
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
@@ -31,7 +28,10 @@ private object NullDecoder : DeserializationStrategy<Nothing?> {
 
     @OptIn(ExperimentalSerializationApi::class)
     override fun deserialize(decoder: Decoder): Nothing? {
-        return decoder.decodeNull()
+        // decodeNull() doesn't consume the literal null therefore parsing doesn't end and in e.g. a heartbeat event
+        // the null gets parsed as a key
+        decoder.decodeNotNullMark()
+        return null
     }
 
 }

--- a/gateway/src/main/kotlin/Event.kt
+++ b/gateway/src/main/kotlin/Event.kt
@@ -31,7 +31,7 @@ private object NullDecoder : DeserializationStrategy<Nothing?> {
         // decodeNull() doesn't consume the literal null therefore parsing doesn't end and in e.g. a heartbeat event
         // the null gets parsed as a key
         decoder.decodeNotNullMark()
-        return null
+        return decoder.decodeNull()
     }
 
 }


### PR DESCRIPTION
This resolves an issue with kx.ser causing de serialization of events that end with a `null` to fail