### PR TITLE
Migrate to kotlinx-datetime

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -4,6 +4,7 @@ object Versions {
     const val ktor = "1.5.3"
     const val kotlinxCoroutines = "1.5.0-RC"
     const val kotlinLogging = "2.0.4"
+    const val dateTime = "0.2.0"
     const val atomicFu = "0.16.1"
     const val binaryCompatibilityValidator = "0.4.0"
 
@@ -28,6 +29,7 @@ object Dependencies {
         "org.jetbrains.kotlinx:kotlinx-serialization-json:${Versions.kotlinxSerialization}"
     const val `kotlinx-coroutines` = "org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.kotlinxCoroutines}"
     const val `kotlinx-atomicfu` = "org.jetbrains.kotlinx:atomicfu-jvm:${Versions.atomicFu}"
+    const val `kotlinx-datetime` = "org.jetbrains.kotlinx:kotlinx-datetime:${Versions.dateTime}"
 
     const val `kotlin-logging` = "io.github.microutils:kotlin-logging:${Versions.kotlinLogging}"
 

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -13,6 +13,10 @@ configurations {
     }
 }
 
+dependencies {
+    api(Dependencies.`kotlinx-datetime`)
+}
+
 tasks.withType<KotlinCompile> {
     kotlinOptions {
         jvmTarget = Jvm.target

--- a/common/src/main/kotlin/entity/Snowflake.kt
+++ b/common/src/main/kotlin/entity/Snowflake.kt
@@ -1,5 +1,6 @@
 package dev.kord.common.entity
 
+import kotlinx.datetime.Clock
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.PrimitiveKind
@@ -7,10 +8,9 @@ import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
-import java.time.Instant
+import kotlinx.datetime.Instant
 import kotlin.time.Duration
 import kotlin.time.TimeMark
-import kotlin.time.toKotlinDuration
 
 /**
  * A unique identifier for entities [used by discord](https://discord.com/developers/docs/reference#snowflakes).
@@ -28,11 +28,11 @@ class Snowflake(val value: Long) : Comparable<Snowflake> {
     /**
      * Creates a Snowflake from a given [instant].
      */
-    constructor(instant: Instant) : this((instant.toEpochMilli() shl 22) - discordEpochLong)
+    constructor(instant: Instant) : this((instant.toEpochMilliseconds() shl 22) - discordEpochLong)
 
     val asString get() = value.toString()
 
-    val timeStamp: Instant get() = Instant.ofEpochMilli(discordEpochLong + (value shr 22))
+    val timeStamp: Instant get() = Instant.fromEpochMilliseconds(discordEpochLong + (value shr 22))
 
     val timeMark: TimeMark get() = SnowflakeMark(value shr 22)
 
@@ -48,7 +48,7 @@ class Snowflake(val value: Long) : Comparable<Snowflake> {
 
     companion object {
         private const val discordEpochLong = 1420070400000L
-        val discordEpochStart: Instant = Instant.ofEpochMilli(discordEpochLong)
+        val discordEpochStart: Instant = Instant.fromEpochMilliseconds(discordEpochLong)
 
         /**
          * The maximum value a Snowflake can hold.
@@ -78,7 +78,5 @@ class Snowflake(val value: Long) : Comparable<Snowflake> {
 
 private class SnowflakeMark(val epochMilliseconds: Long) : TimeMark() {
 
-    override fun elapsedNow(): Duration =
-        java.time.Duration.between(Instant.ofEpochMilli(epochMilliseconds), Instant.now()).toKotlinDuration()
-
+    override fun elapsedNow(): Duration = Instant.fromEpochMilliseconds(epochMilliseconds) - Clock.System.now()
 }

--- a/common/src/main/kotlin/ratelimit/BucketRateLimiter.kt
+++ b/common/src/main/kotlin/ratelimit/BucketRateLimiter.kt
@@ -2,11 +2,9 @@ package dev.kord.common.ratelimit
 
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import java.time.Clock
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
 import kotlin.time.Duration
-import kotlin.time.milliseconds
-import kotlin.time.toKotlinDuration
-import java.time.Duration as JavaDuration
 
 
 /**
@@ -19,30 +17,30 @@ import java.time.Duration as JavaDuration
 class BucketRateLimiter(
     private val capacity: Int,
     private val refillInterval: Duration,
-    private val clock: Clock = Clock.systemUTC()
+    private val clock: Clock = Clock.System
 ) : RateLimiter {
 
     private val mutex = Mutex()
 
     private var count = 0
-    private var nextInterval = 0L
+    private var nextInterval = Instant.fromEpochMilliseconds(0)
 
     init {
         require(capacity > 0) { "capacity must be a positive number" }
         require(refillInterval.isPositive()) { "refill interval must be positive" }
     }
 
-    private val isNextInterval get() = nextInterval <= clock.millis()
+    private val isNextInterval get() = nextInterval <= clock.now()
 
     private val isAtCapacity get() = count == capacity
 
     private fun resetState() {
         count = 0
-        nextInterval = clock.millis() + refillInterval.inWholeMilliseconds
+        nextInterval = clock.now() + refillInterval
     }
 
     private suspend fun delayUntilNextInterval() {
-        val delay = nextInterval - clock.millis()
+        val delay = nextInterval - clock.now()
         kotlinx.coroutines.delay(delay)
     }
 

--- a/common/src/test/kotlin/FixedClock.kt
+++ b/common/src/test/kotlin/FixedClock.kt
@@ -1,0 +1,8 @@
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+
+fun Clock.Companion.fixed(instant: Instant): Clock = FixedClock(instant)
+
+private class FixedClock(private val instant: Instant): Clock {
+    override fun now(): Instant = instant
+}

--- a/common/src/test/kotlin/ratelimit/BucketRateLimiterTest.kt
+++ b/common/src/test/kotlin/ratelimit/BucketRateLimiterTest.kt
@@ -1,25 +1,25 @@
 package ratelimit
 
 import dev.kord.common.ratelimit.BucketRateLimiter
+import fixed
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
-import java.time.Clock
-import java.time.Instant
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
 import java.time.ZoneOffset
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.asserter
 import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
-import kotlin.time.milliseconds
 
 @ExperimentalTime
 @ExperimentalCoroutinesApi
 class BucketRateLimiterTest {
 
     val interval = Duration.milliseconds(1_000_000)
-    val instant = Instant.now()
-    val clock = Clock.fixed(instant, ZoneOffset.UTC)
+    val instant = Clock.System.now()
+    val clock = Clock.fixed(instant)
     lateinit var rateLimiter: BucketRateLimiter
 
     @BeforeTest

--- a/core/src/main/kotlin/Util.kt
+++ b/core/src/main/kotlin/Util.kt
@@ -21,8 +21,7 @@ import dev.kord.rest.json.JsonErrorCode
 import dev.kord.rest.request.RestRequestException
 import dev.kord.rest.route.Position
 import kotlinx.coroutines.flow.*
-import java.time.Instant
-import java.time.format.DateTimeFormatter
+import kotlinx.datetime.Instant
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
@@ -38,9 +37,8 @@ internal fun Long?.toSnowflakeOrNull(): Snowflake? = when {
     else -> Snowflake(this)
 }
 
-internal fun String.toInstant() = DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(this, Instant::from)
-internal fun Int.toInstant() = Instant.ofEpochMilli(toLong())
-internal fun Long.toInstant() = Instant.ofEpochMilli(this)
+internal fun Int.toInstant() = Instant.fromEpochMilliseconds(toLong())
+internal fun Long.toInstant() = Instant.fromEpochMilliseconds(this)
 
 @OptIn(ExperimentalContracts::class)
 internal inline fun <T> catchNotFound(block: () -> T): T? {

--- a/core/src/main/kotlin/behavior/channel/GuildMessageChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/GuildMessageChannelBehavior.kt
@@ -16,8 +16,9 @@ import dev.kord.rest.request.RestRequestException
 import dev.kord.rest.service.RestClient
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
-import java.time.Duration
-import java.time.Instant
+import kotlinx.datetime.Clock
+import kotlin.time.Duration
+import kotlinx.datetime.Instant
 import java.util.*
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
@@ -70,11 +71,11 @@ interface GuildMessageChannelBehavior : GuildChannelBehavior, MessageChannelBeha
      * @throws [RestRequestException] if something went wrong during the request.
      */
     suspend fun bulkDelete(messages: Iterable<Snowflake>) {
-        val daysLimit = Instant.now() - Duration.ofDays(14)
+        val daysLimit = Clock.System.now() - Duration.days(14)
         //split up in bulk delete and manual delete
         // if message.timeMark + 14 days > now, then the message isn't 14 days old yet, and we can add it to the bulk delete
         // if message.timeMark + 14 days < now, then the message is more than 14 days old, and we'll have to manually delete them
-        val (younger, older) = messages.partition { it.timeStamp.isAfter(daysLimit) }
+        val (younger, older) = messages.partition { it.timeStamp > daysLimit }
 
         younger.chunked(100).forEach {
             if (it.size < 2) kord.rest.channel.deleteMessage(id, it.first())

--- a/core/src/main/kotlin/behavior/channel/MessageChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/MessageChannelBehavior.kt
@@ -18,7 +18,8 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
-import java.time.Instant
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
 import java.util.*
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
@@ -210,7 +211,7 @@ interface MessageChannelBehavior : ChannelBehavior, Strategizable {
      * @throws [RestRequestException] if something went wrong during the request.
      */
     suspend fun typeUntil(instant: Instant) {
-        while (instant.isBefore(Instant.now())) {
+        while (instant < Clock.System.now()) {
             type()
             delay(Duration.seconds(8).inWholeMilliseconds) //bracing ourselves for some network delays
         }

--- a/core/src/main/kotlin/entity/Activity.kt
+++ b/core/src/main/kotlin/entity/Activity.kt
@@ -5,7 +5,7 @@ import dev.kord.common.entity.*
 import dev.kord.common.entity.optional.value
 import dev.kord.core.cache.data.ActivityData
 import dev.kord.core.toInstant
-import java.time.Instant
+import kotlinx.datetime.Instant
 
 class Activity(val data: ActivityData) {
 

--- a/core/src/main/kotlin/entity/Embed.kt
+++ b/core/src/main/kotlin/entity/Embed.kt
@@ -9,9 +9,9 @@ import dev.kord.common.entity.optional.value
 import dev.kord.core.Kord
 import dev.kord.core.KordObject
 import dev.kord.core.cache.data.*
-import dev.kord.core.toInstant
 import dev.kord.rest.builder.message.EmbedBuilder
-import java.time.Instant
+import kotlinx.datetime.Instant
+import kotlinx.datetime.toInstant
 
 internal const val embedDeprecationMessage = """
 Embed types should be considered deprecated and might be removed in a future API version.

--- a/core/src/main/kotlin/entity/Guild.kt
+++ b/core/src/main/kotlin/entity/Guild.kt
@@ -27,8 +27,8 @@ import dev.kord.core.supplier.getChannelOfOrNull
 import dev.kord.rest.Image
 import dev.kord.rest.service.RestClient
 import kotlinx.coroutines.flow.first
-import java.time.Instant
-import java.time.format.DateTimeFormatter
+import kotlinx.datetime.Instant
+import kotlinx.datetime.toInstant
 import java.util.*
 
 /**
@@ -182,12 +182,7 @@ class Guild(
      * The time at which this guild was joined, if present.
      */
     val joinedTime: Instant?
-        get() = data.joinedAt.value?.let {
-            DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(
-                it,
-                Instant::from
-            )
-        }
+        get() = data.joinedAt.value?.toInstant()
 
     /**
      * The id of the owner.

--- a/core/src/main/kotlin/entity/Integration.kt
+++ b/core/src/main/kotlin/entity/Integration.kt
@@ -11,12 +11,11 @@ import dev.kord.core.cache.data.IntegrationData
 import dev.kord.core.exception.EntityNotFoundException
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
-import dev.kord.core.toInstant
 import dev.kord.rest.builder.integration.IntegrationModifyBuilder
 import dev.kord.rest.request.RestRequestException
-import java.time.Duration
-import java.time.Instant
-import java.time.temporal.ChronoUnit
+import kotlin.time.Duration
+import kotlinx.datetime.Instant
+import kotlinx.datetime.toInstant
 import java.util.*
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
@@ -99,7 +98,7 @@ class Integration(
      * The grace period in days before expiring subscribers.
      */
     val expireGracePeriod: Duration
-        get() = Duration.of(data.expireGracePeriod.toLong(), ChronoUnit.DAYS)
+        get() = Duration.days(data.expireGracePeriod)
 
     /**
      * The id of the [user][User] for this integration.

--- a/core/src/main/kotlin/entity/Member.kt
+++ b/core/src/main/kotlin/entity/Member.kt
@@ -12,10 +12,9 @@ import dev.kord.core.cache.data.MemberData
 import dev.kord.core.cache.data.UserData
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
-import dev.kord.core.toInstant
 import kotlinx.coroutines.flow.*
-import java.time.Instant
-import java.time.format.DateTimeFormatter
+import kotlinx.datetime.toInstant
+import kotlinx.datetime.Instant
 import java.util.*
 
 /**
@@ -39,7 +38,7 @@ class Member(
     /**
      * When the user joined this [guild].
      */
-    val joinedAt: Instant get() = DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(memberData.joinedAt, Instant::from)
+    val joinedAt: Instant get() = memberData.joinedAt.toInstant()
 
     /**
      * The guild-specific nickname of the user, if present.

--- a/core/src/main/kotlin/entity/Message.kt
+++ b/core/src/main/kotlin/entity/Message.kt
@@ -20,8 +20,8 @@ import dev.kord.core.supplier.EntitySupplyStrategy
 import dev.kord.core.supplier.getChannelOf
 import dev.kord.core.supplier.getChannelOfOrNull
 import kotlinx.coroutines.flow.*
-import java.time.Instant
-import java.time.format.DateTimeFormatter
+import kotlinx.datetime.Instant
+import kotlinx.datetime.toInstant
 import java.util.*
 
 /**
@@ -70,9 +70,7 @@ class Message(
      * Returns null if the message was never edited.
      */
     val editedTimestamp: Instant?
-        get() = data.editedTimestamp?.let {
-            DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(it, Instant::from)
-        }
+        get() = data.editedTimestamp?.toInstant()
 
     /**
      * The embedded content of this message.
@@ -205,7 +203,7 @@ class Message(
     /**
      * The instant when this message was created.
      */
-    val timestamp: Instant get() = DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(data.timestamp, Instant::from)
+    val timestamp: Instant get() = data.timestamp.toInstant()
 
     /**
      * Whether this message was send using `\tts`.

--- a/core/src/main/kotlin/entity/Template.kt
+++ b/core/src/main/kotlin/entity/Template.kt
@@ -5,8 +5,8 @@ import dev.kord.core.Kord
 import dev.kord.core.KordObject
 import dev.kord.core.behavior.TemplateBehavior
 import dev.kord.core.cache.data.TemplateData
-import java.time.Instant
-import java.time.format.DateTimeFormatter
+import kotlinx.datetime.Instant
+import kotlinx.datetime.toInstant
 
 class Template(val data: TemplateData, override val kord: Kord) : KordObject, TemplateBehavior {
     override val code: String get() = data.code
@@ -21,9 +21,9 @@ class Template(val data: TemplateData, override val kord: Kord) : KordObject, Te
 
     val creator: User get() = User(data.creator, kord)
 
-    val createdAt: Instant get() = DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(data.createdAt, Instant::from)
+    val createdAt: Instant get() = data.createdAt.toInstant()
 
-    val updatedAt: Instant get() = DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(data.updatedAt, Instant::from)
+    val updatedAt: Instant get() = data.updatedAt.toInstant()
 
     override val guildId: Snowflake get() = data.sourceGuildId
 

--- a/core/src/main/kotlin/entity/channel/MessageChannel.kt
+++ b/core/src/main/kotlin/entity/channel/MessageChannel.kt
@@ -7,8 +7,8 @@ import dev.kord.core.behavior.MessageBehavior
 import dev.kord.core.behavior.channel.MessageChannelBehavior
 import dev.kord.core.entity.Message
 import dev.kord.core.supplier.EntitySupplyStrategy
-import dev.kord.core.toInstant
-import java.time.Instant
+import kotlinx.datetime.Instant
+import kotlinx.datetime.toInstant
 
 /**
  * An instance of a Discord channel that can use messages.

--- a/core/src/main/kotlin/event/channel/ChannelPinsUpdateEvent.kt
+++ b/core/src/main/kotlin/event/channel/ChannelPinsUpdateEvent.kt
@@ -12,8 +12,8 @@ import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 import dev.kord.core.supplier.getChannelOf
 import dev.kord.core.supplier.getChannelOfOrNull
-import dev.kord.core.toInstant
-import java.time.Instant
+import kotlinx.datetime.Instant
+import kotlinx.datetime.toInstant
 
 class ChannelPinsUpdateEvent(
     val data: ChannelPinsUpdateEventData,

--- a/core/src/main/kotlin/event/channel/TypingStartEvent.kt
+++ b/core/src/main/kotlin/event/channel/TypingStartEvent.kt
@@ -18,7 +18,7 @@ import dev.kord.core.supplier.EntitySupplyStrategy
 import dev.kord.core.supplier.getChannelOf
 import dev.kord.core.supplier.getChannelOfOrNull
 import dev.kord.core.toInstant
-import java.time.Instant
+import kotlinx.datetime.Instant
 
 class TypingStartEvent(
     val data: TypingStartEventData,

--- a/core/src/main/kotlin/event/guild/InviteCreateEvent.kt
+++ b/core/src/main/kotlin/event/guild/InviteCreateEvent.kt
@@ -21,10 +21,9 @@ import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 import dev.kord.core.supplier.getChannelOf
 import dev.kord.core.supplier.getChannelOfOrNull
-import dev.kord.core.toInstant
-import java.time.Instant
+import kotlinx.datetime.Instant
+import kotlinx.datetime.toInstant
 import kotlin.time.Duration
-import kotlin.time.seconds
 
 /**
  * Sent when a new invite to a channel is created.

--- a/core/src/main/kotlin/event/guild/MemberUpdateEvent.kt
+++ b/core/src/main/kotlin/event/guild/MemberUpdateEvent.kt
@@ -9,7 +9,7 @@ import dev.kord.core.event.Event
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 import kotlinx.coroutines.flow.Flow
-import java.time.Instant
+import kotlinx.datetime.Instant
 
 private const val deprecationMessage = "The full member is now available in this Event."
 

--- a/core/src/test/kotlin/performance/KordEventDropTest.kt
+++ b/core/src/test/kotlin/performance/KordEventDropTest.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import java.time.Clock
+import kotlinx.datetime.Clock
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.coroutines.CoroutineContext
@@ -49,7 +49,7 @@ class KordEventDropTest {
         resources = ClientResources("token", Shards(1), HttpClient(), EntitySupplyStrategy.cache, Intents.none),
         cache = DataCache.none(),
         MasterGateway(mapOf(0 to SpammyGateway)),
-        RestClient(KtorRequestHandler("token", clock = Clock.systemUTC())),
+        RestClient(KtorRequestHandler("token", clock = Clock.System)),
         Snowflake("420"),
         MutableSharedFlow(extraBufferCapacity = Int.MAX_VALUE),
         Dispatchers.Default

--- a/gateway/src/main/kotlin/builder/PresenceBuilder.kt
+++ b/gateway/src/main/kotlin/builder/PresenceBuilder.kt
@@ -7,7 +7,7 @@ import dev.kord.common.entity.DiscordBotActivity
 import dev.kord.common.entity.optional.Optional
 import dev.kord.gateway.DiscordPresence
 import dev.kord.gateway.UpdateStatus
-import java.time.Instant
+import kotlinx.datetime.Instant
 
 @KordDsl
 class PresenceBuilder {
@@ -36,7 +36,7 @@ class PresenceBuilder {
         game = DiscordBotActivity(name, ActivityType.Competing)
     }
 
-    fun toUpdateStatus(): UpdateStatus = UpdateStatus(since?.toEpochMilli(), game?.let(::listOf).orEmpty(), status, afk)
+    fun toUpdateStatus(): UpdateStatus = UpdateStatus(since?.toEpochMilliseconds(), game?.let(::listOf).orEmpty(), status, afk)
 
-    fun toPresence(): DiscordPresence = DiscordPresence(status, afk, since?.toEpochMilli(), game)
+    fun toPresence(): DiscordPresence = DiscordPresence(status, afk, since?.toEpochMilliseconds(), game)
 }

--- a/gateway/src/test/kotlin/gateway/DefaultGatewayTest.kt
+++ b/gateway/src/test/kotlin/gateway/DefaultGatewayTest.kt
@@ -20,10 +20,8 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
-import java.time.Duration
 import kotlin.time.ExperimentalTime
 import kotlin.time.Duration as KDuration
-import kotlin.time.toKotlinDuration
 
 @FlowPreview
 @KtorExperimentalAPI
@@ -46,7 +44,7 @@ class DefaultGatewayTest {
             }
 
             reconnectRetry = LinearRetry(KDuration.seconds(2), KDuration.seconds(20), 10)
-            sendRateLimiter = BucketRateLimiter(120, Duration.ofSeconds(60).toKotlinDuration())
+            sendRateLimiter = BucketRateLimiter(120, KDuration.seconds(60))
         }
 
         gateway.events.filterIsInstance<MessageCreate>().flowOn(Dispatchers.Default).onEach {

--- a/rest/src/main/kotlin/builder/guild/VoiceStateModifyBuilder.kt
+++ b/rest/src/main/kotlin/builder/guild/VoiceStateModifyBuilder.kt
@@ -8,7 +8,7 @@ import dev.kord.common.entity.optional.map
 import dev.kord.rest.builder.RequestBuilder
 import dev.kord.rest.json.request.CurrentVoiceStateModifyRequest
 import dev.kord.rest.json.request.VoiceStateModifyRequest
-import java.time.Instant
+import kotlinx.datetime.Instant
 
 class CurrentVoiceStateModifyBuilder(val channelId: Snowflake) : RequestBuilder<CurrentVoiceStateModifyRequest> {
 

--- a/rest/src/main/kotlin/builder/message/EmbedBuilder.kt
+++ b/rest/src/main/kotlin/builder/message/EmbedBuilder.kt
@@ -10,10 +10,6 @@ import dev.kord.common.entity.optional.mapList
 import dev.kord.rest.builder.RequestBuilder
 import dev.kord.rest.json.request.*
 import kotlinx.datetime.Instant
-import kotlinx.datetime.ZoneOffset
-import kotlinx.datetime.toJavaInstant
-import kotlinx.datetime.toLocalDateTime
-import java.time.format.DateTimeFormatter
 
 /**
  * A builder for discord embeds.
@@ -155,9 +151,7 @@ class EmbedBuilder : RequestBuilder<EmbedRequest> {
         Optional.Value("embed"),
         _description,
         _url,
-        // TODO: Replace this with kotlinx.datetime
-        // See: https://github.com/Kotlin/kotlinx-datetime/issues/116
-        _timestamp.map { DateTimeFormatter.ISO_INSTANT.format(it.toJavaInstant()) },
+        _timestamp,
         _color,
         _footer.map { it.toRequest() },
         _image.map { EmbedImageRequest(it) },

--- a/rest/src/main/kotlin/builder/message/EmbedBuilder.kt
+++ b/rest/src/main/kotlin/builder/message/EmbedBuilder.kt
@@ -9,7 +9,10 @@ import dev.kord.common.entity.optional.map
 import dev.kord.common.entity.optional.mapList
 import dev.kord.rest.builder.RequestBuilder
 import dev.kord.rest.json.request.*
-import java.time.Instant
+import kotlinx.datetime.Instant
+import kotlinx.datetime.ZoneOffset
+import kotlinx.datetime.toJavaInstant
+import kotlinx.datetime.toLocalDateTime
 import java.time.format.DateTimeFormatter
 
 /**
@@ -152,7 +155,9 @@ class EmbedBuilder : RequestBuilder<EmbedRequest> {
         Optional.Value("embed"),
         _description,
         _url,
-        _timestamp.map { DateTimeFormatter.ISO_INSTANT.format(it) },
+        // TODO: Replace this with kotlinx.datetime
+        // See: https://github.com/Kotlin/kotlinx-datetime/issues/116
+        _timestamp.map { DateTimeFormatter.ISO_INSTANT.format(it.toJavaInstant()) },
         _color,
         _footer.map { it.toRequest() },
         _image.map { EmbedImageRequest(it) },

--- a/rest/src/main/kotlin/json/request/MessageRequests.kt
+++ b/rest/src/main/kotlin/json/request/MessageRequests.kt
@@ -5,6 +5,7 @@ import dev.kord.common.entity.*
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
 import dev.kord.common.entity.optional.OptionalInt
+import kotlinx.datetime.Instant
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -38,7 +39,7 @@ data class EmbedRequest(
     val type: Optional<String> = Optional.Missing(),
     val description: Optional<String> = Optional.Missing(),
     val url: Optional<String> = Optional.Missing(),
-    val timestamp: Optional<String> = Optional.Missing(),
+    val timestamp: Optional<Instant> = Optional.Missing(),
     val color: Optional<Color> = Optional.Missing(),
     val footer: Optional<EmbedFooterRequest> = Optional.Missing(),
     val image: Optional<EmbedImageRequest> = Optional.Missing(),

--- a/rest/src/main/kotlin/ratelimit/AbstractRateLimiter.kt
+++ b/rest/src/main/kotlin/ratelimit/AbstractRateLimiter.kt
@@ -28,7 +28,7 @@ abstract class AbstractRateLimiter internal constructor(val clock: Clock) : Requ
     internal fun RequestIdentifier.addBucket(id: BucketKey) = routeBuckets.getOrPut(this) { mutableSetOf() }.add(id)
 
     internal suspend fun Reset.await() {
-        val duration = clock.now() - value
+        val duration = value - clock.now()
         if (duration.isNegative()) return
         delay(duration)
     }

--- a/rest/src/main/kotlin/ratelimit/ExclusionRequestRateLimiter.kt
+++ b/rest/src/main/kotlin/ratelimit/ExclusionRequestRateLimiter.kt
@@ -6,7 +6,7 @@ import dev.kord.rest.request.identifier
 import kotlinx.coroutines.sync.Mutex
 import mu.KLogger
 import mu.KotlinLogging
-import java.time.Clock
+import kotlinx.datetime.Clock
 
 private val requestLogger = KotlinLogging.logger {}
 
@@ -17,7 +17,7 @@ private val requestLogger = KotlinLogging.logger {}
  *
  * @param clock a [Clock] used for calculating suspension times, present for testing purposes.
  */
-class ExclusionRequestRateLimiter(clock: Clock = Clock.systemUTC()) : AbstractRateLimiter(clock) {
+class ExclusionRequestRateLimiter(clock: Clock = Clock.System) : AbstractRateLimiter(clock) {
 
     override val logger: KLogger get() = requestLogger
     private val sequentialLock = Mutex()

--- a/rest/src/main/kotlin/ratelimit/ParallelRequestRateLimiter.kt
+++ b/rest/src/main/kotlin/ratelimit/ParallelRequestRateLimiter.kt
@@ -6,7 +6,7 @@ import dev.kord.rest.request.RequestIdentifier
 import dev.kord.rest.request.identifier
 import mu.KLogger
 import mu.KotlinLogging
-import java.time.Clock
+import kotlinx.datetime.Clock
 
 private val parallelLogger = KotlinLogging.logger {}
 
@@ -24,7 +24,7 @@ private val parallelLogger = KotlinLogging.logger {}
  * @param clock a [Clock] used for calculating suspension times, present for testing purposes.
  */
 @KordUnsafe
-class ParallelRequestRateLimiter(clock: Clock = Clock.systemUTC()) : AbstractRateLimiter(clock) {
+class ParallelRequestRateLimiter(clock: Clock = Clock.System) : AbstractRateLimiter(clock) {
 
     override val logger: KLogger
         get() = parallelLogger

--- a/rest/src/main/kotlin/ratelimit/RequestRateLimiter.kt
+++ b/rest/src/main/kotlin/ratelimit/RequestRateLimiter.kt
@@ -1,8 +1,7 @@
 package dev.kord.rest.ratelimit
 
 import dev.kord.rest.request.Request
-import java.lang.Exception
-import java.time.Instant
+import kotlinx.datetime.Instant
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract

--- a/rest/src/main/kotlin/request/KtorRequestHandler.kt
+++ b/rest/src/main/kotlin/request/KtorRequestHandler.kt
@@ -14,7 +14,7 @@ import io.ktor.http.*
 import io.ktor.http.content.*
 import kotlinx.serialization.json.Json
 import mu.KotlinLogging
-import java.time.Clock
+import kotlinx.datetime.Clock
 
 internal val jsonDefault = Json {
     encodeDefaults = false
@@ -35,7 +35,7 @@ internal val jsonDefault = Json {
 class KtorRequestHandler(
     private val client: HttpClient,
     private val requestRateLimiter: RequestRateLimiter = ExclusionRequestRateLimiter(),
-    private val clock: Clock = Clock.systemUTC(),
+    private val clock: Clock = Clock.System,
     private val parser: Json = jsonDefault,
 ) : RequestHandler {
     private val logger = KotlinLogging.logger("[R]:[KTOR]:[${requestRateLimiter.javaClass.simpleName}]")
@@ -107,7 +107,7 @@ class KtorRequestHandler(
 fun KtorRequestHandler(
     token: String,
     requestRateLimiter: RequestRateLimiter = ExclusionRequestRateLimiter(),
-    clock: Clock = Clock.systemUTC(),
+    clock: Clock = Clock.System,
     parser: Json = jsonDefault,
 ): KtorRequestHandler {
     val client = HttpClient(CIO) {

--- a/rest/src/test/kotlin/ratelimit/ExclusionRequestRateLimiterTest.kt
+++ b/rest/src/test/kotlin/ratelimit/ExclusionRequestRateLimiterTest.kt
@@ -1,7 +1,7 @@
 package dev.kord.rest.ratelimit
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import java.time.Clock
+import kotlinx.datetime.Clock
 import kotlin.time.ExperimentalTime
 
 @ExperimentalTime

--- a/rest/src/test/kotlin/ratelimit/ParallelRequestRateLimiterTest.kt
+++ b/rest/src/test/kotlin/ratelimit/ParallelRequestRateLimiterTest.kt
@@ -1,7 +1,7 @@
 package dev.kord.rest.ratelimit
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import java.time.Clock
+import kotlinx.datetime.Clock
 import kotlin.time.ExperimentalTime
 
 @ExperimentalTime

--- a/rest/src/test/kotlin/ratelimit/TestClock.kt
+++ b/rest/src/test/kotlin/ratelimit/TestClock.kt
@@ -9,6 +9,4 @@ import kotlin.time.Duration
 @ExperimentalCoroutinesApi
 class TestClock(val instant: Instant, val scope: TestCoroutineScope) : Clock {
     override fun now(): Instant = instant + Duration.milliseconds(scope.currentTime)
-//    override fun getZone(): ZoneId = zoneId
-//    override fun withZone(zone: ZoneId): Clock = TestClock(instant, scope, zone)
 }

--- a/rest/src/test/kotlin/ratelimit/TestClock.kt
+++ b/rest/src/test/kotlin/ratelimit/TestClock.kt
@@ -2,13 +2,13 @@ package dev.kord.rest.ratelimit
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineScope
-import java.time.Clock
-import java.time.Instant
-import java.time.ZoneId
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlin.time.Duration
 
 @ExperimentalCoroutinesApi
-class TestClock(val instant: Instant, val scope: TestCoroutineScope, val zoneId: ZoneId) : Clock() {
-    override fun getZone(): ZoneId = zoneId
-    override fun instant(): Instant = instant.plusMillis(scope.currentTime)
-    override fun withZone(zone: ZoneId): Clock = TestClock(instant, scope, zone)
+class TestClock(val instant: Instant, val scope: TestCoroutineScope) : Clock {
+    override fun now(): Instant = instant + Duration.milliseconds(scope.currentTime)
+//    override fun getZone(): ZoneId = zoneId
+//    override fun withZone(zone: ZoneId): Clock = TestClock(instant, scope, zone)
 }


### PR DESCRIPTION
~~As `kotlinx-datetime` version `0.2.0` actually fixed most of the issues we had in #43 I migrated most of the code
The only dependency we still have on `java.time` is the EmbedBuilder needing to convert from an `Instant` to ISO which is not possible afaik (See Kotlin/kotlinx-datetime#116)
All other usages to `java.time` have been replaced~~ NVM

Fixes #43