### PR TITLE
Fix Number Interaction Option deserialization

### DIFF
--- a/common/src/main/kotlin/entity/Interactions.kt
+++ b/common/src/main/kotlin/entity/Interactions.kt
@@ -329,6 +329,7 @@ sealed class Option {
                 ApplicationCommandOptionType.Boolean,
                 ApplicationCommandOptionType.Channel,
                 ApplicationCommandOptionType.Integer,
+                ApplicationCommandOptionType.Number,
                 ApplicationCommandOptionType.Mentionable,
                 ApplicationCommandOptionType.Role,
                 ApplicationCommandOptionType.String,


### PR DESCRIPTION
Currently you aren't able to use the "number" option because it always fails to deserialize, this fixes the issue.