### PR TITLE
Allow multiple embeds in messages

### DIFF
--- a/core/src/main/kotlin/behavior/channel/MessageChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/MessageChannelBehavior.kt
@@ -265,7 +265,7 @@ suspend inline fun MessageChannelBehavior.createMessage(builder: MessageCreateBu
 }
 
 /**
- * Requests to create a message with only an [embed][MessageCreateBuilder.embed].
+ * Requests to create a message with only an [embed][MessageCreateBuilder.embeds].
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */

--- a/rest/src/main/kotlin/builder/message/MessageCreateBuilder.kt
+++ b/rest/src/main/kotlin/builder/message/MessageCreateBuilder.kt
@@ -34,8 +34,7 @@ class MessageCreateBuilder : RequestBuilder<MultipartMessageCreateRequest> {
     private var _tts: OptionalBoolean = OptionalBoolean.Missing
     var tts: Boolean? by ::_tts.delegate()
 
-    private var _embed: Optional<EmbedBuilder> = Optional.Missing()
-    var embed: EmbedBuilder? by ::_embed.delegate()
+    val embeds: MutableList<EmbedBuilder> = mutableListOf()
 
     private var _allowedMentions: Optional<AllowedMentionsBuilder> = Optional.Missing()
     var allowedMentions: AllowedMentionsBuilder? by ::_allowedMentions.delegate()
@@ -63,7 +62,7 @@ class MessageCreateBuilder : RequestBuilder<MultipartMessageCreateRequest> {
     @OptIn(ExperimentalContracts::class)
     inline fun embed(block: EmbedBuilder.() -> Unit) {
         contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
-        embed = (embed ?: EmbedBuilder()).apply(block)
+        embeds.add(EmbedBuilder().apply(block))
     }
 
     fun addFile(name: String, content: InputStream) {
@@ -101,7 +100,7 @@ class MessageCreateBuilder : RequestBuilder<MultipartMessageCreateRequest> {
             _content,
             _nonce,
             _tts,
-            _embed.map { it.toRequest() },
+            Optional.missingOnEmpty(embeds.map(EmbedBuilder::toRequest)),
             _allowedMentions.map { it.build() },
             _messageReference.map {
                 DiscordMessageReference(

--- a/rest/src/main/kotlin/builder/message/MessageModifyBuilder.kt
+++ b/rest/src/main/kotlin/builder/message/MessageModifyBuilder.kt
@@ -21,8 +21,8 @@ class MessageModifyBuilder : RequestBuilder<MessageEditPatchRequest> {
     private var _content: Optional<String?> = Optional.Missing()
     var content: String? by ::_content.delegate()
 
-    private var _embed: Optional<EmbedBuilder?> = Optional.Missing()
-    var embed: EmbedBuilder? by ::_embed.delegate()
+    private var _embeds: Optional<MutableList<EmbedBuilder>> = Optional.Missing()
+    var embeds: MutableList<EmbedBuilder>? by ::_embeds.delegate()
 
     private var _flags: Optional<MessageFlags?> = Optional.Missing()
     var flags: MessageFlags? by ::_flags.delegate()
@@ -38,10 +38,9 @@ class MessageModifyBuilder : RequestBuilder<MessageEditPatchRequest> {
 
     @OptIn(ExperimentalContracts::class)
     inline fun embed(block: EmbedBuilder.() -> Unit) {
-        contract {
-            callsInPlace(block, InvocationKind.EXACTLY_ONCE)
-        }
-        embed = (embed ?: EmbedBuilder()).also(block)
+        contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
+        if(embeds == null) embeds = mutableListOf()
+        embeds!!.add(EmbedBuilder().apply(block))
     }
 
     /**
@@ -69,7 +68,7 @@ class MessageModifyBuilder : RequestBuilder<MessageEditPatchRequest> {
     @OptIn(KordPreview::class)
     override fun toRequest(): MessageEditPatchRequest = MessageEditPatchRequest(
         _content,
-        _embed.mapNullable { it?.toRequest() },
+        _embeds.mapList { it.toRequest() },
         _flags,
         _allowedMentions.mapNullable { it?.build() },
         _components.mapList { it.build() }

--- a/rest/src/main/kotlin/builder/webhook/ExecuteWebhookBuilder.kt
+++ b/rest/src/main/kotlin/builder/webhook/ExecuteWebhookBuilder.kt
@@ -40,7 +40,7 @@ class ExecuteWebhookBuilder : RequestBuilder<MultiPartWebhookExecuteRequest> {
 
     val files: MutableList<Pair<String, InputStream>> = mutableListOf()
 
-    var embeds: MutableList<EmbedRequest> = mutableListOf()
+    val embeds: MutableList<EmbedRequest> = mutableListOf()
 
     private var _allowedMentions: Optional<AllowedMentionsBuilder> = Optional.Missing()
     var allowedMentions: AllowedMentionsBuilder? by ::_allowedMentions.delegate()

--- a/rest/src/main/kotlin/json/request/MessageRequests.kt
+++ b/rest/src/main/kotlin/json/request/MessageRequests.kt
@@ -4,9 +4,7 @@ import dev.kord.common.Color
 import dev.kord.common.entity.*
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
-import dev.kord.common.entity.optional.OptionalInt
 import kotlinx.datetime.Instant
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -15,7 +13,7 @@ data class MessageCreateRequest(
     val content: Optional<String> = Optional.Missing(),
     val nonce: Optional<String> = Optional.Missing(),
     val tts: OptionalBoolean = OptionalBoolean.Missing,
-    val embed: Optional<EmbedRequest> = Optional.Missing(),
+    val embeds: Optional<List<EmbedRequest>> = Optional.Missing(),
     @SerialName("allowed_mentions")
     val allowedMentions: Optional<AllowedMentions> = Optional.Missing(),
     @SerialName("message_reference")
@@ -76,7 +74,7 @@ data class EmbedFieldRequest(
 @Serializable
 data class MessageEditPatchRequest(
     val content: Optional<String?> = Optional.Missing(),
-    val embed: Optional<EmbedRequest?> = Optional.Missing(),
+    val embeds: Optional<List<EmbedRequest>> = Optional.Missing(),
     val flags: Optional<MessageFlags?> = Optional.Missing(),
     @SerialName("allowed_mentions")
     val allowedMentions: Optional<AllowedMentions?> = Optional.Missing(),


### PR DESCRIPTION
old `embed` field is now deprecated and replaced with `embeds`
https://discord.com/developers/docs/resources/channel#create-message-jsonform-params