### PR TITLE
feat: Add possibility to define Job parent to create live entities

### DIFF
--- a/core/src/main/kotlin/live/LiveGuild.kt
+++ b/core/src/main/kotlin/live/LiveGuild.kt
@@ -18,19 +18,16 @@ import dev.kord.core.event.role.RoleUpdateEvent
 import dev.kord.core.event.user.PresenceUpdateEvent
 import dev.kord.core.event.user.VoiceStateUpdateEvent
 import dev.kord.core.live.exception.LiveCancellationException
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.job
+import kotlinx.coroutines.*
 
 @KordPreview
 fun Guild.live(
-    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(kord.coroutineContext.job))
+    coroutineScope: CoroutineScope = kord + SupervisorJob(kord.coroutineContext.job)
 ): LiveGuild = LiveGuild(this, coroutineScope)
 
 @KordPreview
 inline fun Guild.live(
-    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(kord.coroutineContext.job)),
+    coroutineScope: CoroutineScope = kord + SupervisorJob(kord.coroutineContext.job),
     block: LiveGuild.() -> Unit
 ) = this.live(coroutineScope).apply(block)
 
@@ -166,7 +163,7 @@ fun LiveGuild.onGuildDelete(scope: CoroutineScope = this, block: suspend (GuildD
 @KordPreview
 class LiveGuild(
     guild: Guild,
-    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(guild.kord.coroutineContext.job))
+    coroutineScope: CoroutineScope = guild.kord + SupervisorJob(guild.kord.coroutineContext.job)
 ) : AbstractLiveKordEntity(guild.kord, coroutineScope), KordEntity {
 
     override val id: Snowflake

--- a/core/src/main/kotlin/live/LiveGuild.kt
+++ b/core/src/main/kotlin/live/LiveGuild.kt
@@ -18,22 +18,19 @@ import dev.kord.core.event.role.RoleUpdateEvent
 import dev.kord.core.event.user.PresenceUpdateEvent
 import dev.kord.core.event.user.VoiceStateUpdateEvent
 import dev.kord.core.live.exception.LiveCancellationException
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.job
+import kotlinx.coroutines.*
 
 @KordPreview
 fun Guild.live(
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: Job? = kord.coroutineContext.job
+    parent: CoroutineScope = kord
 ): LiveGuild = LiveGuild(this, dispatcher, parent)
 
 @KordPreview
 inline fun Guild.live(
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
     block: LiveGuild.() -> Unit,
-    parent: Job? = kord.coroutineContext.job
+    parent: CoroutineScope = kord
 ) = this.live(dispatcher, parent).apply(block)
 
 @KordPreview
@@ -143,7 +140,7 @@ fun LiveGuild.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(cons
 class LiveGuild(
     guild: Guild,
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: Job? = guild.kord.coroutineContext.job
+    parent: CoroutineScope = guild.kord
 ) : AbstractLiveKordEntity(guild.kord, dispatcher, parent), KordEntity {
 
     override val id: Snowflake

--- a/core/src/main/kotlin/live/LiveGuild.kt
+++ b/core/src/main/kotlin/live/LiveGuild.kt
@@ -18,7 +18,9 @@ import dev.kord.core.event.role.RoleUpdateEvent
 import dev.kord.core.event.user.PresenceUpdateEvent
 import dev.kord.core.event.user.VoiceStateUpdateEvent
 import dev.kord.core.live.exception.LiveCancellationException
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 
 @KordPreview
 fun Guild.live(
@@ -34,99 +36,124 @@ inline fun Guild.live(
 ) = this.live(dispatcher, parent).apply(block)
 
 @KordPreview
-fun LiveGuild.onEmojisUpdate(block: suspend (EmojisUpdateEvent) -> Unit) = on(consumer = block)
+fun LiveGuild.onEmojisUpdate(scope: CoroutineScope = this, block: suspend (EmojisUpdateEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
-fun LiveGuild.onIntegrationsUpdate(block: suspend (IntegrationsUpdateEvent) -> Unit) = on(consumer = block)
+fun LiveGuild.onIntegrationsUpdate(scope: CoroutineScope = this, block: suspend (IntegrationsUpdateEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
-fun LiveGuild.onBanAdd(block: suspend (BanAddEvent) -> Unit) = on(consumer = block)
+fun LiveGuild.onBanAdd(scope: CoroutineScope = this, block: suspend (BanAddEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
-fun LiveGuild.onBanRemove(block: suspend (BanRemoveEvent) -> Unit) = on(consumer = block)
+fun LiveGuild.onBanRemove(scope: CoroutineScope = this, block: suspend (BanRemoveEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
-fun LiveGuild.onPresenceUpdate(block: suspend (PresenceUpdateEvent) -> Unit) = on(consumer = block)
+fun LiveGuild.onPresenceUpdate(scope: CoroutineScope = this, block: suspend (PresenceUpdateEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
-fun LiveGuild.onVoiceServerUpdate(block: suspend (VoiceServerUpdateEvent) -> Unit) = on(consumer = block)
+fun LiveGuild.onVoiceServerUpdate(scope: CoroutineScope = this, block: suspend (VoiceServerUpdateEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
-fun LiveGuild.onVoiceStateUpdate(block: suspend (VoiceStateUpdateEvent) -> Unit) = on(consumer = block)
+fun LiveGuild.onVoiceStateUpdate(scope: CoroutineScope = this, block: suspend (VoiceStateUpdateEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
-fun LiveGuild.onWebhookUpdate(block: suspend (WebhookUpdateEvent) -> Unit) = on(consumer = block)
+fun LiveGuild.onWebhookUpdate(scope: CoroutineScope = this, block: suspend (WebhookUpdateEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
-fun LiveGuild.onRoleCreate(block: suspend (RoleCreateEvent) -> Unit) = on(consumer = block)
+fun LiveGuild.onRoleCreate(scope: CoroutineScope = this, block: suspend (RoleCreateEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
-fun LiveGuild.onRoleUpdate(block: suspend (RoleUpdateEvent) -> Unit) = on(consumer = block)
+fun LiveGuild.onRoleUpdate(scope: CoroutineScope = this, block: suspend (RoleUpdateEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
-fun LiveGuild.onRoleDelete(block: suspend (RoleDeleteEvent) -> Unit) = on(consumer = block)
+fun LiveGuild.onRoleDelete(scope: CoroutineScope = this, block: suspend (RoleDeleteEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
-fun LiveGuild.onMemberJoin(block: suspend (MemberJoinEvent) -> Unit) = on(consumer = block)
+fun LiveGuild.onMemberJoin(scope: CoroutineScope = this, block: suspend (MemberJoinEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
-fun LiveGuild.onMemberUpdate(block: suspend (MemberUpdateEvent) -> Unit) = on(consumer = block)
+fun LiveGuild.onMemberUpdate(scope: CoroutineScope = this, block: suspend (MemberUpdateEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
-fun LiveGuild.onMemberLeave(block: suspend (MemberLeaveEvent) -> Unit) = on(consumer = block)
+fun LiveGuild.onMemberLeave(scope: CoroutineScope = this, block: suspend (MemberLeaveEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
-fun LiveGuild.onReactionAdd(block: suspend (ReactionAddEvent) -> Unit) = on(consumer = block)
+fun LiveGuild.onReactionAdd(scope: CoroutineScope = this, block: suspend (ReactionAddEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
 inline fun LiveGuild.onReactionAdd(
     reaction: ReactionEmoji,
-    crossinline block: suspend (ReactionAddEvent) -> Unit
-) = on<ReactionAddEvent> {
+    scope: CoroutineScope = this, crossinline block: suspend (ReactionAddEvent) -> Unit
+) = on<ReactionAddEvent>(scope) {
     if (it.emoji == reaction) {
         block(it)
     }
 }
 
 @KordPreview
-fun LiveGuild.onReactionRemove(block: suspend (ReactionRemoveEvent) -> Unit) = on(consumer = block)
+fun LiveGuild.onReactionRemove(scope: CoroutineScope = this, block: suspend (ReactionRemoveEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
 inline fun LiveGuild.onReactionRemove(
     reaction: ReactionEmoji,
-    crossinline block: suspend (ReactionRemoveEvent) -> Unit
-) = on<ReactionRemoveEvent> {
+    scope: CoroutineScope = this, crossinline block: suspend (ReactionRemoveEvent) -> Unit
+) = on<ReactionRemoveEvent>(scope) {
     if (it.emoji == reaction) {
         block(it)
     }
 }
 
 @KordPreview
-fun LiveGuild.onReactionRemoveAll(block: suspend (ReactionRemoveAllEvent) -> Unit) = on(consumer = block)
+fun LiveGuild.onReactionRemoveAll(scope: CoroutineScope = this, block: suspend (ReactionRemoveAllEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
-fun LiveGuild.onMessageCreate(block: suspend (MessageCreateEvent) -> Unit) = on(consumer = block)
+fun LiveGuild.onMessageCreate(scope: CoroutineScope = this, block: suspend (MessageCreateEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
-fun LiveGuild.onMessageUpdate(block: suspend (MessageUpdateEvent) -> Unit) = on(consumer = block)
+fun LiveGuild.onMessageUpdate(scope: CoroutineScope = this, block: suspend (MessageUpdateEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
-fun LiveGuild.onMessageDelete(block: suspend (MessageDeleteEvent) -> Unit) = on(consumer = block)
+fun LiveGuild.onMessageDelete(scope: CoroutineScope = this, block: suspend (MessageDeleteEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
-fun LiveGuild.onChannelCreate(block: suspend (ChannelCreateEvent) -> Unit) = on(consumer = block)
+fun LiveGuild.onChannelCreate(scope: CoroutineScope = this, block: suspend (ChannelCreateEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
-fun LiveGuild.onChannelUpdate(block: suspend (ChannelUpdateEvent) -> Unit) = on(consumer = block)
+fun LiveGuild.onChannelUpdate(scope: CoroutineScope = this, block: suspend (ChannelUpdateEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
-fun LiveGuild.onChannelDelete(block: suspend (ChannelDeleteEvent) -> Unit) = on(consumer = block)
+fun LiveGuild.onChannelDelete(scope: CoroutineScope = this, block: suspend (ChannelDeleteEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
-fun LiveGuild.onGuildCreate(block: suspend (GuildCreateEvent) -> Unit) = on(consumer = block)
+fun LiveGuild.onGuildCreate(scope: CoroutineScope = this, block: suspend (GuildCreateEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
-fun LiveGuild.onGuildUpdate(block: suspend (GuildUpdateEvent) -> Unit) = on(consumer = block)
+fun LiveGuild.onGuildUpdate(scope: CoroutineScope = this, block: suspend (GuildUpdateEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shut down",
@@ -134,7 +161,8 @@ fun LiveGuild.onGuildUpdate(block: suspend (GuildUpdateEvent) -> Unit) = on(cons
     DeprecationLevel.ERROR
 )
 @KordPreview
-fun LiveGuild.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
+fun LiveGuild.onGuildDelete(scope: CoroutineScope = this, block: suspend (GuildDeleteEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
 class LiveGuild(

--- a/core/src/main/kotlin/live/LiveGuild.kt
+++ b/core/src/main/kotlin/live/LiveGuild.kt
@@ -18,22 +18,21 @@ import dev.kord.core.event.role.RoleUpdateEvent
 import dev.kord.core.event.user.PresenceUpdateEvent
 import dev.kord.core.event.user.VoiceStateUpdateEvent
 import dev.kord.core.live.exception.LiveCancellationException
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.job
 
 @KordPreview
 fun Guild.live(
-    dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: CoroutineScope = kord
-): LiveGuild = LiveGuild(this, dispatcher, parent)
+    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(kord.coroutineContext.job))
+): LiveGuild = LiveGuild(this, coroutineScope)
 
 @KordPreview
 inline fun Guild.live(
-    dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    block: LiveGuild.() -> Unit,
-    parent: CoroutineScope = kord
-) = this.live(dispatcher, parent).apply(block)
+    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(kord.coroutineContext.job)),
+    block: LiveGuild.() -> Unit
+) = this.live(coroutineScope).apply(block)
 
 @KordPreview
 fun LiveGuild.onEmojisUpdate(scope: CoroutineScope = this, block: suspend (EmojisUpdateEvent) -> Unit) =
@@ -167,9 +166,8 @@ fun LiveGuild.onGuildDelete(scope: CoroutineScope = this, block: suspend (GuildD
 @KordPreview
 class LiveGuild(
     guild: Guild,
-    dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: CoroutineScope = guild.kord
-) : AbstractLiveKordEntity(guild.kord, dispatcher, parent), KordEntity {
+    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(guild.kord.coroutineContext.job))
+) : AbstractLiveKordEntity(guild.kord, coroutineScope), KordEntity {
 
     override val id: Snowflake
         get() = guild.id

--- a/core/src/main/kotlin/live/LiveGuild.kt
+++ b/core/src/main/kotlin/live/LiveGuild.kt
@@ -20,14 +20,21 @@ import dev.kord.core.event.user.VoiceStateUpdateEvent
 import dev.kord.core.live.exception.LiveCancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.job
 
 @KordPreview
-fun Guild.live(dispatcher: CoroutineDispatcher = Dispatchers.Default): LiveGuild =
-    LiveGuild(this, dispatcher)
+fun Guild.live(
+    dispatcher: CoroutineDispatcher = Dispatchers.Default,
+    parent: Job? = kord.coroutineContext.job
+): LiveGuild = LiveGuild(this, dispatcher, parent)
 
 @KordPreview
-inline fun Guild.live(dispatcher: CoroutineDispatcher = Dispatchers.Default, block: LiveGuild.() -> Unit) =
-    this.live(dispatcher).apply(block)
+inline fun Guild.live(
+    dispatcher: CoroutineDispatcher = Dispatchers.Default,
+    block: LiveGuild.() -> Unit,
+    parent: Job? = kord.coroutineContext.job
+) = this.live(dispatcher, parent).apply(block)
 
 @KordPreview
 fun LiveGuild.onEmojisUpdate(block: suspend (EmojisUpdateEvent) -> Unit) = on(consumer = block)
@@ -135,8 +142,9 @@ fun LiveGuild.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(cons
 @KordPreview
 class LiveGuild(
     guild: Guild,
-    dispatcher: CoroutineDispatcher = Dispatchers.Default
-) : AbstractLiveKordEntity(guild.kord, dispatcher), KordEntity {
+    dispatcher: CoroutineDispatcher = Dispatchers.Default,
+    parent: Job? = guild.kord.coroutineContext.job
+) : AbstractLiveKordEntity(guild.kord, dispatcher, parent), KordEntity {
 
     override val id: Snowflake
         get() = guild.id

--- a/core/src/main/kotlin/live/LiveKordEntity.kt
+++ b/core/src/main/kotlin/live/LiveKordEntity.kt
@@ -31,10 +31,10 @@ interface LiveKordEntity : KordEntity, CoroutineScope {
 abstract class AbstractLiveKordEntity(
     override val kord: Kord,
     dispatcher: CoroutineDispatcher,
-    parent: Job? = kord.coroutineContext.job
+    parent: CoroutineScope = kord
 ) : LiveKordEntity {
 
-    override val coroutineContext: CoroutineContext = dispatcher + SupervisorJob(parent)
+    override val coroutineContext: CoroutineContext = dispatcher + SupervisorJob(parent.coroutineContext.job)
 
     private val mutex = Mutex()
 

--- a/core/src/main/kotlin/live/LiveKordEntity.kt
+++ b/core/src/main/kotlin/live/LiveKordEntity.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlin.coroutines.CoroutineContext
 
 /**
  * A Discord entity that only emits events *related* to this entity.
@@ -30,11 +29,8 @@ interface LiveKordEntity : KordEntity, CoroutineScope {
 @KordPreview
 abstract class AbstractLiveKordEntity(
     override val kord: Kord,
-    dispatcher: CoroutineDispatcher,
-    parent: CoroutineScope = kord
-) : LiveKordEntity {
-
-    override val coroutineContext: CoroutineContext = dispatcher + SupervisorJob(parent.coroutineContext.job)
+    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(kord.coroutineContext.job))
+) : LiveKordEntity, CoroutineScope by coroutineScope {
 
     private val mutex = Mutex()
 

--- a/core/src/main/kotlin/live/LiveKordEntity.kt
+++ b/core/src/main/kotlin/live/LiveKordEntity.kt
@@ -29,7 +29,7 @@ interface LiveKordEntity : KordEntity, CoroutineScope {
 @KordPreview
 abstract class AbstractLiveKordEntity(
     override val kord: Kord,
-    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(kord.coroutineContext.job))
+    coroutineScope: CoroutineScope = kord + SupervisorJob(kord.coroutineContext.job)
 ) : LiveKordEntity, CoroutineScope by coroutineScope {
 
     private val mutex = Mutex()

--- a/core/src/main/kotlin/live/LiveMember.kt
+++ b/core/src/main/kotlin/live/LiveMember.kt
@@ -11,22 +11,21 @@ import dev.kord.core.event.guild.MemberLeaveEvent
 import dev.kord.core.event.guild.MemberUpdateEvent
 import dev.kord.core.live.channel.LiveGuildChannel
 import dev.kord.core.live.exception.LiveCancellationException
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.job
 
 @KordPreview
 fun Member.live(
-    dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: CoroutineScope = kord
-) = LiveMember(this, dispatcher, parent)
+    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(kord.coroutineContext.job))
+) = LiveMember(this, coroutineScope)
 
 @KordPreview
 inline fun Member.live(
-    dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: CoroutineScope = kord,
+    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(kord.coroutineContext.job)),
     block: LiveMember.() -> Unit
-) = this.live(dispatcher, parent).apply(block)
+) = this.live(coroutineScope).apply(block)
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shut down",
@@ -75,9 +74,8 @@ fun LiveGuildChannel.onGuildDelete(scope: CoroutineScope = this, block: suspend 
 @KordPreview
 class LiveMember(
     member: Member,
-    dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: CoroutineScope = member.kord
-) : AbstractLiveKordEntity(member.kord, dispatcher, parent), KordEntity {
+    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(member.kord.coroutineContext.job))
+) : AbstractLiveKordEntity(member.kord, coroutineScope), KordEntity {
 
     override val id: Snowflake
         get() = member.id

--- a/core/src/main/kotlin/live/LiveMember.kt
+++ b/core/src/main/kotlin/live/LiveMember.kt
@@ -13,13 +13,21 @@ import dev.kord.core.live.channel.LiveGuildChannel
 import dev.kord.core.live.exception.LiveCancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.job
 
 @KordPreview
-fun Member.live(dispatcher: CoroutineDispatcher = Dispatchers.Default) = LiveMember(this, dispatcher)
+fun Member.live(
+    dispatcher: CoroutineDispatcher = Dispatchers.Default,
+    parent: Job? = kord.coroutineContext.job
+) = LiveMember(this, dispatcher, parent)
 
 @KordPreview
-inline fun Member.live(dispatcher: CoroutineDispatcher = Dispatchers.Default, block: LiveMember.() -> Unit) =
-    this.live(dispatcher).apply(block)
+inline fun Member.live(
+    dispatcher: CoroutineDispatcher = Dispatchers.Default,
+    parent: Job? = kord.coroutineContext.job,
+    block: LiveMember.() -> Unit
+) = this.live(dispatcher, parent).apply(block)
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shut down",
@@ -63,8 +71,9 @@ fun LiveGuildChannel.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = 
 @KordPreview
 class LiveMember(
     member: Member,
-    dispatcher: CoroutineDispatcher = Dispatchers.Default
-) : AbstractLiveKordEntity(member.kord, dispatcher), KordEntity {
+    dispatcher: CoroutineDispatcher = Dispatchers.Default,
+    parent: Job? = member.kord.coroutineContext.job
+) : AbstractLiveKordEntity(member.kord, dispatcher, parent), KordEntity {
 
     override val id: Snowflake
         get() = member.id

--- a/core/src/main/kotlin/live/LiveMember.kt
+++ b/core/src/main/kotlin/live/LiveMember.kt
@@ -11,21 +11,18 @@ import dev.kord.core.event.guild.MemberLeaveEvent
 import dev.kord.core.event.guild.MemberUpdateEvent
 import dev.kord.core.live.channel.LiveGuildChannel
 import dev.kord.core.live.exception.LiveCancellationException
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.job
+import kotlinx.coroutines.*
 
 @KordPreview
 fun Member.live(
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: Job? = kord.coroutineContext.job
+    parent: CoroutineScope = kord
 ) = LiveMember(this, dispatcher, parent)
 
 @KordPreview
 inline fun Member.live(
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: Job? = kord.coroutineContext.job,
+    parent: CoroutineScope = kord,
     block: LiveMember.() -> Unit
 ) = this.live(dispatcher, parent).apply(block)
 
@@ -72,7 +69,7 @@ fun LiveGuildChannel.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = 
 class LiveMember(
     member: Member,
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: Job? = member.kord.coroutineContext.job
+    parent: CoroutineScope = member.kord
 ) : AbstractLiveKordEntity(member.kord, dispatcher, parent), KordEntity {
 
     override val id: Snowflake

--- a/core/src/main/kotlin/live/LiveMember.kt
+++ b/core/src/main/kotlin/live/LiveMember.kt
@@ -11,7 +11,9 @@ import dev.kord.core.event.guild.MemberLeaveEvent
 import dev.kord.core.event.guild.MemberUpdateEvent
 import dev.kord.core.live.channel.LiveGuildChannel
 import dev.kord.core.live.exception.LiveCancellationException
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 
 @KordPreview
 fun Member.live(
@@ -32,10 +34,12 @@ inline fun Member.live(
     DeprecationLevel.ERROR
 )
 @KordPreview
-fun LiveMember.onLeave(block: suspend (MemberLeaveEvent) -> Unit) = on(consumer = block)
+fun LiveMember.onLeave(scope: CoroutineScope = this, block: suspend (MemberLeaveEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
-fun LiveMember.onUpdate(block: suspend (MemberUpdateEvent) -> Unit) = on(consumer = block)
+fun LiveMember.onUpdate(scope: CoroutineScope = this, block: suspend (MemberUpdateEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shut down",
@@ -43,7 +47,8 @@ fun LiveMember.onUpdate(block: suspend (MemberUpdateEvent) -> Unit) = on(consume
     DeprecationLevel.ERROR
 )
 @KordPreview
-fun LiveMember.onBanAdd(block: suspend (BanAddEvent) -> Unit) = on(consumer = block)
+fun LiveMember.onBanAdd(scope: CoroutineScope = this, block: suspend (BanAddEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @Deprecated(
     "The block is not called when the live entity is shut down",
@@ -51,11 +56,12 @@ fun LiveMember.onBanAdd(block: suspend (BanAddEvent) -> Unit) = on(consumer = bl
     DeprecationLevel.ERROR
 )
 @KordPreview
-inline fun LiveGuildChannel.onShutdown(crossinline block: suspend (Event) -> Unit) = on<Event> {
-    if (it is MemberLeaveEvent || it is BanAddEvent || it is GuildDeleteEvent) {
-        block(it)
+inline fun LiveGuildChannel.onShutdown(scope: CoroutineScope = this, crossinline block: suspend (Event) -> Unit) =
+    on<Event>(scope) {
+        if (it is MemberLeaveEvent || it is BanAddEvent || it is GuildDeleteEvent) {
+            block(it)
+        }
     }
-}
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shut down",
@@ -63,7 +69,8 @@ inline fun LiveGuildChannel.onShutdown(crossinline block: suspend (Event) -> Uni
     DeprecationLevel.ERROR
 )
 @KordPreview
-fun LiveGuildChannel.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
+fun LiveGuildChannel.onGuildDelete(scope: CoroutineScope = this, block: suspend (GuildDeleteEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
 class LiveMember(

--- a/core/src/main/kotlin/live/LiveMember.kt
+++ b/core/src/main/kotlin/live/LiveMember.kt
@@ -11,19 +11,16 @@ import dev.kord.core.event.guild.MemberLeaveEvent
 import dev.kord.core.event.guild.MemberUpdateEvent
 import dev.kord.core.live.channel.LiveGuildChannel
 import dev.kord.core.live.exception.LiveCancellationException
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.job
+import kotlinx.coroutines.*
 
 @KordPreview
 fun Member.live(
-    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(kord.coroutineContext.job))
+    coroutineScope: CoroutineScope = kord + SupervisorJob(kord.coroutineContext.job)
 ) = LiveMember(this, coroutineScope)
 
 @KordPreview
 inline fun Member.live(
-    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(kord.coroutineContext.job)),
+    coroutineScope: CoroutineScope = kord + SupervisorJob(kord.coroutineContext.job),
     block: LiveMember.() -> Unit
 ) = this.live(coroutineScope).apply(block)
 
@@ -74,7 +71,7 @@ fun LiveGuildChannel.onGuildDelete(scope: CoroutineScope = this, block: suspend 
 @KordPreview
 class LiveMember(
     member: Member,
-    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(member.kord.coroutineContext.job))
+    coroutineScope: CoroutineScope = member.kord + SupervisorJob(member.kord.coroutineContext.job)
 ) : AbstractLiveKordEntity(member.kord, coroutineScope), KordEntity {
 
     override val id: Snowflake

--- a/core/src/main/kotlin/live/LiveMessage.kt
+++ b/core/src/main/kotlin/live/LiveMessage.kt
@@ -14,21 +14,18 @@ import dev.kord.core.event.guild.GuildDeleteEvent
 import dev.kord.core.event.message.*
 import dev.kord.core.live.exception.LiveCancellationException
 import dev.kord.core.supplier.EntitySupplyStrategy
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.job
+import kotlinx.coroutines.*
 
 @KordPreview
 suspend fun Message.live(
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: Job? = kord.coroutineContext.job
+    parent: CoroutineScope = kord
 ) = LiveMessage(this, withStrategy(EntitySupplyStrategy.cacheWithRestFallback).getGuildOrNull()?.id, dispatcher, parent)
 
 @KordPreview
 suspend fun Message.live(
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: Job? = kord.coroutineContext.job,
+    parent: CoroutineScope = kord,
     block: LiveMessage.() -> Unit
 ) = this.live(dispatcher, parent).apply(block)
 
@@ -123,7 +120,7 @@ class LiveMessage(
     message: Message,
     val guildId: Snowflake?,
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: Job? = message.kord.coroutineContext.job
+    parent: CoroutineScope = message.kord
 ) : AbstractLiveKordEntity(message.kord, dispatcher, parent), KordEntity {
 
     override val id: Snowflake

--- a/core/src/main/kotlin/live/LiveMessage.kt
+++ b/core/src/main/kotlin/live/LiveMessage.kt
@@ -14,7 +14,9 @@ import dev.kord.core.event.guild.GuildDeleteEvent
 import dev.kord.core.event.message.*
 import dev.kord.core.live.exception.LiveCancellationException
 import dev.kord.core.supplier.EntitySupplyStrategy
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 
 @KordPreview
 suspend fun Message.live(
@@ -30,33 +32,36 @@ suspend fun Message.live(
 ) = this.live(dispatcher, parent).apply(block)
 
 @KordPreview
-fun LiveMessage.onReactionAdd(block: suspend (ReactionAddEvent) -> Unit) = on(consumer = block)
+fun LiveMessage.onReactionAdd(scope: CoroutineScope = this, block: suspend (ReactionAddEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
 inline fun LiveMessage.onReactionAdd(
     reaction: ReactionEmoji,
-    crossinline block: suspend (ReactionAddEvent) -> Unit
-) = on<ReactionAddEvent> {
+    scope: CoroutineScope = this, crossinline block: suspend (ReactionAddEvent) -> Unit
+) = on<ReactionAddEvent>(scope) {
     if (it.emoji == reaction) {
         block(it)
     }
 }
 
 @KordPreview
-fun LiveMessage.onReactionRemove(block: suspend (ReactionRemoveEvent) -> Unit) = on(consumer = block)
+fun LiveMessage.onReactionRemove(scope: CoroutineScope = this, block: suspend (ReactionRemoveEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
 inline fun LiveMessage.onReactionRemove(
     reaction: ReactionEmoji,
-    crossinline block: suspend (ReactionRemoveEvent) -> Unit
-) = on<ReactionRemoveEvent> {
+    scope: CoroutineScope = this, crossinline block: suspend (ReactionRemoveEvent) -> Unit
+) = on<ReactionRemoveEvent>(scope) {
     if (it.emoji == reaction) {
         block(it)
     }
 }
 
 @KordPreview
-fun LiveMessage.onReactionRemoveAll(block: suspend (ReactionRemoveAllEvent) -> Unit) = on(consumer = block)
+fun LiveMessage.onReactionRemoveAll(scope: CoroutineScope = this, block: suspend (ReactionRemoveAllEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @Suppress("DeprecatedCallableAddReplaceWith")
 @Deprecated(
@@ -64,10 +69,12 @@ fun LiveMessage.onReactionRemoveAll(block: suspend (ReactionRemoveAllEvent) -> U
     level = DeprecationLevel.ERROR
 )
 @KordPreview
-fun LiveMessage.onCreate(block: suspend (MessageCreateEvent) -> Unit) = on(consumer = block)
+fun LiveMessage.onCreate(scope: CoroutineScope = this, block: suspend (MessageCreateEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
-fun LiveMessage.onUpdate(block: suspend (MessageUpdateEvent) -> Unit) = on(consumer = block)
+fun LiveMessage.onUpdate(scope: CoroutineScope = this, block: suspend (MessageUpdateEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @Deprecated(
     "The block is not called when the live entity is shut down",
@@ -75,13 +82,14 @@ fun LiveMessage.onUpdate(block: suspend (MessageUpdateEvent) -> Unit) = on(consu
     DeprecationLevel.ERROR
 )
 @KordPreview
-inline fun LiveMessage.onShutdown(crossinline block: suspend (Event) -> Unit) = on<Event> {
-    if (it is MessageDeleteEvent || it is MessageBulkDeleteEvent
-        || it is ChannelDeleteEvent || it is GuildDeleteEvent
-    ) {
-        block(it)
+inline fun LiveMessage.onShutdown(scope: CoroutineScope = this, crossinline block: suspend (Event) -> Unit) =
+    on<Event>(scope) {
+        if (it is MessageDeleteEvent || it is MessageBulkDeleteEvent
+            || it is ChannelDeleteEvent || it is GuildDeleteEvent
+        ) {
+            block(it)
+        }
     }
-}
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shut down",
@@ -89,7 +97,8 @@ inline fun LiveMessage.onShutdown(crossinline block: suspend (Event) -> Unit) = 
     DeprecationLevel.ERROR
 )
 @KordPreview
-fun LiveMessage.onOnlyDelete(block: suspend (MessageDeleteEvent) -> Unit) = on(consumer = block)
+fun LiveMessage.onOnlyDelete(scope: CoroutineScope = this, block: suspend (MessageDeleteEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shut down",
@@ -97,7 +106,8 @@ fun LiveMessage.onOnlyDelete(block: suspend (MessageDeleteEvent) -> Unit) = on(c
     DeprecationLevel.ERROR
 )
 @KordPreview
-fun LiveMessage.onBulkDelete(block: suspend (MessageBulkDeleteEvent) -> Unit) = on(consumer = block)
+fun LiveMessage.onBulkDelete(scope: CoroutineScope = this, block: suspend (MessageBulkDeleteEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shut down",
@@ -105,7 +115,8 @@ fun LiveMessage.onBulkDelete(block: suspend (MessageBulkDeleteEvent) -> Unit) = 
     DeprecationLevel.ERROR
 )
 @KordPreview
-fun LiveMessage.onChannelDelete(block: suspend (ChannelDeleteEvent) -> Unit) = on(consumer = block)
+fun LiveMessage.onChannelDelete(scope: CoroutineScope = this, block: suspend (ChannelDeleteEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shut down",
@@ -113,7 +124,8 @@ fun LiveMessage.onChannelDelete(block: suspend (ChannelDeleteEvent) -> Unit) = o
     DeprecationLevel.ERROR
 )
 @KordPreview
-fun LiveMessage.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
+fun LiveMessage.onGuildDelete(scope: CoroutineScope = this, block: suspend (GuildDeleteEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
 class LiveMessage(

--- a/core/src/main/kotlin/live/LiveMessage.kt
+++ b/core/src/main/kotlin/live/LiveMessage.kt
@@ -14,19 +14,16 @@ import dev.kord.core.event.guild.GuildDeleteEvent
 import dev.kord.core.event.message.*
 import dev.kord.core.live.exception.LiveCancellationException
 import dev.kord.core.supplier.EntitySupplyStrategy
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.job
+import kotlinx.coroutines.*
 
 @KordPreview
 suspend fun Message.live(
-    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(kord.coroutineContext.job))
+    coroutineScope: CoroutineScope = kord + SupervisorJob(kord.coroutineContext.job)
 ) = LiveMessage(this, withStrategy(EntitySupplyStrategy.cacheWithRestFallback).getGuildOrNull()?.id, coroutineScope)
 
 @KordPreview
 suspend fun Message.live(
-    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(kord.coroutineContext.job)),
+    coroutineScope: CoroutineScope = kord + SupervisorJob(kord.coroutineContext.job),
     block: LiveMessage.() -> Unit
 ) = this.live(coroutineScope).apply(block)
 
@@ -130,7 +127,7 @@ fun LiveMessage.onGuildDelete(scope: CoroutineScope = this, block: suspend (Guil
 class LiveMessage(
     message: Message,
     val guildId: Snowflake?,
-    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(message.kord.coroutineContext.job))
+    coroutineScope: CoroutineScope = message.kord + SupervisorJob(message.kord.coroutineContext.job)
 ) : AbstractLiveKordEntity(message.kord, coroutineScope), KordEntity {
 
     override val id: Snowflake

--- a/core/src/main/kotlin/live/LiveRole.kt
+++ b/core/src/main/kotlin/live/LiveRole.kt
@@ -9,7 +9,9 @@ import dev.kord.core.event.guild.GuildDeleteEvent
 import dev.kord.core.event.role.RoleDeleteEvent
 import dev.kord.core.event.role.RoleUpdateEvent
 import dev.kord.core.live.exception.LiveCancellationException
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 
 @KordPreview
 fun Role.live(
@@ -30,10 +32,12 @@ inline fun Role.live(
     DeprecationLevel.ERROR
 )
 @KordPreview
-fun LiveRole.onDelete(block: suspend (RoleDeleteEvent) -> Unit) = on(consumer = block)
+fun LiveRole.onDelete(scope: CoroutineScope = this, block: suspend (RoleDeleteEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
-fun LiveRole.onUpdate(block: suspend (RoleUpdateEvent) -> Unit) = on(consumer = block)
+fun LiveRole.onUpdate(scope: CoroutineScope = this, block: suspend (RoleUpdateEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @Deprecated(
     "The block is not called when the live entity is shut down",
@@ -41,11 +45,12 @@ fun LiveRole.onUpdate(block: suspend (RoleUpdateEvent) -> Unit) = on(consumer = 
     DeprecationLevel.ERROR
 )
 @KordPreview
-inline fun LiveRole.onShutdown(crossinline block: suspend (Event) -> Unit) = on<Event> {
-    if (it is RoleDeleteEvent || it is GuildDeleteEvent) {
-        block(it)
+inline fun LiveRole.onShutdown(scope: CoroutineScope = this, crossinline block: suspend (Event) -> Unit) =
+    on<Event>(scope) {
+        if (it is RoleDeleteEvent || it is GuildDeleteEvent) {
+            block(it)
+        }
     }
-}
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shut down",
@@ -53,7 +58,8 @@ inline fun LiveRole.onShutdown(crossinline block: suspend (Event) -> Unit) = on<
     DeprecationLevel.ERROR
 )
 @KordPreview
-fun LiveRole.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
+fun LiveRole.onGuildDelete(scope: CoroutineScope = this, block: suspend (GuildDeleteEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
 class LiveRole(

--- a/core/src/main/kotlin/live/LiveRole.kt
+++ b/core/src/main/kotlin/live/LiveRole.kt
@@ -9,21 +9,18 @@ import dev.kord.core.event.guild.GuildDeleteEvent
 import dev.kord.core.event.role.RoleDeleteEvent
 import dev.kord.core.event.role.RoleUpdateEvent
 import dev.kord.core.live.exception.LiveCancellationException
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.job
+import kotlinx.coroutines.*
 
 @KordPreview
 fun Role.live(
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: Job? = kord.coroutineContext.job
+    parent: CoroutineScope = kord
 ) = LiveRole(this, dispatcher, parent)
 
 @KordPreview
 inline fun Role.live(
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: Job? = kord.coroutineContext.job,
+    parent: CoroutineScope = kord,
     block: LiveRole.() -> Unit
 ) = this.live(dispatcher, parent).apply(block)
 
@@ -62,7 +59,7 @@ fun LiveRole.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consu
 class LiveRole(
     role: Role,
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: Job? = role.kord.coroutineContext.job
+    parent: CoroutineScope = role.kord
 ) : AbstractLiveKordEntity(role.kord, dispatcher, parent), KordEntity {
 
     override val id: Snowflake

--- a/core/src/main/kotlin/live/LiveRole.kt
+++ b/core/src/main/kotlin/live/LiveRole.kt
@@ -11,13 +11,21 @@ import dev.kord.core.event.role.RoleUpdateEvent
 import dev.kord.core.live.exception.LiveCancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.job
 
 @KordPreview
-fun Role.live(dispatcher: CoroutineDispatcher = Dispatchers.Default) = LiveRole(this, dispatcher)
+fun Role.live(
+    dispatcher: CoroutineDispatcher = Dispatchers.Default,
+    parent: Job? = kord.coroutineContext.job
+) = LiveRole(this, dispatcher, parent)
 
 @KordPreview
-inline fun Role.live(dispatcher: CoroutineDispatcher = Dispatchers.Default, block: LiveRole.() -> Unit) =
-    this.live(dispatcher).apply(block)
+inline fun Role.live(
+    dispatcher: CoroutineDispatcher = Dispatchers.Default,
+    parent: Job? = kord.coroutineContext.job,
+    block: LiveRole.() -> Unit
+) = this.live(dispatcher, parent).apply(block)
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shut down",
@@ -53,8 +61,9 @@ fun LiveRole.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consu
 @KordPreview
 class LiveRole(
     role: Role,
-    dispatcher: CoroutineDispatcher = Dispatchers.Default
-) : AbstractLiveKordEntity(role.kord, dispatcher), KordEntity {
+    dispatcher: CoroutineDispatcher = Dispatchers.Default,
+    parent: Job? = role.kord.coroutineContext.job
+) : AbstractLiveKordEntity(role.kord, dispatcher, parent), KordEntity {
 
     override val id: Snowflake
         get() = role.id

--- a/core/src/main/kotlin/live/LiveRole.kt
+++ b/core/src/main/kotlin/live/LiveRole.kt
@@ -9,19 +9,16 @@ import dev.kord.core.event.guild.GuildDeleteEvent
 import dev.kord.core.event.role.RoleDeleteEvent
 import dev.kord.core.event.role.RoleUpdateEvent
 import dev.kord.core.live.exception.LiveCancellationException
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.job
+import kotlinx.coroutines.*
 
 @KordPreview
 fun Role.live(
-    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(kord.coroutineContext.job))
+    coroutineScope: CoroutineScope = kord + SupervisorJob(kord.coroutineContext.job)
 ) = LiveRole(this, coroutineScope)
 
 @KordPreview
 inline fun Role.live(
-    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(kord.coroutineContext.job)),
+    coroutineScope: CoroutineScope = kord + SupervisorJob(kord.coroutineContext.job),
     block: LiveRole.() -> Unit
 ) = this.live(coroutineScope).apply(block)
 
@@ -63,7 +60,7 @@ fun LiveRole.onGuildDelete(scope: CoroutineScope = this, block: suspend (GuildDe
 @KordPreview
 class LiveRole(
     role: Role,
-    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(role.kord.coroutineContext.job))
+    coroutineScope: CoroutineScope = role.kord + SupervisorJob(role.kord.coroutineContext.job)
 ) : AbstractLiveKordEntity(role.kord, coroutineScope), KordEntity {
 
     override val id: Snowflake

--- a/core/src/main/kotlin/live/LiveRole.kt
+++ b/core/src/main/kotlin/live/LiveRole.kt
@@ -9,22 +9,21 @@ import dev.kord.core.event.guild.GuildDeleteEvent
 import dev.kord.core.event.role.RoleDeleteEvent
 import dev.kord.core.event.role.RoleUpdateEvent
 import dev.kord.core.live.exception.LiveCancellationException
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.job
 
 @KordPreview
 fun Role.live(
-    dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: CoroutineScope = kord
-) = LiveRole(this, dispatcher, parent)
+    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(kord.coroutineContext.job))
+) = LiveRole(this, coroutineScope)
 
 @KordPreview
 inline fun Role.live(
-    dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: CoroutineScope = kord,
+    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(kord.coroutineContext.job)),
     block: LiveRole.() -> Unit
-) = this.live(dispatcher, parent).apply(block)
+) = this.live(coroutineScope).apply(block)
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shut down",
@@ -64,9 +63,8 @@ fun LiveRole.onGuildDelete(scope: CoroutineScope = this, block: suspend (GuildDe
 @KordPreview
 class LiveRole(
     role: Role,
-    dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: CoroutineScope = role.kord
-) : AbstractLiveKordEntity(role.kord, dispatcher, parent), KordEntity {
+    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(role.kord.coroutineContext.job))
+) : AbstractLiveKordEntity(role.kord, coroutineScope), KordEntity {
 
     override val id: Snowflake
         get() = role.id

--- a/core/src/main/kotlin/live/LiveUser.kt
+++ b/core/src/main/kotlin/live/LiveUser.kt
@@ -6,22 +6,21 @@ import dev.kord.core.entity.KordEntity
 import dev.kord.core.entity.User
 import dev.kord.core.event.Event
 import dev.kord.core.event.user.UserUpdateEvent
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.job
 
 @KordPreview
 fun User.live(
-    dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: CoroutineScope = kord
-) = LiveUser(this, dispatcher, parent)
+    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(kord.coroutineContext.job))
+) = LiveUser(this, coroutineScope)
 
 @KordPreview
 inline fun User.live(
-    dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: CoroutineScope = kord,
+    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(kord.coroutineContext.job)),
     block: LiveUser.() -> Unit
-) = this.live(dispatcher, parent).apply(block)
+) = this.live(coroutineScope).apply(block)
 
 @KordPreview
 fun LiveUser.onUpdate(scope: CoroutineScope = this, block: suspend (UserUpdateEvent) -> Unit) =
@@ -30,9 +29,8 @@ fun LiveUser.onUpdate(scope: CoroutineScope = this, block: suspend (UserUpdateEv
 @KordPreview
 class LiveUser(
     user: User,
-    dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: CoroutineScope = user.kord
-) : AbstractLiveKordEntity(user.kord, dispatcher, parent), KordEntity {
+    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(user.kord.coroutineContext.job))
+) : AbstractLiveKordEntity(user.kord, coroutineScope), KordEntity {
 
     override val id: Snowflake
         get() = user.id

--- a/core/src/main/kotlin/live/LiveUser.kt
+++ b/core/src/main/kotlin/live/LiveUser.kt
@@ -6,21 +6,18 @@ import dev.kord.core.entity.KordEntity
 import dev.kord.core.entity.User
 import dev.kord.core.event.Event
 import dev.kord.core.event.user.UserUpdateEvent
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.job
+import kotlinx.coroutines.*
 
 @KordPreview
 fun User.live(
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: Job? = kord.coroutineContext.job
+    parent: CoroutineScope = kord
 ) = LiveUser(this, dispatcher, parent)
 
 @KordPreview
 inline fun User.live(
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: Job? = kord.coroutineContext.job,
+    parent: CoroutineScope = kord,
     block: LiveUser.() -> Unit
 ) = this.live(dispatcher, parent).apply(block)
 
@@ -31,7 +28,7 @@ fun LiveUser.onUpdate(block: suspend (UserUpdateEvent) -> Unit) = on(consumer = 
 class LiveUser(
     user: User,
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: Job? = user.kord.coroutineContext.job
+    parent: CoroutineScope = user.kord
 ) : AbstractLiveKordEntity(user.kord, dispatcher, parent), KordEntity {
 
     override val id: Snowflake

--- a/core/src/main/kotlin/live/LiveUser.kt
+++ b/core/src/main/kotlin/live/LiveUser.kt
@@ -6,7 +6,9 @@ import dev.kord.core.entity.KordEntity
 import dev.kord.core.entity.User
 import dev.kord.core.event.Event
 import dev.kord.core.event.user.UserUpdateEvent
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 
 @KordPreview
 fun User.live(
@@ -22,7 +24,8 @@ inline fun User.live(
 ) = this.live(dispatcher, parent).apply(block)
 
 @KordPreview
-fun LiveUser.onUpdate(block: suspend (UserUpdateEvent) -> Unit) = on(consumer = block)
+fun LiveUser.onUpdate(scope: CoroutineScope = this, block: suspend (UserUpdateEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
 class LiveUser(

--- a/core/src/main/kotlin/live/LiveUser.kt
+++ b/core/src/main/kotlin/live/LiveUser.kt
@@ -8,15 +8,21 @@ import dev.kord.core.event.Event
 import dev.kord.core.event.user.UserUpdateEvent
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.job
 
 @KordPreview
-fun User.live(dispatcher: CoroutineDispatcher = Dispatchers.Default) = LiveUser(this, dispatcher)
+fun User.live(
+    dispatcher: CoroutineDispatcher = Dispatchers.Default,
+    parent: Job? = kord.coroutineContext.job
+) = LiveUser(this, dispatcher, parent)
 
 @KordPreview
 inline fun User.live(
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
+    parent: Job? = kord.coroutineContext.job,
     block: LiveUser.() -> Unit
-) = this.live(dispatcher).apply(block)
+) = this.live(dispatcher, parent).apply(block)
 
 @KordPreview
 fun LiveUser.onUpdate(block: suspend (UserUpdateEvent) -> Unit) = on(consumer = block)
@@ -24,8 +30,9 @@ fun LiveUser.onUpdate(block: suspend (UserUpdateEvent) -> Unit) = on(consumer = 
 @KordPreview
 class LiveUser(
     user: User,
-    dispatcher: CoroutineDispatcher = Dispatchers.Default
-) : AbstractLiveKordEntity(user.kord, dispatcher), KordEntity {
+    dispatcher: CoroutineDispatcher = Dispatchers.Default,
+    parent: Job? = user.kord.coroutineContext.job
+) : AbstractLiveKordEntity(user.kord, dispatcher, parent), KordEntity {
 
     override val id: Snowflake
         get() = user.id

--- a/core/src/main/kotlin/live/LiveUser.kt
+++ b/core/src/main/kotlin/live/LiveUser.kt
@@ -6,19 +6,16 @@ import dev.kord.core.entity.KordEntity
 import dev.kord.core.entity.User
 import dev.kord.core.event.Event
 import dev.kord.core.event.user.UserUpdateEvent
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.job
+import kotlinx.coroutines.*
 
 @KordPreview
 fun User.live(
-    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(kord.coroutineContext.job))
+    coroutineScope: CoroutineScope = kord + SupervisorJob(kord.coroutineContext.job)
 ) = LiveUser(this, coroutineScope)
 
 @KordPreview
 inline fun User.live(
-    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(kord.coroutineContext.job)),
+    coroutineScope: CoroutineScope = kord + SupervisorJob(kord.coroutineContext.job),
     block: LiveUser.() -> Unit
 ) = this.live(coroutineScope).apply(block)
 
@@ -29,7 +26,7 @@ fun LiveUser.onUpdate(scope: CoroutineScope = this, block: suspend (UserUpdateEv
 @KordPreview
 class LiveUser(
     user: User,
-    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(user.kord.coroutineContext.job))
+    coroutineScope: CoroutineScope = user.kord + SupervisorJob(user.kord.coroutineContext.job)
 ) : AbstractLiveKordEntity(user.kord, coroutineScope), KordEntity {
 
     override val id: Snowflake

--- a/core/src/main/kotlin/live/channel/LiveCategory.kt
+++ b/core/src/main/kotlin/live/channel/LiveCategory.kt
@@ -13,16 +13,21 @@ import dev.kord.core.live.exception.LiveCancellationException
 import dev.kord.core.live.on
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.job
 
 @KordPreview
-fun Category.live(dispatcher: CoroutineDispatcher = Dispatchers.Default) =
-    LiveCategory(this, dispatcher)
+fun Category.live(
+    dispatcher: CoroutineDispatcher = Dispatchers.Default,
+    parent: Job? = kord.coroutineContext.job
+) = LiveCategory(this, dispatcher, parent)
 
 @KordPreview
 inline fun Category.live(
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
+    parent: Job? = kord.coroutineContext.job,
     block: LiveCategory.() -> Unit
-) = this.live(dispatcher).apply(block)
+) = this.live(dispatcher, parent).apply(block)
 
 @Suppress("DeprecatedCallableAddReplaceWith")
 @Deprecated(
@@ -66,8 +71,9 @@ fun LiveCategory.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(c
 @KordPreview
 class LiveCategory(
     channel: Category,
-    dispatcher: CoroutineDispatcher = Dispatchers.Default
-) : LiveChannel(channel.kord, dispatcher), KordEntity {
+    dispatcher: CoroutineDispatcher = Dispatchers.Default,
+    parent: Job? = channel.kord.coroutineContext.job,
+) : LiveChannel(channel.kord, dispatcher, parent), KordEntity {
 
     override val id: Snowflake
         get() = channel.id

--- a/core/src/main/kotlin/live/channel/LiveCategory.kt
+++ b/core/src/main/kotlin/live/channel/LiveCategory.kt
@@ -11,21 +11,18 @@ import dev.kord.core.event.channel.CategoryUpdateEvent
 import dev.kord.core.event.guild.GuildDeleteEvent
 import dev.kord.core.live.exception.LiveCancellationException
 import dev.kord.core.live.on
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.job
+import kotlinx.coroutines.*
 
 @KordPreview
 fun Category.live(
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: Job? = kord.coroutineContext.job
+    parent: CoroutineScope = kord
 ) = LiveCategory(this, dispatcher, parent)
 
 @KordPreview
 inline fun Category.live(
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: Job? = kord.coroutineContext.job,
+    parent: CoroutineScope = kord,
     block: LiveCategory.() -> Unit
 ) = this.live(dispatcher, parent).apply(block)
 
@@ -72,7 +69,7 @@ fun LiveCategory.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(c
 class LiveCategory(
     channel: Category,
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: Job? = channel.kord.coroutineContext.job,
+    parent: CoroutineScope = channel.kord,
 ) : LiveChannel(channel.kord, dispatcher, parent), KordEntity {
 
     override val id: Snowflake

--- a/core/src/main/kotlin/live/channel/LiveCategory.kt
+++ b/core/src/main/kotlin/live/channel/LiveCategory.kt
@@ -11,7 +11,9 @@ import dev.kord.core.event.channel.CategoryUpdateEvent
 import dev.kord.core.event.guild.GuildDeleteEvent
 import dev.kord.core.live.exception.LiveCancellationException
 import dev.kord.core.live.on
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 
 @KordPreview
 fun Category.live(
@@ -32,10 +34,12 @@ inline fun Category.live(
     level = DeprecationLevel.ERROR
 )
 @KordPreview
-fun LiveCategory.onCreate(block: suspend (CategoryCreateEvent) -> Unit) = on(consumer = block)
+fun LiveCategory.onCreate(scope: CoroutineScope = this, block: suspend (CategoryCreateEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
-fun LiveCategory.onUpdate(block: suspend (CategoryUpdateEvent) -> Unit) = on(consumer = block)
+fun LiveCategory.onUpdate(scope: CoroutineScope = this, block: suspend (CategoryUpdateEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @Deprecated(
     "The block is not called when the live entity is shut down",
@@ -43,11 +47,12 @@ fun LiveCategory.onUpdate(block: suspend (CategoryUpdateEvent) -> Unit) = on(con
     DeprecationLevel.ERROR
 )
 @KordPreview
-inline fun LiveCategory.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
-    if (it is CategoryDeleteEvent || it is GuildDeleteEvent) {
-        block(it)
+inline fun LiveCategory.onShutDown(scope: CoroutineScope = this, crossinline block: suspend (Event) -> Unit) =
+    on<Event>(scope) {
+        if (it is CategoryDeleteEvent || it is GuildDeleteEvent) {
+            block(it)
+        }
     }
-}
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shut down",
@@ -55,7 +60,8 @@ inline fun LiveCategory.onShutDown(crossinline block: suspend (Event) -> Unit) =
     DeprecationLevel.ERROR
 )
 @KordPreview
-fun LiveCategory.onDelete(block: suspend (CategoryDeleteEvent) -> Unit) = on(consumer = block)
+fun LiveCategory.onDelete(scope: CoroutineScope = this, block: suspend (CategoryDeleteEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shut down",
@@ -63,7 +69,8 @@ fun LiveCategory.onDelete(block: suspend (CategoryDeleteEvent) -> Unit) = on(con
     DeprecationLevel.ERROR
 )
 @KordPreview
-fun LiveCategory.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
+fun LiveCategory.onGuildDelete(scope: CoroutineScope = this, block: suspend (GuildDeleteEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
 class LiveCategory(

--- a/core/src/main/kotlin/live/channel/LiveCategory.kt
+++ b/core/src/main/kotlin/live/channel/LiveCategory.kt
@@ -11,22 +11,21 @@ import dev.kord.core.event.channel.CategoryUpdateEvent
 import dev.kord.core.event.guild.GuildDeleteEvent
 import dev.kord.core.live.exception.LiveCancellationException
 import dev.kord.core.live.on
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.job
 
 @KordPreview
 fun Category.live(
-    dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: CoroutineScope = kord
-) = LiveCategory(this, dispatcher, parent)
+    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(kord.coroutineContext.job))
+) = LiveCategory(this, coroutineScope)
 
 @KordPreview
 inline fun Category.live(
-    dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: CoroutineScope = kord,
+    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(kord.coroutineContext.job)),
     block: LiveCategory.() -> Unit
-) = this.live(dispatcher, parent).apply(block)
+) = this.live(coroutineScope).apply(block)
 
 @Suppress("DeprecatedCallableAddReplaceWith")
 @Deprecated(
@@ -75,9 +74,8 @@ fun LiveCategory.onGuildDelete(scope: CoroutineScope = this, block: suspend (Gui
 @KordPreview
 class LiveCategory(
     channel: Category,
-    dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: CoroutineScope = channel.kord,
-) : LiveChannel(channel.kord, dispatcher, parent), KordEntity {
+    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(channel.kord.coroutineContext.job))
+) : LiveChannel(channel.kord, coroutineScope), KordEntity {
 
     override val id: Snowflake
         get() = channel.id

--- a/core/src/main/kotlin/live/channel/LiveCategory.kt
+++ b/core/src/main/kotlin/live/channel/LiveCategory.kt
@@ -11,19 +11,16 @@ import dev.kord.core.event.channel.CategoryUpdateEvent
 import dev.kord.core.event.guild.GuildDeleteEvent
 import dev.kord.core.live.exception.LiveCancellationException
 import dev.kord.core.live.on
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.job
+import kotlinx.coroutines.*
 
 @KordPreview
 fun Category.live(
-    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(kord.coroutineContext.job))
+    coroutineScope: CoroutineScope = kord + SupervisorJob(kord.coroutineContext.job)
 ) = LiveCategory(this, coroutineScope)
 
 @KordPreview
 inline fun Category.live(
-    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(kord.coroutineContext.job)),
+    coroutineScope: CoroutineScope = kord + SupervisorJob(kord.coroutineContext.job),
     block: LiveCategory.() -> Unit
 ) = this.live(coroutineScope).apply(block)
 
@@ -74,7 +71,7 @@ fun LiveCategory.onGuildDelete(scope: CoroutineScope = this, block: suspend (Gui
 @KordPreview
 class LiveCategory(
     channel: Category,
-    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(channel.kord.coroutineContext.job))
+    coroutineScope: CoroutineScope = channel.kord + SupervisorJob(channel.kord.coroutineContext.job)
 ) : LiveChannel(channel.kord, coroutineScope), KordEntity {
 
     override val id: Snowflake

--- a/core/src/main/kotlin/live/channel/LiveChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveChannel.kt
@@ -17,14 +17,19 @@ import dev.kord.core.live.AbstractLiveKordEntity
 import dev.kord.core.live.on
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.job
 
 @KordPreview
-fun Channel.live(dispatcher: CoroutineDispatcher = Dispatchers.Default) = when (this) {
-    is DmChannel -> this.live(dispatcher)
-    is NewsChannel -> this.live(dispatcher)
-    is StoreChannel -> this.live(dispatcher)
-    is TextChannel -> this.live(dispatcher)
-    is VoiceChannel -> this.live(dispatcher)
+fun Channel.live(
+    dispatcher: CoroutineDispatcher = Dispatchers.Default,
+    parent: Job? = kord.coroutineContext.job
+) = when (this) {
+    is DmChannel -> this.live(dispatcher, parent)
+    is NewsChannel -> this.live(dispatcher, parent)
+    is StoreChannel -> this.live(dispatcher, parent)
+    is TextChannel -> this.live(dispatcher, parent)
+    is VoiceChannel -> this.live(dispatcher, parent)
     else -> error("unsupported channel type")
 }
 
@@ -104,8 +109,11 @@ fun LiveChannel.onGuildCreate(block: suspend (GuildCreateEvent) -> Unit) = on(co
 fun LiveChannel.onGuildUpdate(block: suspend (GuildUpdateEvent) -> Unit) = on(consumer = block)
 
 @KordPreview
-abstract class LiveChannel(kord: Kord, dispatcher: CoroutineDispatcher = Dispatchers.Default) :
-    AbstractLiveKordEntity(kord, dispatcher) {
+abstract class LiveChannel(
+    kord: Kord,
+    dispatcher: CoroutineDispatcher = Dispatchers.Default,
+    parent: Job? = kord.coroutineContext.job
+) : AbstractLiveKordEntity(kord, dispatcher, parent) {
 
     abstract val channel: Channel
 

--- a/core/src/main/kotlin/live/channel/LiveChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveChannel.kt
@@ -15,29 +15,28 @@ import dev.kord.core.event.message.*
 import dev.kord.core.event.user.VoiceStateUpdateEvent
 import dev.kord.core.live.AbstractLiveKordEntity
 import dev.kord.core.live.on
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.job
 
 @KordPreview
 fun Channel.live(
-    dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: CoroutineScope = kord
+    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(kord.coroutineContext.job))
 ) = when (this) {
-    is DmChannel -> this.live(dispatcher, parent)
-    is NewsChannel -> this.live(dispatcher, parent)
-    is StoreChannel -> this.live(dispatcher, parent)
-    is TextChannel -> this.live(dispatcher, parent)
-    is VoiceChannel -> this.live(dispatcher, parent)
+    is DmChannel -> this.live(coroutineScope)
+    is NewsChannel -> this.live(coroutineScope)
+    is StoreChannel -> this.live(coroutineScope)
+    is TextChannel -> this.live(coroutineScope)
+    is VoiceChannel -> this.live(coroutineScope)
     else -> error("unsupported channel type")
 }
 
 @KordPreview
 inline fun Channel.live(
-    dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: CoroutineScope = kord,
+    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(kord.coroutineContext.job)),
     block: LiveChannel.() -> Unit
-) = this.live(dispatcher, parent).apply(block)
+) = this.live(coroutineScope).apply(block)
 
 @KordPreview
 fun LiveChannel.onVoiceStateUpdate(scope: CoroutineScope = this, block: suspend (VoiceStateUpdateEvent) -> Unit) =
@@ -127,9 +126,8 @@ fun LiveChannel.onGuildUpdate(scope: CoroutineScope = this, block: suspend (Guil
 @KordPreview
 abstract class LiveChannel(
     kord: Kord,
-    dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: CoroutineScope = kord
-) : AbstractLiveKordEntity(kord, dispatcher, parent) {
+    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(kord.coroutineContext.job))
+) : AbstractLiveKordEntity(kord, coroutineScope) {
 
     abstract val channel: Channel
 

--- a/core/src/main/kotlin/live/channel/LiveChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveChannel.kt
@@ -15,14 +15,11 @@ import dev.kord.core.event.message.*
 import dev.kord.core.event.user.VoiceStateUpdateEvent
 import dev.kord.core.live.AbstractLiveKordEntity
 import dev.kord.core.live.on
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.job
+import kotlinx.coroutines.*
 
 @KordPreview
 fun Channel.live(
-    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(kord.coroutineContext.job))
+    coroutineScope: CoroutineScope = kord + SupervisorJob(kord.coroutineContext.job)
 ) = when (this) {
     is DmChannel -> this.live(coroutineScope)
     is NewsChannel -> this.live(coroutineScope)
@@ -34,7 +31,7 @@ fun Channel.live(
 
 @KordPreview
 inline fun Channel.live(
-    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(kord.coroutineContext.job)),
+    coroutineScope: CoroutineScope = kord + SupervisorJob(kord.coroutineContext.job),
     block: LiveChannel.() -> Unit
 ) = this.live(coroutineScope).apply(block)
 
@@ -126,7 +123,7 @@ fun LiveChannel.onGuildUpdate(scope: CoroutineScope = this, block: suspend (Guil
 @KordPreview
 abstract class LiveChannel(
     kord: Kord,
-    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(kord.coroutineContext.job))
+    coroutineScope: CoroutineScope = kord + SupervisorJob(kord.coroutineContext.job)
 ) : AbstractLiveKordEntity(kord, coroutineScope) {
 
     abstract val channel: Channel

--- a/core/src/main/kotlin/live/channel/LiveChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveChannel.kt
@@ -15,15 +15,12 @@ import dev.kord.core.event.message.*
 import dev.kord.core.event.user.VoiceStateUpdateEvent
 import dev.kord.core.live.AbstractLiveKordEntity
 import dev.kord.core.live.on
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.job
+import kotlinx.coroutines.*
 
 @KordPreview
 fun Channel.live(
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: Job? = kord.coroutineContext.job
+    parent: CoroutineScope = kord
 ) = when (this) {
     is DmChannel -> this.live(dispatcher, parent)
     is NewsChannel -> this.live(dispatcher, parent)
@@ -34,8 +31,11 @@ fun Channel.live(
 }
 
 @KordPreview
-inline fun Channel.live(dispatcher: CoroutineDispatcher = Dispatchers.Default, block: LiveChannel.() -> Unit) =
-    this.live(dispatcher).apply(block)
+inline fun Channel.live(
+    dispatcher: CoroutineDispatcher = Dispatchers.Default,
+    parent: CoroutineScope = kord,
+    block: LiveChannel.() -> Unit
+) = this.live(dispatcher, parent).apply(block)
 
 @KordPreview
 fun LiveChannel.onVoiceStateUpdate(block: suspend (VoiceStateUpdateEvent) -> Unit) = on(consumer = block)
@@ -112,7 +112,7 @@ fun LiveChannel.onGuildUpdate(block: suspend (GuildUpdateEvent) -> Unit) = on(co
 abstract class LiveChannel(
     kord: Kord,
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: Job? = kord.coroutineContext.job
+    parent: CoroutineScope = kord
 ) : AbstractLiveKordEntity(kord, dispatcher, parent) {
 
     abstract val channel: Channel

--- a/core/src/main/kotlin/live/channel/LiveChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveChannel.kt
@@ -15,7 +15,9 @@ import dev.kord.core.event.message.*
 import dev.kord.core.event.user.VoiceStateUpdateEvent
 import dev.kord.core.live.AbstractLiveKordEntity
 import dev.kord.core.live.on
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 
 @KordPreview
 fun Channel.live(
@@ -38,45 +40,54 @@ inline fun Channel.live(
 ) = this.live(dispatcher, parent).apply(block)
 
 @KordPreview
-fun LiveChannel.onVoiceStateUpdate(block: suspend (VoiceStateUpdateEvent) -> Unit) = on(consumer = block)
+fun LiveChannel.onVoiceStateUpdate(scope: CoroutineScope = this, block: suspend (VoiceStateUpdateEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
-fun LiveChannel.onReactionAdd(block: suspend (ReactionAddEvent) -> Unit) = on(consumer = block)
+fun LiveChannel.onReactionAdd(scope: CoroutineScope = this, block: suspend (ReactionAddEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
 inline fun LiveChannel.onReactionAdd(
     reaction: ReactionEmoji,
+    scope: CoroutineScope = this,
     crossinline block: suspend (ReactionAddEvent) -> Unit
-) = on<ReactionAddEvent> {
+) = on<ReactionAddEvent>(scope) {
     if (it.emoji == reaction) {
         block(it)
     }
 }
 
 @KordPreview
-fun LiveChannel.onReactionRemove(block: suspend (ReactionRemoveEvent) -> Unit) = on(consumer = block)
+fun LiveChannel.onReactionRemove(scope: CoroutineScope = this, block: suspend (ReactionRemoveEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
 inline fun LiveChannel.onReactionRemove(
     reaction: ReactionEmoji,
+    scope: CoroutineScope = this,
     crossinline block: suspend (ReactionRemoveEvent) -> Unit
-) = on<ReactionRemoveEvent> {
+) = on<ReactionRemoveEvent>(scope) {
     if (it.emoji == reaction) {
         block(it)
     }
 }
 
 @KordPreview
-fun LiveChannel.onReactionRemoveAll(block: suspend (ReactionRemoveAllEvent) -> Unit) = on(consumer = block)
+fun LiveChannel.onReactionRemoveAll(scope: CoroutineScope = this, block: suspend (ReactionRemoveAllEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
-fun LiveChannel.onMessageCreate(block: suspend (MessageCreateEvent) -> Unit) = on(consumer = block)
+fun LiveChannel.onMessageCreate(scope: CoroutineScope = this, block: suspend (MessageCreateEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
-fun LiveChannel.onMessageUpdate(block: suspend (MessageUpdateEvent) -> Unit) = on(consumer = block)
+fun LiveChannel.onMessageUpdate(scope: CoroutineScope = this, block: suspend (MessageUpdateEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
-fun LiveChannel.onMessageDelete(block: suspend (MessageDeleteEvent) -> Unit) = on(consumer = block)
+fun LiveChannel.onMessageDelete(scope: CoroutineScope = this, block: suspend (MessageDeleteEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @Suppress("DeprecatedCallableAddReplaceWith")
 @Deprecated(
@@ -84,10 +95,12 @@ fun LiveChannel.onMessageDelete(block: suspend (MessageDeleteEvent) -> Unit) = o
     level = DeprecationLevel.ERROR
 )
 @KordPreview
-fun LiveChannel.onChannelCreate(block: suspend (ChannelCreateEvent) -> Unit) = on(consumer = block)
+fun LiveChannel.onChannelCreate(scope: CoroutineScope = this, block: suspend (ChannelCreateEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
-fun LiveChannel.onChannelUpdate(block: suspend (ChannelUpdateEvent) -> Unit) = on(consumer = block)
+fun LiveChannel.onChannelUpdate(scope: CoroutineScope = this, block: suspend (ChannelUpdateEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shut down",
@@ -95,7 +108,8 @@ fun LiveChannel.onChannelUpdate(block: suspend (ChannelUpdateEvent) -> Unit) = o
     DeprecationLevel.ERROR
 )
 @KordPreview
-fun LiveChannel.onChannelDelete(block: suspend (ChannelDeleteEvent) -> Unit) = on(consumer = block)
+fun LiveChannel.onChannelDelete(scope: CoroutineScope = this, block: suspend (ChannelDeleteEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @Deprecated(
     "The block is never called because the guild where the channel is located is already created",
@@ -103,10 +117,12 @@ fun LiveChannel.onChannelDelete(block: suspend (ChannelDeleteEvent) -> Unit) = o
     DeprecationLevel.ERROR
 )
 @KordPreview
-fun LiveChannel.onGuildCreate(block: suspend (GuildCreateEvent) -> Unit) = on(consumer = block)
+fun LiveChannel.onGuildCreate(scope: CoroutineScope = this, block: suspend (GuildCreateEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
-fun LiveChannel.onGuildUpdate(block: suspend (GuildUpdateEvent) -> Unit) = on(consumer = block)
+fun LiveChannel.onGuildUpdate(scope: CoroutineScope = this, block: suspend (GuildUpdateEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
 abstract class LiveChannel(

--- a/core/src/main/kotlin/live/channel/LiveDmChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveDmChannel.kt
@@ -11,21 +11,18 @@ import dev.kord.core.event.channel.DMChannelUpdateEvent
 import dev.kord.core.event.guild.GuildDeleteEvent
 import dev.kord.core.live.exception.LiveCancellationException
 import dev.kord.core.live.on
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.job
+import kotlinx.coroutines.*
 
 @KordPreview
 fun DmChannel.live(
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: Job? = kord.coroutineContext.job
+    parent: CoroutineScope = kord
 ) = LiveDmChannel(this, dispatcher, parent)
 
 @KordPreview
 inline fun DmChannel.live(
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: Job? = kord.coroutineContext.job,
+    parent: CoroutineScope = kord,
     block: LiveDmChannel.() -> Unit
 ) = this.live(dispatcher, parent).apply(block)
 
@@ -72,7 +69,7 @@ fun LiveDmChannel.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(
 class LiveDmChannel(
     channel: DmChannel,
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: Job? = channel.kord.coroutineContext.job
+    parent: CoroutineScope = channel.kord
 ) : LiveChannel(channel.kord, dispatcher, parent), KordEntity {
 
     override val id: Snowflake

--- a/core/src/main/kotlin/live/channel/LiveDmChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveDmChannel.kt
@@ -11,22 +11,21 @@ import dev.kord.core.event.channel.DMChannelUpdateEvent
 import dev.kord.core.event.guild.GuildDeleteEvent
 import dev.kord.core.live.exception.LiveCancellationException
 import dev.kord.core.live.on
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.job
 
 @KordPreview
 fun DmChannel.live(
-    dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: CoroutineScope = kord
-) = LiveDmChannel(this, dispatcher, parent)
+    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(kord.coroutineContext.job))
+) = LiveDmChannel(this, coroutineScope)
 
 @KordPreview
 inline fun DmChannel.live(
-    dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: CoroutineScope = kord,
+    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(kord.coroutineContext.job)),
     block: LiveDmChannel.() -> Unit
-) = this.live(dispatcher, parent).apply(block)
+) = this.live(coroutineScope).apply(block)
 
 @Suppress("DeprecatedCallableAddReplaceWith")
 @Deprecated(
@@ -75,9 +74,8 @@ fun LiveDmChannel.onGuildDelete(scope: CoroutineScope = this, block: suspend (Gu
 @KordPreview
 class LiveDmChannel(
     channel: DmChannel,
-    dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: CoroutineScope = channel.kord
-) : LiveChannel(channel.kord, dispatcher, parent), KordEntity {
+    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(channel.kord.coroutineContext.job))
+) : LiveChannel(channel.kord, coroutineScope), KordEntity {
 
     override val id: Snowflake
         get() = channel.id

--- a/core/src/main/kotlin/live/channel/LiveDmChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveDmChannel.kt
@@ -13,15 +13,21 @@ import dev.kord.core.live.exception.LiveCancellationException
 import dev.kord.core.live.on
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.job
 
 @KordPreview
-fun DmChannel.live(dispatcher: CoroutineDispatcher = Dispatchers.Default) = LiveDmChannel(this, dispatcher)
+fun DmChannel.live(
+    dispatcher: CoroutineDispatcher = Dispatchers.Default,
+    parent: Job? = kord.coroutineContext.job
+) = LiveDmChannel(this, dispatcher, parent)
 
 @KordPreview
 inline fun DmChannel.live(
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
+    parent: Job? = kord.coroutineContext.job,
     block: LiveDmChannel.() -> Unit
-) = this.live(dispatcher).apply(block)
+) = this.live(dispatcher, parent).apply(block)
 
 @Suppress("DeprecatedCallableAddReplaceWith")
 @Deprecated(
@@ -65,8 +71,9 @@ fun LiveDmChannel.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(
 @KordPreview
 class LiveDmChannel(
     channel: DmChannel,
-    dispatcher: CoroutineDispatcher = Dispatchers.Default
-) : LiveChannel(channel.kord, dispatcher), KordEntity {
+    dispatcher: CoroutineDispatcher = Dispatchers.Default,
+    parent: Job? = channel.kord.coroutineContext.job
+) : LiveChannel(channel.kord, dispatcher, parent), KordEntity {
 
     override val id: Snowflake
         get() = channel.id

--- a/core/src/main/kotlin/live/channel/LiveDmChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveDmChannel.kt
@@ -11,19 +11,16 @@ import dev.kord.core.event.channel.DMChannelUpdateEvent
 import dev.kord.core.event.guild.GuildDeleteEvent
 import dev.kord.core.live.exception.LiveCancellationException
 import dev.kord.core.live.on
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.job
+import kotlinx.coroutines.*
 
 @KordPreview
 fun DmChannel.live(
-    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(kord.coroutineContext.job))
+    coroutineScope: CoroutineScope = kord + SupervisorJob(kord.coroutineContext.job)
 ) = LiveDmChannel(this, coroutineScope)
 
 @KordPreview
 inline fun DmChannel.live(
-    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(kord.coroutineContext.job)),
+    coroutineScope: CoroutineScope = kord + SupervisorJob(kord.coroutineContext.job),
     block: LiveDmChannel.() -> Unit
 ) = this.live(coroutineScope).apply(block)
 
@@ -74,7 +71,7 @@ fun LiveDmChannel.onGuildDelete(scope: CoroutineScope = this, block: suspend (Gu
 @KordPreview
 class LiveDmChannel(
     channel: DmChannel,
-    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(channel.kord.coroutineContext.job))
+    coroutineScope: CoroutineScope = channel.kord + SupervisorJob(channel.kord.coroutineContext.job)
 ) : LiveChannel(channel.kord, coroutineScope), KordEntity {
 
     override val id: Snowflake

--- a/core/src/main/kotlin/live/channel/LiveDmChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveDmChannel.kt
@@ -11,7 +11,9 @@ import dev.kord.core.event.channel.DMChannelUpdateEvent
 import dev.kord.core.event.guild.GuildDeleteEvent
 import dev.kord.core.live.exception.LiveCancellationException
 import dev.kord.core.live.on
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 
 @KordPreview
 fun DmChannel.live(
@@ -32,10 +34,12 @@ inline fun DmChannel.live(
     level = DeprecationLevel.ERROR
 )
 @KordPreview
-fun LiveDmChannel.onCreate(block: suspend (DMChannelCreateEvent) -> Unit) = on(consumer = block)
+fun LiveDmChannel.onCreate(scope: CoroutineScope = this, block: suspend (DMChannelCreateEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
-fun LiveDmChannel.onUpdate(block: suspend (DMChannelUpdateEvent) -> Unit) = on(consumer = block)
+fun LiveDmChannel.onUpdate(scope: CoroutineScope = this, block: suspend (DMChannelUpdateEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @Deprecated(
     "The block is not called when the live entity is shut down",
@@ -43,11 +47,12 @@ fun LiveDmChannel.onUpdate(block: suspend (DMChannelUpdateEvent) -> Unit) = on(c
     DeprecationLevel.ERROR
 )
 @KordPreview
-inline fun LiveDmChannel.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
-    if (it is DMChannelDeleteEvent || it is GuildDeleteEvent) {
-        block(it)
+inline fun LiveDmChannel.onShutDown(scope: CoroutineScope = this, crossinline block: suspend (Event) -> Unit) =
+    on<Event>(scope) {
+        if (it is DMChannelDeleteEvent || it is GuildDeleteEvent) {
+            block(it)
+        }
     }
-}
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shut down",
@@ -55,7 +60,8 @@ inline fun LiveDmChannel.onShutDown(crossinline block: suspend (Event) -> Unit) 
     DeprecationLevel.ERROR
 )
 @KordPreview
-fun LiveDmChannel.onDelete(block: suspend (DMChannelDeleteEvent) -> Unit) = on(consumer = block)
+fun LiveDmChannel.onDelete(scope: CoroutineScope = this, block: suspend (DMChannelDeleteEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shut down",
@@ -63,7 +69,8 @@ fun LiveDmChannel.onDelete(block: suspend (DMChannelDeleteEvent) -> Unit) = on(c
     DeprecationLevel.ERROR
 )
 @KordPreview
-fun LiveDmChannel.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
+fun LiveDmChannel.onGuildDelete(scope: CoroutineScope = this, block: suspend (GuildDeleteEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
 class LiveDmChannel(

--- a/core/src/main/kotlin/live/channel/LiveGuildChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveGuildChannel.kt
@@ -14,16 +14,21 @@ import dev.kord.core.live.exception.LiveCancellationException
 import dev.kord.core.live.on
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.job
 
 @KordPreview
-fun GuildChannel.live(dispatcher: CoroutineDispatcher = Dispatchers.Default) =
-    LiveGuildChannel(this, dispatcher)
+fun GuildChannel.live(
+    dispatcher: CoroutineDispatcher = Dispatchers.Default,
+    parent: Job? = kord.coroutineContext.job
+) = LiveGuildChannel(this, dispatcher, parent)
 
 @KordPreview
 inline fun GuildChannel.live(
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
+    parent: Job? = kord.coroutineContext.job,
     block: LiveGuildChannel.() -> Unit
-) = this.live(dispatcher).apply(block)
+) = this.live(dispatcher, parent).apply(block)
 
 @Suppress("DeprecatedCallableAddReplaceWith")
 @Deprecated(
@@ -67,8 +72,9 @@ fun LiveGuildChannel.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = 
 @KordPreview
 class LiveGuildChannel(
     channel: GuildChannel,
-    dispatcher: CoroutineDispatcher = Dispatchers.Default
-) : LiveChannel(channel.kord, dispatcher), KordEntity {
+    dispatcher: CoroutineDispatcher = Dispatchers.Default,
+    parent: Job? = channel.kord.coroutineContext.job
+) : LiveChannel(channel.kord, dispatcher, parent), KordEntity {
 
     override val id: Snowflake
         get() = channel.id

--- a/core/src/main/kotlin/live/channel/LiveGuildChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveGuildChannel.kt
@@ -12,21 +12,18 @@ import dev.kord.core.event.channel.ChannelUpdateEvent
 import dev.kord.core.event.guild.GuildDeleteEvent
 import dev.kord.core.live.exception.LiveCancellationException
 import dev.kord.core.live.on
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.job
+import kotlinx.coroutines.*
 
 @KordPreview
 fun GuildChannel.live(
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: Job? = kord.coroutineContext.job
+    parent: CoroutineScope = kord
 ) = LiveGuildChannel(this, dispatcher, parent)
 
 @KordPreview
 inline fun GuildChannel.live(
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: Job? = kord.coroutineContext.job,
+    parent: CoroutineScope = kord,
     block: LiveGuildChannel.() -> Unit
 ) = this.live(dispatcher, parent).apply(block)
 
@@ -73,7 +70,7 @@ fun LiveGuildChannel.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = 
 class LiveGuildChannel(
     channel: GuildChannel,
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: Job? = channel.kord.coroutineContext.job
+    parent: CoroutineScope = channel.kord
 ) : LiveChannel(channel.kord, dispatcher, parent), KordEntity {
 
     override val id: Snowflake

--- a/core/src/main/kotlin/live/channel/LiveGuildChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveGuildChannel.kt
@@ -12,19 +12,16 @@ import dev.kord.core.event.channel.ChannelUpdateEvent
 import dev.kord.core.event.guild.GuildDeleteEvent
 import dev.kord.core.live.exception.LiveCancellationException
 import dev.kord.core.live.on
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.job
+import kotlinx.coroutines.*
 
 @KordPreview
 fun GuildChannel.live(
-    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(kord.coroutineContext.job))
+    coroutineScope: CoroutineScope = kord + SupervisorJob(kord.coroutineContext.job)
 ) = LiveGuildChannel(this, coroutineScope)
 
 @KordPreview
 inline fun GuildChannel.live(
-    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(kord.coroutineContext.job)),
+    coroutineScope: CoroutineScope = kord + SupervisorJob(kord.coroutineContext.job),
     block: LiveGuildChannel.() -> Unit
 ) = this.live(coroutineScope).apply(block)
 
@@ -75,7 +72,7 @@ fun LiveGuildChannel.onGuildDelete(scope: CoroutineScope = this, block: suspend 
 @KordPreview
 class LiveGuildChannel(
     channel: GuildChannel,
-    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(channel.kord.coroutineContext.job))
+    coroutineScope: CoroutineScope = channel.kord + SupervisorJob(channel.kord.coroutineContext.job)
 ) : LiveChannel(channel.kord, coroutineScope), KordEntity {
 
     override val id: Snowflake

--- a/core/src/main/kotlin/live/channel/LiveGuildChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveGuildChannel.kt
@@ -12,7 +12,9 @@ import dev.kord.core.event.channel.ChannelUpdateEvent
 import dev.kord.core.event.guild.GuildDeleteEvent
 import dev.kord.core.live.exception.LiveCancellationException
 import dev.kord.core.live.on
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 
 @KordPreview
 fun GuildChannel.live(
@@ -33,10 +35,12 @@ inline fun GuildChannel.live(
     level = DeprecationLevel.ERROR
 )
 @KordPreview
-fun LiveGuildChannel.onCreate(block: suspend (ChannelCreateEvent) -> Unit) = on(consumer = block)
+fun LiveGuildChannel.onCreate(scope: CoroutineScope = this, block: suspend (ChannelCreateEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
-fun LiveGuildChannel.onUpdate(block: suspend (ChannelUpdateEvent) -> Unit) = on(consumer = block)
+fun LiveGuildChannel.onUpdate(scope: CoroutineScope = this, block: suspend (ChannelUpdateEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @Deprecated(
     "The block is not called when the live entity is shut down",
@@ -44,11 +48,12 @@ fun LiveGuildChannel.onUpdate(block: suspend (ChannelUpdateEvent) -> Unit) = on(
     DeprecationLevel.ERROR
 )
 @KordPreview
-inline fun LiveGuildChannel.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
-    if (it is ChannelDeleteEvent || it is GuildDeleteEvent) {
-        block(it)
+inline fun LiveGuildChannel.onShutDown(scope: CoroutineScope = this, crossinline block: suspend (Event) -> Unit) =
+    on<Event>(scope) {
+        if (it is ChannelDeleteEvent || it is GuildDeleteEvent) {
+            block(it)
+        }
     }
-}
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shut down",
@@ -56,7 +61,8 @@ inline fun LiveGuildChannel.onShutDown(crossinline block: suspend (Event) -> Uni
     DeprecationLevel.ERROR
 )
 @KordPreview
-fun LiveGuildChannel.onDelete(block: suspend (ChannelDeleteEvent) -> Unit) = on(consumer = block)
+fun LiveGuildChannel.onDelete(scope: CoroutineScope = this, block: suspend (ChannelDeleteEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shut down",
@@ -64,7 +70,8 @@ fun LiveGuildChannel.onDelete(block: suspend (ChannelDeleteEvent) -> Unit) = on(
     DeprecationLevel.ERROR
 )
 @KordPreview
-fun LiveGuildChannel.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
+fun LiveGuildChannel.onGuildDelete(scope: CoroutineScope = this, block: suspend (GuildDeleteEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
 class LiveGuildChannel(

--- a/core/src/main/kotlin/live/channel/LiveGuildChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveGuildChannel.kt
@@ -12,22 +12,21 @@ import dev.kord.core.event.channel.ChannelUpdateEvent
 import dev.kord.core.event.guild.GuildDeleteEvent
 import dev.kord.core.live.exception.LiveCancellationException
 import dev.kord.core.live.on
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.job
 
 @KordPreview
 fun GuildChannel.live(
-    dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: CoroutineScope = kord
-) = LiveGuildChannel(this, dispatcher, parent)
+    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(kord.coroutineContext.job))
+) = LiveGuildChannel(this, coroutineScope)
 
 @KordPreview
 inline fun GuildChannel.live(
-    dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: CoroutineScope = kord,
+    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(kord.coroutineContext.job)),
     block: LiveGuildChannel.() -> Unit
-) = this.live(dispatcher, parent).apply(block)
+) = this.live(coroutineScope).apply(block)
 
 @Suppress("DeprecatedCallableAddReplaceWith")
 @Deprecated(
@@ -76,9 +75,8 @@ fun LiveGuildChannel.onGuildDelete(scope: CoroutineScope = this, block: suspend 
 @KordPreview
 class LiveGuildChannel(
     channel: GuildChannel,
-    dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: CoroutineScope = channel.kord
-) : LiveChannel(channel.kord, dispatcher, parent), KordEntity {
+    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(channel.kord.coroutineContext.job))
+) : LiveChannel(channel.kord, coroutineScope), KordEntity {
 
     override val id: Snowflake
         get() = channel.id

--- a/core/src/main/kotlin/live/channel/LiveGuildMessageChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveGuildMessageChannel.kt
@@ -11,7 +11,9 @@ import dev.kord.core.event.channel.ChannelUpdateEvent
 import dev.kord.core.event.guild.GuildDeleteEvent
 import dev.kord.core.live.exception.LiveCancellationException
 import dev.kord.core.live.on
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 
 @KordPreview
 fun GuildMessageChannel.live(
@@ -32,10 +34,12 @@ inline fun GuildMessageChannel.live(
     level = DeprecationLevel.ERROR
 )
 @KordPreview
-fun LiveGuildMessageChannel.onCreate(block: suspend (ChannelCreateEvent) -> Unit) = on(consumer = block)
+fun LiveGuildMessageChannel.onCreate(scope: CoroutineScope = this, block: suspend (ChannelCreateEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
-fun LiveGuildMessageChannel.onUpdate(block: suspend (ChannelUpdateEvent) -> Unit) = on(consumer = block)
+fun LiveGuildMessageChannel.onUpdate(scope: CoroutineScope = this, block: suspend (ChannelUpdateEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @Deprecated(
     "The block is not called when the live entity is shut down",
@@ -43,7 +47,10 @@ fun LiveGuildMessageChannel.onUpdate(block: suspend (ChannelUpdateEvent) -> Unit
     DeprecationLevel.ERROR
 )
 @KordPreview
-inline fun LiveGuildMessageChannel.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
+inline fun LiveGuildMessageChannel.onShutDown(
+    scope: CoroutineScope = this,
+    crossinline block: suspend (Event) -> Unit
+) = on<Event>(scope) {
     if (it is ChannelDeleteEvent || it is GuildDeleteEvent) {
         block(it)
     }
@@ -55,7 +62,8 @@ inline fun LiveGuildMessageChannel.onShutDown(crossinline block: suspend (Event)
     DeprecationLevel.ERROR
 )
 @KordPreview
-fun LiveGuildMessageChannel.onChannelDelete(block: suspend (ChannelDeleteEvent) -> Unit) = on(consumer = block)
+fun LiveGuildMessageChannel.onChannelDelete(scope: CoroutineScope = this, block: suspend (ChannelDeleteEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shut down",
@@ -63,7 +71,8 @@ fun LiveGuildMessageChannel.onChannelDelete(block: suspend (ChannelDeleteEvent) 
     DeprecationLevel.ERROR
 )
 @KordPreview
-fun LiveGuildMessageChannel.onDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
+fun LiveGuildMessageChannel.onDelete(scope: CoroutineScope = this, block: suspend (GuildDeleteEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
 class LiveGuildMessageChannel(

--- a/core/src/main/kotlin/live/channel/LiveGuildMessageChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveGuildMessageChannel.kt
@@ -11,22 +11,21 @@ import dev.kord.core.event.channel.ChannelUpdateEvent
 import dev.kord.core.event.guild.GuildDeleteEvent
 import dev.kord.core.live.exception.LiveCancellationException
 import dev.kord.core.live.on
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.job
 
 @KordPreview
 fun GuildMessageChannel.live(
-    dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: CoroutineScope = kord
-) = LiveGuildMessageChannel(this, dispatcher, parent)
+    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(kord.coroutineContext.job))
+) = LiveGuildMessageChannel(this, coroutineScope)
 
 @KordPreview
 inline fun GuildMessageChannel.live(
-    dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: CoroutineScope = kord,
+    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(kord.coroutineContext.job)),
     block: LiveGuildMessageChannel.() -> Unit
-) = this.live(dispatcher, parent).apply(block)
+) = this.live(coroutineScope).apply(block)
 
 @Suppress("DeprecatedCallableAddReplaceWith")
 @Deprecated(
@@ -77,9 +76,8 @@ fun LiveGuildMessageChannel.onDelete(scope: CoroutineScope = this, block: suspen
 @KordPreview
 class LiveGuildMessageChannel(
     channel: GuildMessageChannel,
-    dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: CoroutineScope = channel.kord
-) : LiveChannel(channel.kord, dispatcher, parent), KordEntity {
+    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(channel.kord.coroutineContext.job))
+) : LiveChannel(channel.kord, coroutineScope), KordEntity {
 
     override val id: Snowflake
         get() = channel.id

--- a/core/src/main/kotlin/live/channel/LiveGuildMessageChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveGuildMessageChannel.kt
@@ -11,19 +11,16 @@ import dev.kord.core.event.channel.ChannelUpdateEvent
 import dev.kord.core.event.guild.GuildDeleteEvent
 import dev.kord.core.live.exception.LiveCancellationException
 import dev.kord.core.live.on
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.job
+import kotlinx.coroutines.*
 
 @KordPreview
 fun GuildMessageChannel.live(
-    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(kord.coroutineContext.job))
+    coroutineScope: CoroutineScope = kord + SupervisorJob(kord.coroutineContext.job)
 ) = LiveGuildMessageChannel(this, coroutineScope)
 
 @KordPreview
 inline fun GuildMessageChannel.live(
-    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(kord.coroutineContext.job)),
+    coroutineScope: CoroutineScope = kord + SupervisorJob(kord.coroutineContext.job),
     block: LiveGuildMessageChannel.() -> Unit
 ) = this.live(coroutineScope).apply(block)
 
@@ -76,7 +73,7 @@ fun LiveGuildMessageChannel.onDelete(scope: CoroutineScope = this, block: suspen
 @KordPreview
 class LiveGuildMessageChannel(
     channel: GuildMessageChannel,
-    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(channel.kord.coroutineContext.job))
+    coroutineScope: CoroutineScope = channel.kord + SupervisorJob(channel.kord.coroutineContext.job)
 ) : LiveChannel(channel.kord, coroutineScope), KordEntity {
 
     override val id: Snowflake

--- a/core/src/main/kotlin/live/channel/LiveGuildMessageChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveGuildMessageChannel.kt
@@ -13,16 +13,21 @@ import dev.kord.core.live.exception.LiveCancellationException
 import dev.kord.core.live.on
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.job
 
 @KordPreview
-fun GuildMessageChannel.live(dispatcher: CoroutineDispatcher = Dispatchers.Default) =
-    LiveGuildMessageChannel(this, dispatcher)
+fun GuildMessageChannel.live(
+    dispatcher: CoroutineDispatcher = Dispatchers.Default,
+    parent: Job? = kord.coroutineContext.job
+) = LiveGuildMessageChannel(this, dispatcher, parent)
 
 @KordPreview
 inline fun GuildMessageChannel.live(
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
+    parent: Job? = kord.coroutineContext.job,
     block: LiveGuildMessageChannel.() -> Unit
-) = this.live(dispatcher).apply(block)
+) = this.live(dispatcher, parent).apply(block)
 
 @Suppress("DeprecatedCallableAddReplaceWith")
 @Deprecated(
@@ -66,8 +71,9 @@ fun LiveGuildMessageChannel.onDelete(block: suspend (GuildDeleteEvent) -> Unit) 
 @KordPreview
 class LiveGuildMessageChannel(
     channel: GuildMessageChannel,
-    dispatcher: CoroutineDispatcher = Dispatchers.Default
-) : LiveChannel(channel.kord, dispatcher), KordEntity {
+    dispatcher: CoroutineDispatcher = Dispatchers.Default,
+    parent: Job? = channel.kord.coroutineContext.job
+) : LiveChannel(channel.kord, dispatcher, parent), KordEntity {
 
     override val id: Snowflake
         get() = channel.id

--- a/core/src/main/kotlin/live/channel/LiveGuildMessageChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveGuildMessageChannel.kt
@@ -11,21 +11,18 @@ import dev.kord.core.event.channel.ChannelUpdateEvent
 import dev.kord.core.event.guild.GuildDeleteEvent
 import dev.kord.core.live.exception.LiveCancellationException
 import dev.kord.core.live.on
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.job
+import kotlinx.coroutines.*
 
 @KordPreview
 fun GuildMessageChannel.live(
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: Job? = kord.coroutineContext.job
+    parent: CoroutineScope = kord
 ) = LiveGuildMessageChannel(this, dispatcher, parent)
 
 @KordPreview
 inline fun GuildMessageChannel.live(
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: Job? = kord.coroutineContext.job,
+    parent: CoroutineScope = kord,
     block: LiveGuildMessageChannel.() -> Unit
 ) = this.live(dispatcher, parent).apply(block)
 
@@ -72,7 +69,7 @@ fun LiveGuildMessageChannel.onDelete(block: suspend (GuildDeleteEvent) -> Unit) 
 class LiveGuildMessageChannel(
     channel: GuildMessageChannel,
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: Job? = channel.kord.coroutineContext.job
+    parent: CoroutineScope = channel.kord
 ) : LiveChannel(channel.kord, dispatcher, parent), KordEntity {
 
     override val id: Snowflake

--- a/core/src/main/kotlin/live/channel/LiveVoiceChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveVoiceChannel.kt
@@ -11,7 +11,9 @@ import dev.kord.core.event.channel.VoiceChannelUpdateEvent
 import dev.kord.core.event.guild.GuildDeleteEvent
 import dev.kord.core.live.exception.LiveCancellationException
 import dev.kord.core.live.on
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 
 @KordPreview
 fun VoiceChannel.live(
@@ -32,10 +34,12 @@ inline fun VoiceChannel.live(
     level = DeprecationLevel.ERROR
 )
 @KordPreview
-fun LiveVoiceChannel.onCreate(block: suspend (VoiceChannelCreateEvent) -> Unit) = on(consumer = block)
+fun LiveVoiceChannel.onCreate(scope: CoroutineScope = this, block: suspend (VoiceChannelCreateEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
-fun LiveVoiceChannel.onUpdate(block: suspend (VoiceChannelUpdateEvent) -> Unit) = on(consumer = block)
+fun LiveVoiceChannel.onUpdate(scope: CoroutineScope = this, block: suspend (VoiceChannelUpdateEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @Deprecated(
     "The block is not called when the live entity is shut down",
@@ -43,11 +47,12 @@ fun LiveVoiceChannel.onUpdate(block: suspend (VoiceChannelUpdateEvent) -> Unit) 
     DeprecationLevel.ERROR
 )
 @KordPreview
-inline fun LiveVoiceChannel.onShutDown(crossinline block: suspend (Event) -> Unit) = on<Event> {
-    if (it is VoiceChannelDeleteEvent || it is GuildDeleteEvent) {
-        block(it)
+inline fun LiveVoiceChannel.onShutDown(scope: CoroutineScope = this, crossinline block: suspend (Event) -> Unit) =
+    on<Event>(scope) {
+        if (it is VoiceChannelDeleteEvent || it is GuildDeleteEvent) {
+            block(it)
+        }
     }
-}
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shut down",
@@ -55,7 +60,8 @@ inline fun LiveVoiceChannel.onShutDown(crossinline block: suspend (Event) -> Uni
     DeprecationLevel.ERROR
 )
 @KordPreview
-fun LiveVoiceChannel.onDelete(block: suspend (VoiceChannelDeleteEvent) -> Unit) = on(consumer = block)
+fun LiveVoiceChannel.onDelete(scope: CoroutineScope = this, block: suspend (VoiceChannelDeleteEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @Deprecated(
     "The block is not called when the entity is deleted because the live entity is shut down",
@@ -63,7 +69,8 @@ fun LiveVoiceChannel.onDelete(block: suspend (VoiceChannelDeleteEvent) -> Unit) 
     DeprecationLevel.ERROR
 )
 @KordPreview
-fun LiveVoiceChannel.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = on(consumer = block)
+fun LiveVoiceChannel.onGuildDelete(scope: CoroutineScope = this, block: suspend (GuildDeleteEvent) -> Unit) =
+    on(scope = scope, consumer = block)
 
 @KordPreview
 class LiveVoiceChannel(

--- a/core/src/main/kotlin/live/channel/LiveVoiceChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveVoiceChannel.kt
@@ -11,19 +11,16 @@ import dev.kord.core.event.channel.VoiceChannelUpdateEvent
 import dev.kord.core.event.guild.GuildDeleteEvent
 import dev.kord.core.live.exception.LiveCancellationException
 import dev.kord.core.live.on
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.job
+import kotlinx.coroutines.*
 
 @KordPreview
 fun VoiceChannel.live(
-    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(kord.coroutineContext.job))
+    coroutineScope: CoroutineScope = kord + SupervisorJob(kord.coroutineContext.job)
 ) = LiveVoiceChannel(this, coroutineScope)
 
 @KordPreview
 inline fun VoiceChannel.live(
-    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(kord.coroutineContext.job)),
+    coroutineScope: CoroutineScope = kord + SupervisorJob(kord.coroutineContext.job),
     block: LiveVoiceChannel.() -> Unit
 ) = this.live(coroutineScope).apply(block)
 
@@ -74,7 +71,7 @@ fun LiveVoiceChannel.onGuildDelete(scope: CoroutineScope = this, block: suspend 
 @KordPreview
 class LiveVoiceChannel(
     channel: VoiceChannel,
-    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(channel.kord.coroutineContext.job))
+    coroutineScope: CoroutineScope = channel.kord + SupervisorJob(channel.kord.coroutineContext.job)
 ) : LiveChannel(channel.kord, coroutineScope), KordEntity {
 
     override val id: Snowflake

--- a/core/src/main/kotlin/live/channel/LiveVoiceChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveVoiceChannel.kt
@@ -11,21 +11,18 @@ import dev.kord.core.event.channel.VoiceChannelUpdateEvent
 import dev.kord.core.event.guild.GuildDeleteEvent
 import dev.kord.core.live.exception.LiveCancellationException
 import dev.kord.core.live.on
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.job
+import kotlinx.coroutines.*
 
 @KordPreview
 fun VoiceChannel.live(
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: Job? = kord.coroutineContext.job
+    parent: CoroutineScope = kord
 ) = LiveVoiceChannel(this, dispatcher, parent)
 
 @KordPreview
 inline fun VoiceChannel.live(
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: Job? = kord.coroutineContext.job,
+    parent: CoroutineScope = kord,
     block: LiveVoiceChannel.() -> Unit
 ) = this.live(dispatcher, parent).apply(block)
 
@@ -72,7 +69,7 @@ fun LiveVoiceChannel.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = 
 class LiveVoiceChannel(
     channel: VoiceChannel,
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: Job? = channel.kord.coroutineContext.job
+    parent: CoroutineScope = channel.kord
 ) : LiveChannel(channel.kord, dispatcher, parent), KordEntity {
 
     override val id: Snowflake

--- a/core/src/main/kotlin/live/channel/LiveVoiceChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveVoiceChannel.kt
@@ -13,16 +13,21 @@ import dev.kord.core.live.exception.LiveCancellationException
 import dev.kord.core.live.on
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.job
 
 @KordPreview
-fun VoiceChannel.live(dispatcher: CoroutineDispatcher = Dispatchers.Default) =
-    LiveVoiceChannel(this, dispatcher)
+fun VoiceChannel.live(
+    dispatcher: CoroutineDispatcher = Dispatchers.Default,
+    parent: Job? = kord.coroutineContext.job
+) = LiveVoiceChannel(this, dispatcher, parent)
 
 @KordPreview
 inline fun VoiceChannel.live(
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
+    parent: Job? = kord.coroutineContext.job,
     block: LiveVoiceChannel.() -> Unit
-) = this.live(dispatcher).apply(block)
+) = this.live(dispatcher, parent).apply(block)
 
 @Suppress("DeprecatedCallableAddReplaceWith")
 @Deprecated(
@@ -66,8 +71,9 @@ fun LiveVoiceChannel.onGuildDelete(block: suspend (GuildDeleteEvent) -> Unit) = 
 @KordPreview
 class LiveVoiceChannel(
     channel: VoiceChannel,
-    dispatcher: CoroutineDispatcher = Dispatchers.Default
-) : LiveChannel(channel.kord, dispatcher), KordEntity {
+    dispatcher: CoroutineDispatcher = Dispatchers.Default,
+    parent: Job? = channel.kord.coroutineContext.job
+) : LiveChannel(channel.kord, dispatcher, parent), KordEntity {
 
     override val id: Snowflake
         get() = channel.id

--- a/core/src/main/kotlin/live/channel/LiveVoiceChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveVoiceChannel.kt
@@ -11,22 +11,21 @@ import dev.kord.core.event.channel.VoiceChannelUpdateEvent
 import dev.kord.core.event.guild.GuildDeleteEvent
 import dev.kord.core.live.exception.LiveCancellationException
 import dev.kord.core.live.on
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.job
 
 @KordPreview
 fun VoiceChannel.live(
-    dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: CoroutineScope = kord
-) = LiveVoiceChannel(this, dispatcher, parent)
+    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(kord.coroutineContext.job))
+) = LiveVoiceChannel(this, coroutineScope)
 
 @KordPreview
 inline fun VoiceChannel.live(
-    dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: CoroutineScope = kord,
+    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(kord.coroutineContext.job)),
     block: LiveVoiceChannel.() -> Unit
-) = this.live(dispatcher, parent).apply(block)
+) = this.live(coroutineScope).apply(block)
 
 @Suppress("DeprecatedCallableAddReplaceWith")
 @Deprecated(
@@ -75,9 +74,8 @@ fun LiveVoiceChannel.onGuildDelete(scope: CoroutineScope = this, block: suspend 
 @KordPreview
 class LiveVoiceChannel(
     channel: VoiceChannel,
-    dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    parent: CoroutineScope = channel.kord
-) : LiveChannel(channel.kord, dispatcher, parent), KordEntity {
+    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob(channel.kord.coroutineContext.job))
+) : LiveChannel(channel.kord, coroutineScope), KordEntity {
 
     override val id: Snowflake
         get() = channel.id

--- a/core/src/test/kotlin/live/LiveKordEntityTest.kt
+++ b/core/src/test/kotlin/live/LiveKordEntityTest.kt
@@ -33,7 +33,7 @@ class LiveKordEntityTest : AbstractLiveEntityTest<LiveKordEntityTest.LiveEntityM
 
     @Disabled
     inner class LiveEntityMock(kord: Kord) :
-        AbstractLiveKordEntity(kord, Dispatchers.Default) {
+        AbstractLiveKordEntity(kord) {
 
         var counter: CounterAtomicLatch? = null
 


### PR DESCRIPTION
In some case, it's useful to define the `SupervisorJob` different than kord's job.

```
kord -> MyObject -> LiveEntity
```
_MyObject is a CoroutineScope and can be the parent of the live entity_

So for this reason, a specific job can be sent through constructor of live entities