### PR TITLE
Add missing session start limit field

### DIFF
--- a/rest/src/main/kotlin/json/response/Gateway.kt
+++ b/rest/src/main/kotlin/json/response/Gateway.kt
@@ -19,5 +19,7 @@ data class SessionStartLimitResponse(
     val total: Int,
     val remaining: Int,
     @SerialName("reset_after")
-    val resetAfter: Int
+    val resetAfter: Int,
+    @SerialName("max_concurrency")
+    val maxConcurrency: Int
 )


### PR DESCRIPTION
- Adds the `max_concurrency` field

**Docs:** <https://discord.com/developers/docs/topics/gateway#session-start-limit-object-session-start-limit-structure>