### PR TITLE
Followup embeds

### DIFF
--- a/core/src/main/kotlin/behavior/interaction/InteractionBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/InteractionBehavior.kt
@@ -127,7 +127,6 @@ suspend inline fun InteractionBehavior.respondPublic(
 @KordPreview
 @OptIn(ExperimentalContracts::class)
 suspend inline fun InteractionBehavior.respondEphemeral(
-    content: String,
     builder: EphemeralInteractionResponseCreateBuilder.() -> Unit = {}
 ): EphemeralInteractionResponseBehavior {
 

--- a/rest/src/main/kotlin/builder/interaction/EphemeralInteractionBuilders.kt
+++ b/rest/src/main/kotlin/builder/interaction/EphemeralInteractionBuilders.kt
@@ -31,6 +31,15 @@ class EphemeralInteractionResponseModifyBuilder : BaseInteractionResponseModifyB
 
     val components: MutableList<MessageComponentBuilder> = mutableListOf()
 
+
+    @OptIn(ExperimentalContracts::class)
+    inline fun embed(builder: EmbedBuilder.() -> Unit) {
+        contract {
+            callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+        }
+        embeds.add(EmbedBuilder().apply(builder))
+    }
+
     @OptIn(ExperimentalContracts::class)
     inline fun allowedMentions(builder: AllowedMentionsBuilder.() -> Unit) {
         contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
@@ -72,6 +81,14 @@ class EphemeralInteractionResponseCreateBuilder : BaseInteractionResponseCreateB
     private var _allowedMentions: Optional<AllowedMentionsBuilder> = Optional.Missing()
     override var allowedMentions: AllowedMentionsBuilder? by ::_allowedMentions.delegate()
 
+
+    @OptIn(ExperimentalContracts::class)
+    inline fun embed(builder: EmbedBuilder.() -> Unit) {
+        contract {
+            callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+        }
+        embeds.add(EmbedBuilder().apply(builder))
+    }
 
     override fun toRequest(): MultipartInteractionResponseCreateRequest {
         val flags = Optional.Value(MessageFlags(MessageFlag.Ephemeral))


### PR DESCRIPTION
* Adds missing embed functions for interaction/followups
*  Makes embed properties final and mutable lists
* Remove redundant content parameter for ephemeral responses since it can now be either embed or regular content