### PR TITLE
Include json error in exception message

### DIFF
--- a/rest/src/main/kotlin/json/response/DiscordErrorResponse.kt
+++ b/rest/src/main/kotlin/json/response/DiscordErrorResponse.kt
@@ -16,6 +16,6 @@ import kotlinx.serialization.json.*
 @Serializable
 class DiscordErrorResponse(
     val code: JsonErrorCode = JsonErrorCode.Unknown,
-    val errors: JsonElement,
-    val message: String?,
+    val errors: JsonElement? = null,
+    val message: String? = null,
 )

--- a/rest/src/main/kotlin/json/response/DiscordErrorResponse.kt
+++ b/rest/src/main/kotlin/json/response/DiscordErrorResponse.kt
@@ -1,21 +1,14 @@
 package dev.kord.rest.json.response
 
-import dev.kord.common.entity.optional.Optional
-import dev.kord.common.entity.optional.optional
 import dev.kord.rest.json.JsonErrorCode
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.builtins.ListSerializer
-import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonDecoder
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.*
 
 /**
  * Represents a [Discord error response](https://discord.com/developers/docs/topics/opcodes-and-status-codes#json).
@@ -23,50 +16,6 @@ import kotlinx.serialization.json.jsonObject
 @Serializable
 class DiscordErrorResponse(
     val code: JsonErrorCode = JsonErrorCode.Unknown,
-    val errors: Map<String, DiscordFieldError> = emptyMap(),
-    val message: String = "",
-)
-
-/**
- * An error for a specific field.
- */
-@Serializable(DiscordFieldError.Serializer::class)
-class DiscordFieldError(
-    @SerialName("_errors")
-    val errors: List<DiscordErrorDetail> = emptyList(),
-    val nestedErrors: Optional<JsonObject> = Optional.Missing()
-) {
-    internal object Serializer : KSerializer<DiscordFieldError> {
-
-        override val descriptor: SerialDescriptor
-            get() = JsonObject.serializer().descriptor
-
-
-        override fun deserialize(decoder: Decoder): DiscordFieldError {
-            decoder as JsonDecoder
-            val json = decoder.decodeJsonElement().jsonObject
-            // Direct Error message
-            if (json.containsKey("_errors"))
-                return DiscordFieldError(
-                    Json.decodeFromJsonElement(ListSerializer(DiscordErrorDetail.serializer()), json["_errors"]!!)
-                )
-
-            // Nested fields have no definite structure.
-            return DiscordFieldError(nestedErrors = json.optional())
-        }
-
-        override fun serialize(encoder: Encoder, value: DiscordFieldError) {
-            TODO("Not yet implemented")
-        }
-
-    }
-}
-
-/**
- * The detailed code and message for a [DiscordFieldError].
- */
-@Serializable
-class DiscordErrorDetail(
-    val code: String,
-    val message: String,
+    val errors: JsonElement,
+    val message: String?,
 )

--- a/rest/src/main/kotlin/request/KtorRequestHandler.kt
+++ b/rest/src/main/kotlin/request/KtorRequestHandler.kt
@@ -60,10 +60,9 @@ class KtorRequestHandler(
                 logger.debug { response.logString(body) }
                 if (response.contentType() == ContentType.Application.Json)
                     throw KtorRequestException(
-                        response,
-                        DiscordErrorResponse.serializer().optional.deserialize(parser, body)
+                        response, request, DiscordErrorResponse.serializer().optional.deserialize(parser, body)
                     )
-                else throw KtorRequestException(response, null)
+                else throw KtorRequestException(response, request, null)
             }
             else -> {
                 logger.debug { response.logString(body) }


### PR DESCRIPTION
Changed the `RestRequestException` message to include the JSON error message. `DiscordFieldError` was removed, it made it hard to reconstruct the message and is not documented by Discord. It was replaced by the literal json.

This does mean that rest exceptions are no longer serializer agnostic (relying on kx.ser-json), the alternative could be to deser the field as a literal JSON string.

Additionally, the request that caused the error was added to the exception, but omitted from the message for brevity.

The motivation for this change is to provide better logging and error handling. Users no longer have to rely on logging to obtain the full REST error message.