### PR TITLE
Add buttons to Activity

### DIFF
--- a/common/src/main/kotlin/entity/DiscordActivity.kt
+++ b/common/src/main/kotlin/entity/DiscordActivity.kt
@@ -35,7 +35,8 @@ data class DiscordActivity(
     val assets: Optional<DiscordActivityAssets> = Optional.Missing(),
     val secrets: Optional<DiscordActivitySecrets> = Optional.Missing(),
     val instance: OptionalBoolean = OptionalBoolean.Missing,
-    val flags: Optional<ActivityFlags> = Optional.Missing()
+    val flags: Optional<ActivityFlags> = Optional.Missing(),
+    val buttons: Optional<List<String>> = Optional.Missing()
 )
 
 enum class ActivityFlag(val value: Int) {

--- a/core/src/main/kotlin/cache/data/ActivityData.kt
+++ b/core/src/main/kotlin/cache/data/ActivityData.kt
@@ -40,7 +40,8 @@ data class ActivityData(
                 assets,
                 secrets,
                 instance,
-                flags
+                flags,
+                buttons
             )
         }
     }

--- a/core/src/main/kotlin/cache/data/ActivityData.kt
+++ b/core/src/main/kotlin/cache/data/ActivityData.kt
@@ -22,6 +22,7 @@ data class ActivityData(
     val secrets: Optional<DiscordActivitySecrets> = Optional.Missing(),
     val instance: OptionalBoolean = OptionalBoolean.Missing,
     val flags: Optional<ActivityFlags> = Optional.Missing(),
+    val buttons: Optional<List<String>> = Optional.Missing()
 ) {
     companion object {
         fun from(entity: DiscordActivity) = with(entity) {

--- a/core/src/main/kotlin/entity/Activity.kt
+++ b/core/src/main/kotlin/entity/Activity.kt
@@ -57,6 +57,9 @@ class Activity(val data: ActivityData) {
     val flags: ActivityFlags?
         get() = data.flags.value
 
+    val buttons: List<String>?
+        get() = data.buttons.value
+
     override fun toString(): String {
         return "Activity(data=$data)"
     }


### PR DESCRIPTION
This one is a little odd because discord/discord-api-docs#2219 added more than just buttons, but buttons are the only one missing that got merged into this: https://discord.com/developers/docs/topics/gateway#activity-object