### PR TITLE
fix: Resolve issue about several calls for update method

### DIFF
--- a/core/src/main/kotlin/live/LiveKordEntity.kt
+++ b/core/src/main/kotlin/live/LiveKordEntity.kt
@@ -31,17 +31,12 @@ abstract class AbstractLiveKordEntity(final override val kord: Kord, dispatcher:
     override val coroutineContext: CoroutineContext = dispatcher + SupervisorJob(kord.coroutineContext.job)
 
     @Suppress("EXPERIMENTAL_API_USAGE")
-    final override val events: Flow<Event>
-        get() = kord.events
-            .takeWhile { isActive }
-            .filter { filter(it) }
+    final override val events: SharedFlow<Event> =
+        kord.events.filter { filter(it) }.onEach { update(it) }.shareIn(this, SharingStarted.Eagerly)
+
 
     protected abstract fun filter(event: Event): Boolean
     protected abstract fun update(event: Event)
-
-    init {
-        events.onEach { update(it) }.launchIn(this)
-    }
 
     override fun shutDown(cause: CancellationException) = cancel(cause)
 }

--- a/core/src/main/kotlin/live/LiveKordEntity.kt
+++ b/core/src/main/kotlin/live/LiveKordEntity.kt
@@ -10,8 +10,6 @@ import dev.kord.core.kordLogger
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.*
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -32,20 +30,17 @@ abstract class AbstractLiveKordEntity(final override val kord: Kord, dispatcher:
 
     override val coroutineContext: CoroutineContext = dispatcher + SupervisorJob(kord.coroutineContext.job)
 
-    private val mutex = Mutex()
-
     @Suppress("EXPERIMENTAL_API_USAGE")
     final override val events: Flow<Event>
         get() = kord.events
             .takeWhile { isActive }
             .filter { filter(it) }
-            .onEach { mutex.withLock { update(it) } }
 
     protected abstract fun filter(event: Event): Boolean
     protected abstract fun update(event: Event)
 
     init {
-        events.launchIn(this)
+        events.onEach { update(it) }.launchIn(this)
     }
 
     override fun shutDown(cause: CancellationException) = cancel(cause)
@@ -60,5 +55,3 @@ inline fun <reified T : Event> LiveKordEntity.on(noinline consumer: suspend (T) 
     events.buffer(Channel.UNLIMITED).filterIsInstance<T>().onEach {
         runCatching { consumer(it) }.onFailure { kordLogger.catching(it) }
     }.catch { kordLogger.catching(it) }.launchIn(this)
-
-

--- a/core/src/main/kotlin/live/LiveKordEntity.kt
+++ b/core/src/main/kotlin/live/LiveKordEntity.kt
@@ -34,7 +34,6 @@ abstract class AbstractLiveKordEntity(final override val kord: Kord, dispatcher:
     final override val events: SharedFlow<Event> =
         kord.events.filter { filter(it) }.onEach { update(it) }.shareIn(this, SharingStarted.Eagerly)
 
-
     protected abstract fun filter(event: Event): Boolean
     protected abstract fun update(event: Event)
 

--- a/core/src/test/kotlin/live/LiveKordEntityTest.kt
+++ b/core/src/test/kotlin/live/LiveKordEntityTest.kt
@@ -114,7 +114,6 @@ class LiveKordEntityTest : AbstractLiveEntityTest<LiveKordEntityTest.LiveEntityM
 
     @Test
     fun `Check if the filter and update are executed`() {
-        // The expected count is 2 because each job will increment the counter.
         // The update function is called once time (increment counter) and BanAddEvent is managed (increment counter)
         countdownContext(2) {
             live.counter = this

--- a/core/src/test/kotlin/live/LiveKordEntityTest.kt
+++ b/core/src/test/kotlin/live/LiveKordEntityTest.kt
@@ -114,10 +114,9 @@ class LiveKordEntityTest : AbstractLiveEntityTest<LiveKordEntityTest.LiveEntityM
 
     @Test
     fun `Check if the filter and update are executed`() {
-        // The expected count is 4 because each job will increment the counter.
-        // Each job (BanAddEvent, GuildDeleteEvent and initial) will process the update function.
-        // Another count is the action for BanAddEvent
-        countdownContext(4) {
+        // The expected count is 2 because each job will increment the counter.
+        // The update function is called once time (increment counter) and BanAddEvent is managed (increment counter)
+        countdownContext(2) {
             live.counter = this
 
             live.on<BanAddEvent> {


### PR DESCRIPTION
# Context

When an event is received and is validated by the filter, for each job children, the method `update` is called.

## Example

For the example, we have a simple live entity class like that : 
```kt
class MyLiveEntity(kord: Kord) : AbstractLiveKordEntity(kord, Dispatchers.Default) {

        override val id: Snowflake = randomId()

        override fun filter(event: Event): Boolean =  event is BanAddEvent

        override fun update(event: Event) {
            when (event) {
                is BanAddEvent -> println("I'm a ban add event")
            }
        }
    }
```

This is the issue, we have several children job, each job manage a type of event, but currently, for each job, the method "update"' is called, however, it should only be called once

```kt
live.on<BanAddEvent> { // 1 user job
   // action
}

live.on<GuildDeleteEvent> { // 2 user job
   // never called
}

// add the job who is created during initialization of live entity

sendEvent(banAddEvent) // A event valid for the filter is sent
// There are 3 jobs, so the update method is called 3 times, so the print will be executed 3 times
```

# Fix

Thanks to the initial job created, the `update` function is only called by it, and all user jobs (from the method `on<..> {..}`) never call the `update` method
