### PR TITLE
Add a cache aware rest entity supplier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 0.7.3
+
+## Additions
+
+* Added a StoreEntitySupplier that will store it's fetched elements in the target cache.
+* Added a strategy for a caching rest supplier.
+* Added a strategy for a caching with a caching rest fall back strategy.
+
+
 # 0.7.2
 
 ## Additions

--- a/core/src/main/kotlin/supplier/CacheAwareRestSupplier.kt
+++ b/core/src/main/kotlin/supplier/CacheAwareRestSupplier.kt
@@ -7,27 +7,29 @@ import dev.kord.core.Kord
 import dev.kord.core.entity.*
 import dev.kord.core.entity.channel.Channel
 import dev.kord.core.entity.channel.GuildChannel
-import dev.kord.rest.request.RestRequestException
-import dev.kord.rest.service.RestClient
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+
 /**
  * [EntitySupplier] that uses a [RestEntitySupplier] to resolve entities.
  *
  * Resolved entities will always be stored in [cache] if it wasn't null or empty for flows.
  */
-class CacheAwareRestEntitySupplier(val restSupplier: RestEntitySupplier,
-                                   val cache: DataCache,
-                                   val kord: Kord) : EntitySupplier {
+class CacheAwareRestEntitySupplier(
+    val restSupplier: RestEntitySupplier,
+    val cache: DataCache,
+    val kord: Kord
+) : EntitySupplier {
 
 
     override val guilds: Flow<Guild>
-        get() = flow {
-            storeAndEmit(restSupplier.guilds) { it.data }
-        }
+        get() = storeAndEmit(restSupplier.guilds) { it.data }
+
     override val regions: Flow<Region>
-        get() = flow {
-            storeAndEmit(restSupplier.regions) { it.data }
-        }
+        get() = storeAndEmit(restSupplier.regions) { it.data }
+
 
     override suspend fun getGuildOrNull(id: Snowflake): Guild? {
         return storeAndReturn(restSupplier.getGuildOrNull(id)) { it.data }
@@ -46,15 +48,13 @@ class CacheAwareRestEntitySupplier(val restSupplier: RestEntitySupplier,
     }
 
     override fun getGuildChannels(guildId: Snowflake): Flow<GuildChannel> {
-        return flow {
-            storeAndEmit(restSupplier.getGuildChannels(guildId)) { it.data }
-        }
+        return storeAndEmit(restSupplier.getGuildChannels(guildId)) { it.data }
+
     }
 
     override fun getChannelPins(channelId: Snowflake): Flow<Message> {
-        return flow {
-            storeAndEmit(restSupplier.getChannelPins(channelId)) { it.data }
-        }
+        return storeAndEmit(restSupplier.getChannelPins(channelId)) { it.data }
+
     }
 
     override suspend fun getMemberOrNull(guildId: Snowflake, userId: Snowflake): Member? {
@@ -66,21 +66,15 @@ class CacheAwareRestEntitySupplier(val restSupplier: RestEntitySupplier,
     }
 
     override fun getMessagesAfter(messageId: Snowflake, channelId: Snowflake, limit: Int): Flow<Message> {
-        return flow {
-            storeAndEmit(restSupplier.getMessagesAfter(messageId, channelId, limit)) { it.data }
-        }
+        return storeAndEmit(restSupplier.getMessagesAfter(messageId, channelId, limit)) { it.data }
     }
 
     override fun getMessagesBefore(messageId: Snowflake, channelId: Snowflake, limit: Int): Flow<Message> {
-        return flow {
-            storeAndEmit(restSupplier.getMessagesBefore(messageId, channelId, limit)) { it.data }
-        }
+        return storeAndEmit(restSupplier.getMessagesBefore(messageId, channelId, limit)) { it.data }
     }
 
     override fun getMessagesAround(messageId: Snowflake, channelId: Snowflake, limit: Int): Flow<Message> {
-        return flow {
-            storeAndEmit(restSupplier.getMessagesAround(messageId, channelId, limit)) { it.data }
-        }
+        return storeAndEmit(restSupplier.getMessagesAround(messageId, channelId, limit)) { it.data }
     }
 
     override suspend fun getSelfOrNull(): User? {
@@ -96,9 +90,7 @@ class CacheAwareRestEntitySupplier(val restSupplier: RestEntitySupplier,
     }
 
     override fun getGuildRoles(guildId: Snowflake): Flow<Role> {
-        return flow {
-            storeAndEmit(restSupplier.getGuildRoles(guildId)) { it.data }
-        }
+        return storeAndEmit(restSupplier.getGuildRoles(guildId)) { it.data }
     }
 
     override suspend fun getGuildBanOrNull(guildId: Snowflake, userId: Snowflake): Ban? {
@@ -106,21 +98,15 @@ class CacheAwareRestEntitySupplier(val restSupplier: RestEntitySupplier,
     }
 
     override fun getGuildBans(guildId: Snowflake): Flow<Ban> {
-        return flow {
-            storeAndEmit(restSupplier.getGuildBans(guildId)) { it.data }
-        }
+        return storeAndEmit(restSupplier.getGuildBans(guildId)) { it.data }
     }
 
     override fun getGuildMembers(guildId: Snowflake, limit: Int): Flow<Member> {
-        return flow {
-            storeAndEmit(restSupplier.getGuildMembers(guildId, limit)) { it.data }
-        }
+        return storeAndEmit(restSupplier.getGuildMembers(guildId, limit)) { it.data }
     }
 
     override fun getGuildVoiceRegions(guildId: Snowflake): Flow<Region> {
-        return flow {
-            storeAndEmit(restSupplier.getGuildVoiceRegions(guildId)) { it.data }
-        }
+        return storeAndEmit(restSupplier.getGuildVoiceRegions(guildId)) { it.data }
     }
 
     override suspend fun getEmojiOrNull(guildId: Snowflake, emojiId: Snowflake): GuildEmoji? {
@@ -128,27 +114,21 @@ class CacheAwareRestEntitySupplier(val restSupplier: RestEntitySupplier,
     }
 
     override fun getEmojis(guildId: Snowflake): Flow<GuildEmoji> {
-        return flow {
-            storeAndEmit(restSupplier.getEmojis(guildId)) { it.data }
-        }
+        return storeAndEmit(restSupplier.getEmojis(guildId)) { it.data }
+
     }
 
     override fun getCurrentUserGuilds(limit: Int): Flow<Guild> {
-        return flow {
-            storeAndEmit(restSupplier.getCurrentUserGuilds(limit)) { it.data }
-        }
+        return storeAndEmit(restSupplier.getCurrentUserGuilds(limit)) { it.data }
+
     }
 
     override fun getChannelWebhooks(channelId: Snowflake): Flow<Webhook> {
-        return flow {
-            storeAndEmit(restSupplier.getChannelWebhooks(channelId)) { it.data }
-        }
+        return storeAndEmit(restSupplier.getChannelWebhooks(channelId)) { it.data }
     }
 
     override fun getGuildWebhooks(guildId: Snowflake): Flow<Webhook> {
-        return flow {
-            storeAndEmit(restSupplier.getGuildWebhooks(guildId)) { it.data }
-        }
+        return storeAndEmit(restSupplier.getGuildWebhooks(guildId)) { it.data }
     }
 
     override suspend fun getWebhookOrNull(id: Snowflake): Webhook? {
@@ -157,7 +137,6 @@ class CacheAwareRestEntitySupplier(val restSupplier: RestEntitySupplier,
 
     override suspend fun getWebhookWithTokenOrNull(id: Snowflake, token: String): Webhook? {
         return storeAndReturn(restSupplier.getWebhookWithTokenOrNull(id, token)) { it.data }
-
     }
 
     override suspend fun getTemplateOrNull(code: String): Template? {
@@ -165,9 +144,7 @@ class CacheAwareRestEntitySupplier(val restSupplier: RestEntitySupplier,
     }
 
     override fun getTemplates(guildId: Snowflake): Flow<Template> {
-        return flow {
-            storeAndEmit(restSupplier.getTemplates(guildId)) { it.data }
-        }
+        return storeAndEmit(restSupplier.getTemplates(guildId)) { it.data }
     }
 
     override suspend fun getStageInstanceOrNull(channelId: Snowflake): StageInstance? {
@@ -179,9 +156,11 @@ class CacheAwareRestEntitySupplier(val restSupplier: RestEntitySupplier,
         kord.cache.put(data)
     }
 
-    private suspend inline fun <T, R> FlowCollector<T>.storeAndEmit(source: Flow<T>, crossinline transform: (T) -> R) {
-        source.mapAndStore { transform(it) }
-        emitAll(source)
+    private inline fun <T, R> storeAndEmit(source: Flow<T>, crossinline transform: (T) -> R): Flow<T> {
+        return flow {
+            source.mapAndStore { transform(it) }
+            emitAll(source)
+        }
     }
 
     private suspend inline fun <T, reified R : Any> storeAndReturn(value: T?, transform: (T) -> R): T? {

--- a/core/src/main/kotlin/supplier/CacheAwareRestSupplier.kt
+++ b/core/src/main/kotlin/supplier/CacheAwareRestSupplier.kt
@@ -1,0 +1,192 @@
+package dev.kord.core.supplier
+
+import dev.kord.cache.api.DataCache
+import dev.kord.cache.api.put
+import dev.kord.common.entity.Snowflake
+import dev.kord.core.Kord
+import dev.kord.core.entity.*
+import dev.kord.core.entity.channel.Channel
+import dev.kord.core.entity.channel.GuildChannel
+import dev.kord.rest.request.RestRequestException
+import dev.kord.rest.service.RestClient
+import kotlinx.coroutines.flow.*
+/**
+ * [EntitySupplier] that uses a [RestEntitySupplier] to resolve entities.
+ *
+ * Resolved entities will always be stored in [cache] if it wasn't null or empty for flows.
+ */
+class CacheAwareRestEntitySupplier(val restSupplier: RestEntitySupplier,
+                                   val cache: DataCache,
+                                   val kord: Kord) : EntitySupplier {
+
+
+    override val guilds: Flow<Guild>
+        get() = flow {
+            storeAndEmit(restSupplier.guilds) { it.data }
+        }
+    override val regions: Flow<Region>
+        get() = flow {
+            storeAndEmit(restSupplier.regions) { it.data }
+        }
+
+    override suspend fun getGuildOrNull(id: Snowflake): Guild? {
+        return storeAndReturn(restSupplier.getGuildOrNull(id)) { it.data }
+    }
+
+    override suspend fun getGuildPreviewOrNull(guildId: Snowflake): GuildPreview? {
+        return storeAndReturn(restSupplier.getGuildPreviewOrNull(guildId)) { it.data }
+    }
+
+    override suspend fun getGuildWidgetOrNull(guildId: Snowflake): GuildWidget? {
+        return storeAndReturn(restSupplier.getGuildWidgetOrNull(guildId)) { it.data }
+    }
+
+    override suspend fun getChannelOrNull(id: Snowflake): Channel? {
+        return storeAndReturn(restSupplier.getChannelOrNull(id)) { it.data }
+    }
+
+    override fun getGuildChannels(guildId: Snowflake): Flow<GuildChannel> {
+        return flow {
+            storeAndEmit(restSupplier.getGuildChannels(guildId)) { it.data }
+        }
+    }
+
+    override fun getChannelPins(channelId: Snowflake): Flow<Message> {
+        return flow {
+            storeAndEmit(restSupplier.getChannelPins(channelId)) { it.data }
+        }
+    }
+
+    override suspend fun getMemberOrNull(guildId: Snowflake, userId: Snowflake): Member? {
+        return storeAndReturn(restSupplier.getMemberOrNull(guildId, userId)) { it.data }
+    }
+
+    override suspend fun getMessageOrNull(channelId: Snowflake, messageId: Snowflake): Message? {
+        return storeAndReturn(restSupplier.getMessageOrNull(channelId, messageId)) { it.data }
+    }
+
+    override fun getMessagesAfter(messageId: Snowflake, channelId: Snowflake, limit: Int): Flow<Message> {
+        return flow {
+            storeAndEmit(restSupplier.getMessagesAfter(messageId, channelId, limit)) { it.data }
+        }
+    }
+
+    override fun getMessagesBefore(messageId: Snowflake, channelId: Snowflake, limit: Int): Flow<Message> {
+        return flow {
+            storeAndEmit(restSupplier.getMessagesBefore(messageId, channelId, limit)) { it.data }
+        }
+    }
+
+    override fun getMessagesAround(messageId: Snowflake, channelId: Snowflake, limit: Int): Flow<Message> {
+        return flow {
+            storeAndEmit(restSupplier.getMessagesAround(messageId, channelId, limit)) { it.data }
+        }
+    }
+
+    override suspend fun getSelfOrNull(): User? {
+        return storeAndReturn(restSupplier.getSelfOrNull()) { it.data }
+    }
+
+    override suspend fun getUserOrNull(id: Snowflake): User? {
+        return storeAndReturn(restSupplier.getUserOrNull(id)) { it.data }
+    }
+
+    override suspend fun getRoleOrNull(guildId: Snowflake, roleId: Snowflake): Role? {
+        return storeAndReturn(restSupplier.getRoleOrNull(guildId, roleId)) { it.data }
+    }
+
+    override fun getGuildRoles(guildId: Snowflake): Flow<Role> {
+        return flow {
+            storeAndEmit(restSupplier.getGuildRoles(guildId)) { it.data }
+        }
+    }
+
+    override suspend fun getGuildBanOrNull(guildId: Snowflake, userId: Snowflake): Ban? {
+        return storeAndReturn(getGuildBanOrNull(guildId, userId)) { it.data }
+    }
+
+    override fun getGuildBans(guildId: Snowflake): Flow<Ban> {
+        return flow {
+            storeAndEmit(restSupplier.getGuildBans(guildId)) { it.data }
+        }
+    }
+
+    override fun getGuildMembers(guildId: Snowflake, limit: Int): Flow<Member> {
+        return flow {
+            storeAndEmit(restSupplier.getGuildMembers(guildId, limit)) { it.data }
+        }
+    }
+
+    override fun getGuildVoiceRegions(guildId: Snowflake): Flow<Region> {
+        return flow {
+            storeAndEmit(restSupplier.getGuildVoiceRegions(guildId)) { it.data }
+        }
+    }
+
+    override suspend fun getEmojiOrNull(guildId: Snowflake, emojiId: Snowflake): GuildEmoji? {
+        return storeAndReturn(restSupplier.getEmojiOrNull(guildId, emojiId)) { it.data }
+    }
+
+    override fun getEmojis(guildId: Snowflake): Flow<GuildEmoji> {
+        return flow {
+            storeAndEmit(restSupplier.getEmojis(guildId)) { it.data }
+        }
+    }
+
+    override fun getCurrentUserGuilds(limit: Int): Flow<Guild> {
+        return flow {
+            storeAndEmit(restSupplier.getCurrentUserGuilds(limit)) { it.data }
+        }
+    }
+
+    override fun getChannelWebhooks(channelId: Snowflake): Flow<Webhook> {
+        return flow {
+            storeAndEmit(restSupplier.getChannelWebhooks(channelId)) { it.data }
+        }
+    }
+
+    override fun getGuildWebhooks(guildId: Snowflake): Flow<Webhook> {
+        return flow {
+            storeAndEmit(restSupplier.getGuildWebhooks(guildId)) { it.data }
+        }
+    }
+
+    override suspend fun getWebhookOrNull(id: Snowflake): Webhook? {
+        return storeAndReturn(restSupplier.getWebhookOrNull(id)) { it.data }
+    }
+
+    override suspend fun getWebhookWithTokenOrNull(id: Snowflake, token: String): Webhook? {
+        return storeAndReturn(restSupplier.getWebhookWithTokenOrNull(id, token)) { it.data }
+
+    }
+
+    override suspend fun getTemplateOrNull(code: String): Template? {
+        return storeAndReturn(restSupplier.getTemplateOrNull(code)) { it.data }
+    }
+
+    override fun getTemplates(guildId: Snowflake): Flow<Template> {
+        return flow {
+            storeAndEmit(restSupplier.getTemplates(guildId)) { it.data }
+        }
+    }
+
+    override suspend fun getStageInstanceOrNull(channelId: Snowflake): StageInstance? {
+        return storeAndReturn(restSupplier.getStageInstanceOrNull(channelId)) { it.data }
+    }
+
+    private suspend inline fun <T, R> Flow<T>.mapAndStore(crossinline transform: (T) -> R) {
+        val data = this.map { transform(it) }
+        kord.cache.put(data)
+    }
+
+    private suspend inline fun <T, R> FlowCollector<T>.storeAndEmit(source: Flow<T>, crossinline transform: (T) -> R) {
+        source.mapAndStore { transform(it) }
+        emitAll(source)
+    }
+
+    private suspend inline fun <T, reified R : Any> storeAndReturn(value: T?, transform: (T) -> R): T? {
+        if (value == null) return null
+        cache.put(transform(value))
+        return value
+    }
+}

--- a/core/src/main/kotlin/supplier/CacheAwareRestSupplier.kt
+++ b/core/src/main/kotlin/supplier/CacheAwareRestSupplier.kt
@@ -13,84 +13,84 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 
 /**
- * [EntitySupplier] that uses a [RestEntitySupplier] to resolve entities.
+ * [EntitySupplier] that delegates to another [EntitySupplier] to resolve entities.
  *
  * Resolved entities will always be stored in [cache] if it wasn't null or empty for flows.
  */
-class CacheAwareRestEntitySupplier(
-    val restSupplier: RestEntitySupplier,
-    val cache: DataCache,
-    val kord: Kord
+class StoreEntitySupplier(
+    private val supplier: EntitySupplier,
+    private val cache: DataCache,
+    private val kord: Kord
 ) : EntitySupplier {
 
 
     override val guilds: Flow<Guild>
-        get() = storeAndEmit(restSupplier.guilds) { it.data }
+        get() = storeAndEmit(supplier.guilds) { it.data }
 
     override val regions: Flow<Region>
-        get() = storeAndEmit(restSupplier.regions) { it.data }
+        get() = storeAndEmit(supplier.regions) { it.data }
 
 
     override suspend fun getGuildOrNull(id: Snowflake): Guild? {
-        return storeAndReturn(restSupplier.getGuildOrNull(id)) { it.data }
+        return storeAndReturn(supplier.getGuildOrNull(id)) { it.data }
     }
 
     override suspend fun getGuildPreviewOrNull(guildId: Snowflake): GuildPreview? {
-        return storeAndReturn(restSupplier.getGuildPreviewOrNull(guildId)) { it.data }
+        return storeAndReturn(supplier.getGuildPreviewOrNull(guildId)) { it.data }
     }
 
     override suspend fun getGuildWidgetOrNull(guildId: Snowflake): GuildWidget? {
-        return storeAndReturn(restSupplier.getGuildWidgetOrNull(guildId)) { it.data }
+        return storeAndReturn(supplier.getGuildWidgetOrNull(guildId)) { it.data }
     }
 
     override suspend fun getChannelOrNull(id: Snowflake): Channel? {
-        return storeAndReturn(restSupplier.getChannelOrNull(id)) { it.data }
+        return storeAndReturn(supplier.getChannelOrNull(id)) { it.data }
     }
 
     override fun getGuildChannels(guildId: Snowflake): Flow<GuildChannel> {
-        return storeAndEmit(restSupplier.getGuildChannels(guildId)) { it.data }
+        return storeAndEmit(supplier.getGuildChannels(guildId)) { it.data }
 
     }
 
     override fun getChannelPins(channelId: Snowflake): Flow<Message> {
-        return storeAndEmit(restSupplier.getChannelPins(channelId)) { it.data }
+        return storeAndEmit(supplier.getChannelPins(channelId)) { it.data }
 
     }
 
     override suspend fun getMemberOrNull(guildId: Snowflake, userId: Snowflake): Member? {
-        return storeAndReturn(restSupplier.getMemberOrNull(guildId, userId)) { it.data }
+        return storeAndReturn(supplier.getMemberOrNull(guildId, userId)) { it.data }
     }
 
     override suspend fun getMessageOrNull(channelId: Snowflake, messageId: Snowflake): Message? {
-        return storeAndReturn(restSupplier.getMessageOrNull(channelId, messageId)) { it.data }
+        return storeAndReturn(supplier.getMessageOrNull(channelId, messageId)) { it.data }
     }
 
     override fun getMessagesAfter(messageId: Snowflake, channelId: Snowflake, limit: Int): Flow<Message> {
-        return storeAndEmit(restSupplier.getMessagesAfter(messageId, channelId, limit)) { it.data }
+        return storeAndEmit(supplier.getMessagesAfter(messageId, channelId, limit)) { it.data }
     }
 
     override fun getMessagesBefore(messageId: Snowflake, channelId: Snowflake, limit: Int): Flow<Message> {
-        return storeAndEmit(restSupplier.getMessagesBefore(messageId, channelId, limit)) { it.data }
+        return storeAndEmit(supplier.getMessagesBefore(messageId, channelId, limit)) { it.data }
     }
 
     override fun getMessagesAround(messageId: Snowflake, channelId: Snowflake, limit: Int): Flow<Message> {
-        return storeAndEmit(restSupplier.getMessagesAround(messageId, channelId, limit)) { it.data }
+        return storeAndEmit(supplier.getMessagesAround(messageId, channelId, limit)) { it.data }
     }
 
     override suspend fun getSelfOrNull(): User? {
-        return storeAndReturn(restSupplier.getSelfOrNull()) { it.data }
+        return storeAndReturn(supplier.getSelfOrNull()) { it.data }
     }
 
     override suspend fun getUserOrNull(id: Snowflake): User? {
-        return storeAndReturn(restSupplier.getUserOrNull(id)) { it.data }
+        return storeAndReturn(supplier.getUserOrNull(id)) { it.data }
     }
 
     override suspend fun getRoleOrNull(guildId: Snowflake, roleId: Snowflake): Role? {
-        return storeAndReturn(restSupplier.getRoleOrNull(guildId, roleId)) { it.data }
+        return storeAndReturn(supplier.getRoleOrNull(guildId, roleId)) { it.data }
     }
 
     override fun getGuildRoles(guildId: Snowflake): Flow<Role> {
-        return storeAndEmit(restSupplier.getGuildRoles(guildId)) { it.data }
+        return storeAndEmit(supplier.getGuildRoles(guildId)) { it.data }
     }
 
     override suspend fun getGuildBanOrNull(guildId: Snowflake, userId: Snowflake): Ban? {
@@ -98,57 +98,57 @@ class CacheAwareRestEntitySupplier(
     }
 
     override fun getGuildBans(guildId: Snowflake): Flow<Ban> {
-        return storeAndEmit(restSupplier.getGuildBans(guildId)) { it.data }
+        return storeAndEmit(supplier.getGuildBans(guildId)) { it.data }
     }
 
     override fun getGuildMembers(guildId: Snowflake, limit: Int): Flow<Member> {
-        return storeAndEmit(restSupplier.getGuildMembers(guildId, limit)) { it.data }
+        return storeAndEmit(supplier.getGuildMembers(guildId, limit)) { it.data }
     }
 
     override fun getGuildVoiceRegions(guildId: Snowflake): Flow<Region> {
-        return storeAndEmit(restSupplier.getGuildVoiceRegions(guildId)) { it.data }
+        return storeAndEmit(supplier.getGuildVoiceRegions(guildId)) { it.data }
     }
 
     override suspend fun getEmojiOrNull(guildId: Snowflake, emojiId: Snowflake): GuildEmoji? {
-        return storeAndReturn(restSupplier.getEmojiOrNull(guildId, emojiId)) { it.data }
+        return storeAndReturn(supplier.getEmojiOrNull(guildId, emojiId)) { it.data }
     }
 
     override fun getEmojis(guildId: Snowflake): Flow<GuildEmoji> {
-        return storeAndEmit(restSupplier.getEmojis(guildId)) { it.data }
+        return storeAndEmit(supplier.getEmojis(guildId)) { it.data }
 
     }
 
     override fun getCurrentUserGuilds(limit: Int): Flow<Guild> {
-        return storeAndEmit(restSupplier.getCurrentUserGuilds(limit)) { it.data }
+        return storeAndEmit(supplier.getCurrentUserGuilds(limit)) { it.data }
 
     }
 
     override fun getChannelWebhooks(channelId: Snowflake): Flow<Webhook> {
-        return storeAndEmit(restSupplier.getChannelWebhooks(channelId)) { it.data }
+        return storeAndEmit(supplier.getChannelWebhooks(channelId)) { it.data }
     }
 
     override fun getGuildWebhooks(guildId: Snowflake): Flow<Webhook> {
-        return storeAndEmit(restSupplier.getGuildWebhooks(guildId)) { it.data }
+        return storeAndEmit(supplier.getGuildWebhooks(guildId)) { it.data }
     }
 
     override suspend fun getWebhookOrNull(id: Snowflake): Webhook? {
-        return storeAndReturn(restSupplier.getWebhookOrNull(id)) { it.data }
+        return storeAndReturn(supplier.getWebhookOrNull(id)) { it.data }
     }
 
     override suspend fun getWebhookWithTokenOrNull(id: Snowflake, token: String): Webhook? {
-        return storeAndReturn(restSupplier.getWebhookWithTokenOrNull(id, token)) { it.data }
+        return storeAndReturn(supplier.getWebhookWithTokenOrNull(id, token)) { it.data }
     }
 
     override suspend fun getTemplateOrNull(code: String): Template? {
-        return storeAndReturn(restSupplier.getTemplateOrNull(code)) { it.data }
+        return storeAndReturn(supplier.getTemplateOrNull(code)) { it.data }
     }
 
     override fun getTemplates(guildId: Snowflake): Flow<Template> {
-        return storeAndEmit(restSupplier.getTemplates(guildId)) { it.data }
+        return storeAndEmit(supplier.getTemplates(guildId)) { it.data }
     }
 
     override suspend fun getStageInstanceOrNull(channelId: Snowflake): StageInstance? {
-        return storeAndReturn(restSupplier.getStageInstanceOrNull(channelId)) { it.data }
+        return storeAndReturn(supplier.getStageInstanceOrNull(channelId)) { it.data }
     }
 
     private suspend inline fun <T, R> Flow<T>.mapAndStore(crossinline transform: (T) -> R) {
@@ -158,8 +158,9 @@ class CacheAwareRestEntitySupplier(
 
     private inline fun <T, R> storeAndEmit(source: Flow<T>, crossinline transform: (T) -> R): Flow<T> {
         return flow {
-            source.mapAndStore { transform(it) }
             emitAll(source)
+            source.mapAndStore { transform(it) }
+
         }
     }
 

--- a/core/src/main/kotlin/supplier/EntitySupplyStrategy.kt
+++ b/core/src/main/kotlin/supplier/EntitySupplyStrategy.kt
@@ -41,11 +41,11 @@ interface EntitySupplyStrategy<T : EntitySupplier> {
         /**
          * A supplier providing a strategy which exclusively uses REST calls to fetch entities.
          * fetched entities are stored in [Kord's cache][kord.cache].
-         * See [CacheAwareRestEntitySupplier] for more details.
+         * See [StoreEntitySupplier] for more details.
          */
-        val cacheAwareRest = object : EntitySupplyStrategy<EntitySupplier> {
+        val cachingRest = object : EntitySupplyStrategy<EntitySupplier> {
             override fun supply(kord: Kord): EntitySupplier {
-                return CacheAwareRestEntitySupplier(rest.supply(kord), kord.cache, kord)
+                return StoreEntitySupplier(rest.supply(kord), kord.cache, kord)
             }
 
             override fun toString(): String = "EntitySupplyStrategy.cacheAwareRest"
@@ -67,13 +67,13 @@ interface EntitySupplyStrategy<T : EntitySupplier> {
 
         /**
          * A supplier providing a strategy which will first operate on the [cache] supplier. When an entity
-         * is not present from cache it will be fetched from [cacheAwareRest] instead which will update [cache] with fetched elements.
+         * is not present from cache it will be fetched from [cachingRest] instead which will update [cache] with fetched elements.
          * Operations that return flows will only fall back to rest when the returned flow contained no elements.
          */
-        val cacheWithCacheAwareRestFallback = object : EntitySupplyStrategy<EntitySupplier> {
+        val cacheWithCachingRestFallback = object : EntitySupplyStrategy<EntitySupplier> {
 
             override fun supply(kord: Kord): EntitySupplier =
-                cache.supply(kord).withFallback(cacheAwareRest.supply(kord))
+                cache.supply(kord).withFallback(cachingRest.supply(kord))
 
             override fun toString(): String = "EntitySupplyStrategy.cacheWithCacheAwareRestFallback"
         }


### PR DESCRIPTION
* Adds a cache-aware rest entity supplier that will store it's fetched elements in the target cache.
* Adds a strategy to use the cache-aware rest entity supplier.
* Adds a strategy to use cache with a cache-aware rest entity supplier fallback.