### PR TITLE
Top channels

### DIFF
--- a/core/src/main/kotlin/Unsafe.kt
+++ b/core/src/main/kotlin/Unsafe.kt
@@ -35,11 +35,17 @@ class Unsafe(private val kord: Kord) {
     fun messageChannel(id: Snowflake): MessageChannelBehavior =
         MessageChannelBehavior(id, kord)
 
-    fun guildChannel(guildId: Snowflake, id: Snowflake): TopGuildChannelBehavior =
+    fun topGuildChannel(guildId: Snowflake, id: Snowflake): TopGuildChannelBehavior =
         TopGuildChannelBehavior(guildId = guildId, id = id, kord = kord)
 
-    fun guildMessageChannel(guildId: Snowflake, id: Snowflake): TopGuildMessageChannelBehavior =
+    fun topGuildMessageChannel(guildId: Snowflake, id: Snowflake): TopGuildMessageChannelBehavior =
         TopGuildMessageChannelBehavior(guildId = guildId, id = id, kord = kord)
+
+    fun guildChannel(guildId: Snowflake, id: Snowflake): GuildChannelBehavior =
+        GuildChannelBehavior(guildId, id, kord)
+
+    fun guildMessageChannel(guildId: Snowflake, id: Snowflake): GuildMessageChannelBehavior =
+        GuildMessageChannelBehavior(guildId, id, kord)
 
     fun newsChannel(guildId: Snowflake, id: Snowflake): NewsChannelBehavior =
         NewsChannelBehavior(guildId = guildId, id = id, kord = kord)
@@ -53,10 +59,8 @@ class Unsafe(private val kord: Kord) {
     fun storeChannel(guildId: Snowflake, id: Snowflake): StoreChannelBehavior =
         StoreChannelBehavior(guildId = guildId, id = id, kord = kord)
 
-
     fun publicThreadParent(guildId: Snowflake, id: Snowflake): ThreadParentChannelBehavior =
         ThreadParentChannelBehavior(guildId, id, kord)
-
 
     fun privateThreadParent(guildId: Snowflake, id: Snowflake): PrivateThreadParentChannelBehavior =
         PrivateThreadParentChannelBehavior(guildId, id, kord)

--- a/core/src/main/kotlin/Unsafe.kt
+++ b/core/src/main/kotlin/Unsafe.kt
@@ -35,11 +35,11 @@ class Unsafe(private val kord: Kord) {
     fun messageChannel(id: Snowflake): MessageChannelBehavior =
         MessageChannelBehavior(id, kord)
 
-    fun guildChannel(guildId: Snowflake, id: Snowflake): GuildChannelBehavior =
-        GuildChannelBehavior(guildId = guildId, id = id, kord = kord)
+    fun guildChannel(guildId: Snowflake, id: Snowflake): TopGuildChannelBehavior =
+        TopGuildChannelBehavior(guildId = guildId, id = id, kord = kord)
 
-    fun guildMessageChannel(guildId: Snowflake, id: Snowflake): GuildMessageChannelBehavior =
-        GuildMessageChannelBehavior(guildId = guildId, id = id, kord = kord)
+    fun guildMessageChannel(guildId: Snowflake, id: Snowflake): TopGuildMessageChannelBehavior =
+        TopGuildMessageChannelBehavior(guildId = guildId, id = id, kord = kord)
 
     fun newsChannel(guildId: Snowflake, id: Snowflake): NewsChannelBehavior =
         NewsChannelBehavior(guildId = guildId, id = id, kord = kord)

--- a/core/src/main/kotlin/Unsafe.kt
+++ b/core/src/main/kotlin/Unsafe.kt
@@ -61,8 +61,8 @@ class Unsafe(private val kord: Kord) {
     fun privateThreadParent(guildId: Snowflake, id: Snowflake): PrivateThreadParentChannelBehavior =
         PrivateThreadParentChannelBehavior(guildId, id, kord)
 
-    fun thread(id: Snowflake): ThreadChannelBehavior =
-        ThreadChannelBehavior(id, kord)
+    fun thread(guildId: Snowflake, parentId: Snowflake, id: Snowflake): ThreadChannelBehavior =
+        ThreadChannelBehavior(guildId, parentId, id, kord)
 
 
     fun guild(id: Snowflake): GuildBehavior =
@@ -77,8 +77,8 @@ class Unsafe(private val kord: Kord) {
     fun user(id: Snowflake): UserBehavior =
         UserBehavior(id, kord)
 
-    fun threadUser(id: Snowflake, threadId: Snowflake) =
-        ThreadUserBehavior(id, threadId, kord)
+    fun threadMember(id: Snowflake, threadId: Snowflake) =
+        ThreadMemberBehavior(id, threadId, kord)
 
     fun member(guildId: Snowflake, id: Snowflake): MemberBehavior =
         MemberBehavior(guildId = guildId, id = id, kord = kord)

--- a/core/src/main/kotlin/behavior/GuildBehavior.kt
+++ b/core/src/main/kotlin/behavior/GuildBehavior.kt
@@ -81,7 +81,7 @@ interface GuildBehavior : KordEntity, Strategizable {
      * The returned flow is lazily executed, any [RequestException] will be thrown on
      * [terminal operators](https://kotlinlang.org/docs/reference/coroutines/flow.html#terminal-flow-operators) instead.
      */
-    val channels: Flow<GuildChannel>
+    val channels: Flow<TopGuildChannel>
         get() = supplier.getGuildChannels(id)
 
     /**
@@ -395,29 +395,29 @@ interface GuildBehavior : KordEntity, Strategizable {
     suspend fun getBanOrNull(userId: Snowflake): Ban? = supplier.getGuildBanOrNull(id, userId)
 
     /**
-     * Requests to get the [GuildChannel] represented by the [channelId].
+     * Requests to get the [TopGuildChannel] represented by the [channelId].
      *
      * @throws [RequestException] if anything went wrong during the request.
-     * @throws [EntityNotFoundException] if the [GuildChannel] wasn't present.
-     * @throws [ClassCastException] if the channel is not a [GuildChannel].
+     * @throws [EntityNotFoundException] if the [TopGuildChannel] wasn't present.
+     * @throws [ClassCastException] if the channel is not a [TopGuildChannel].
      * @throws [IllegalArgumentException] if the channel is not part of this guild.
      */
-    suspend fun getChannel(channelId: Snowflake): GuildChannel {
-        val channel = supplier.getChannelOf<GuildChannel>(channelId)
+    suspend fun getChannel(channelId: Snowflake): TopGuildChannel {
+        val channel = supplier.getChannelOf<TopGuildChannel>(channelId)
         require(channel.guildId == this.id) { "channel ${channelId.value} is not in guild ${this.id}" }
         return channel
     }
 
     /**
-     * Requests to get the [GuildChannel] represented by the [channelId],
-     * returns null if the [GuildChannel] isn't present.
+     * Requests to get the [TopGuildChannel] represented by the [channelId],
+     * returns null if the [TopGuildChannel] isn't present.
      *
      * @throws [RequestException] if anything went wrong during the request.
-     * @throws [ClassCastException] if the channel is not a [GuildChannel].
+     * @throws [ClassCastException] if the channel is not a [TopGuildChannel].
      * @throws [IllegalArgumentException] if the channel is not part of this guild.
      */
-    suspend fun getChannelOrNull(channelId: Snowflake): GuildChannel? {
-        val channel = supplier.getChannelOfOrNull<GuildChannel>(channelId) ?: return null
+    suspend fun getChannelOrNull(channelId: Snowflake): TopGuildChannel? {
+        val channel = supplier.getChannelOfOrNull<TopGuildChannel>(channelId) ?: return null
         require(channel.guildId == this.id) { "channel ${channelId.value} is not in guild ${this.id}" }
         return channel
     }
@@ -853,28 +853,28 @@ suspend inline fun GuildBehavior.ban(userId: Snowflake, builder: BanCreateBuilde
 }
 
 /**
- * Requests to get the [GuildChannel] represented by the [channelId] as type [T].
+ * Requests to get the [TopGuildChannel] represented by the [channelId] as type [T].
  *
  * @throws [RequestException] if anything went wrong during the request.
  * @throws [EntityNotFoundException] if the [T] wasn't present.
  * @throws [ClassCastException] if the channel is not of type [T].
  * @throws [IllegalArgumentException] if the channel is not part of this guild.
  */
-suspend inline fun <reified T : GuildChannel> GuildBehavior.getChannelOf(channelId: Snowflake): T {
+suspend inline fun <reified T : TopGuildChannel> GuildBehavior.getChannelOf(channelId: Snowflake): T {
     val channel = supplier.getChannelOf<T>(channelId)
     require(channel.guildId == this.id) { "channel ${channelId.value} is not in guild ${this.id}" }
     return channel
 }
 
 /**
- * Requests to get the [GuildChannel] represented by the [channelId] as type [T],
- * returns null if the [GuildChannel] isn't present.
+ * Requests to get the [TopGuildChannel] represented by the [channelId] as type [T],
+ * returns null if the [TopGuildChannel] isn't present.
  *
  * @throws [RequestException] if anything went wrong during the request.
  * @throws [ClassCastException] if the channel is not of type [T].
  * @throws [IllegalArgumentException] if the channel is not part of this guild.
  */
-suspend inline fun <reified T : GuildChannel> GuildBehavior.getChannelOfOrNull(channelId: Snowflake): T? {
+suspend inline fun <reified T : TopGuildChannel> GuildBehavior.getChannelOfOrNull(channelId: Snowflake): T? {
     val channel = supplier.getChannelOfOrNull<T>(channelId) ?: return null
     require(channel.guildId == this.id) { "channel ${channelId.value} is not in guild ${this.id}" }
     return channel

--- a/core/src/main/kotlin/behavior/GuildBehavior.kt
+++ b/core/src/main/kotlin/behavior/GuildBehavior.kt
@@ -402,22 +402,22 @@ interface GuildBehavior : KordEntity, Strategizable {
      * @throws [ClassCastException] if the channel is not a [TopGuildChannel].
      * @throws [IllegalArgumentException] if the channel is not part of this guild.
      */
-    suspend fun getChannel(channelId: Snowflake): TopGuildChannel {
-        val channel = supplier.getChannelOf<TopGuildChannel>(channelId)
+    suspend fun getChannel(channelId: Snowflake): GuildChannel {
+        val channel = supplier.getChannelOf<GuildChannel>(channelId)
         require(channel.guildId == this.id) { "channel ${channelId.value} is not in guild ${this.id}" }
         return channel
     }
 
     /**
-     * Requests to get the [TopGuildChannel] represented by the [channelId],
-     * returns null if the [TopGuildChannel] isn't present.
+     * Requests to get the [GuildChannel] represented by the [channelId],
+     * returns null if the [GuildChannel] isn't present.
      *
      * @throws [RequestException] if anything went wrong during the request.
      * @throws [ClassCastException] if the channel is not a [TopGuildChannel].
      * @throws [IllegalArgumentException] if the channel is not part of this guild.
      */
-    suspend fun getChannelOrNull(channelId: Snowflake): TopGuildChannel? {
-        val channel = supplier.getChannelOfOrNull<TopGuildChannel>(channelId) ?: return null
+    suspend fun getChannelOrNull(channelId: Snowflake): GuildChannel? {
+        val channel = supplier.getChannelOfOrNull<GuildChannel>(channelId) ?: return null
         require(channel.guildId == this.id) { "channel ${channelId.value} is not in guild ${this.id}" }
         return channel
     }
@@ -853,28 +853,28 @@ suspend inline fun GuildBehavior.ban(userId: Snowflake, builder: BanCreateBuilde
 }
 
 /**
- * Requests to get the [TopGuildChannel] represented by the [channelId] as type [T].
+ * Requests to get the [GuildChannel] represented by the [channelId] as type [T].
  *
  * @throws [RequestException] if anything went wrong during the request.
  * @throws [EntityNotFoundException] if the [T] wasn't present.
  * @throws [ClassCastException] if the channel is not of type [T].
  * @throws [IllegalArgumentException] if the channel is not part of this guild.
  */
-suspend inline fun <reified T : TopGuildChannel> GuildBehavior.getChannelOf(channelId: Snowflake): T {
+suspend inline fun <reified T : GuildChannel> GuildBehavior.getChannelOf(channelId: Snowflake): T {
     val channel = supplier.getChannelOf<T>(channelId)
     require(channel.guildId == this.id) { "channel ${channelId.value} is not in guild ${this.id}" }
     return channel
 }
 
 /**
- * Requests to get the [TopGuildChannel] represented by the [channelId] as type [T],
- * returns null if the [TopGuildChannel] isn't present.
+ * Requests to get the [GuildChannel] represented by the [channelId] as type [T],
+ * returns null if the [GuildChannel] isn't present.
  *
  * @throws [RequestException] if anything went wrong during the request.
  * @throws [ClassCastException] if the channel is not of type [T].
  * @throws [IllegalArgumentException] if the channel is not part of this guild.
  */
-suspend inline fun <reified T : TopGuildChannel> GuildBehavior.getChannelOfOrNull(channelId: Snowflake): T? {
+suspend inline fun <reified T : GuildChannel> GuildBehavior.getChannelOfOrNull(channelId: Snowflake): T? {
     val channel = supplier.getChannelOfOrNull<T>(channelId) ?: return null
     require(channel.guildId == this.id) { "channel ${channelId.value} is not in guild ${this.id}" }
     return channel

--- a/core/src/main/kotlin/behavior/ThreadMemberBehavior.kt
+++ b/core/src/main/kotlin/behavior/ThreadMemberBehavior.kt
@@ -2,36 +2,33 @@ package dev.kord.core.behavior
 
 import dev.kord.common.entity.Snowflake
 import dev.kord.core.Kord
-import dev.kord.core.behavior.channel.threads.ThreadChannelBehavior
 import dev.kord.core.entity.channel.thread.ThreadChannel
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 import dev.kord.core.supplier.getChannelOf
 import dev.kord.core.supplier.getChannelOfOrNull
 
-interface ThreadUserBehavior : UserBehavior {
+interface ThreadMemberBehavior : UserBehavior {
 
     val threadId: Snowflake
-
-    val thread: ThreadChannelBehavior get() = ThreadChannelBehavior(threadId, kord)
 
     suspend fun getThread(): ThreadChannel = supplier.getChannelOf(threadId)
 
     suspend fun getThreadOrNull(): ThreadChannel? = supplier.getChannelOfOrNull(threadId)
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): UserBehavior {
-        return ThreadUserBehavior(id, threadId, kord, strategy.supply(kord))
+        return ThreadMemberBehavior(id, threadId, kord, strategy.supply(kord))
 
     }
 }
 
-fun ThreadUserBehavior(
+fun ThreadMemberBehavior(
     id: Snowflake,
     threadId: Snowflake,
     kord: Kord,
     supplier: EntitySupplier = kord.defaultSupplier
-): ThreadUserBehavior {
-    return object : ThreadUserBehavior {
+): ThreadMemberBehavior {
+    return object : ThreadMemberBehavior {
         override val id: Snowflake
             get() = id
         override val threadId: Snowflake

--- a/core/src/main/kotlin/behavior/channel/BaseVoiceChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/BaseVoiceChannelBehavior.kt
@@ -8,7 +8,7 @@ import dev.kord.core.entity.VoiceState
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
-interface BaseVoiceChannelBehavior : GuildChannelBehavior {
+interface BaseVoiceChannelBehavior : TopGuildChannelBehavior {
 
     /**
      * Requests to retrieve the present voice states of this channel.

--- a/core/src/main/kotlin/behavior/channel/CategoryBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/CategoryBehavior.kt
@@ -1,10 +1,8 @@
 package dev.kord.core.behavior.channel
 
-import dev.kord.common.annotation.DeprecatedSinceKord
 import dev.kord.common.entity.Snowflake
 import dev.kord.common.exception.RequestException
 import dev.kord.core.Kord
-import dev.kord.core.behavior.GuildBehavior
 import dev.kord.core.cache.data.ChannelData
 import dev.kord.core.entity.channel.*
 import dev.kord.core.exception.EntityNotFoundException
@@ -31,7 +29,7 @@ import kotlin.contracts.contract
 /**
  * The behavior of a Discord category associated to a [guild].
  */
-interface CategoryBehavior : GuildChannelBehavior {
+interface CategoryBehavior : TopGuildChannelBehavior {
 
     /**
      * Requests to get this behavior as a [Category].
@@ -89,7 +87,7 @@ fun CategoryBehavior(
     override fun hashCode(): Int = Objects.hash(id, guildId)
 
     override fun equals(other: Any?): Boolean = when (other) {
-        is GuildChannelBehavior -> other.id == id && other.guildId == guildId
+        is TopGuildChannelBehavior -> other.id == id && other.guildId == guildId
         is ChannelBehavior -> other.id == id
         else -> false
     }

--- a/core/src/main/kotlin/behavior/channel/GuildChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/GuildChannelBehavior.kt
@@ -94,7 +94,7 @@ fun GuildChannelBehavior(
     override fun hashCode(): Int = Objects.hash(id, guildId)
 
     override fun equals(other: Any?): Boolean = when (other) {
-        is TopGuildChannelBehavior -> other.id == id && other.guildId == guildId
+        is GuildChannelBehavior -> other.id == id && other.guildId == guildId
         is ChannelBehavior -> other.id == id
         else -> false
     }

--- a/core/src/main/kotlin/behavior/channel/GuildChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/GuildChannelBehavior.kt
@@ -4,25 +4,13 @@ import dev.kord.common.entity.Snowflake
 import dev.kord.common.exception.RequestException
 import dev.kord.core.Kord
 import dev.kord.core.behavior.GuildBehavior
-import dev.kord.core.cache.data.InviteData
 import dev.kord.core.entity.*
 import dev.kord.core.entity.channel.GuildChannel
+import dev.kord.core.entity.channel.TopGuildChannel
 import dev.kord.core.exception.EntityNotFoundException
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
-import dev.kord.rest.builder.channel.ChannelPermissionModifyBuilder
-import dev.kord.rest.request.RestRequestException
-import dev.kord.rest.service.RestClient
-import dev.kord.rest.service.editMemberPermissions
-import dev.kord.rest.service.editRolePermission
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.withIndex
 import java.util.*
-import kotlin.contracts.ExperimentalContracts
-import kotlin.contracts.InvocationKind
-import kotlin.contracts.contract
 
 /**
  * The behavior of a Discord channel associated to a [guild].
@@ -40,26 +28,7 @@ interface GuildChannelBehavior : ChannelBehavior, Strategizable {
     val guild: GuildBehavior get() = GuildBehavior(guildId, kord)
 
     /**
-     * Requests to get the invites of this channel.
-     *
-     * This property is not resolvable through cache and will always use the [RestClient] instead.
-     *
-     * The returned flow is lazily executed, any [RequestException] will be thrown on
-     * [terminal operators](https://kotlinlang.org/docs/reference/coroutines/flow.html#terminal-flow-operators) instead.
-     */
-    val invites: Flow<Invite>
-        get() = flow {
-            val responses = kord.rest.channel.getChannelInvites(id)
-
-            for (response in responses) {
-                val data = InviteData.from(response)
-
-                emit(Invite(data, kord))
-            }
-        }
-
-    /**
-     * Requests to get this behavior as a [GuildChannel].
+     * Requests to get this behavior as a [TopGuildChannel].
      *
      * @throws [RequestException] if something went wrong during the request.
      * @throws [EntityNotFoundException] if the channel wasn't present.
@@ -68,7 +37,7 @@ interface GuildChannelBehavior : ChannelBehavior, Strategizable {
     override suspend fun asChannel(): GuildChannel = super.asChannel() as GuildChannel
 
     /**
-     * Requests to get this behavior as a [GuildChannel],
+     * Requests to get this behavior as a [TopGuildChannel],
      * returns null if the channel isn't present or if the channel isn't a guild channel.
      *
      * @throws [RequestException] if something went wrong during the request.
@@ -91,40 +60,18 @@ interface GuildChannelBehavior : ChannelBehavior, Strategizable {
      */
     suspend fun getGuildOrNull(): Guild? = supplier.getGuildOrNull(guildId)
 
-    /**
-     * Requests to add or replace a [PermissionOverwrite] to this entity.
-     *
-     * @param reason the reason showing up in the audit log
-     * @throws [RestRequestException] if something went wrong during the request.
-     */
-    suspend fun addOverwrite(overwrite: PermissionOverwrite, reason: String?) {
-        kord.rest.channel.editChannelPermissions(
-            channelId = id,
-            overwriteId = overwrite.target,
-            permissions = overwrite.asRequest(),
-            reason = reason
-        )
-    }
-
-    /**
-     * Requests to get the position of this channel in the [guild], as displayed in Discord,
-     *.
-     *
-     * @throws [RequestException] if something went wrong during the request.
-     */
-    suspend fun getPosition(): Int = supplier.getGuildChannels(guildId).withIndex().first { it.value.id == id }.index
 
     override fun compareTo(other: Entity): Int {
         if (other !is GuildChannelBehavior) return super.compareTo(other)
         val discordOrder = compareBy<GuildChannelBehavior> { it.guildId }
-            .thenBy { (it as? GuildChannel)?.guildId }
+            .thenBy { (it as? TopGuildChannel)?.guildId }
             .thenBy { it.id }
 
         return discordOrder.compare(this, other)
     }
 
     /**
-     * Returns a new [GuildChannelBehavior] with the given [strategy].
+     * Returns a new [TopGuildChannelBehavior] with the given [strategy].
      */
     override fun withStrategy(
         strategy: EntitySupplyStrategy<*>
@@ -147,7 +94,7 @@ fun GuildChannelBehavior(
     override fun hashCode(): Int = Objects.hash(id, guildId)
 
     override fun equals(other: Any?): Boolean = when (other) {
-        is GuildChannelBehavior -> other.id == id && other.guildId == guildId
+        is TopGuildChannelBehavior -> other.id == id && other.guildId == guildId
         is ChannelBehavior -> other.id == id
         else -> false
     }
@@ -157,34 +104,3 @@ fun GuildChannelBehavior(
     }
 }
 
-/**
- * Requests to add or replace a [PermissionOverwrite] for the [roleId].
- *
- *  @throws [RestRequestException] if something went wrong during the request.
- */
-@OptIn(ExperimentalContracts::class)
-suspend inline fun GuildChannelBehavior.editRolePermission(
-    roleId: Snowflake,
-    builder: ChannelPermissionModifyBuilder.() -> Unit
-) {
-    contract {
-        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
-    }
-    kord.rest.channel.editRolePermission(channelId = id, roleId = roleId, builder = builder)
-}
-
-/**
- * Requests to add or replace a [PermissionOverwrite] for the [memberId].
- *
- * @throws [RestRequestException] if something went wrong during the request.
- */
-@OptIn(ExperimentalContracts::class)
-suspend inline fun GuildChannelBehavior.editMemberPermission(
-    memberId: Snowflake,
-    builder: ChannelPermissionModifyBuilder.() -> Unit
-) {
-    contract {
-        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
-    }
-    kord.rest.channel.editMemberPermissions(channelId = id, memberId = memberId, builder = builder)
-}

--- a/core/src/main/kotlin/behavior/channel/GuildMessageChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/GuildMessageChannelBehavior.kt
@@ -69,6 +69,12 @@ internal fun GuildMessageChannelBehavior(
     override val kord: Kord = kord
     override val supplier: EntitySupplier = strategy.supply(kord)
 
+    override fun equals(other: Any?): Boolean = when (other) {
+        is GuildChannelBehavior -> other.id == id && other.guildId == guildId
+        is ChannelBehavior -> other.id == id
+        else -> false
+    }
+
     override fun toString(): String {
         return "GuildMessageChannelBehavior(id=$id, guildId=$guildId, kord=$kord, supplier=$supplier)"
     }

--- a/core/src/main/kotlin/behavior/channel/MessageChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/MessageChannelBehavior.kt
@@ -6,7 +6,6 @@ import dev.kord.core.Kord
 import dev.kord.core.cache.data.MessageData
 import dev.kord.core.entity.Message
 import dev.kord.core.entity.Strategizable
-import dev.kord.core.entity.channel.GuildChannel
 import dev.kord.core.entity.channel.MessageChannel
 import dev.kord.core.exception.EntityNotFoundException
 import dev.kord.core.supplier.EntitySupplier

--- a/core/src/main/kotlin/behavior/channel/NewsChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/NewsChannelBehavior.kt
@@ -112,7 +112,7 @@ fun NewsChannelBehavior(
     override fun hashCode(): Int = Objects.hash(id, guildId)
 
     override fun equals(other: Any?): Boolean = when (other) {
-        is TopGuildChannelBehavior -> other.id == id && other.guildId == guildId
+        is GuildChannelBehavior -> other.id == id && other.guildId == guildId
         is ChannelBehavior -> other.id == id
         else -> false
     }

--- a/core/src/main/kotlin/behavior/channel/NewsChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/NewsChannelBehavior.kt
@@ -112,7 +112,7 @@ fun NewsChannelBehavior(
     override fun hashCode(): Int = Objects.hash(id, guildId)
 
     override fun equals(other: Any?): Boolean = when (other) {
-        is GuildChannelBehavior -> other.id == id && other.guildId == guildId
+        is TopGuildChannelBehavior -> other.id == id && other.guildId == guildId
         is ChannelBehavior -> other.id == id
         else -> false
     }

--- a/core/src/main/kotlin/behavior/channel/StoreChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/StoreChannelBehavior.kt
@@ -20,7 +20,7 @@ import kotlin.contracts.contract
 /**
  * The behavior of a Discord Store Channel associated to a guild.
  */
-interface StoreChannelBehavior : GuildChannelBehavior {
+interface StoreChannelBehavior : TopGuildChannelBehavior {
 
     /**
      * Requests to get the this behavior as a [StoreChannel].
@@ -63,7 +63,7 @@ fun StoreChannelBehavior(
     override fun hashCode(): Int = Objects.hash(id, guildId)
 
     override fun equals(other: Any?): Boolean = when (other) {
-        is GuildChannelBehavior -> other.id == id && other.guildId == guildId
+        is TopGuildChannelBehavior -> other.id == id && other.guildId == guildId
         is ChannelBehavior -> other.id == id
         else -> false
     }

--- a/core/src/main/kotlin/behavior/channel/StoreChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/StoreChannelBehavior.kt
@@ -63,7 +63,7 @@ fun StoreChannelBehavior(
     override fun hashCode(): Int = Objects.hash(id, guildId)
 
     override fun equals(other: Any?): Boolean = when (other) {
-        is TopGuildChannelBehavior -> other.id == id && other.guildId == guildId
+        is GuildChannelBehavior -> other.id == id && other.guildId == guildId
         is ChannelBehavior -> other.id == id
         else -> false
     }

--- a/core/src/main/kotlin/behavior/channel/TextChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/TextChannelBehavior.kt
@@ -109,7 +109,7 @@ fun TextChannelBehavior(
     override fun hashCode(): Int = Objects.hash(id, guildId)
 
     override fun equals(other: Any?): Boolean = when (other) {
-        is TopGuildChannelBehavior -> other.id == id && other.guildId == guildId
+        is GuildChannelBehavior -> other.id == id && other.guildId == guildId
         is ChannelBehavior -> other.id == id
         else -> false
     }

--- a/core/src/main/kotlin/behavior/channel/TextChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/TextChannelBehavior.kt
@@ -109,7 +109,7 @@ fun TextChannelBehavior(
     override fun hashCode(): Int = Objects.hash(id, guildId)
 
     override fun equals(other: Any?): Boolean = when (other) {
-        is GuildChannelBehavior -> other.id == id && other.guildId == guildId
+        is TopGuildChannelBehavior -> other.id == id && other.guildId == guildId
         is ChannelBehavior -> other.id == id
         else -> false
     }

--- a/core/src/main/kotlin/behavior/channel/TopGuildChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/TopGuildChannelBehavior.kt
@@ -24,12 +24,9 @@ import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
 /**
- * The behavior of a Discord non-thread channel associated to a [guild].
- * [TopGuildChannelBehavior] incapsulates the behavior we have known pre-threads such as
- * [NewsChannelBehavior] and [dev.kord.core.behavior.channel.TextChannelBehavior].
+ * The behavior of a non-thread Discord channel associated to a [guild].
  *
- * for the behaviors supported for all guild message channels please see [dev.kord.core.behavior.channel.GuildMessageChannelBehavior].
- *
+ * 'Top' channels are those that do not require a parent channel to be created, and can be found at the top of the UI's hierarchy.
  */
 interface TopGuildChannelBehavior : GuildChannelBehavior {
 

--- a/core/src/main/kotlin/behavior/channel/TopGuildChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/TopGuildChannelBehavior.kt
@@ -1,0 +1,155 @@
+package dev.kord.core.behavior.channel
+
+import dev.kord.common.entity.Snowflake
+import dev.kord.common.exception.RequestException
+import dev.kord.core.Kord
+import dev.kord.core.cache.data.InviteData
+import dev.kord.core.entity.*
+import dev.kord.core.entity.channel.TopGuildChannel
+import dev.kord.core.exception.EntityNotFoundException
+import dev.kord.core.supplier.EntitySupplier
+import dev.kord.core.supplier.EntitySupplyStrategy
+import dev.kord.rest.builder.channel.ChannelPermissionModifyBuilder
+import dev.kord.rest.request.RestRequestException
+import dev.kord.rest.service.RestClient
+import dev.kord.rest.service.editMemberPermissions
+import dev.kord.rest.service.editRolePermission
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.withIndex
+import java.util.*
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+
+/**
+ * The behavior of a Discord channel associated to a [guild].
+ */
+interface TopGuildChannelBehavior : GuildChannelBehavior {
+
+    /**
+     * Requests to get the invites of this channel.
+     *
+     * This property is not resolvable through cache and will always use the [RestClient] instead.
+     *
+     * The returned flow is lazily executed, any [RequestException] will be thrown on
+     * [terminal operators](https://kotlinlang.org/docs/reference/coroutines/flow.html#terminal-flow-operators) instead.
+     */
+    val invites: Flow<Invite>
+        get() = flow {
+            val responses = kord.rest.channel.getChannelInvites(id)
+
+            for (response in responses) {
+                val data = InviteData.from(response)
+
+                emit(Invite(data, kord))
+            }
+        }
+
+    /**
+     * Requests to get this behavior as a [TopGuildChannel].
+     *
+     * @throws [RequestException] if something went wrong during the request.
+     * @throws [EntityNotFoundException] if the channel wasn't present.
+     * @throws [ClassCastException] if the channel isn't a guild channel.
+     */
+    override suspend fun asChannel(): TopGuildChannel = super.asChannel() as TopGuildChannel
+
+    /**
+     * Requests to get this behavior as a [TopGuildChannel],
+     * returns null if the channel isn't present or if the channel isn't a guild channel.
+     *
+     * @throws [RequestException] if something went wrong during the request.
+     */
+    override suspend fun asChannelOrNull(): TopGuildChannel? = super.asChannelOrNull() as? TopGuildChannel
+
+    /**
+     * Requests to add or replace a [PermissionOverwrite] to this entity.
+     *
+     * @param reason the reason showing up in the audit log
+     * @throws [RestRequestException] if something went wrong during the request.
+     */
+    suspend fun addOverwrite(overwrite: PermissionOverwrite, reason: String?) {
+        kord.rest.channel.editChannelPermissions(
+            channelId = id,
+            overwriteId = overwrite.target,
+            permissions = overwrite.asRequest(),
+            reason = reason
+        )
+    }
+
+    /**
+     * Requests to get the position of this channel in the [guild], as displayed in Discord,
+     *.
+     *
+     * @throws [RequestException] if something went wrong during the request.
+     */
+    suspend fun getPosition(): Int = supplier.getGuildChannels(guildId).withIndex().first { it.value.id == id }.index
+
+
+    /**
+     * Returns a new [TopGuildChannelBehavior] with the given [strategy].
+     */
+    override fun withStrategy(
+        strategy: EntitySupplyStrategy<*>
+    ): TopGuildChannelBehavior = TopGuildChannelBehavior(guildId, id, kord, strategy)
+
+
+}
+
+fun TopGuildChannelBehavior(
+    guildId: Snowflake,
+    id: Snowflake,
+    kord: Kord,
+    strategy: EntitySupplyStrategy<*> = kord.resources.defaultStrategy
+): TopGuildChannelBehavior = object : TopGuildChannelBehavior {
+    override val guildId: Snowflake = guildId
+    override val id: Snowflake = id
+    override val kord: Kord = kord
+    override val supplier: EntitySupplier = strategy.supply(kord)
+
+    override fun hashCode(): Int = Objects.hash(id, guildId)
+
+    override fun equals(other: Any?): Boolean = when (other) {
+        is TopGuildChannelBehavior -> other.id == id && other.guildId == guildId
+        is ChannelBehavior -> other.id == id
+        else -> false
+    }
+
+    override fun toString(): String {
+        return "TopGuildChannelBehavior(id=$id, guildId=$guildId, kord=$kord, supplier=$supplier)"
+    }
+}
+
+/**
+ * Requests to add or replace a [PermissionOverwrite] for the [roleId].
+ *
+ *  @throws [RestRequestException] if something went wrong during the request.
+ */
+@OptIn(ExperimentalContracts::class)
+suspend inline fun TopGuildChannelBehavior.editRolePermission(
+    roleId: Snowflake,
+    builder: ChannelPermissionModifyBuilder.() -> Unit
+) {
+    contract {
+        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+    }
+    kord.rest.channel.editRolePermission(channelId = id, roleId = roleId, builder = builder)
+}
+
+/**
+ * Requests to add or replace a [PermissionOverwrite] for the [memberId].
+ *
+ * @throws [RestRequestException] if something went wrong during the request.
+ */
+@OptIn(ExperimentalContracts::class)
+suspend inline fun TopGuildChannelBehavior.editMemberPermission(
+    memberId: Snowflake,
+    builder: ChannelPermissionModifyBuilder.() -> Unit
+) {
+    contract {
+        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+    }
+    kord.rest.channel.editMemberPermissions(channelId = id, memberId = memberId, builder = builder)
+}

--- a/core/src/main/kotlin/behavior/channel/TopGuildChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/TopGuildChannelBehavior.kt
@@ -112,7 +112,7 @@ fun TopGuildChannelBehavior(
     override fun hashCode(): Int = Objects.hash(id, guildId)
 
     override fun equals(other: Any?): Boolean = when (other) {
-        is TopGuildChannelBehavior -> other.id == id && other.guildId == guildId
+        is GuildChannelBehavior -> other.id == id && other.guildId == guildId
         is ChannelBehavior -> other.id == id
         else -> false
     }

--- a/core/src/main/kotlin/behavior/channel/TopGuildChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/TopGuildChannelBehavior.kt
@@ -24,7 +24,12 @@ import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
 /**
- * The behavior of a Discord channel associated to a [guild].
+ * The behavior of a Discord non-thread channel associated to a [guild].
+ * [TopGuildChannelBehavior] incapsulates the behavior we have known pre-threads such as
+ * [NewsChannelBehavior] and [dev.kord.core.behavior.channel.TextChannelBehavior].
+ *
+ * for the behaviors supported for all guild message channels please see [dev.kord.core.behavior.channel.GuildMessageChannelBehavior].
+ *
  */
 interface TopGuildChannelBehavior : GuildChannelBehavior {
 
@@ -98,7 +103,7 @@ interface TopGuildChannelBehavior : GuildChannelBehavior {
 
 }
 
-fun TopGuildChannelBehavior(
+internal fun TopGuildChannelBehavior(
     guildId: Snowflake,
     id: Snowflake,
     kord: Kord,

--- a/core/src/main/kotlin/behavior/channel/TopGuildMessageChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/TopGuildMessageChannelBehavior.kt
@@ -20,11 +20,9 @@ import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
 /**
- * The behavior of a Discord non-thread message channel associated to a [guild].
- * [TopGuildChannelBehavior] encapsulates the behavior we have known pre-threads such as
- * [VoiceChannelBehavior] and [TextChannelBehavior].
+ * The behavior of a non-thread Discord message channel associated to a [guild].
  *
- * for the behaviors supported for all guild channels please see [GuildChannelBehavior].
+ * 'Top' channels are those that do not require a parent channel to be created, and can be found at the top of the UI's hierarchy.
  *
  */
 interface TopGuildMessageChannelBehavior : TopGuildChannelBehavior, GuildMessageChannelBehavior {

--- a/core/src/main/kotlin/behavior/channel/TopGuildMessageChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/TopGuildMessageChannelBehavior.kt
@@ -1,0 +1,113 @@
+package dev.kord.core.behavior.channel
+
+import dev.kord.common.entity.Snowflake
+import dev.kord.common.exception.RequestException
+import dev.kord.core.Kord
+import dev.kord.core.cache.data.WebhookData
+import dev.kord.core.entity.Webhook
+import dev.kord.core.entity.channel.TopGuildMessageChannel
+import dev.kord.core.exception.EntityNotFoundException
+import dev.kord.core.supplier.EntitySupplier
+import dev.kord.core.supplier.EntitySupplyStrategy
+import dev.kord.rest.builder.webhook.WebhookCreateBuilder
+import dev.kord.rest.request.RestRequestException
+import dev.kord.rest.service.RestClient
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import java.util.*
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+
+/**
+ * The behavior of a Discord message channel associated to a [guild].
+ */
+interface TopGuildMessageChannelBehavior : TopGuildChannelBehavior, GuildMessageChannelBehavior {
+
+    /**
+     * Requests to get all webhooks for this channel.
+     *
+     * This property is not resolvable through cache and will always use the [RestClient] instead.
+     *
+     * The returned flow is lazily executed, any [RequestException] will be thrown on
+     * [terminal operators](https://kotlinlang.org/docs/reference/coroutines/flow.html#terminal-flow-operators) instead.
+     */
+    val webhooks: Flow<Webhook>
+        get() = flow {
+            for (response in kord.rest.webhook.getChannelWebhooks(id)) {
+                val data = WebhookData.from(response)
+                emit(Webhook(data, kord))
+            }
+        }
+
+    /**
+     * Requests to get the this behavior as a [TopGuildMessageChannel].
+     *
+     * @throws [RequestException] if something went wrong during the request.
+     * @throws [EntityNotFoundException] if the channel wasn't present.
+     * @throws [ClassCastException] if the channel isn't a guild message channel.
+     */
+    override suspend fun asChannel(): TopGuildMessageChannel =
+        super<TopGuildChannelBehavior>.asChannel() as TopGuildMessageChannel
+
+    /**
+     * Requests to get this behavior as a [TopGuildMessageChannel],
+     * returns null if the channel isn't present or if the channel isn't a guild channel.
+     *
+     * @throws [RequestException] if something went wrong during the request.
+     */
+    override suspend fun asChannelOrNull(): TopGuildMessageChannel? =
+        super<TopGuildChannelBehavior>.asChannelOrNull() as? TopGuildMessageChannel
+
+    /**
+     * Returns a new [TopGuildMessageChannelBehavior] with the given [strategy].
+     */
+    override fun withStrategy(strategy: EntitySupplyStrategy<*>): TopGuildMessageChannelBehavior =
+        TopGuildMessageChannelBehavior(guildId, id, kord, strategy)
+}
+
+internal fun TopGuildMessageChannelBehavior(
+    guildId: Snowflake,
+    id: Snowflake,
+    kord: Kord,
+    strategy: EntitySupplyStrategy<*> = kord.resources.defaultStrategy
+) = object : TopGuildMessageChannelBehavior {
+    override val guildId: Snowflake = guildId
+    override val id: Snowflake = id
+    override val kord: Kord = kord
+    override val supplier: EntitySupplier = strategy.supply(kord)
+
+    override fun hashCode(): Int = Objects.hash(id, guildId)
+
+    override fun equals(other: Any?): Boolean = when (other) {
+        is GuildChannelBehavior -> other.id == id && other.guildId == guildId
+        is ChannelBehavior -> other.id == id
+        else -> false
+    }
+
+    override fun toString(): String {
+        return "TopGuildMessageChannelBehavior(id=$id, guildId=$guildId, kord=$kord, supplier=$supplier)"
+    }
+}
+
+
+/**
+ * Requests to create a new webhook configured by the [builder].
+ *
+ * @return The created [Webhook] with the [Webhook.token] field present.
+ *
+ * @throws [RestRequestException] if something went wrong during the request.
+ */
+@OptIn(ExperimentalContracts::class)
+suspend inline fun TopGuildMessageChannelBehavior.createWebhook(
+    name: String,
+    builder: WebhookCreateBuilder.() -> Unit = {}
+): Webhook {
+    contract {
+        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+    }
+    val response = kord.rest.webhook.createWebhook(id, name, builder)
+    val data = WebhookData.from(response)
+
+    return Webhook(data, kord)
+}

--- a/core/src/main/kotlin/behavior/channel/TopGuildMessageChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/TopGuildMessageChannelBehavior.kt
@@ -20,7 +20,12 @@ import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
 /**
- * The behavior of a Discord message channel associated to a [guild].
+ * The behavior of a Discord non-thread message channel associated to a [guild].
+ * [TopGuildChannelBehavior] encapsulates the behavior we have known pre-threads such as
+ * [VoiceChannelBehavior] and [TextChannelBehavior].
+ *
+ * for the behaviors supported for all guild channels please see [GuildChannelBehavior].
+ *
  */
 interface TopGuildMessageChannelBehavior : TopGuildChannelBehavior, GuildMessageChannelBehavior {
 

--- a/core/src/main/kotlin/behavior/channel/VoiceChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/VoiceChannelBehavior.kt
@@ -60,7 +60,7 @@ fun VoiceChannelBehavior(
     override fun hashCode(): Int = Objects.hash(id, guildId)
 
     override fun equals(other: Any?): Boolean = when (other) {
-        is GuildChannelBehavior -> other.id == id && other.guildId == guildId
+        is TopGuildChannelBehavior -> other.id == id && other.guildId == guildId
         is ChannelBehavior -> other.id == id
         else -> false
     }

--- a/core/src/main/kotlin/behavior/channel/VoiceChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/VoiceChannelBehavior.kt
@@ -60,7 +60,7 @@ fun VoiceChannelBehavior(
     override fun hashCode(): Int = Objects.hash(id, guildId)
 
     override fun equals(other: Any?): Boolean = when (other) {
-        is TopGuildChannelBehavior -> other.id == id && other.guildId == guildId
+        is GuildChannelBehavior -> other.id == id && other.guildId == guildId
         is ChannelBehavior -> other.id == id
         else -> false
     }

--- a/core/src/main/kotlin/behavior/channel/threads/ThreadChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/threads/ThreadChannelBehavior.kt
@@ -105,7 +105,7 @@ interface ThreadChannelBehavior : GuildMessageChannelBehavior {
     }
 
     override suspend fun asChannelOrNull(): ThreadChannel? {
-        return super.asChannelOrNull() as ThreadChannel
+        return super.asChannelOrNull() as? ThreadChannel
     }
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): ThreadChannelBehavior {

--- a/core/src/main/kotlin/behavior/channel/threads/ThreadChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/threads/ThreadChannelBehavior.kt
@@ -3,27 +3,35 @@ package dev.kord.core.behavior.channel.threads
 import dev.kord.common.entity.Snowflake
 import dev.kord.common.exception.RequestException
 import dev.kord.core.Kord
-import dev.kord.core.behavior.channel.MessageChannelBehavior
+import dev.kord.core.behavior.channel.GuildMessageChannelBehavior
 import dev.kord.core.cache.data.toData
 import dev.kord.core.entity.channel.Channel
+import dev.kord.core.entity.channel.ThreadParentChannel
 import dev.kord.core.entity.channel.thread.ThreadChannel
-import dev.kord.core.entity.channel.thread.ThreadUser
+import dev.kord.core.entity.channel.thread.ThreadMember
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
+import dev.kord.core.supplier.getChannelOf
+import dev.kord.core.supplier.getChannelOfOrNull
 import dev.kord.rest.builder.channel.thread.ThreadModifyBuilder
 import kotlinx.coroutines.flow.Flow
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
-interface ThreadChannelBehavior : MessageChannelBehavior {
+interface ThreadChannelBehavior : GuildMessageChannelBehavior {
+
+    val parentId: Snowflake
+
+    val parent: ThreadParentChannelBehavior get() = ThreadParentChannelBehavior(guildId, parentId, kord)
+
     /**
      * Requests to get all members of the current thread.
      *
      * The returned flow is lazily executed, any [RequestException] will be thrown on
      * [terminal operators](https://kotlinlang.org/docs/reference/coroutines/flow.html#terminal-flow-operators) instead.
      */
-    val members: Flow<ThreadUser>
+    val members: Flow<ThreadMember>
         get() = supplier.getThreadMembers(id)
 
     /**
@@ -83,6 +91,15 @@ interface ThreadChannelBehavior : MessageChannelBehavior {
         super.delete(reason)
     }
 
+    suspend fun getParent(): ThreadParentChannel {
+        return supplier.getChannelOf(parentId)
+    }
+
+    suspend fun getParentOrNull(): ThreadParentChannel? {
+        return supplier.getChannelOfOrNull(parentId)
+    }
+
+
     override suspend fun asChannel(): ThreadChannel {
         return super.asChannel() as ThreadChannel
     }
@@ -92,7 +109,7 @@ interface ThreadChannelBehavior : MessageChannelBehavior {
     }
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): ThreadChannelBehavior {
-        return ThreadChannelBehavior(id, kord, strategy.supply(kord))
+        return ThreadChannelBehavior(guildId, parentId, id, kord, strategy.supply(kord))
     }
 
 }
@@ -115,6 +132,8 @@ suspend inline fun ThreadChannelBehavior.edit(builder: ThreadModifyBuilder.() ->
 }
 
 internal fun ThreadChannelBehavior(
+    guildId: Snowflake,
+    parentId: Snowflake,
     id: Snowflake,
     kord: Kord,
     supplier: EntitySupplier = kord.defaultSupplier
@@ -126,6 +145,12 @@ internal fun ThreadChannelBehavior(
 
         override val id: Snowflake
             get() = id
+
+        override val parentId: Snowflake
+            get() = parentId
+
+        override val guildId: Snowflake
+            get() = guildId
 
         override val supplier: EntitySupplier
             get() = supplier

--- a/core/src/main/kotlin/behavior/channel/threads/ThreadChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/threads/ThreadChannelBehavior.kt
@@ -9,6 +9,7 @@ import dev.kord.core.entity.channel.Channel
 import dev.kord.core.entity.channel.ThreadParentChannel
 import dev.kord.core.entity.channel.thread.ThreadChannel
 import dev.kord.core.entity.channel.thread.ThreadMember
+import dev.kord.core.exception.EntityNotFoundException
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 import dev.kord.core.supplier.getChannelOf
@@ -91,10 +92,22 @@ interface ThreadChannelBehavior : GuildMessageChannelBehavior {
         super.delete(reason)
     }
 
+    /**
+     * Requests to get this channel's [ThreadParentChannel].
+     *
+     * @throws [RequestException] if something went wrong during the request.
+     * @throws [EntityNotFoundException] if the thread parent wasn't present.
+     */
     suspend fun getParent(): ThreadParentChannel {
         return supplier.getChannelOf(parentId)
     }
 
+    /**
+     * Requests to get this channel's [ThreadParentChannel],
+     * returns null if the thread parent isn't present.
+     *
+     * @throws [RequestException] if something went wrong during the request.
+     */
     suspend fun getParentOrNull(): ThreadParentChannel? {
         return supplier.getChannelOfOrNull(parentId)
     }

--- a/core/src/main/kotlin/behavior/channel/threads/ThreadParentChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/threads/ThreadParentChannelBehavior.kt
@@ -6,7 +6,7 @@ import dev.kord.common.entity.Snowflake
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.exception.RequestException
 import dev.kord.core.Kord
-import dev.kord.core.behavior.channel.GuildMessageChannelBehavior
+import dev.kord.core.behavior.channel.TopGuildMessageChannelBehavior
 import dev.kord.core.cache.data.ChannelData
 import dev.kord.core.entity.channel.Channel
 import dev.kord.core.entity.channel.ThreadParentChannel
@@ -21,7 +21,7 @@ import kotlinx.datetime.Instant
 /**
  * Behavior of channels that can contain public threads.
  */
-interface ThreadParentChannelBehavior : GuildMessageChannelBehavior {
+interface ThreadParentChannelBehavior : TopGuildMessageChannelBehavior {
     /**
      * Returns all active public and private threads in the channel.
      * Threads are ordered by their id, in descending order.

--- a/core/src/main/kotlin/behavior/channel/threads/ThreadParentChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/threads/ThreadParentChannelBehavior.kt
@@ -6,6 +6,8 @@ import dev.kord.common.entity.Snowflake
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.exception.RequestException
 import dev.kord.core.Kord
+import dev.kord.core.behavior.channel.ChannelBehavior
+import dev.kord.core.behavior.channel.GuildChannelBehavior
 import dev.kord.core.behavior.channel.TopGuildMessageChannelBehavior
 import dev.kord.core.cache.data.ChannelData
 import dev.kord.core.entity.channel.Channel
@@ -17,6 +19,7 @@ import dev.kord.rest.json.request.StartThreadRequest
 import kotlinx.coroutines.flow.Flow
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
+import java.util.*
 
 /**
  * Behavior of channels that can contain public threads.
@@ -126,7 +129,8 @@ internal suspend fun ThreadParentChannelBehavior.unsafeStartPublicThreadWithMess
     reason: String? = null
 ): ThreadChannel {
 
-    val response = kord.rest.channel.startThreadWithMessage(id, messageId, StartThreadRequest(name, archiveDuration), reason)
+    val response =
+        kord.rest.channel.startThreadWithMessage(id, messageId, StartThreadRequest(name, archiveDuration), reason)
     val data = ChannelData.from(response)
 
     return Channel.from(data, kord) as ThreadChannel
@@ -152,6 +156,14 @@ internal fun ThreadParentChannelBehavior(
         override val supplier: EntitySupplier
             get() = supplier
 
+        override fun hashCode(): Int = Objects.hash(id, guildId)
+
+        override fun equals(other: Any?): Boolean = when (other) {
+            is GuildChannelBehavior -> other.id == id && other.guildId == guildId
+            is ChannelBehavior -> other.id == id
+            else -> false
+        }
+
     }
 }
 
@@ -175,6 +187,14 @@ internal fun PrivateThreadParentChannelBehavior(
             get() = id
         override val supplier: EntitySupplier
             get() = supplier
+
+        override fun hashCode(): Int = Objects.hash(id, guildId)
+
+        override fun equals(other: Any?): Boolean = when (other) {
+            is GuildChannelBehavior -> other.id == id && other.guildId == guildId
+            is ChannelBehavior -> other.id == id
+            else -> false
+        }
 
     }
 }

--- a/core/src/main/kotlin/cache/DataCacheExtensions.kt
+++ b/core/src/main/kotlin/cache/DataCacheExtensions.kt
@@ -1,7 +1,6 @@
 package dev.kord.core.cache
 
 import dev.kord.cache.api.DataCache
-import dev.kord.cache.api.find
 import dev.kord.cache.api.query
 import dev.kord.core.cache.data.*
 
@@ -14,7 +13,7 @@ internal suspend fun DataCache.registerKordData() = register(
     GuildData.description,
     MemberData.description,
     UserData.description,
-    ThreadUserData.description,
+    ThreadMemberData.description,
     MessageData.description,
     EmojiData.description,
     WebhookData.description,

--- a/core/src/main/kotlin/cache/data/ChannelData.kt
+++ b/core/src/main/kotlin/cache/data/ChannelData.kt
@@ -3,7 +3,6 @@ package dev.kord.core.cache.data
 import dev.kord.cache.api.data.description
 import dev.kord.common.entity.*
 import dev.kord.common.entity.optional.*
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -31,7 +30,7 @@ data class ChannelData(
     val messageCount: OptionalInt = OptionalInt.Missing,
     val memberCount: OptionalInt = OptionalInt.Missing,
     val defaultAutoArchiveDuration: Optional<ArchiveDuration> = Optional.Missing(),
-    val member: Optional<ThreadUserData> = Optional.Missing()
+    val member: Optional<ThreadMemberData> = Optional.Missing()
 ) {
 
 
@@ -63,7 +62,7 @@ data class ChannelData(
                 messageCount,
                 memberCount,
                 defaultAutoArchiveDuration,
-                member.map { ThreadUserData.from(it, id) }
+                member.map { ThreadMemberData.from(it, id) }
             )
         }
     }

--- a/core/src/main/kotlin/cache/data/ThreadListSyncData.kt
+++ b/core/src/main/kotlin/cache/data/ThreadListSyncData.kt
@@ -8,7 +8,7 @@ class ThreadListSyncData(
     val guildId: Snowflake,
     val channelIds: Optional<List<Snowflake>> = Optional.Missing(),
     val threads: List<ChannelData>,
-    val members: List<ThreadUserData>
+    val members: List<ThreadMemberData>
 ) {
     companion object {
         fun from(event: ThreadListSync): ThreadListSyncData = with(event.sync) {
@@ -16,7 +16,7 @@ class ThreadListSyncData(
                 guildId,
                 channelIds,
                 threads.map { it.toData() },
-                members.map { ThreadUserData.from(it) }
+                members.map { ThreadMemberData.from(it) }
             )
         }
     }

--- a/core/src/main/kotlin/cache/data/ThreadMemberData.kt
+++ b/core/src/main/kotlin/cache/data/ThreadMemberData.kt
@@ -8,7 +8,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class ThreadUserData(
+data class ThreadMemberData(
     val id: Snowflake,
     @SerialName("user_id")
     val userId: OptionalSnowflake = OptionalSnowflake.Missing,
@@ -17,13 +17,13 @@ data class ThreadUserData(
     val flags: Int
 ) {
     companion object {
-        val description = description(ThreadUserData::id)
+        val description = description(ThreadMemberData::id)
 
 
-        fun from(data: DiscordThreadMember, thread: Snowflake? = null): ThreadUserData =
+        fun from(data: DiscordThreadMember, thread: Snowflake? = null): ThreadMemberData =
             with(data) {
                 val id = this.id.value ?: thread!!
-                ThreadUserData(id, userId, joinTimestamp, flags)
+                ThreadMemberData(id, userId, joinTimestamp, flags)
             }
     }
 }

--- a/core/src/main/kotlin/cache/data/ThreadMembersUpdateEventData.kt
+++ b/core/src/main/kotlin/cache/data/ThreadMembersUpdateEventData.kt
@@ -9,7 +9,7 @@ class ThreadMembersUpdateEventData(
     val id: Snowflake,
     val guildId: Snowflake,
     val memberCount: Int,
-    val addedMembers: Optional<List<ThreadUserData>> = Optional.Missing(),
+    val addedMembers: Optional<List<ThreadMemberData>> = Optional.Missing(),
     val removedMemberIds: Optional<List<Snowflake>> = Optional.Missing()
 ) {
     companion object {
@@ -18,7 +18,7 @@ class ThreadMembersUpdateEventData(
                 id,
                 guildId,
                 memberCount,
-                addedMembers.mapList { ThreadUserData.from(it) },
+                addedMembers.mapList { ThreadMemberData.from(it) },
                 removedMemberIds
             )
         }

--- a/core/src/main/kotlin/entity/Guild.kt
+++ b/core/src/main/kotlin/entity/Guild.kt
@@ -9,7 +9,9 @@ import dev.kord.core.behavior.GuildBehavior
 import dev.kord.core.behavior.MemberBehavior
 import dev.kord.core.behavior.RoleBehavior
 import dev.kord.core.behavior.channel.GuildChannelBehavior
+import dev.kord.core.behavior.channel.TopGuildChannelBehavior
 import dev.kord.core.behavior.channel.GuildMessageChannelBehavior
+import dev.kord.core.behavior.channel.TopGuildMessageChannelBehavior
 import dev.kord.core.behavior.channel.TextChannelBehavior
 import dev.kord.core.behavior.channel.VoiceChannelBehavior
 import dev.kord.core.cache.data.GuildData
@@ -111,7 +113,7 @@ class Guild(
     val bannerHash: String? get() = data.banner
 
     /**
-     * The ids of all [channels][GuildChannel].
+     * The ids of all [channels][TopGuildChannel].
      */
     val channelIds: Set<Snowflake> get() = data.channels.orEmpty().toSet()
 
@@ -155,13 +157,13 @@ class Guild(
         ReplaceWith("widgetChannelId"),
         DeprecationLevel.ERROR
     )
-    val embedChannel: GuildChannelBehavior? by ::widgetChannel
+    val embedChannel: TopGuildChannelBehavior? by ::widgetChannel
 
     /**
      * The behavior of the channel widgets will redirect users to, if present.
      */
-    val widgetChannel: GuildChannelBehavior?
-        get() = widgetChannelId?.let { GuildChannelBehavior(guildId = id, id = it, kord = kord) }
+    val widgetChannel: TopGuildChannelBehavior?
+        get() = widgetChannelId?.let { TopGuildChannelBehavior(guildId = id, id = it, kord = kord) }
 
     /**
      * The ids of custom emojis in this guild.
@@ -238,18 +240,18 @@ class Guild(
     /**
      * The behavior of the channel where guild notices such as welcome messages and boost events are posted.
      */
-    val publicUpdatesChannel: GuildMessageChannelBehavior?
+    val publicUpdatesChannel: TopGuildMessageChannelBehavior?
         get() = publicUpdatesChannelId?.let {
-            GuildMessageChannelBehavior(guildId = id, id = it, kord = kord)
+            TopGuildMessageChannelBehavior(guildId = id, id = it, kord = kord)
         }
 
     val preferredLocale: Locale get() = Locale.forLanguageTag(data.preferredLocale)
 
     /**
-     * The behaviors of all [channels][GuildChannel].
+     * The behaviors of all [channels][TopGuildChannel].
      */
-    val channelBehaviors: Set<GuildChannelBehavior>
-        get() = data.channels.orEmpty().asSequence().map { GuildChannelBehavior(id = it, guildId = id, kord = kord) }
+    val channelBehaviors: Set<TopGuildChannelBehavior>
+        get() = data.channels.orEmpty().asSequence().map { TopGuildChannelBehavior(id = it, guildId = id, kord = kord) }
             .toSet()
 
     /**
@@ -270,9 +272,9 @@ class Guild(
     /**
      * The channel behavior in which a discoverable server's rules should be found.
      **/
-    val rulesChannel: GuildMessageChannelBehavior?
+    val rulesChannel: TopGuildMessageChannelBehavior?
         get() = data.rulesChannelId?.let {
-            GuildMessageChannelBehavior(id, it, kord)
+            TopGuildMessageChannelBehavior(id, it, kord)
         }
 
     /**
@@ -367,12 +369,12 @@ class Guild(
     }
 
     /**
-     * Requests to get the [GuildChannel] represented by the [embedChannel],
-     * returns null if the [GuildChannel] isn't present or [embedChannel] is null.
+     * Requests to get the [TopGuildChannel] represented by the [embedChannel],
+     * returns null if the [TopGuildChannel] isn't present or [embedChannel] is null.
      *
      * @throws [RequestException] if anything went wrong during the request.
      */
-    suspend fun getEmbedChannel(): GuildChannel? = widgetChannelId?.let { supplier.getChannelOfOrNull(it) }
+    suspend fun getEmbedChannel(): TopGuildChannel? = widgetChannelId?.let { supplier.getChannelOfOrNull(it) }
 
     /**
      * Requests to get the [GuildEmoji] represented by the [emojiId] in this guild.
@@ -460,7 +462,7 @@ class Guild(
     /**
      * Requests to get The channel where guild notices such as welcome messages and boost events are posted.
      */
-    suspend fun getPublicUpdatesChannel(): GuildMessageChannel? = publicUpdatesChannel?.asChannel()
+    suspend fun getPublicUpdatesChannel(): TopGuildMessageChannel? = publicUpdatesChannel?.asChannel()
 
     /**
      * Requests to get the [voice region][Region] of this guild.
@@ -473,11 +475,11 @@ class Guild(
 
     /**
      * Requests to get the the channel in which a discoverable server's rules should be found represented
-     *, returns null if the [GuildMessageChannel] isn't present, or [rulesChannelId] is null.
+     *, returns null if the [TopGuildMessageChannel] isn't present, or [rulesChannelId] is null.
      *
      * @throws [RequestException] if anything went wrong during the request.
      */
-    suspend fun getRulesChannel(): GuildMessageChannel? = rulesChannel?.asChannel()
+    suspend fun getRulesChannel(): TopGuildMessageChannel? = rulesChannel?.asChannel()
 
     /**
      * Gets the splash url in the specified [format], if present.
@@ -509,7 +511,7 @@ class Guild(
      *
      * @throws [RequestException] if anything went wrong during the request.
      */
-    suspend fun getWidgetChannel(): GuildMessageChannel? =
+    suspend fun getWidgetChannel(): TopGuildMessageChannel? =
         widgetChannelId?.let { supplier.getChannelOfOrNull(it) }
 
     /**

--- a/core/src/main/kotlin/entity/GuildWidget.kt
+++ b/core/src/main/kotlin/entity/GuildWidget.kt
@@ -7,7 +7,7 @@ import dev.kord.core.behavior.GuildBehavior
 import dev.kord.core.behavior.channel.ChannelBehavior
 import dev.kord.core.cache.data.GuildWidgetData
 import dev.kord.core.entity.channel.Channel
-import dev.kord.core.entity.channel.GuildChannel
+import dev.kord.core.entity.channel.TopGuildChannel
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 import dev.kord.core.supplier.getChannelOfOrNull
@@ -35,7 +35,7 @@ class GuildWidget(
 
     suspend fun getGuildOrNull(): Guild? = supplier.getGuildOrNull(guildId)
 
-    suspend fun getChannelOrNull(): GuildChannel? = data.channelId?.let { supplier.getChannelOfOrNull(it) }
+    suspend fun getChannelOrNull(): TopGuildChannel? = data.channelId?.let { supplier.getChannelOfOrNull(it) }
 
     suspend inline fun <reified T : Channel> getChannelOfOrNull(): T? =
         data.channelId?.let { supplier.getChannelOfOrNull(it) }

--- a/core/src/main/kotlin/entity/Message.kt
+++ b/core/src/main/kotlin/entity/Message.kt
@@ -13,8 +13,8 @@ import dev.kord.core.behavior.UserBehavior
 import dev.kord.core.behavior.channel.ChannelBehavior
 import dev.kord.core.cache.data.MessageData
 import dev.kord.core.entity.channel.Channel
-import dev.kord.core.entity.channel.GuildChannel
-import dev.kord.core.entity.channel.GuildMessageChannel
+import dev.kord.core.entity.channel.TopGuildChannel
+import dev.kord.core.entity.channel.TopGuildMessageChannel
 import dev.kord.core.entity.channel.MessageChannel
 import dev.kord.core.entity.component.Component
 import dev.kord.core.entity.interaction.Interaction
@@ -245,7 +245,7 @@ class Message(
     /**
      * Requests to get the [author] as a member.
      *
-     * Returns null if the message was not send in a [GuildMessageChannel], or if the [author] is not a [User].
+     * Returns null if the message was not send in a [TopGuildMessageChannel], or if the [author] is not a [User].
      */
     suspend fun getAuthorAsMember(): Member? {
         val author = author ?: return null
@@ -260,7 +260,7 @@ class Message(
      * @throws [EntityNotFoundException] if the [Guild] wasn't present.
      * @throws [ClassCastException] if this message wasn't made in a guild.
      */
-    suspend fun getGuild(): Guild = supplier.getChannelOf<GuildChannel>(channelId).getGuild()
+    suspend fun getGuild(): Guild = supplier.getChannelOf<TopGuildChannel>(channelId).getGuild()
 
     /**
      * Requests to get the guild of this message,
@@ -268,7 +268,7 @@ class Message(
      *
      * @throws [RequestException] if anything went wrong during the request.
      */
-    suspend fun getGuildOrNull(): Guild? = supplier.getChannelOfOrNull<GuildChannel>(channelId)?.getGuildOrNull()
+    suspend fun getGuildOrNull(): Guild? = supplier.getChannelOfOrNull<TopGuildChannel>(channelId)?.getGuildOrNull()
 
     /**
      * Returns a new [Message] with the given [strategy].

--- a/core/src/main/kotlin/entity/Message.kt
+++ b/core/src/main/kotlin/entity/Message.kt
@@ -12,10 +12,7 @@ import dev.kord.core.behavior.MessageBehavior
 import dev.kord.core.behavior.UserBehavior
 import dev.kord.core.behavior.channel.ChannelBehavior
 import dev.kord.core.cache.data.MessageData
-import dev.kord.core.entity.channel.Channel
-import dev.kord.core.entity.channel.TopGuildChannel
-import dev.kord.core.entity.channel.TopGuildMessageChannel
-import dev.kord.core.entity.channel.MessageChannel
+import dev.kord.core.entity.channel.*
 import dev.kord.core.entity.component.Component
 import dev.kord.core.entity.interaction.Interaction
 import dev.kord.core.entity.interaction.MessageInteraction
@@ -260,7 +257,7 @@ class Message(
      * @throws [EntityNotFoundException] if the [Guild] wasn't present.
      * @throws [ClassCastException] if this message wasn't made in a guild.
      */
-    suspend fun getGuild(): Guild = supplier.getChannelOf<TopGuildChannel>(channelId).getGuild()
+    suspend fun getGuild(): Guild = supplier.getChannelOf<GuildChannel>(channelId).getGuild()
 
     /**
      * Requests to get the guild of this message,
@@ -268,7 +265,7 @@ class Message(
      *
      * @throws [RequestException] if anything went wrong during the request.
      */
-    suspend fun getGuildOrNull(): Guild? = supplier.getChannelOfOrNull<TopGuildChannel>(channelId)?.getGuildOrNull()
+    suspend fun getGuildOrNull(): Guild? = supplier.getChannelOfOrNull<GuildChannel>(channelId)?.getGuildOrNull()
 
     /**
      * Returns a new [Message] with the given [strategy].

--- a/core/src/main/kotlin/entity/PermissionOverwriteEntity.kt
+++ b/core/src/main/kotlin/entity/PermissionOverwriteEntity.kt
@@ -6,8 +6,9 @@ import dev.kord.core.Kord
 import dev.kord.core.KordObject
 import dev.kord.core.behavior.GuildBehavior
 import dev.kord.core.behavior.channel.GuildChannelBehavior
+import dev.kord.core.behavior.channel.TopGuildChannelBehavior
 import dev.kord.core.cache.data.PermissionOverwriteData
-import dev.kord.core.entity.channel.GuildChannel
+import dev.kord.core.entity.channel.TopGuildChannel
 import dev.kord.core.exception.EntityNotFoundException
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
@@ -25,23 +26,23 @@ class PermissionOverwriteEntity(
 
     val guild: GuildBehavior get() = GuildBehavior(guildId, kord)
 
-    val channel: GuildChannelBehavior get() = GuildChannelBehavior(guildId, channelId, kord)
+    val channel: TopGuildChannelBehavior get() = TopGuildChannelBehavior(guildId, channelId, kord)
 
     /**
      * Requests to get the channel this overwrite applies to.
      *
      * @throws [RequestException] if anything went wrong during the request.
-     * @throws [EntityNotFoundException] if the [GuildChannel] wasn't present.
+     * @throws [EntityNotFoundException] if the [TopGuildChannel] wasn't present.
      */
-    suspend fun getChannel(): GuildChannel = supplier.getChannelOf(channelId)
+    suspend fun getChannel(): TopGuildChannel = supplier.getChannelOf(channelId)
 
     /**
      * Requests to get the channel this overwrite applies to,
-     * returns null if the [GuildChannel] isn't present.
+     * returns null if the [TopGuildChannel] isn't present.
      *
      * @throws [RequestException] if anything went wrong during the request.
      */
-    suspend fun getChannelOrNull(): GuildChannel? = supplier.getChannelOfOrNull(channelId)
+    suspend fun getChannelOrNull(): TopGuildChannel? = supplier.getChannelOfOrNull(channelId)
 
     /**
      * Requests to get the the guild of this overwrite.

--- a/core/src/main/kotlin/entity/Webhook.kt
+++ b/core/src/main/kotlin/entity/Webhook.kt
@@ -7,10 +7,9 @@ import dev.kord.common.exception.RequestException
 import dev.kord.core.Kord
 import dev.kord.core.behavior.GuildBehavior
 import dev.kord.core.behavior.WebhookBehavior
-import dev.kord.core.behavior.channel.GuildMessageChannelBehavior
 import dev.kord.core.behavior.channel.MessageChannelBehavior
 import dev.kord.core.cache.data.WebhookData
-import dev.kord.core.entity.channel.GuildMessageChannel
+import dev.kord.core.entity.channel.TopGuildMessageChannel
 import dev.kord.core.entity.channel.MessageChannel
 import dev.kord.core.exception.EntityNotFoundException
 import dev.kord.core.supplier.EntitySupplier
@@ -65,13 +64,13 @@ data class Webhook(
      * Requests to get the channel this webhook operates in.
      *
      * @throws [RequestException] if anything went wrong during the request.
-     * @throws [EntityNotFoundException] if the [GuildMessageChannel] wasn't present.
+     * @throws [EntityNotFoundException] if the [TopGuildMessageChannel] wasn't present.
      */
     suspend fun getChannel(): MessageChannel = supplier.getChannelOf(channelId)
 
     /**
      * Requests to get the channel this webhook operates in,
-     * returns null if the [GuildMessageChannel] isn't present.
+     * returns null if the [TopGuildMessageChannel] isn't present.
      *
      * @throws [RequestException] if anything went wrong during the request.
      */

--- a/core/src/main/kotlin/entity/channel/CategorizableChannel.kt
+++ b/core/src/main/kotlin/entity/channel/CategorizableChannel.kt
@@ -5,7 +5,6 @@ import dev.kord.common.entity.optional.value
 import dev.kord.core.behavior.channel.CategoryBehavior
 import dev.kord.core.cache.data.InviteData
 import dev.kord.core.entity.Invite
-import dev.kord.core.toSnowflakeOrNull
 import dev.kord.rest.builder.channel.InviteCreateBuilder
 import dev.kord.rest.request.RestRequestException
 import kotlin.contracts.ExperimentalContracts
@@ -15,7 +14,7 @@ import kotlin.contracts.contract
 /**
  * An instance of a Discord channel associated to a [category].
  */
-interface CategorizableChannel : GuildChannel {
+interface CategorizableChannel : TopGuildChannel {
 
     /**
      * The id of the [category] this channel belongs to, if any.

--- a/core/src/main/kotlin/entity/channel/Category.kt
+++ b/core/src/main/kotlin/entity/channel/Category.kt
@@ -4,6 +4,7 @@ import dev.kord.common.entity.Snowflake
 import dev.kord.core.Kord
 import dev.kord.core.behavior.channel.CategoryBehavior
 import dev.kord.core.behavior.channel.ChannelBehavior
+import dev.kord.core.behavior.channel.GuildChannelBehavior
 import dev.kord.core.behavior.channel.TopGuildChannelBehavior
 import dev.kord.core.cache.data.ChannelData
 import dev.kord.core.entity.Entity
@@ -42,7 +43,7 @@ class Category(
     override fun hashCode(): Int = Objects.hash(id, guildId)
 
     override fun equals(other: Any?): Boolean = when (other) {
-        is TopGuildChannelBehavior -> other.id == id && other.guildId == guildId
+        is GuildChannelBehavior -> other.id == id && other.guildId == guildId
         is ChannelBehavior -> other.id == id
         else -> false
     }

--- a/core/src/main/kotlin/entity/channel/Category.kt
+++ b/core/src/main/kotlin/entity/channel/Category.kt
@@ -4,10 +4,9 @@ import dev.kord.common.entity.Snowflake
 import dev.kord.core.Kord
 import dev.kord.core.behavior.channel.CategoryBehavior
 import dev.kord.core.behavior.channel.ChannelBehavior
-import dev.kord.core.behavior.channel.GuildChannelBehavior
+import dev.kord.core.behavior.channel.TopGuildChannelBehavior
 import dev.kord.core.cache.data.ChannelData
 import dev.kord.core.entity.Entity
-import dev.kord.core.entity.KordEntity
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 import java.util.*
@@ -19,17 +18,17 @@ class Category(
     override val data: ChannelData,
     override val kord: Kord,
     override val supplier: EntitySupplier = kord.defaultSupplier,
-) : GuildChannel, CategoryBehavior {
+) : TopGuildChannel, CategoryBehavior {
 
     override val guildId: Snowflake
         get() = super.guildId
 
-    override val guild get() = super<GuildChannel>.guild
+    override val guild get() = super<TopGuildChannel>.guild
 
     override suspend fun asChannel(): Category = this
 
     override fun compareTo(other: Entity): Int {
-        return super<GuildChannel>.compareTo(other)
+        return super<TopGuildChannel>.compareTo(other)
     }
 
 
@@ -43,7 +42,7 @@ class Category(
     override fun hashCode(): Int = Objects.hash(id, guildId)
 
     override fun equals(other: Any?): Boolean = when (other) {
-        is GuildChannelBehavior -> other.id == id && other.guildId == guildId
+        is TopGuildChannelBehavior -> other.id == id && other.guildId == guildId
         is ChannelBehavior -> other.id == id
         else -> false
     }

--- a/core/src/main/kotlin/entity/channel/GuildChannel.kt
+++ b/core/src/main/kotlin/entity/channel/GuildChannel.kt
@@ -8,8 +8,8 @@ import dev.kord.common.entity.optional.orEmpty
 import dev.kord.common.entity.optional.value
 import dev.kord.common.exception.RequestException
 import dev.kord.core.behavior.channel.GuildChannelBehavior
+import dev.kord.core.behavior.channel.TopGuildChannelBehavior
 import dev.kord.core.cache.data.PermissionOverwriteData
-import dev.kord.core.entity.PermissionOverwrite
 import dev.kord.core.entity.PermissionOverwriteEntity
 import dev.kord.core.supplier.EntitySupplyStrategy
 
@@ -25,74 +25,6 @@ interface GuildChannel : Channel, GuildChannelBehavior {
      * The name of this channel.
      */
     val name: String get() = data.name.value!!
-
-    /**
-     * The raw position of this channel in the guild as displayed by Discord.
-     */
-    val rawPosition: Int get() = data.position.value!!
-
-    /**
-     * The permission overwrites for this channel.
-     */
-    val permissionOverwrites: Set<PermissionOverwriteEntity>
-        get() = data.permissionOverwrites.orEmpty().asSequence()
-            .map { PermissionOverwriteData(it.id, it.type, it.allow, it.deny) }
-            .map { PermissionOverwriteEntity(guildId, id, it, kord) }
-            .toSet()
-
-    /**
-     * Calculates the effective permissions of the [memberId] in this channel, applying the overwrite for the member
-     * and their roles on top of the base permissions.
-     *
-     * @throws [RequestException] if something went wrong during the request.
-     * @throws IllegalArgumentException if the [memberId] is not part of this guild.
-     */
-    suspend fun getEffectivePermissions(memberId: Snowflake): Permissions {
-        val member = supplier.getMemberOrNull(guildId, memberId)
-        require(member != null) {
-            "member ${memberId.asString} is not in guild ${guildId.asString}"
-        }
-
-        val base = member.getPermissions()
-
-        if (Permission.Administrator in base) return Permissions { +Permission.All }
-
-        val everyoneOverwrite = getPermissionOverwritesForRole(guildId)
-        val roleOverwrites = member.roleIds.mapNotNull { getPermissionOverwritesForRole(it) }
-        val memberOverwrite = getPermissionOverwritesForMember(memberId)
-
-        return Permissions {
-            +base
-            everyoneOverwrite?.let {
-                +it.allowed
-                -it.denied
-            }
-            roleOverwrites.map {
-                +it.allowed
-                -it.denied
-            }
-            memberOverwrite?.let {
-                +it.allowed
-                -it.denied
-            }
-        }
-
-    }
-
-    /**
-     * Gets the permission overwrite for the [memberId] in this channel, if present.
-     */
-    fun getPermissionOverwritesForMember(memberId: Snowflake): PermissionOverwriteEntity? =
-        getPermissionOverwritesForType(memberId, OverwriteType.Member)
-
-    /**
-     * Gets the permission overwrite for the [roleId] in this channel, if present.
-     */
-    fun getPermissionOverwritesForRole(roleId: Snowflake): PermissionOverwriteEntity? =
-        getPermissionOverwritesForType(roleId, OverwriteType.Role)
-
-    private fun getPermissionOverwritesForType(id: Snowflake, type: OverwriteType): PermissionOverwriteEntity? =
-        permissionOverwrites.firstOrNull { it.target == id && it.type == type }
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): GuildChannel
 

--- a/core/src/main/kotlin/entity/channel/GuildMessageChannel.kt
+++ b/core/src/main/kotlin/entity/channel/GuildMessageChannel.kt
@@ -3,15 +3,7 @@ package dev.kord.core.entity.channel
 import dev.kord.core.behavior.channel.GuildMessageChannelBehavior
 import dev.kord.core.supplier.EntitySupplyStrategy
 
-/**
- * An instance of a Discord message channel associated to a [guild].
- */
-interface GuildMessageChannel : CategorizableChannel, MessageChannel, GuildMessageChannelBehavior {
-
-    /**
-     * The channel topic, if present.
-     */
-    val topic: String? get() = data.topic.value
+interface GuildMessageChannel : GuildChannel, MessageChannel, GuildMessageChannelBehavior {
 
     /**
      * Returns a new [GuildMessageChannel] with the given [strategy].

--- a/core/src/main/kotlin/entity/channel/InviteChannel.kt
+++ b/core/src/main/kotlin/entity/channel/InviteChannel.kt
@@ -8,7 +8,7 @@ import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
-interface InviteChannel : GuildChannel
+interface InviteChannel : TopGuildChannel
 
 /**
  * Request to create an invite for this channel.

--- a/core/src/main/kotlin/entity/channel/NewsChannel.kt
+++ b/core/src/main/kotlin/entity/channel/NewsChannel.kt
@@ -1,12 +1,10 @@
 package dev.kord.core.entity.channel
 
-import dev.kord.common.entity.ArchiveDuration
 import dev.kord.core.Kord
 import dev.kord.core.behavior.channel.ChannelBehavior
-import dev.kord.core.behavior.channel.GuildChannelBehavior
+import dev.kord.core.behavior.channel.TopGuildChannelBehavior
 import dev.kord.core.behavior.channel.NewsChannelBehavior
 import dev.kord.core.cache.data.ChannelData
-import dev.kord.core.entity.channel.thread.ThreadChannel
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 import java.util.*
@@ -18,14 +16,14 @@ class NewsChannel(
     override val data: ChannelData,
     override val kord: Kord,
     override val supplier: EntitySupplier = kord.defaultSupplier
-) : CategorizableChannel, GuildMessageChannel, ThreadParentChannel,  NewsChannelBehavior {
+) : CategorizableChannel, TopGuildMessageChannel, ThreadParentChannel,  NewsChannelBehavior {
 
     override suspend fun asChannel(): NewsChannel = this
 
     override fun hashCode(): Int = Objects.hash(id, guildId)
 
     override fun equals(other: Any?): Boolean = when (other) {
-        is GuildChannelBehavior -> other.id == id && other.guildId == guildId
+        is TopGuildChannelBehavior -> other.id == id && other.guildId == guildId
         is ChannelBehavior -> other.id == id
         else -> false
     }

--- a/core/src/main/kotlin/entity/channel/StageVoiceChannel.kt
+++ b/core/src/main/kotlin/entity/channel/StageVoiceChannel.kt
@@ -3,7 +3,7 @@ package dev.kord.core.entity.channel
 import dev.kord.common.entity.optional.getOrThrow
 import dev.kord.core.Kord
 import dev.kord.core.behavior.channel.ChannelBehavior
-import dev.kord.core.behavior.channel.GuildChannelBehavior
+import dev.kord.core.behavior.channel.TopGuildChannelBehavior
 import dev.kord.core.behavior.channel.StageChannelBehavior
 import dev.kord.core.cache.data.ChannelData
 import dev.kord.core.supplier.EntitySupplier
@@ -43,7 +43,7 @@ class StageChannel(
     override fun hashCode(): Int = Objects.hash(id, guildId)
 
     override fun equals(other: Any?): Boolean = when (other) {
-        is GuildChannelBehavior -> other.id == id && other.guildId == guildId
+        is TopGuildChannelBehavior -> other.id == id && other.guildId == guildId
         is ChannelBehavior -> other.id == id
         else -> false
     }

--- a/core/src/main/kotlin/entity/channel/StageVoiceChannel.kt
+++ b/core/src/main/kotlin/entity/channel/StageVoiceChannel.kt
@@ -3,6 +3,7 @@ package dev.kord.core.entity.channel
 import dev.kord.common.entity.optional.getOrThrow
 import dev.kord.core.Kord
 import dev.kord.core.behavior.channel.ChannelBehavior
+import dev.kord.core.behavior.channel.GuildChannelBehavior
 import dev.kord.core.behavior.channel.TopGuildChannelBehavior
 import dev.kord.core.behavior.channel.StageChannelBehavior
 import dev.kord.core.cache.data.ChannelData
@@ -43,7 +44,7 @@ class StageChannel(
     override fun hashCode(): Int = Objects.hash(id, guildId)
 
     override fun equals(other: Any?): Boolean = when (other) {
-        is TopGuildChannelBehavior -> other.id == id && other.guildId == guildId
+        is GuildChannelBehavior -> other.id == id && other.guildId == guildId
         is ChannelBehavior -> other.id == id
         else -> false
     }

--- a/core/src/main/kotlin/entity/channel/StoreChannel.kt
+++ b/core/src/main/kotlin/entity/channel/StoreChannel.kt
@@ -2,7 +2,7 @@ package dev.kord.core.entity.channel
 
 import dev.kord.core.Kord
 import dev.kord.core.behavior.channel.ChannelBehavior
-import dev.kord.core.behavior.channel.GuildChannelBehavior
+import dev.kord.core.behavior.channel.TopGuildChannelBehavior
 import dev.kord.core.behavior.channel.StoreChannelBehavior
 import dev.kord.core.cache.data.ChannelData
 import dev.kord.core.supplier.EntitySupplier
@@ -16,7 +16,7 @@ data class StoreChannel(
     override val data: ChannelData,
     override val kord: Kord,
     override val supplier: EntitySupplier = kord.defaultSupplier
-) : CategorizableChannel, GuildChannel, StoreChannelBehavior {
+) : CategorizableChannel, TopGuildChannel, StoreChannelBehavior {
 
 
     override suspend fun asChannel(): StoreChannel = this
@@ -30,7 +30,7 @@ data class StoreChannel(
     override fun hashCode(): Int = Objects.hash(id, guildId)
 
     override fun equals(other: Any?): Boolean = when (other) {
-        is GuildChannelBehavior -> other.id == id && other.guildId == guildId
+        is TopGuildChannelBehavior -> other.id == id && other.guildId == guildId
         is ChannelBehavior -> other.id == id
         else -> false
     }

--- a/core/src/main/kotlin/entity/channel/StoreChannel.kt
+++ b/core/src/main/kotlin/entity/channel/StoreChannel.kt
@@ -2,6 +2,7 @@ package dev.kord.core.entity.channel
 
 import dev.kord.core.Kord
 import dev.kord.core.behavior.channel.ChannelBehavior
+import dev.kord.core.behavior.channel.GuildChannelBehavior
 import dev.kord.core.behavior.channel.TopGuildChannelBehavior
 import dev.kord.core.behavior.channel.StoreChannelBehavior
 import dev.kord.core.cache.data.ChannelData
@@ -30,7 +31,7 @@ data class StoreChannel(
     override fun hashCode(): Int = Objects.hash(id, guildId)
 
     override fun equals(other: Any?): Boolean = when (other) {
-        is TopGuildChannelBehavior -> other.id == id && other.guildId == guildId
+        is GuildChannelBehavior -> other.id == id && other.guildId == guildId
         is ChannelBehavior -> other.id == id
         else -> false
     }

--- a/core/src/main/kotlin/entity/channel/TextChannel.kt
+++ b/core/src/main/kotlin/entity/channel/TextChannel.kt
@@ -3,6 +3,7 @@ package dev.kord.core.entity.channel
 import dev.kord.common.entity.optional.getOrThrow
 import dev.kord.core.Kord
 import dev.kord.core.behavior.channel.ChannelBehavior
+import dev.kord.core.behavior.channel.GuildChannelBehavior
 import dev.kord.core.behavior.channel.TopGuildChannelBehavior
 import dev.kord.core.behavior.channel.TextChannelBehavior
 import dev.kord.core.cache.data.ChannelData
@@ -40,7 +41,7 @@ class TextChannel(
     override fun hashCode(): Int = Objects.hash(id, guildId)
 
     override fun equals(other: Any?): Boolean = when (other) {
-        is TopGuildChannelBehavior -> other.id == id && other.guildId == guildId
+        is GuildChannelBehavior -> other.id == id && other.guildId == guildId
         is ChannelBehavior -> other.id == id
         else -> false
     }

--- a/core/src/main/kotlin/entity/channel/TextChannel.kt
+++ b/core/src/main/kotlin/entity/channel/TextChannel.kt
@@ -3,7 +3,7 @@ package dev.kord.core.entity.channel
 import dev.kord.common.entity.optional.getOrThrow
 import dev.kord.core.Kord
 import dev.kord.core.behavior.channel.ChannelBehavior
-import dev.kord.core.behavior.channel.GuildChannelBehavior
+import dev.kord.core.behavior.channel.TopGuildChannelBehavior
 import dev.kord.core.behavior.channel.TextChannelBehavior
 import dev.kord.core.cache.data.ChannelData
 import dev.kord.core.supplier.EntitySupplier
@@ -17,7 +17,7 @@ class TextChannel(
     override val data: ChannelData,
     override val kord: Kord,
     override val supplier: EntitySupplier = kord.defaultSupplier
-) : GuildMessageChannel, TextChannelBehavior, ThreadParentChannel {
+) : CategorizableChannel, TextChannelBehavior, ThreadParentChannel {
 
     /**
      * Whether the channel is nsfw.
@@ -40,7 +40,7 @@ class TextChannel(
     override fun hashCode(): Int = Objects.hash(id, guildId)
 
     override fun equals(other: Any?): Boolean = when (other) {
-        is GuildChannelBehavior -> other.id == id && other.guildId == guildId
+        is TopGuildChannelBehavior -> other.id == id && other.guildId == guildId
         is ChannelBehavior -> other.id == id
         else -> false
     }

--- a/core/src/main/kotlin/entity/channel/ThreadParentChannel.kt
+++ b/core/src/main/kotlin/entity/channel/ThreadParentChannel.kt
@@ -1,14 +1,9 @@
 package dev.kord.core.entity.channel
 
-import dev.kord.common.entity.ArchiveDuration
-import dev.kord.core.Kord
 import dev.kord.core.behavior.channel.threads.ThreadParentChannelBehavior
-import dev.kord.core.cache.data.ChannelData
-import dev.kord.core.entity.channel.thread.ThreadChannel
-import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 
-interface ThreadParentChannel : ThreadParentChannelBehavior, GuildMessageChannel {
+interface ThreadParentChannel : ThreadParentChannelBehavior, TopGuildMessageChannel {
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): ThreadParentChannel
 }

--- a/core/src/main/kotlin/entity/channel/TopGuildChannel.kt
+++ b/core/src/main/kotlin/entity/channel/TopGuildChannel.kt
@@ -1,0 +1,93 @@
+package dev.kord.core.entity.channel
+
+import dev.kord.common.entity.OverwriteType
+import dev.kord.common.entity.Permission
+import dev.kord.common.entity.Permissions
+import dev.kord.common.entity.Snowflake
+import dev.kord.common.entity.optional.orEmpty
+import dev.kord.common.entity.optional.value
+import dev.kord.common.exception.RequestException
+import dev.kord.core.behavior.channel.TopGuildChannelBehavior
+import dev.kord.core.cache.data.PermissionOverwriteData
+import dev.kord.core.entity.PermissionOverwriteEntity
+import dev.kord.core.supplier.EntitySupplyStrategy
+
+/**
+ * An instance of a Discord channel associated to a [guild].
+ */
+interface TopGuildChannel : GuildChannel, TopGuildChannelBehavior {
+
+    override val guildId: Snowflake
+        get() = data.guildId.value!!
+
+    /**
+     * The raw position of this channel in the guild as displayed by Discord.
+     */
+    val rawPosition: Int get() = data.position.value!!
+
+    /**
+     * The permission overwrites for this channel.
+     */
+    val permissionOverwrites: Set<PermissionOverwriteEntity>
+        get() = data.permissionOverwrites.orEmpty().asSequence()
+            .map { PermissionOverwriteData(it.id, it.type, it.allow, it.deny) }
+            .map { PermissionOverwriteEntity(guildId, id, it, kord) }
+            .toSet()
+
+    /**
+     * Calculates the effective permissions of the [memberId] in this channel, applying the overwrite for the member
+     * and their roles on top of the base permissions.
+     *
+     * @throws [RequestException] if something went wrong during the request.
+     * @throws IllegalArgumentException if the [memberId] is not part of this guild.
+     */
+    suspend fun getEffectivePermissions(memberId: Snowflake): Permissions {
+        val member = supplier.getMemberOrNull(guildId, memberId)
+        require(member != null) {
+            "member ${memberId.asString} is not in guild ${guildId.asString}"
+        }
+
+        val base = member.getPermissions()
+
+        if (Permission.Administrator in base) return Permissions { +Permission.All }
+
+        val everyoneOverwrite = getPermissionOverwritesForRole(guildId)
+        val roleOverwrites = member.roleIds.mapNotNull { getPermissionOverwritesForRole(it) }
+        val memberOverwrite = getPermissionOverwritesForMember(memberId)
+
+        return Permissions {
+            +base
+            everyoneOverwrite?.let {
+                +it.allowed
+                -it.denied
+            }
+            roleOverwrites.map {
+                +it.allowed
+                -it.denied
+            }
+            memberOverwrite?.let {
+                +it.allowed
+                -it.denied
+            }
+        }
+
+    }
+
+    /**
+     * Gets the permission overwrite for the [memberId] in this channel, if present.
+     */
+    fun getPermissionOverwritesForMember(memberId: Snowflake): PermissionOverwriteEntity? =
+        getPermissionOverwritesForType(memberId, OverwriteType.Member)
+
+    /**
+     * Gets the permission overwrite for the [roleId] in this channel, if present.
+     */
+    fun getPermissionOverwritesForRole(roleId: Snowflake): PermissionOverwriteEntity? =
+        getPermissionOverwritesForType(roleId, OverwriteType.Role)
+
+    private fun getPermissionOverwritesForType(id: Snowflake, type: OverwriteType): PermissionOverwriteEntity? =
+        permissionOverwrites.firstOrNull { it.target == id && it.type == type }
+
+    override fun withStrategy(strategy: EntitySupplyStrategy<*>): TopGuildChannel
+
+}

--- a/core/src/main/kotlin/entity/channel/TopGuildMessageChannel.kt
+++ b/core/src/main/kotlin/entity/channel/TopGuildMessageChannel.kt
@@ -1,0 +1,21 @@
+package dev.kord.core.entity.channel
+
+import dev.kord.core.behavior.channel.TopGuildMessageChannelBehavior
+import dev.kord.core.supplier.EntitySupplyStrategy
+
+/**
+ * An instance of a Discord message channel associated to a [guild].
+ */
+interface TopGuildMessageChannel : CategorizableChannel, GuildMessageChannel, TopGuildMessageChannelBehavior {
+
+    /**
+     * The channel topic, if present.
+     */
+    val topic: String? get() = data.topic.value
+
+    /**
+     * Returns a new [TopGuildMessageChannel] with the given [strategy].
+     */
+    override fun withStrategy(strategy: EntitySupplyStrategy<*>): TopGuildMessageChannel
+
+}

--- a/core/src/main/kotlin/entity/channel/VoiceChannel.kt
+++ b/core/src/main/kotlin/entity/channel/VoiceChannel.kt
@@ -3,7 +3,7 @@ package dev.kord.core.entity.channel
 import dev.kord.common.entity.optional.getOrThrow
 import dev.kord.core.Kord
 import dev.kord.core.behavior.channel.ChannelBehavior
-import dev.kord.core.behavior.channel.GuildChannelBehavior
+import dev.kord.core.behavior.channel.TopGuildChannelBehavior
 import dev.kord.core.behavior.channel.VoiceChannelBehavior
 import dev.kord.core.cache.data.ChannelData
 import dev.kord.core.supplier.EntitySupplier
@@ -43,7 +43,7 @@ class VoiceChannel(
     override fun hashCode(): Int = Objects.hash(id, guildId)
 
     override fun equals(other: Any?): Boolean = when (other) {
-        is GuildChannelBehavior -> other.id == id && other.guildId == guildId
+        is TopGuildChannelBehavior -> other.id == id && other.guildId == guildId
         is ChannelBehavior -> other.id == id
         else -> false
     }

--- a/core/src/main/kotlin/entity/channel/VoiceChannel.kt
+++ b/core/src/main/kotlin/entity/channel/VoiceChannel.kt
@@ -3,6 +3,7 @@ package dev.kord.core.entity.channel
 import dev.kord.common.entity.optional.getOrThrow
 import dev.kord.core.Kord
 import dev.kord.core.behavior.channel.ChannelBehavior
+import dev.kord.core.behavior.channel.GuildChannelBehavior
 import dev.kord.core.behavior.channel.TopGuildChannelBehavior
 import dev.kord.core.behavior.channel.VoiceChannelBehavior
 import dev.kord.core.cache.data.ChannelData
@@ -43,7 +44,7 @@ class VoiceChannel(
     override fun hashCode(): Int = Objects.hash(id, guildId)
 
     override fun equals(other: Any?): Boolean = when (other) {
-        is TopGuildChannelBehavior -> other.id == id && other.guildId == guildId
+        is GuildChannelBehavior -> other.id == id && other.guildId == guildId
         is ChannelBehavior -> other.id == id
         else -> false
     }

--- a/core/src/main/kotlin/entity/channel/thread/DeletedThreadChannel.kt
+++ b/core/src/main/kotlin/entity/channel/thread/DeletedThreadChannel.kt
@@ -1,5 +1,6 @@
 package dev.kord.core.entity.channel.thread
 
+import dev.kord.common.entity.ChannelType
 import dev.kord.common.entity.Snowflake
 import dev.kord.common.exception.RequestException
 import dev.kord.core.Kord
@@ -25,6 +26,8 @@ class DeletedThreadChannel(
 
     val id: Snowflake
         get() = data.id
+
+    val type: ChannelType get() = data.type
 
     val guildId: Snowflake
         get() =  data.guildId.value!!

--- a/core/src/main/kotlin/entity/channel/thread/DeletedThreadChannel.kt
+++ b/core/src/main/kotlin/entity/channel/thread/DeletedThreadChannel.kt
@@ -1,20 +1,81 @@
 package dev.kord.core.entity.channel.thread
 
 import dev.kord.common.entity.Snowflake
+import dev.kord.common.exception.RequestException
 import dev.kord.core.Kord
+import dev.kord.core.behavior.GuildBehavior
+import dev.kord.core.behavior.channel.GuildChannelBehavior
+import dev.kord.core.behavior.channel.threads.ThreadParentChannelBehavior
 import dev.kord.core.cache.data.ChannelData
-import dev.kord.core.entity.channel.Channel
+import dev.kord.core.entity.Guild
+import dev.kord.core.entity.Strategizable
+import dev.kord.core.entity.channel.GuildChannel
+import dev.kord.core.entity.channel.ThreadParentChannel
+import dev.kord.core.exception.EntityNotFoundException
 import dev.kord.core.supplier.EntitySupplier
+import dev.kord.core.supplier.EntitySupplyStrategy
+import dev.kord.core.supplier.getChannelOf
+import dev.kord.core.supplier.getChannelOfOrNull
 
 class DeletedThreadChannel(
-    override val data: ChannelData,
-    override val kord: Kord,
+    val data: ChannelData,
+    val kord: Kord,
     override val supplier: EntitySupplier = kord.defaultSupplier
-) : Channel {
+)  : Strategizable {
+
+    val id: Snowflake
+        get() = data.id
 
     val guildId: Snowflake
-        get() = data.guildId.value!!
+        get() =  data.guildId.value!!
+
+    val guild: GuildBehavior get() = GuildBehavior(guildId, kord)
 
     val parentId: Snowflake get() = data.parentId!!.value!!
+
+    val parent: ThreadParentChannelBehavior get() = ThreadParentChannelBehavior(guildId, id, kord)
+
+    /**
+     * Requests to get this channel's [Guild].
+     *
+     * @throws [RequestException] if something went wrong during the request.
+     * @throws [EntityNotFoundException] if the guild wasn't present.
+     */
+    suspend fun getGuild(): Guild = supplier.getGuild(guildId)
+
+    /**
+     * Requests to get this channel's [Guild],
+     * returns null if the guild isn't present.
+     *
+     * @throws [RequestException] if something went wrong during the request.
+     */
+    suspend fun getGuildOrNull(): Guild? = supplier.getGuildOrNull(guildId)
+
+
+    /**
+     * Requests to get this channel's [ThreadParentChannel].
+     *
+     * @throws [RequestException] if something went wrong during the request.
+     * @throws [EntityNotFoundException] if the thread parent wasn't present.
+     */
+    suspend fun getParent(): ThreadParentChannel {
+        return supplier.getChannelOf(parentId)
+    }
+
+    /**
+     * Requests to get this channel's [ThreadParentChannel],
+     * returns null if the thread parent isn't present.
+     *
+     * @throws [RequestException] if something went wrong during the request.
+     */
+    suspend fun getParentOrNull(): ThreadParentChannel? {
+        return supplier.getChannelOfOrNull(parentId)
+    }
+
+
+    override fun withStrategy(strategy: EntitySupplyStrategy<*>): DeletedThreadChannel {
+        return DeletedThreadChannel(data, kord, strategy.supply(kord))
+    }
+
 
 }

--- a/core/src/main/kotlin/entity/channel/thread/NewsChannelThread.kt
+++ b/core/src/main/kotlin/entity/channel/thread/NewsChannelThread.kt
@@ -1,10 +1,13 @@
 package dev.kord.core.entity.channel.thread
 
+import dev.kord.common.entity.Snowflake
 import dev.kord.core.Kord
 import dev.kord.core.cache.data.ChannelData
 import dev.kord.core.entity.channel.NewsChannel
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
+import dev.kord.core.supplier.getChannelOf
+import dev.kord.core.supplier.getChannelOfOrNull
 
 /**
  * A thread channel instance whose parent is a [NewsChannel].
@@ -19,6 +22,18 @@ class NewsChannelThread(
     override suspend fun asChannel(): NewsChannelThread = super.asChannel() as NewsChannelThread
 
     override suspend fun asChannelOrNull(): NewsChannelThread? = super.asChannelOrNull() as? NewsChannelThread
+
+
+    override suspend fun getParent(): NewsChannel {
+        return supplier.getChannelOf(parentId)
+    }
+
+    override suspend fun getParentOrNull(): NewsChannel? {
+        return supplier.getChannelOfOrNull(parentId)
+    }
+
+    override val guildId: Snowflake
+        get() = data.guildId.value!!
 
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): NewsChannelThread {

--- a/core/src/main/kotlin/entity/channel/thread/TextChannelThread.kt
+++ b/core/src/main/kotlin/entity/channel/thread/TextChannelThread.kt
@@ -1,12 +1,14 @@
 package dev.kord.core.entity.channel.thread
 
 import dev.kord.common.entity.ChannelType
+import dev.kord.common.entity.Snowflake
 import dev.kord.core.Kord
 import dev.kord.core.cache.data.ChannelData
-import dev.kord.core.entity.channel.GuildMessageChannel
 import dev.kord.core.entity.channel.TextChannel
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
+import dev.kord.core.supplier.getChannelOf
+import dev.kord.core.supplier.getChannelOfOrNull
 
 /**
  * A thread channel instance whose parent is a [TextChannel].
@@ -21,6 +23,16 @@ class TextChannelThread(
      */
     val isPrivate get() = data.type == ChannelType.PrivateThread
 
+    override suspend fun getParent(): TextChannel {
+        return supplier.getChannelOf(parentId)
+    }
+
+    override suspend fun getParentOrNull(): TextChannel? {
+        return supplier.getChannelOfOrNull(parentId)
+    }
+
+    override val guildId: Snowflake
+        get() = data.guildId.value!!
 
     override suspend fun asChannel(): TextChannelThread = super.asChannel() as TextChannelThread
 

--- a/core/src/main/kotlin/entity/channel/thread/ThreadChannel.kt
+++ b/core/src/main/kotlin/entity/channel/thread/ThreadChannel.kt
@@ -8,6 +8,7 @@ import dev.kord.core.Kord
 import dev.kord.core.behavior.UserBehavior
 import dev.kord.core.behavior.channel.threads.ThreadChannelBehavior
 import dev.kord.core.cache.data.ChannelData
+import dev.kord.core.entity.channel.Channel
 import dev.kord.core.entity.channel.GuildMessageChannel
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
@@ -26,6 +27,8 @@ interface ThreadChannel : GuildMessageChannel, ThreadChannelBehavior {
 
     val owner: UserBehavior
         get() = UserBehavior(ownerId, kord)
+
+    override val parentId: Snowflake get() = data.parentId.value!!
 
 
     /**
@@ -86,15 +89,7 @@ interface ThreadChannel : GuildMessageChannel, ThreadChannelBehavior {
     /**
      * The member of the current user in the thread.
      */
-    val member: ThreadUser? get() = data.member.unwrap { ThreadUser(it, kord) }
-
-    override suspend fun asChannel(): ThreadChannel {
-        return super<GuildMessageChannel>.asChannel() as ThreadChannel
-    }
-
-    override suspend fun asChannelOrNull(): ThreadChannel? {
-        return super<GuildMessageChannel>.asChannelOrNull() as? ThreadChannel
-    }
+    val member: ThreadMember? get() = data.member.unwrap { ThreadMember(it, kord) }
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): ThreadChannel {
         return ThreadChannel(data, kord, strategy.supply(kord))
@@ -112,5 +107,7 @@ internal fun ThreadChannel(data: ChannelData, kord: Kord, supplier: EntitySuppli
             get() = kord
         override val supplier: EntitySupplier
             get() = supplier
+        override val guildId: Snowflake
+            get() = data.guildId.value!!
     }
 }

--- a/core/src/main/kotlin/entity/channel/thread/ThreadChannel.kt
+++ b/core/src/main/kotlin/entity/channel/thread/ThreadChannel.kt
@@ -8,7 +8,6 @@ import dev.kord.core.Kord
 import dev.kord.core.behavior.UserBehavior
 import dev.kord.core.behavior.channel.threads.ThreadChannelBehavior
 import dev.kord.core.cache.data.ChannelData
-import dev.kord.core.entity.channel.Channel
 import dev.kord.core.entity.channel.GuildMessageChannel
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
@@ -61,7 +60,6 @@ interface ThreadChannel : GuildMessageChannel, ThreadChannelBehavior {
      */
     val autoArchiveDuration: ArchiveDuration get() = threadData.autoArchiveDuration
 
-
     /**
      * amount of seconds a user has to wait before sending another message
      * bots, users with the permission [Manage Messages][dev.kord.common.entity.Permission.ManageMessages] or
@@ -90,6 +88,7 @@ interface ThreadChannel : GuildMessageChannel, ThreadChannelBehavior {
      * The member of the current user in the thread.
      */
     val member: ThreadMember? get() = data.member.unwrap { ThreadMember(it, kord) }
+
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): ThreadChannel {
         return ThreadChannel(data, kord, strategy.supply(kord))

--- a/core/src/main/kotlin/entity/channel/thread/ThreadMember.kt
+++ b/core/src/main/kotlin/entity/channel/thread/ThreadMember.kt
@@ -2,16 +2,16 @@ package dev.kord.core.entity.channel.thread
 
 import dev.kord.common.entity.Snowflake
 import dev.kord.core.Kord
-import dev.kord.core.behavior.ThreadUserBehavior
-import dev.kord.core.cache.data.ThreadUserData
+import dev.kord.core.behavior.ThreadMemberBehavior
+import dev.kord.core.cache.data.ThreadMemberData
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 
-class ThreadUser(
-    val data: ThreadUserData,
+class ThreadMember(
+    val data: ThreadMemberData,
     override val kord: Kord,
     override val supplier: EntitySupplier = kord.defaultSupplier
-) : ThreadUserBehavior {
+) : ThreadMemberBehavior {
     override val id: Snowflake
         get() = data.userId.orElse(kord.selfId)
 
@@ -23,7 +23,7 @@ class ThreadUser(
     val flags: Int = data.flags
 
 
-    override fun withStrategy(strategy: EntitySupplyStrategy<*>): ThreadUser {
-        return ThreadUser(data, kord, strategy.supply(kord))
+    override fun withStrategy(strategy: EntitySupplyStrategy<*>): ThreadMember {
+        return ThreadMember(data, kord, strategy.supply(kord))
     }
 }

--- a/core/src/main/kotlin/entity/interaction/Interaction.kt
+++ b/core/src/main/kotlin/entity/interaction/Interaction.kt
@@ -13,7 +13,7 @@ import dev.kord.core.behavior.GuildInteractionBehavior
 import dev.kord.core.behavior.MemberBehavior
 import dev.kord.core.behavior.UserBehavior
 import dev.kord.core.behavior.channel.GuildMessageChannelBehavior
-import dev.kord.core.behavior.interaction.ComponentInteractionBehavior
+import dev.kord.core.behavior.channel.TopGuildMessageChannelBehavior
 import dev.kord.core.behavior.interaction.InteractionBehavior
 import dev.kord.core.cache.data.ApplicationInteractionData
 import dev.kord.core.cache.data.InteractionData
@@ -21,9 +21,6 @@ import dev.kord.core.cache.data.ResolvedObjectsData
 import dev.kord.core.entity.*
 import dev.kord.core.entity.channel.DmChannel
 import dev.kord.core.entity.channel.ResolvedChannel
-import dev.kord.core.entity.component.ActionRowComponent
-import dev.kord.core.entity.component.ButtonComponent
-import dev.kord.core.entity.component.Component
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 
@@ -380,8 +377,8 @@ class GuildInteraction(
         kord
     )
 
-    override val channel: GuildMessageChannelBehavior
-        get() = GuildMessageChannelBehavior(guildId, channelId, kord)
+    override val channel: TopGuildMessageChannelBehavior
+        get() = TopGuildMessageChannelBehavior(guildId, channelId, kord)
 
     override val user: UserBehavior
         get() = UserBehavior(member.id, kord)

--- a/core/src/main/kotlin/entity/interaction/Interaction.kt
+++ b/core/src/main/kotlin/entity/interaction/Interaction.kt
@@ -13,6 +13,7 @@ import dev.kord.core.behavior.GuildInteractionBehavior
 import dev.kord.core.behavior.MemberBehavior
 import dev.kord.core.behavior.UserBehavior
 import dev.kord.core.behavior.channel.GuildMessageChannelBehavior
+import dev.kord.core.behavior.channel.MessageChannelBehavior
 import dev.kord.core.behavior.channel.TopGuildMessageChannelBehavior
 import dev.kord.core.behavior.interaction.InteractionBehavior
 import dev.kord.core.cache.data.ApplicationInteractionData
@@ -377,8 +378,8 @@ class GuildInteraction(
         kord
     )
 
-    override val channel: TopGuildMessageChannelBehavior
-        get() = TopGuildMessageChannelBehavior(guildId, channelId, kord)
+    override val channel: GuildMessageChannelBehavior
+        get() = GuildMessageChannelBehavior(guildId, channelId, kord)
 
     override val user: UserBehavior
         get() = UserBehavior(member.id, kord)

--- a/core/src/main/kotlin/event/channel/thread/ThreadDeleteEvent.kt
+++ b/core/src/main/kotlin/event/channel/thread/ThreadDeleteEvent.kt
@@ -1,15 +1,22 @@
 package dev.kord.core.event.channel.thread
 
+import dev.kord.core.Kord
 import dev.kord.core.entity.channel.thread.DeletedThreadChannel
 import dev.kord.core.entity.channel.thread.NewsChannelThread
 import dev.kord.core.entity.channel.thread.TextChannelThread
 import dev.kord.core.entity.channel.thread.ThreadChannel
+import dev.kord.core.event.Event
 import dev.kord.core.event.channel.ChannelCreateEvent
 import dev.kord.core.event.channel.ChannelDeleteEvent
 
-sealed interface ThreadChannelDeleteEvent : ChannelDeleteEvent {
-    override val channel: DeletedThreadChannel
+sealed interface ThreadChannelDeleteEvent : Event {
+    val channel: DeletedThreadChannel
+
     val old: ThreadChannel?
+
+    override val kord: Kord
+        get() = channel.kord
+
 }
 
 
@@ -37,9 +44,9 @@ class NewsChannelThreadDeleteEvent(
 
 class UnknownChannelThreadDeleteEvent(
     override val channel: DeletedThreadChannel,
-    old: ThreadChannel?,
+    override val old: ThreadChannel?,
     override val shard: Int
-) : ChannelCreateEvent {
+) : ThreadChannelDeleteEvent {
     override fun toString(): String {
         return "UnknownChannelThreadDeleteEvent(channel=$channel, shard=$shard)"
     }

--- a/core/src/main/kotlin/event/channel/thread/ThreadDeleteEvent.kt
+++ b/core/src/main/kotlin/event/channel/thread/ThreadDeleteEvent.kt
@@ -16,7 +16,7 @@ sealed interface ThreadChannelDeleteEvent : ChannelDeleteEvent {
 class TextChannelThreadDeleteEvent(
     override val channel: DeletedThreadChannel,
     override val old: TextChannelThread?,
-    override val shard: Int
+    override val shard: Int,
 ) : ThreadChannelDeleteEvent {
     override fun toString(): String {
         return "TextThreadChannelDeleteEvent(channel=$channel, shard=$shard)"

--- a/core/src/main/kotlin/event/channel/thread/ThreadListSyncEvent.kt
+++ b/core/src/main/kotlin/event/channel/thread/ThreadListSyncEvent.kt
@@ -11,7 +11,7 @@ import dev.kord.core.entity.Strategizable
 import dev.kord.core.entity.channel.Channel
 import dev.kord.core.entity.channel.GuildChannel
 import dev.kord.core.entity.channel.thread.ThreadChannel
-import dev.kord.core.entity.channel.thread.ThreadUser
+import dev.kord.core.entity.channel.thread.ThreadMember
 import dev.kord.core.event.Event
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
@@ -52,9 +52,9 @@ class ThreadListSyncEvent(
         }
 
     /**
-     * [ThreadUser] objects for the current user for each of the synced threads.
+     * [ThreadMember] objects for the current user for each of the synced threads.
      */
-    val members: List<ThreadUser> get() = data.members.map { ThreadUser(it, kord) }
+    val members: List<ThreadMember> get() = data.members.map { ThreadMember(it, kord) }
 
     suspend fun getGuild(): Guild {
         return supplier.getGuild(guildId)

--- a/core/src/main/kotlin/event/channel/thread/ThreadListSyncEvent.kt
+++ b/core/src/main/kotlin/event/channel/thread/ThreadListSyncEvent.kt
@@ -9,7 +9,7 @@ import dev.kord.core.cache.data.ThreadListSyncData
 import dev.kord.core.entity.Guild
 import dev.kord.core.entity.Strategizable
 import dev.kord.core.entity.channel.Channel
-import dev.kord.core.entity.channel.GuildChannel
+import dev.kord.core.entity.channel.TopGuildChannel
 import dev.kord.core.entity.channel.thread.ThreadChannel
 import dev.kord.core.entity.channel.thread.ThreadMember
 import dev.kord.core.event.Event
@@ -64,7 +64,7 @@ class ThreadListSyncEvent(
         return supplier.getGuildOrNull(guildId)
     }
 
-    suspend fun getChannels(): Flow<GuildChannel> {
+    suspend fun getChannels(): Flow<TopGuildChannel> {
         return supplier.getGuildChannels(guildId).filter { it.id in channelIds }
     }
 

--- a/core/src/main/kotlin/event/channel/thread/ThreadMemberUpdateEvent.kt
+++ b/core/src/main/kotlin/event/channel/thread/ThreadMemberUpdateEvent.kt
@@ -1,11 +1,11 @@
 package dev.kord.core.event.channel.thread
 
 import dev.kord.core.Kord
-import dev.kord.core.entity.channel.thread.ThreadUser
+import dev.kord.core.entity.channel.thread.ThreadMember
 import dev.kord.core.event.Event
 
 class ThreadMemberUpdateEvent(
-    val member: ThreadUser,
+    val member: ThreadMember,
     override val kord: Kord,
     override val shard: Int
 ) : Event

--- a/core/src/main/kotlin/event/channel/thread/ThreadMembersUpdateEvent.kt
+++ b/core/src/main/kotlin/event/channel/thread/ThreadMembersUpdateEvent.kt
@@ -5,7 +5,7 @@ import dev.kord.common.entity.optional.orEmpty
 import dev.kord.core.Kord
 import dev.kord.core.behavior.MemberBehavior
 import dev.kord.core.cache.data.ThreadMembersUpdateEventData
-import dev.kord.core.entity.channel.thread.ThreadUser
+import dev.kord.core.entity.channel.thread.ThreadMember
 import dev.kord.core.event.Event
 
 class ThreadMembersUpdateEvent(
@@ -20,9 +20,9 @@ class ThreadMembersUpdateEvent(
 
     val memberCount: Int get() = data.memberCount
 
-    val addedMembers: List<ThreadUser>
+    val addedMembers: List<ThreadMember>
         get() = data.addedMembers.orEmpty().map {
-            ThreadUser(it, kord)
+            ThreadMember(it, kord)
         }
 
     val removedMemberIds: List<Snowflake> get() = data.removedMemberIds.orEmpty()

--- a/core/src/main/kotlin/event/guild/InviteCreateEvent.kt
+++ b/core/src/main/kotlin/event/guild/InviteCreateEvent.kt
@@ -8,13 +8,12 @@ import dev.kord.core.behavior.GuildBehavior
 import dev.kord.core.behavior.MemberBehavior
 import dev.kord.core.behavior.UserBehavior
 import dev.kord.core.behavior.channel.ChannelBehavior
-import dev.kord.core.behavior.channel.GuildChannelBehavior
 import dev.kord.core.cache.data.InviteCreateData
 import dev.kord.core.entity.Guild
 import dev.kord.core.entity.Member
 import dev.kord.core.entity.Strategizable
 import dev.kord.core.entity.User
-import dev.kord.core.entity.channel.GuildChannel
+import dev.kord.core.entity.channel.TopGuildChannel
 import dev.kord.core.event.Event
 import dev.kord.core.exception.EntityNotFoundException
 import dev.kord.core.supplier.EntitySupplier
@@ -36,12 +35,12 @@ class InviteCreateEvent(
 ) : Event, Strategizable {
 
     /**
-     * The [GuildChannel] the invite is for.
+     * The [TopGuildChannel] the invite is for.
      */
     val channelId: Snowflake get() = data.channelId
 
     /**
-     * The behavior of the [GuildChannel] the invite is for.
+     * The behavior of the [TopGuildChannel] the invite is for.
      */
     val channel: ChannelBehavior get() = ChannelBehavior(id = channelId, kord = kord)
 
@@ -104,12 +103,12 @@ class InviteCreateEvent(
     val uses: Int get() = data.uses
 
     /**
-     * Requests to get the [GuildChannel] this invite is for.
+     * Requests to get the [TopGuildChannel] this invite is for.
      *
      * @throws [RequestException] if anything went wrong during the request.
      * @throws [EntityNotFoundException] if the  wasn't present.
      */
-    suspend fun getChannel(): GuildChannel = supplier.getChannelOf(channelId)
+    suspend fun getChannel(): TopGuildChannel = supplier.getChannelOf(channelId)
 
     /**
      * Requests to get the [Guild] of the invite,
@@ -117,7 +116,7 @@ class InviteCreateEvent(
      *
      * @throws [RequestException] if anything went wrong during the request.
      */
-    suspend fun getChannelOrNUll(): GuildChannel? = supplier.getChannelOfOrNull(channelId)
+    suspend fun getChannelOrNUll(): TopGuildChannel? = supplier.getChannelOfOrNull(channelId)
 
     /**
      * Requests to get the [Guild] of the invite.

--- a/core/src/main/kotlin/event/guild/InviteDeleteEvent.kt
+++ b/core/src/main/kotlin/event/guild/InviteDeleteEvent.kt
@@ -4,10 +4,11 @@ import dev.kord.common.entity.Snowflake
 import dev.kord.core.Kord
 import dev.kord.core.behavior.GuildBehavior
 import dev.kord.core.behavior.channel.GuildChannelBehavior
+import dev.kord.core.behavior.channel.TopGuildChannelBehavior
 import dev.kord.core.cache.data.InviteDeleteData
 import dev.kord.core.entity.Guild
 import dev.kord.core.entity.Strategizable
-import dev.kord.core.entity.channel.GuildChannel
+import dev.kord.core.entity.channel.TopGuildChannel
 import dev.kord.core.event.Event
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
@@ -25,14 +26,14 @@ class InviteDeleteEvent(
 ) : Event, Strategizable {
 
     /**
-     * The [GuildChannel] of the invite.
+     * The [TopGuildChannel] of the invite.
      */
     val channelId: Snowflake get() = data.channelId
 
     /**
-     * The behavior of the [GuildChannel] of the invite.
+     * The behavior of the [TopGuildChannel] of the invite.
      */
-    val channel: GuildChannelBehavior get() = GuildChannelBehavior(guildId = guildId, id = channelId, kord = kord)
+    val channel: TopGuildChannelBehavior get() = TopGuildChannelBehavior(guildId = guildId, id = channelId, kord = kord)
 
     /**
      * The [Guild] of the invite.
@@ -50,11 +51,11 @@ class InviteDeleteEvent(
     val code: String get() = data.code
 
     /**
-     * Requests to get the [GuildChannel] of the invite.
+     * Requests to get the [TopGuildChannel] of the invite.
      */
-    suspend fun getChannel(): GuildChannel = supplier.getChannelOf(channelId)
+    suspend fun getChannel(): TopGuildChannel = supplier.getChannelOf(channelId)
 
-    suspend fun getChannelOrNull(): GuildChannel? = supplier.getChannelOfOrNull(channelId)
+    suspend fun getChannelOrNull(): TopGuildChannel? = supplier.getChannelOfOrNull(channelId)
 
     /**
      * Requests to get the [Guild] of the invite.

--- a/core/src/main/kotlin/event/guild/WebhookUpdateEvent.kt
+++ b/core/src/main/kotlin/event/guild/WebhookUpdateEvent.kt
@@ -4,9 +4,10 @@ import dev.kord.common.entity.Snowflake
 import dev.kord.core.Kord
 import dev.kord.core.behavior.GuildBehavior
 import dev.kord.core.behavior.channel.GuildMessageChannelBehavior
+import dev.kord.core.behavior.channel.TopGuildMessageChannelBehavior
 import dev.kord.core.entity.Guild
 import dev.kord.core.entity.Strategizable
-import dev.kord.core.entity.channel.GuildMessageChannel
+import dev.kord.core.entity.channel.TopGuildMessageChannel
 import dev.kord.core.event.Event
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
@@ -21,13 +22,13 @@ class WebhookUpdateEvent(
     override val supplier: EntitySupplier = kord.defaultSupplier
 ) : Event, Strategizable {
 
-    val channel: GuildMessageChannelBehavior get() = GuildMessageChannelBehavior(guildId, channelId, kord)
+    val channel: TopGuildMessageChannelBehavior get() = TopGuildMessageChannelBehavior(guildId, channelId, kord)
 
     val guild: GuildBehavior get() = GuildBehavior(guildId, kord)
 
-    suspend fun getChannel(): GuildMessageChannel = supplier.getChannelOf(channelId)
+    suspend fun getChannel(): TopGuildMessageChannel = supplier.getChannelOf(channelId)
 
-    suspend fun getChannelOrNull(): GuildMessageChannel? = supplier.getChannelOfOrNull(channelId)
+    suspend fun getChannelOrNull(): TopGuildMessageChannel? = supplier.getChannelOfOrNull(channelId)
 
     suspend fun getGuild(): Guild = guild.asGuild()
 

--- a/core/src/main/kotlin/event/message/ReactionRemoveEmojiEvent.kt
+++ b/core/src/main/kotlin/event/message/ReactionRemoveEmojiEvent.kt
@@ -5,12 +5,13 @@ import dev.kord.core.Kord
 import dev.kord.core.behavior.GuildBehavior
 import dev.kord.core.behavior.MessageBehavior
 import dev.kord.core.behavior.channel.GuildMessageChannelBehavior
+import dev.kord.core.behavior.channel.TopGuildMessageChannelBehavior
 import dev.kord.core.cache.data.ReactionRemoveEmojiData
 import dev.kord.core.entity.Guild
 import dev.kord.core.entity.Message
 import dev.kord.core.entity.ReactionEmoji
 import dev.kord.core.entity.Strategizable
-import dev.kord.core.entity.channel.GuildMessageChannel
+import dev.kord.core.entity.channel.TopGuildMessageChannel
 import dev.kord.core.event.Event
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
@@ -25,12 +26,12 @@ class ReactionRemoveEmojiEvent(
 ) : Event, Strategizable {
 
     /**
-     * The id of the [GuildMessageChannel].
+     * The id of the [TopGuildMessageChannel].
      */
     val channelId: Snowflake get() = data.channelId
 
-    val channel: GuildMessageChannelBehavior
-        get() = GuildMessageChannelBehavior(
+    val channel: TopGuildMessageChannelBehavior
+        get() = TopGuildMessageChannelBehavior(
             guildId = guildId,
             id = channelId,
             kord = kord
@@ -55,9 +56,9 @@ class ReactionRemoveEmojiEvent(
      */
     val emoji: ReactionEmoji get() = ReactionEmoji.from(data.emoji)
 
-    suspend fun getChannel(): GuildMessageChannel = supplier.getChannelOf(channelId)
+    suspend fun getChannel(): TopGuildMessageChannel = supplier.getChannelOf(channelId)
 
-    suspend fun getChannelOrNull(): GuildMessageChannel? = supplier.getChannelOfOrNull(channelId)
+    suspend fun getChannelOrNull(): TopGuildMessageChannel? = supplier.getChannelOfOrNull(channelId)
 
     suspend fun getGuild(): Guild = supplier.getGuild(guildId)
 

--- a/core/src/main/kotlin/event/message/ReactionRemoveEmojiEvent.kt
+++ b/core/src/main/kotlin/event/message/ReactionRemoveEmojiEvent.kt
@@ -30,8 +30,8 @@ class ReactionRemoveEmojiEvent(
      */
     val channelId: Snowflake get() = data.channelId
 
-    val channel: TopGuildMessageChannelBehavior
-        get() = TopGuildMessageChannelBehavior(
+    val channel: GuildMessageChannelBehavior
+        get() = GuildMessageChannelBehavior(
             guildId = guildId,
             id = channelId,
             kord = kord

--- a/core/src/main/kotlin/gateway/handler/ThreadEventHandler.kt
+++ b/core/src/main/kotlin/gateway/handler/ThreadEventHandler.kt
@@ -98,8 +98,8 @@ class ThreadEventHandler(
     }
 
     suspend fun handle(event: ThreadMemberUpdate, shard: Int) {
-        val data = ThreadUserData.from(event.member)
-        val member = ThreadUser(data, kord)
+        val data = ThreadMemberData.from(event.member)
+        val member = ThreadMember(data, kord)
         val coreEvent = ThreadMemberUpdateEvent(member, kord, shard)
         coreFlow.emit(coreEvent)
     }
@@ -107,9 +107,9 @@ class ThreadEventHandler(
     suspend fun handle(event: ThreadMembersUpdate, shard: Int) {
         val data = ThreadMembersUpdateEventData.from(event)
         for (removedMemberId in data.removedMemberIds.orEmpty()) {
-            cache.remove<ThreadUserData> {
-                idEq(ThreadUserData::userId, removedMemberId)
-                idEq(ThreadUserData::id, data.id)
+            cache.remove<ThreadMemberData> {
+                idEq(ThreadMemberData::userId, removedMemberId)
+                idEq(ThreadMemberData::id, data.id)
             }
         }
         for (addedMember in data.addedMembers.orEmpty()) {

--- a/core/src/main/kotlin/live/channel/LiveGuildChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveGuildChannel.kt
@@ -3,8 +3,8 @@ package dev.kord.core.live.channel
 import dev.kord.common.annotation.KordPreview
 import dev.kord.common.entity.Snowflake
 import dev.kord.core.entity.KordEntity
-import dev.kord.core.entity.channel.GuildChannel
-import dev.kord.core.entity.channel.GuildMessageChannel
+import dev.kord.core.entity.channel.TopGuildChannel
+import dev.kord.core.entity.channel.TopGuildMessageChannel
 import dev.kord.core.event.Event
 import dev.kord.core.event.channel.ChannelCreateEvent
 import dev.kord.core.event.channel.ChannelDeleteEvent
@@ -15,12 +15,12 @@ import dev.kord.core.live.on
 import kotlinx.coroutines.*
 
 @KordPreview
-fun GuildChannel.live(
+fun TopGuildChannel.live(
     coroutineScope: CoroutineScope = kord + SupervisorJob(kord.coroutineContext.job)
 ) = LiveGuildChannel(this, coroutineScope)
 
 @KordPreview
-inline fun GuildChannel.live(
+inline fun TopGuildChannel.live(
     coroutineScope: CoroutineScope = kord + SupervisorJob(kord.coroutineContext.job),
     block: LiveGuildChannel.() -> Unit
 ) = this.live(coroutineScope).apply(block)
@@ -71,19 +71,19 @@ fun LiveGuildChannel.onGuildDelete(scope: CoroutineScope = this, block: suspend 
 
 @KordPreview
 class LiveGuildChannel(
-    channel: GuildChannel,
+    channel: TopGuildChannel,
     coroutineScope: CoroutineScope = channel.kord + SupervisorJob(channel.kord.coroutineContext.job)
 ) : LiveChannel(channel.kord, coroutineScope), KordEntity {
 
     override val id: Snowflake
         get() = channel.id
 
-    override var channel: GuildChannel = channel
+    override var channel: TopGuildChannel = channel
         private set
 
     override fun update(event: Event) = when (event) {
-        is ChannelCreateEvent -> channel = event.channel as GuildMessageChannel
-        is ChannelUpdateEvent -> channel = event.channel as GuildMessageChannel
+        is ChannelCreateEvent -> channel = event.channel as TopGuildMessageChannel
+        is ChannelUpdateEvent -> channel = event.channel as TopGuildMessageChannel
         is ChannelDeleteEvent -> shutDown(LiveCancellationException(event, "The channel is deleted"))
 
         is GuildDeleteEvent -> shutDown(LiveCancellationException(event, "The guild is deleted"))

--- a/core/src/main/kotlin/live/channel/LiveGuildMessageChannel.kt
+++ b/core/src/main/kotlin/live/channel/LiveGuildMessageChannel.kt
@@ -3,7 +3,7 @@ package dev.kord.core.live.channel
 import dev.kord.common.annotation.KordPreview
 import dev.kord.common.entity.Snowflake
 import dev.kord.core.entity.KordEntity
-import dev.kord.core.entity.channel.GuildMessageChannel
+import dev.kord.core.entity.channel.TopGuildMessageChannel
 import dev.kord.core.event.Event
 import dev.kord.core.event.channel.ChannelCreateEvent
 import dev.kord.core.event.channel.ChannelDeleteEvent
@@ -14,12 +14,12 @@ import dev.kord.core.live.on
 import kotlinx.coroutines.*
 
 @KordPreview
-fun GuildMessageChannel.live(
+fun TopGuildMessageChannel.live(
     coroutineScope: CoroutineScope = kord + SupervisorJob(kord.coroutineContext.job)
 ) = LiveGuildMessageChannel(this, coroutineScope)
 
 @KordPreview
-inline fun GuildMessageChannel.live(
+inline fun TopGuildMessageChannel.live(
     coroutineScope: CoroutineScope = kord + SupervisorJob(kord.coroutineContext.job),
     block: LiveGuildMessageChannel.() -> Unit
 ) = this.live(coroutineScope).apply(block)
@@ -72,19 +72,19 @@ fun LiveGuildMessageChannel.onDelete(scope: CoroutineScope = this, block: suspen
 
 @KordPreview
 class LiveGuildMessageChannel(
-    channel: GuildMessageChannel,
+    channel: TopGuildMessageChannel,
     coroutineScope: CoroutineScope = channel.kord + SupervisorJob(channel.kord.coroutineContext.job)
 ) : LiveChannel(channel.kord, coroutineScope), KordEntity {
 
     override val id: Snowflake
         get() = channel.id
 
-    override var channel: GuildMessageChannel = channel
+    override var channel: TopGuildMessageChannel = channel
         private set
 
     override fun update(event: Event) = when (event) {
-        is ChannelCreateEvent -> channel = event.channel as GuildMessageChannel
-        is ChannelUpdateEvent -> channel = event.channel as GuildMessageChannel
+        is ChannelCreateEvent -> channel = event.channel as TopGuildMessageChannel
+        is ChannelUpdateEvent -> channel = event.channel as TopGuildMessageChannel
         is ChannelDeleteEvent -> shutDown(LiveCancellationException(event, "The channel is deleted"))
 
         is GuildDeleteEvent -> shutDown(LiveCancellationException(event, "The guild is deleted"))

--- a/core/src/main/kotlin/supplier/CacheAwareRestSupplier.kt
+++ b/core/src/main/kotlin/supplier/CacheAwareRestSupplier.kt
@@ -8,7 +8,7 @@ import dev.kord.core.entity.*
 import dev.kord.core.entity.channel.Channel
 import dev.kord.core.entity.channel.GuildChannel
 import dev.kord.core.entity.channel.thread.ThreadChannel
-import dev.kord.core.entity.channel.thread.ThreadUser
+import dev.kord.core.entity.channel.thread.ThreadMember
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.onEach
 import kotlinx.datetime.Instant
@@ -152,7 +152,7 @@ class StoreEntitySupplier(
         return storeAndReturn(supplier.getStageInstanceOrNull(channelId)) { it.data }
     }
 
-    override fun getThreadMembers(channelId: Snowflake): Flow<ThreadUser> {
+    override fun getThreadMembers(channelId: Snowflake): Flow<ThreadMember> {
         return storeOnEach(supplier.getThreadMembers(channelId)) { it.data }
     }
 

--- a/core/src/main/kotlin/supplier/CacheAwareRestSupplier.kt
+++ b/core/src/main/kotlin/supplier/CacheAwareRestSupplier.kt
@@ -6,7 +6,7 @@ import dev.kord.common.entity.Snowflake
 import dev.kord.core.Kord
 import dev.kord.core.entity.*
 import dev.kord.core.entity.channel.Channel
-import dev.kord.core.entity.channel.GuildChannel
+import dev.kord.core.entity.channel.TopGuildChannel
 import dev.kord.core.entity.channel.thread.ThreadChannel
 import dev.kord.core.entity.channel.thread.ThreadMember
 import kotlinx.coroutines.flow.Flow
@@ -48,7 +48,7 @@ class StoreEntitySupplier(
         return storeAndReturn(supplier.getChannelOrNull(id)) { it.data }
     }
 
-    override fun getGuildChannels(guildId: Snowflake): Flow<GuildChannel> {
+    override fun getGuildChannels(guildId: Snowflake): Flow<TopGuildChannel> {
         return storeOnEach(supplier.getGuildChannels(guildId)) { it.data }
 
     }

--- a/core/src/main/kotlin/supplier/CacheEntitySupplier.kt
+++ b/core/src/main/kotlin/supplier/CacheEntitySupplier.kt
@@ -16,7 +16,7 @@ import dev.kord.core.entity.*
 import dev.kord.core.entity.channel.Channel
 import dev.kord.core.entity.channel.GuildChannel
 import dev.kord.core.entity.channel.thread.ThreadChannel
-import dev.kord.core.entity.channel.thread.ThreadUser
+import dev.kord.core.entity.channel.thread.ThreadMember
 import dev.kord.core.exception.EntityNotFoundException
 import dev.kord.gateway.Gateway
 import kotlinx.coroutines.FlowPreview
@@ -280,10 +280,10 @@ class CacheEntitySupplier(private val kord: Kord) : EntitySupplier {
 
     override suspend fun getStageInstanceOrNull(channelId: Snowflake): StageInstance? = null
 
-    override fun getThreadMembers(channelId: Snowflake): Flow<ThreadUser> {
-        return cache.query<ThreadUserData> {
-            idEq(ThreadUserData::id, channelId)
-        }.asFlow().map { ThreadUser(it, kord) }
+    override fun getThreadMembers(channelId: Snowflake): Flow<ThreadMember> {
+        return cache.query<ThreadMemberData> {
+            idEq(ThreadMemberData::id, channelId)
+        }.asFlow().map { ThreadMember(it, kord) }
     }
 
     override fun getActiveThreads(channelId: Snowflake): Flow<ThreadChannel> {

--- a/core/src/main/kotlin/supplier/CacheEntitySupplier.kt
+++ b/core/src/main/kotlin/supplier/CacheEntitySupplier.kt
@@ -14,7 +14,7 @@ import dev.kord.core.cache.idEq
 import dev.kord.core.cache.idGt
 import dev.kord.core.entity.*
 import dev.kord.core.entity.channel.Channel
-import dev.kord.core.entity.channel.GuildChannel
+import dev.kord.core.entity.channel.TopGuildChannel
 import dev.kord.core.entity.channel.thread.ThreadChannel
 import dev.kord.core.entity.channel.thread.ThreadMember
 import dev.kord.core.exception.EntityNotFoundException
@@ -116,7 +116,7 @@ class CacheEntitySupplier(private val kord: Kord) : EntitySupplier {
         return Channel.from(data, kord)
     }
 
-    override fun getGuildChannels(guildId: Snowflake): Flow<GuildChannel> = cache.query<ChannelData> {
+    override fun getGuildChannels(guildId: Snowflake): Flow<TopGuildChannel> = cache.query<ChannelData> {
         idEq(ChannelData::guildId, guildId)
     }.asFlow().map { Channel.from(it, kord) }.filterIsInstance()
 

--- a/core/src/main/kotlin/supplier/EntitySupplier.kt
+++ b/core/src/main/kotlin/supplier/EntitySupplier.kt
@@ -8,7 +8,7 @@ import dev.kord.core.entity.channel.Channel
 import dev.kord.core.entity.channel.GuildChannel
 import dev.kord.core.entity.channel.MessageChannel
 import dev.kord.core.entity.channel.thread.ThreadChannel
-import dev.kord.core.entity.channel.thread.ThreadUser
+import dev.kord.core.entity.channel.thread.ThreadMember
 import dev.kord.core.exception.EntityNotFoundException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.datetime.Instant
@@ -398,7 +398,7 @@ interface EntitySupplier {
     suspend fun getStageInstance(channelId: Snowflake): StageInstance =
         getStageInstanceOrNull(channelId) ?: EntityNotFoundException.stageInstanceNotFound(channelId)
 
-    fun getThreadMembers(channelId: Snowflake): Flow<ThreadUser>
+    fun getThreadMembers(channelId: Snowflake): Flow<ThreadMember>
 
     fun getActiveThreads(channelId: Snowflake): Flow<ThreadChannel>
 

--- a/core/src/main/kotlin/supplier/EntitySupplier.kt
+++ b/core/src/main/kotlin/supplier/EntitySupplier.kt
@@ -5,7 +5,7 @@ import dev.kord.common.entity.Snowflake
 import dev.kord.common.exception.RequestException
 import dev.kord.core.entity.*
 import dev.kord.core.entity.channel.Channel
-import dev.kord.core.entity.channel.GuildChannel
+import dev.kord.core.entity.channel.TopGuildChannel
 import dev.kord.core.entity.channel.MessageChannel
 import dev.kord.core.entity.channel.thread.ThreadChannel
 import dev.kord.core.entity.channel.thread.ThreadMember
@@ -91,12 +91,12 @@ interface EntitySupplier {
     suspend fun getChannel(id: Snowflake): Channel = getChannelOrNull(id)!!
 
     /**
-     * Requests the [channels][GuildChannel] of the [Guild] with the given [guildId], channels with an [Unknown] type will be filtered out of the list.
+     * Requests the [channels][TopGuildChannel] of the [Guild] with the given [guildId], channels with an [Unknown] type will be filtered out of the list.
      *
      * The returned flow is lazily executed, any [RequestException] will be thrown on
      * [terminal operators](https://kotlinlang.org/docs/reference/coroutines/flow.html#terminal-flow-operators) instead.
      */
-    fun getGuildChannels(guildId: Snowflake): Flow<GuildChannel>
+    fun getGuildChannels(guildId: Snowflake): Flow<TopGuildChannel>
 
     /**
      * Requests the pinned [messages][Message] of the [Channel] with the given [channelId].

--- a/core/src/main/kotlin/supplier/FallbackEntitySupplier.kt
+++ b/core/src/main/kotlin/supplier/FallbackEntitySupplier.kt
@@ -5,7 +5,7 @@ import dev.kord.core.entity.*
 import dev.kord.core.entity.channel.Channel
 import dev.kord.core.entity.channel.GuildChannel
 import dev.kord.core.entity.channel.thread.ThreadChannel
-import dev.kord.core.entity.channel.thread.ThreadUser
+import dev.kord.core.entity.channel.thread.ThreadMember
 import dev.kord.core.switchIfEmpty
 import kotlinx.coroutines.flow.Flow
 import kotlinx.datetime.Instant
@@ -120,7 +120,7 @@ private class FallbackEntitySupplier(val first: EntitySupplier, val second: Enti
     override suspend fun getStageInstanceOrNull(channelId: Snowflake): StageInstance? =
          first.getStageInstanceOrNull(channelId) ?: second.getStageInstanceOrNull(channelId)
 
-    override fun getThreadMembers(channelId: Snowflake): Flow<ThreadUser> {
+    override fun getThreadMembers(channelId: Snowflake): Flow<ThreadMember> {
         return first.getThreadMembers(channelId).switchIfEmpty(second.getThreadMembers(channelId))
     }
 

--- a/core/src/main/kotlin/supplier/FallbackEntitySupplier.kt
+++ b/core/src/main/kotlin/supplier/FallbackEntitySupplier.kt
@@ -3,7 +3,7 @@ package dev.kord.core.supplier
 import dev.kord.common.entity.Snowflake
 import dev.kord.core.entity.*
 import dev.kord.core.entity.channel.Channel
-import dev.kord.core.entity.channel.GuildChannel
+import dev.kord.core.entity.channel.TopGuildChannel
 import dev.kord.core.entity.channel.thread.ThreadChannel
 import dev.kord.core.entity.channel.thread.ThreadMember
 import dev.kord.core.switchIfEmpty
@@ -31,7 +31,7 @@ private class FallbackEntitySupplier(val first: EntitySupplier, val second: Enti
     override suspend fun getChannelOrNull(id: Snowflake): Channel? =
         first.getChannelOrNull(id) ?: second.getChannelOrNull(id)
 
-    override fun getGuildChannels(guildId: Snowflake): Flow<GuildChannel> =
+    override fun getGuildChannels(guildId: Snowflake): Flow<TopGuildChannel> =
         first.getGuildChannels(guildId).switchIfEmpty(second.getGuildChannels(guildId))
 
     override fun getChannelPins(channelId: Snowflake): Flow<Message> =

--- a/core/src/main/kotlin/supplier/RestEntitySupplier.kt
+++ b/core/src/main/kotlin/supplier/RestEntitySupplier.kt
@@ -11,7 +11,7 @@ import dev.kord.core.entity.*
 import dev.kord.core.entity.channel.Channel
 import dev.kord.core.entity.channel.GuildChannel
 import dev.kord.core.entity.channel.thread.ThreadChannel
-import dev.kord.core.entity.channel.thread.ThreadUser
+import dev.kord.core.entity.channel.thread.ThreadMember
 import dev.kord.core.exception.EntityNotFoundException
 import dev.kord.rest.builder.auditlog.AuditLogGetRequestBuilder
 import dev.kord.rest.json.request.AuditLogGetRequest
@@ -339,10 +339,10 @@ class RestEntitySupplier(val kord: Kord) : EntitySupplier {
         return StageInstance(data, kord, this)
     }
 
-    override fun getThreadMembers(channelId: Snowflake): Flow<ThreadUser> = flow {
+    override fun getThreadMembers(channelId: Snowflake): Flow<ThreadMember> = flow {
         kord.rest.channel.listThreadMembers(channelId).onEach {
-            val data = ThreadUserData.from(it)
-            emit(ThreadUser(data, kord))
+            val data = ThreadMemberData.from(it)
+            emit(ThreadMember(data, kord))
         }
     }
 

--- a/core/src/main/kotlin/supplier/RestEntitySupplier.kt
+++ b/core/src/main/kotlin/supplier/RestEntitySupplier.kt
@@ -9,7 +9,7 @@ import dev.kord.core.*
 import dev.kord.core.cache.data.*
 import dev.kord.core.entity.*
 import dev.kord.core.entity.channel.Channel
-import dev.kord.core.entity.channel.GuildChannel
+import dev.kord.core.entity.channel.TopGuildChannel
 import dev.kord.core.entity.channel.thread.ThreadChannel
 import dev.kord.core.entity.channel.thread.ThreadMember
 import dev.kord.core.exception.EntityNotFoundException
@@ -71,7 +71,7 @@ class RestEntitySupplier(val kord: Kord) : EntitySupplier {
     override suspend fun getChannelOrNull(id: Snowflake): Channel? =
         catchNotFound { Channel.from(channel.getChannel(id).toData(), kord) }
 
-    override fun getGuildChannels(guildId: Snowflake): Flow<GuildChannel> = flow {
+    override fun getGuildChannels(guildId: Snowflake): Flow<TopGuildChannel> = flow {
         for (channelData in guild.getGuildChannels(guildId))
             emit(Channel.from(ChannelData.from(channelData), kord))
     }.filterIsInstance()

--- a/core/src/test/kotlin/behavior/channel/GuildChannelBehaviorTest.kt
+++ b/core/src/test/kotlin/behavior/channel/GuildChannelBehaviorTest.kt
@@ -4,7 +4,7 @@ import equality.GuildChannelEqualityTest
 import mockKord
 
 @Suppress("DELEGATED_MEMBER_HIDES_SUPERTYPE_OVERRIDE")
-internal class GuildChannelBehaviorTest : GuildChannelEqualityTest<GuildChannelBehavior> by GuildChannelEqualityTest({ id, guildId ->
+internal class GuildChannelBehaviorTest : GuildChannelEqualityTest<TopGuildChannelBehavior> by GuildChannelEqualityTest({ id, guildId ->
     val kord = mockKord()
-    GuildChannelBehavior(id = id, guildId = guildId, kord = kord)
+    TopGuildChannelBehavior(id = id, guildId = guildId, kord = kord)
 })

--- a/core/src/test/kotlin/behavior/channel/GuildMessageChannelBehaviorTest.kt
+++ b/core/src/test/kotlin/behavior/channel/GuildMessageChannelBehaviorTest.kt
@@ -4,7 +4,7 @@ import equality.GuildChannelEqualityTest
 import mockKord
 
 @Suppress("DELEGATED_MEMBER_HIDES_SUPERTYPE_OVERRIDE")
-internal class GuildMessageChannelBehaviorTest : GuildChannelEqualityTest<GuildMessageChannelBehavior> by GuildChannelEqualityTest({ id, guildId ->
+internal class GuildMessageChannelBehaviorTest : GuildChannelEqualityTest<TopGuildMessageChannelBehavior> by GuildChannelEqualityTest({ id, guildId ->
     val kord = mockKord()
-    GuildMessageChannelBehavior(id = id, guildId = guildId, kord = kord)
+    TopGuildMessageChannelBehavior(id = id, guildId = guildId, kord = kord)
 })

--- a/core/src/test/kotlin/equality/EntityEqualityTest.kt
+++ b/core/src/test/kotlin/equality/EntityEqualityTest.kt
@@ -19,7 +19,6 @@ interface EntityEqualityTest<T : KordEntity> {
         val id = randomId()
         val a = newEntity(id)
         val b = newEntity(id)
-
         assertEquals(a, b)
     }
 

--- a/core/src/test/kotlin/live/channel/LiveGuildChannelTest.kt
+++ b/core/src/test/kotlin/live/channel/LiveGuildChannelTest.kt
@@ -7,7 +7,7 @@ import dev.kord.common.entity.Snowflake
 import dev.kord.common.entity.optional.optionalSnowflake
 import dev.kord.core.Kord
 import dev.kord.core.cache.data.ChannelData
-import dev.kord.core.entity.channel.GuildMessageChannel
+import dev.kord.core.entity.channel.TopGuildMessageChannel
 import dev.kord.core.live.channel.LiveGuildChannel
 import dev.kord.core.live.channel.onUpdate
 import dev.kord.core.supplier.EntitySupplier
@@ -32,8 +32,8 @@ class LiveGuildChannelTest : LiveChannelTest<LiveGuildChannel>() {
         override val kord: Kord,
         override val data: ChannelData,
         override val supplier: EntitySupplier = kord.defaultSupplier
-    ) : GuildMessageChannel {
-        override fun withStrategy(strategy: EntitySupplyStrategy<*>): GuildMessageChannel {
+    ) : TopGuildMessageChannel {
+        override fun withStrategy(strategy: EntitySupplyStrategy<*>): TopGuildMessageChannel {
             error("Not invoked in test")
         }
     }

--- a/core/src/test/kotlin/live/channel/LiveGuildTextTest.kt
+++ b/core/src/test/kotlin/live/channel/LiveGuildTextTest.kt
@@ -7,7 +7,7 @@ import dev.kord.common.entity.Snowflake
 import dev.kord.common.entity.optional.optionalSnowflake
 import dev.kord.core.Kord
 import dev.kord.core.cache.data.ChannelData
-import dev.kord.core.entity.channel.GuildChannel
+import dev.kord.core.entity.channel.TopGuildChannel
 import dev.kord.core.live.channel.LiveGuildChannel
 import dev.kord.core.live.channel.onUpdate
 import dev.kord.core.supplier.EntitySupplier
@@ -32,8 +32,8 @@ class LiveGuildTextTest : LiveChannelTest<LiveGuildChannel>() {
         override val kord: Kord,
         override val data: ChannelData,
         override val supplier: EntitySupplier = kord.defaultSupplier
-    ) : GuildChannel {
-        override fun withStrategy(strategy: EntitySupplyStrategy<*>): GuildChannel {
+    ) : TopGuildChannel {
+        override fun withStrategy(strategy: EntitySupplyStrategy<*>): TopGuildChannel {
             error("Not invoked in test")
         }
     }

--- a/core/src/test/kotlin/rest/RestTest.kt
+++ b/core/src/test/kotlin/rest/RestTest.kt
@@ -10,7 +10,7 @@ import dev.kord.core.behavior.channel.*
 import dev.kord.core.behavior.channel.threads.edit
 import dev.kord.core.entity.Guild
 import dev.kord.core.entity.ReactionEmoji
-import dev.kord.core.entity.channel.GuildMessageChannel
+import dev.kord.core.entity.channel.TopGuildMessageChannel
 import dev.kord.core.entity.channel.TextChannel
 import dev.kord.core.entity.channel.createInvite
 import dev.kord.rest.Image
@@ -99,7 +99,7 @@ class RestServiceTest {
     @Test
     @Order(2)
     fun `create invite`() = runBlocking {
-        val channel = guild.channels.filterIsInstance<GuildMessageChannel>().first()
+        val channel = guild.channels.filterIsInstance<TopGuildMessageChannel>().first()
         val invite = channel.createInvite()
 
         guild.getInvite(invite.code)


### PR DESCRIPTION
* Renames our known channel types (Interfaces only) into TopXGuildChannel Where X is a guild channel variant.
* Reuse `GuildChannel` and `GuildMessageChannel`  to include shared behaviors / data between threads and top level channels.
* Rename ThreadUser to ThreadMember for consistency and maybe future changes for discord
* Add missing behaviors / data for thread-related entities.