### PR TITLE
Filter out non-guilds when fetching rest guilds

### DIFF
--- a/core/src/main/kotlin/supplier/RestEntitySupplier.kt
+++ b/core/src/main/kotlin/supplier/RestEntitySupplier.kt
@@ -19,10 +19,7 @@ import dev.kord.rest.json.request.AuditLogGetRequest
 import dev.kord.rest.request.RestRequestException
 import dev.kord.rest.route.Position
 import dev.kord.rest.service.*
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.*
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
@@ -74,8 +71,8 @@ class RestEntitySupplier(val kord: Kord) : EntitySupplier {
 
     override fun getGuildChannels(guildId: Snowflake): Flow<GuildChannel> = flow {
         for (channelData in guild.getGuildChannels(guildId))
-            emit(Channel.from(ChannelData.from(channelData), kord) as GuildChannel)
-    }
+            emit(Channel.from(ChannelData.from(channelData), kord))
+    }.filterIsInstance()
 
     override fun getChannelPins(channelId: Snowflake): Flow<Message> = flow {
         for (messageData in channel.getChannelPins(channelId))


### PR DESCRIPTION
This is a side-effect from the system we currently employ when it comes to creating channels. Unknown channels are instantiated as an anonymous channel without hierarchy. While we could assume it is a guild channel, it's not in actuality.

So the solution, as we did with cache, is to filter out channels that don't inherit the hierarchy.