### PR TITLE
Change field visibility and single-expression return syntax

### DIFF
--- a/rest/src/main/kotlin/builder/interaction/OptionsBuilder.kt
+++ b/rest/src/main/kotlin/builder/interaction/OptionsBuilder.kt
@@ -17,8 +17,8 @@ import kotlin.contracts.contract
 @KordDsl
 @KordPreview
 sealed class OptionsBuilder(
-    protected var name: String,
-    protected var description: String,
+    var name: String,
+    var description: String,
     protected var type: ApplicationCommandOptionType,
 ) :
     RequestBuilder<ApplicationCommandOption> {

--- a/rest/src/main/kotlin/builder/interaction/OptionsBuilder.kt
+++ b/rest/src/main/kotlin/builder/interaction/OptionsBuilder.kt
@@ -17,9 +17,9 @@ import kotlin.contracts.contract
 @KordDsl
 @KordPreview
 sealed class OptionsBuilder(
-    var name: String,
-    var description: String,
-    var type: ApplicationCommandOptionType,
+    protected var name: String,
+    protected var description: String,
+    protected var type: ApplicationCommandOptionType,
 ) :
     RequestBuilder<ApplicationCommandOption> {
     internal var _default: OptionalBoolean = OptionalBoolean.Missing
@@ -28,9 +28,13 @@ sealed class OptionsBuilder(
     internal var _required: OptionalBoolean = OptionalBoolean.Missing
     var required: Boolean? by ::_required.delegate()
 
-    override fun toRequest(): ApplicationCommandOption {
-        return ApplicationCommandOption(type, name, description, _default, _required)
-    }
+    override fun toRequest() = ApplicationCommandOption(
+        type,
+        name,
+        description,
+        _default,
+        _required
+    )
 }
 
 @KordDsl
@@ -38,7 +42,7 @@ sealed class OptionsBuilder(
 sealed class BaseChoiceBuilder<T>(
     name: String,
     description: String,
-    type: ApplicationCommandOptionType,
+    type: ApplicationCommandOptionType
 ) :
     OptionsBuilder(name, description, type) {
     private var _choices: Optional<MutableList<Choice<*>>> = Optional.Missing()
@@ -46,17 +50,14 @@ sealed class BaseChoiceBuilder<T>(
 
     abstract fun choice(name: String, value: T)
 
-    override fun toRequest(): ApplicationCommandOption {
-        return ApplicationCommandOption(
-            type,
-            name,
-            description,
-            choices = _choices,
-            required = _required,
-            default = _default
-        )
-    }
-
+    override fun toRequest() = ApplicationCommandOption(
+        type,
+        name,
+        description,
+        choices = _choices,
+        required = _required,
+        default = _default
+    )
 }
 
 @KordDsl
@@ -116,12 +117,12 @@ sealed class BaseCommandOptionBuilder(
     private var _options: Optional<MutableList<OptionsBuilder>> = Optional.Missing()
     var options by ::_options.delegate()
 
-    override fun toRequest(): ApplicationCommandOption {
-        return ApplicationCommandOption(type,
-            name,
-            description,
-            options = _options.mapList { it.toRequest() })
-    }
+    override fun toRequest() = ApplicationCommandOption(
+        type,
+        name,
+        description,
+        options = _options.mapList { it.toRequest() }
+    )
 }
 
 @KordDsl

--- a/rest/src/main/kotlin/builder/interaction/OptionsBuilder.kt
+++ b/rest/src/main/kotlin/builder/interaction/OptionsBuilder.kt
@@ -19,7 +19,7 @@ import kotlin.contracts.contract
 sealed class OptionsBuilder(
     var name: String,
     var description: String,
-    protected var type: ApplicationCommandOptionType,
+    val type: ApplicationCommandOptionType,
 ) :
     RequestBuilder<ApplicationCommandOption> {
     internal var _default: OptionalBoolean = OptionalBoolean.Missing
@@ -182,7 +182,6 @@ class SubCommandBuilder(name: String, description: String) :
         options!!.add(MentionableBuilder(name, description).apply(builder))
 
     }
-
 }
 
 @KordDsl


### PR DESCRIPTION
- **Changed the visibility of**
`dev.kord.rest.builder.interaction.OptionsBuilder.name, .description, .type` from `public` to `protected` due to them serving no purpose as public from an API standpoint. E.g
```kt
guild.createApplicationCommand("...", "...") {
    string(name="some_name", description="some_description") { // obligatory fields
        this.name = "some_other_name" //  this line serves no purpose
        this.description = "some_other_description" // this line serves no purpose
        this.type = ApplicationCommandOptionType.String // this is already specified by the `string` choice-builder
    }
}
```
The reason for them not being private is due to `BaseCommandOptionBuilder.toRequest` and `BaseChoiceBuilder.toRequest` requiring access to these fields when returning an `ApplicationCommandOption` object.

- **Changed the .toRequest functions to single expression return syntax**
Reduces some redundancy, e.g return type and unnecessary `return` keyword