### PR TITLE
Add flags to FollowupMessageCreateRequest, add ephemeral flag when using a ephemeral followup

### DIFF
--- a/rest/src/main/kotlin/builder/message/create/EphemeralFollowupMessageCreateBuilder.kt
+++ b/rest/src/main/kotlin/builder/message/create/EphemeralFollowupMessageCreateBuilder.kt
@@ -1,6 +1,8 @@
 package dev.kord.rest.builder.message.create
 
 import dev.kord.common.annotation.KordPreview
+import dev.kord.common.entity.MessageFlag
+import dev.kord.common.entity.MessageFlags
 import dev.kord.common.entity.optional.*
 import dev.kord.rest.builder.RequestBuilder
 import dev.kord.rest.builder.component.MessageComponentBuilder
@@ -32,6 +34,7 @@ class EphemeralFollowupMessageCreateBuilder
                 embeds = Optional(embeds).mapList { it.toRequest() },
                 allowedMentions = Optional(allowedMentions).coerceToMissing().map { it.build() },
                 components = Optional(components).coerceToMissing().mapList { it.build() },
+                flags = Optional(MessageFlags(MessageFlag.Ephemeral))
             ),
         )
     }

--- a/rest/src/main/kotlin/json/request/InteractionsRequests.kt
+++ b/rest/src/main/kotlin/json/request/InteractionsRequests.kt
@@ -87,7 +87,8 @@ class FollowupMessageCreateRequest(
     val embeds: Optional<List<EmbedRequest>> = Optional.Missing(),
     @SerialName("allowed_mentions")
     val allowedMentions: Optional<AllowedMentions> = Optional.Missing(),
-    val components: Optional<List<DiscordComponent>> = Optional.Missing()
+    val components: Optional<List<DiscordComponent>> = Optional.Missing(),
+    val flags: Optional<MessageFlags> = Optional.Missing(),
 )
 
 @Serializable


### PR DESCRIPTION
Currently `FollowupMessageCreateRequest` does not work properly because the Ephemeral flag is never set in the follow up message, this PR fixes this bug.

Untested, but should work. :)