### PR TITLE
Fixes and improvements for Snowflake

### DIFF
--- a/common/src/main/kotlin/entity/Interactions.kt
+++ b/common/src/main/kotlin/entity/Interactions.kt
@@ -1,7 +1,6 @@
 package dev.kord.common.entity
 
 import dev.kord.common.annotation.KordExperimental
-import dev.kord.common.annotation.KordPreview
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
 import dev.kord.common.entity.optional.OptionalSnowflake
@@ -625,7 +624,7 @@ fun CommandArgument<*>.boolean(): Boolean {
 
 
 fun CommandArgument<*>.snowflake(): Snowflake {
-    val id = string().toLongOrNull() ?: error("$value wasn't a Snowflake")
+    val id = string().toULongOrNull() ?: error("$value wasn't a Snowflake")
     return Snowflake(id)
 }
 

--- a/common/src/main/kotlin/entity/Snowflake.kt
+++ b/common/src/main/kotlin/entity/Snowflake.kt
@@ -117,3 +117,11 @@ private class SnowflakeMark(private val timeStamp: Instant) : TimeMark() {
 
     override fun elapsedNow(): Duration = Clock.System.now() - timeStamp
 }
+
+/**
+ * Creates a [Snowflake] from a given Long [value].
+ *
+ * Note: a negative [value] will be interpreted as an unsigned integer with the same binary representation, e.g.
+ * passing `-1L` for [value] will return a [Snowflake] with a [value][Snowflake.value] of [ULong.MAX_VALUE].
+ */
+fun Snowflake(value: Long): Snowflake = Snowflake(value.toULong())

--- a/common/src/main/kotlin/entity/Snowflake.kt
+++ b/common/src/main/kotlin/entity/Snowflake.kt
@@ -78,5 +78,5 @@ class Snowflake(val value: Long) : Comparable<Snowflake> {
 
 private class SnowflakeMark(val epochMilliseconds: Long) : TimeMark() {
 
-    override fun elapsedNow(): Duration = Instant.fromEpochMilliseconds(epochMilliseconds) - Clock.System.now()
+    override fun elapsedNow(): Duration = Clock.System.now() - Instant.fromEpochMilliseconds(epochMilliseconds)
 }

--- a/common/src/main/kotlin/entity/Snowflake.kt
+++ b/common/src/main/kotlin/entity/Snowflake.kt
@@ -34,7 +34,7 @@ class Snowflake(val value: Long) : Comparable<Snowflake> {
 
     val timeStamp: Instant get() = Instant.fromEpochMilliseconds(discordEpochLong + (value shr 22))
 
-    val timeMark: TimeMark get() = SnowflakeMark(discordEpochLong + (value shr 22))
+    val timeMark: TimeMark get() = SnowflakeMark(timeStamp)
 
     override fun compareTo(other: Snowflake): Int = value.shr(22).compareTo(other.value.shr(22))
 
@@ -76,7 +76,7 @@ class Snowflake(val value: Long) : Comparable<Snowflake> {
     }
 }
 
-private class SnowflakeMark(val epochMilliseconds: Long) : TimeMark() {
+private class SnowflakeMark(private val timeStamp: Instant) : TimeMark() {
 
-    override fun elapsedNow(): Duration = Clock.System.now() - Instant.fromEpochMilliseconds(epochMilliseconds)
+    override fun elapsedNow(): Duration = Clock.System.now() - timeStamp
 }

--- a/common/src/main/kotlin/entity/Snowflake.kt
+++ b/common/src/main/kotlin/entity/Snowflake.kt
@@ -1,6 +1,7 @@
 package dev.kord.common.entity
 
 import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.PrimitiveKind
@@ -8,12 +9,17 @@ import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
-import kotlinx.datetime.Instant
 import kotlin.time.Duration
 import kotlin.time.TimeMark
 
 /**
  * A unique identifier for entities [used by discord](https://discord.com/developers/docs/reference#snowflakes).
+ *
+ * Note: this class has a natural ordering that is inconsistent with [equals],
+ * since [compareTo] only compares the first 42 bits of the Long [value] (comparing the timestamp),
+ * whereas [equals] uses all bits of the Long [value].
+ * [compareTo] can return `0` even if [equals] returns `false`,
+ * but [equals] only returns `true` if [compareTo] returns `0`.
  *
  * @constructor Creates a Snowflake from a given Long [value].
  */
@@ -21,7 +27,7 @@ import kotlin.time.TimeMark
 class Snowflake(val value: Long) : Comparable<Snowflake> {
 
     /**
-     * Creates a Snowflake from a given String [value], parsing it a [Long] value.
+     * Creates a Snowflake from a given String [value], parsing it as a [Long] value.
      */
     constructor(value: String) : this(value.toLong())
 
@@ -61,7 +67,6 @@ class Snowflake(val value: Long) : Comparable<Snowflake> {
          * Useful when requesting paginated entities.
          */
         val min: Snowflake = Snowflake(0)
-
     }
 
     internal class Serializer : KSerializer<Snowflake> {

--- a/common/src/main/kotlin/entity/Snowflake.kt
+++ b/common/src/main/kotlin/entity/Snowflake.kt
@@ -34,7 +34,7 @@ class Snowflake(val value: Long) : Comparable<Snowflake> {
 
     val timeStamp: Instant get() = Instant.fromEpochMilliseconds(discordEpochLong + (value shr 22))
 
-    val timeMark: TimeMark get() = SnowflakeMark(value shr 22)
+    val timeMark: TimeMark get() = SnowflakeMark(discordEpochLong + (value shr 22))
 
     override fun compareTo(other: Snowflake): Int = value.shr(22).compareTo(other.value.shr(22))
 

--- a/common/src/main/kotlin/entity/Snowflake.kt
+++ b/common/src/main/kotlin/entity/Snowflake.kt
@@ -32,11 +32,11 @@ class Snowflake(val value: Long) : Comparable<Snowflake> {
 
     val asString get() = value.toString()
 
-    val timeStamp: Instant get() = Instant.fromEpochMilliseconds(discordEpochLong + (value shr 22))
+    val timeStamp: Instant get() = Instant.fromEpochMilliseconds(discordEpochLong + (value ushr 22))
 
     val timeMark: TimeMark get() = SnowflakeMark(timeStamp)
 
-    override fun compareTo(other: Snowflake): Int = value.shr(22).compareTo(other.value.shr(22))
+    override fun compareTo(other: Snowflake): Int = value.ushr(22).compareTo(other.value.ushr(22))
 
     override fun toString(): String = "Snowflake(value=$value)"
 

--- a/common/src/main/kotlin/entity/Snowflake.kt
+++ b/common/src/main/kotlin/entity/Snowflake.kt
@@ -100,9 +100,9 @@ class Snowflake(val value: ULong) : Comparable<Snowflake> {
     }
 
     @OptIn(ExperimentalSerializationApi::class)
-    internal class Serializer : KSerializer<Snowflake> {
-        override val descriptor: SerialDescriptor
-            get() = @OptIn(ExperimentalUnsignedTypes::class) ULong.serializer().descriptor
+    internal object Serializer : KSerializer<Snowflake> {
+        override val descriptor: SerialDescriptor =
+            @OptIn(ExperimentalUnsignedTypes::class) ULong.serializer().descriptor
 
         override fun deserialize(decoder: Decoder): Snowflake =
             Snowflake(decoder.decodeInline(descriptor).decodeLong().toULong())

--- a/common/src/main/kotlin/entity/Snowflake.kt
+++ b/common/src/main/kotlin/entity/Snowflake.kt
@@ -28,7 +28,7 @@ class Snowflake(val value: Long) : Comparable<Snowflake> {
     /**
      * Creates a Snowflake from a given [instant].
      */
-    constructor(instant: Instant) : this((instant.toEpochMilliseconds() shl 22) - discordEpochLong)
+    constructor(instant: Instant) : this((instant.toEpochMilliseconds() - discordEpochLong) shl 22)
 
     val asString get() = value.toString()
 

--- a/common/src/main/kotlin/entity/Snowflake.kt
+++ b/common/src/main/kotlin/entity/Snowflake.kt
@@ -59,7 +59,7 @@ class Snowflake(val value: ULong) : Comparable<Snowflake> {
     /**
      * A [TimeMark] for the point in time this Snowflake represents.
      */
-    val timeMark: TimeMark get() = SnowflakeMark(timeStamp)
+    val timeMark: TimeMark get() = SnowflakeTimeMark(timeStamp)
 
     override fun compareTo(other: Snowflake): Int = value.shr(22).compareTo(other.value.shr(22))
 
@@ -83,8 +83,7 @@ class Snowflake(val value: ULong) : Comparable<Snowflake> {
         /**
          * The last point in time a Snowflake can represent.
          */
-        val endOfTime: Instant =
-            Instant.fromEpochMilliseconds(discordEpochLong + maxMillisecondsSinceDiscordEpoch)
+        val endOfTime: Instant = Instant.fromEpochMilliseconds(discordEpochLong + maxMillisecondsSinceDiscordEpoch)
 
         /**
          * The maximum value a Snowflake can hold.
@@ -113,7 +112,7 @@ class Snowflake(val value: ULong) : Comparable<Snowflake> {
     }
 }
 
-private class SnowflakeMark(private val timeStamp: Instant) : TimeMark() {
+private class SnowflakeTimeMark(private val timeStamp: Instant) : TimeMark() {
 
     override fun elapsedNow(): Duration = Clock.System.now() - timeStamp
 }

--- a/common/src/test/kotlin/entity/SnowflakeTest.kt
+++ b/common/src/test/kotlin/entity/SnowflakeTest.kt
@@ -23,13 +23,13 @@ class SnowflakeTest {
     }
 
     @Test
-    fun `Snowflake created from instant far in the past has timeStamp equal the timeStamp of Snowflake min`() {
+    fun `Snowflake created from instant far in the past has timeStamp equal to the timeStamp of Snowflake min`() {
         val snowflake = Snowflake(Instant.DISTANT_PAST)
         assertEquals(Snowflake.min.timeStamp, snowflake.timeStamp)
     }
 
     @Test
-    fun `Snowflake created from instant far in the future has timeStamp equal the timeStamp of Snowflake max`() {
+    fun `Snowflake created from instant far in the future has timeStamp equal to the timeStamp of Snowflake max`() {
         val snowflake = Snowflake(Instant.DISTANT_FUTURE)
         assertEquals(Snowflake.max.timeStamp, snowflake.timeStamp)
     }

--- a/common/src/test/kotlin/entity/SnowflakeTest.kt
+++ b/common/src/test/kotlin/entity/SnowflakeTest.kt
@@ -11,14 +11,14 @@ import kotlin.test.*
 class SnowflakeTest {
 
     @Test
-    fun `Snowflake with value 0 has timeStamp equal to discordEpochStart`() {
-        val snowflake = Snowflake(0)
+    fun `Snowflake with value ULong MIN_VALUE has timeStamp equal to discordEpochStart`() {
+        val snowflake = Snowflake(ULong.MIN_VALUE)
         assertEquals(Snowflake.discordEpochStart, snowflake.timeStamp)
     }
 
     @Test
-    fun `Snowflake with value -1 has timeStamp equal to endOfTime`() {
-        val snowflake = Snowflake(-1)
+    fun `Snowflake with value ULong MAX_VALUE has timeStamp equal to endOfTime`() {
+        val snowflake = Snowflake(ULong.MAX_VALUE)
         assertEquals(Snowflake.endOfTime, snowflake.timeStamp)
     }
 

--- a/common/src/test/kotlin/entity/SnowflakeTest.kt
+++ b/common/src/test/kotlin/entity/SnowflakeTest.kt
@@ -1,0 +1,57 @@
+package entity
+
+import dev.kord.common.entity.Snowflake
+import kotlinx.datetime.Clock
+import kotlinx.datetime.DateTimeUnit.Companion.MILLISECOND
+import kotlinx.datetime.Instant
+import kotlinx.datetime.minus
+import kotlinx.datetime.plus
+import kotlin.test.*
+
+class SnowflakeTest {
+
+    @Test
+    fun `Snowflake with value 0 has timeStamp equal to the timeStamp of discordEpochStart`() {
+        val snowflake = Snowflake(0)
+        assertEquals(Snowflake.discordEpochStart, snowflake.timeStamp)
+    }
+
+    @Test
+    fun `Snowflake with value -1 has timeStamp equal to the timeStamp of endOfTime`() {
+        val snowflake = Snowflake(-1)
+        assertEquals(Snowflake.endOfTime, snowflake.timeStamp)
+    }
+
+    @Test
+    fun `Snowflake created from instant far in the past has timeStamp equal the timeStamp of Snowflake min`() {
+        val snowflake = Snowflake(Instant.DISTANT_PAST)
+        assertEquals(Snowflake.min.timeStamp, snowflake.timeStamp)
+    }
+
+    @Test
+    fun `Snowflake created from instant far in the future has timeStamp equal the timeStamp of Snowflake max`() {
+        val snowflake = Snowflake(Instant.DISTANT_FUTURE)
+        assertEquals(Snowflake.max.timeStamp, snowflake.timeStamp)
+    }
+
+    @Test
+    fun `Snowflake's timeStamp calculates an Instant close to the Instant the Snowflake was created from`() {
+        val instant = Clock.System.now()
+        val snowflake = Snowflake(instant)
+
+        // snowflake timestamps have a millisecond accuracy -> allow +/-1 millisecond from original instant
+        val validTimeRange = instant.minus(1, MILLISECOND)..instant.plus(1, MILLISECOND)
+
+        assertContains(validTimeRange, snowflake.timeStamp)
+    }
+
+    @Test
+    fun `min Snowflake's timeMark has passed`() {
+        assertTrue(Snowflake.min.timeMark.hasPassedNow())
+    }
+
+    @Test
+    fun `max Snowflake's timeMark has not passed`() {
+        assertFalse(Snowflake.max.timeMark.hasPassedNow())
+    }
+}

--- a/common/src/test/kotlin/entity/SnowflakeTest.kt
+++ b/common/src/test/kotlin/entity/SnowflakeTest.kt
@@ -11,13 +11,13 @@ import kotlin.test.*
 class SnowflakeTest {
 
     @Test
-    fun `Snowflake with value 0 has timeStamp equal to the timeStamp of discordEpochStart`() {
+    fun `Snowflake with value 0 has timeStamp equal to discordEpochStart`() {
         val snowflake = Snowflake(0)
         assertEquals(Snowflake.discordEpochStart, snowflake.timeStamp)
     }
 
     @Test
-    fun `Snowflake with value -1 has timeStamp equal to the timeStamp of endOfTime`() {
+    fun `Snowflake with value -1 has timeStamp equal to endOfTime`() {
         val snowflake = Snowflake(-1)
         assertEquals(Snowflake.endOfTime, snowflake.timeStamp)
     }

--- a/common/src/test/kotlin/entity/optional/OptionalSnowflakeTest.kt
+++ b/common/src/test/kotlin/entity/optional/OptionalSnowflakeTest.kt
@@ -52,7 +52,7 @@ internal class OptionalSnowflakeTest {
         val entity = Json.decodeFromString<ValueOptionalEntity>(json)
         require(entity.value is OptionalSnowflake.Value)
 
-        Assertions.assertEquals(Snowflake(5), entity.value.value)
+        Assertions.assertEquals(Snowflake(5u), entity.value.value)
     }
 
 }

--- a/core/src/main/kotlin/Util.kt
+++ b/core/src/main/kotlin/Util.kt
@@ -33,7 +33,7 @@ internal fun String?.toSnowflakeOrNull(): Snowflake? = when {
     else -> Snowflake(this)
 }
 
-internal fun Long?.toSnowflakeOrNull(): Snowflake? = when {
+internal fun ULong?.toSnowflakeOrNull(): Snowflake? = when {
     this == null -> null
     else -> Snowflake(this)
 }
@@ -215,7 +215,7 @@ internal fun <C : Collection<T>, T : KordEntity> paginateForwards(
  *  Selects the [Position.Before] the oldest item in the batch.
  */
 internal fun <C : Collection<T>, T> paginateBackwards(
-    start: Snowflake = Snowflake(Long.MAX_VALUE),
+    start: Snowflake = Snowflake.max,
     batchSize: Int,
     idSelector: (T) -> Snowflake,
     request: suspend (position: Position) -> C
@@ -226,7 +226,7 @@ internal fun <C : Collection<T>, T> paginateBackwards(
  *  Selects the [Position.Before] the oldest item in the batch.
  */
 internal fun <C : Collection<T>, T : KordEntity> paginateBackwards(
-    start: Snowflake = Snowflake(Long.MAX_VALUE),
+    start: Snowflake = Snowflake.max,
     batchSize: Int,
     request: suspend (position: Position) -> C
 ): Flow<T> =

--- a/core/src/main/kotlin/behavior/GuildBehavior.kt
+++ b/core/src/main/kotlin/behavior/GuildBehavior.kt
@@ -3,7 +3,6 @@ package dev.kord.core.behavior
 import dev.kord.cache.api.query
 import dev.kord.common.annotation.DeprecatedSinceKord
 import dev.kord.common.annotation.KordExperimental
-import dev.kord.common.annotation.KordPreview
 import dev.kord.common.entity.DiscordUser
 import dev.kord.common.entity.Snowflake
 import dev.kord.common.entity.optional.Optional
@@ -201,7 +200,7 @@ interface GuildBehavior : KordEntity, Strategizable {
      */
     val gateway: Gateway?
         get() {
-            val shard = id.value.shr(22) % kord.resources.shards.totalShards.coerceAtLeast(1)
+            val shard = id.value.shr(22).toLong() % kord.resources.shards.totalShards.coerceAtLeast(1)
             return kord.gateway.gateways[shard.toInt()]
         }
 

--- a/core/src/main/kotlin/behavior/channel/MessageChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/MessageChannelBehavior.kt
@@ -19,6 +19,8 @@ import dev.kord.rest.service.RestClient
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.takeWhile
 import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
@@ -67,7 +69,7 @@ interface MessageChannelBehavior : ChannelBehavior, Strategizable {
      * The returned flow is lazily executed, any [RequestException] will be thrown on
      * [terminal operators](https://kotlinlang.org/docs/reference/coroutines/flow.html#terminal-flow-operators) instead.
      */
-    val messages: Flow<Message> get() = getMessagesAfter(Snowflake(0))
+    val messages: Flow<Message> get() = getMessagesAfter(Snowflake.min)
 
     /**
      * Requests to get the pinned messages in this channel.

--- a/core/src/main/kotlin/behavior/channel/threads/ThreadParentChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/threads/ThreadParentChannelBehavior.kt
@@ -97,7 +97,7 @@ interface PrivateThreadParentChannelBehavior : ThreadParentChannelBehavior {
      * [terminal operators](https://kotlinlang.org/docs/reference/coroutines/flow.html#terminal-flow-operators) instead.
      */
     fun getJoinedPrivateArchivedThreads(
-        before: Snowflake = Snowflake(Long.MAX_VALUE),
+        before: Snowflake = Snowflake.max,
         limit: Int = Int.MAX_VALUE
     ): Flow<ThreadChannel> {
         return supplier.getJoinedPrivateArchivedThreads(id, before, limit)

--- a/core/src/test/kotlin/UtilKtTest.kt
+++ b/core/src/test/kotlin/UtilKtTest.kt
@@ -2,7 +2,6 @@ package dev.kord.core
 
 import dev.kord.common.entity.Snowflake
 import kotlinx.coroutines.flow.count
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
@@ -13,13 +12,13 @@ internal class UtilKtTest {
     @ExperimentalStdlibApi
     fun `paginate forwards selects the right id`() = runBlockingTest {
 
-        val flow = paginateForwards(start = Snowflake(0), batchSize = 100, idSelector = { it }) {
+        val flow = paginateForwards(start = Snowflake(0u), batchSize = 100, idSelector = { it }) {
             var value = it.value.value
-            if (value >= 1000) return@paginateForwards emptyList<Snowflake>()
-            value += 1 //don't include the position id
+            if (value >= 1000u) return@paginateForwards emptyList<Snowflake>()
+            value += 1u //don't include the position id
 
             buildList(100) {
-                (value until (value + 100)).reversed().forEach { snowflake -> //biggest/youngest -> smallest/oldest
+                (value until (value + 100u)).reversed().forEach { snowflake -> //biggest/youngest -> smallest/oldest
                     add(Snowflake(snowflake))
                 }
             }
@@ -32,13 +31,13 @@ internal class UtilKtTest {
     @ExperimentalStdlibApi
     fun `paginate backwards selects the right id`() = runBlockingTest {
 
-        val flow = paginateBackwards(start = Snowflake(1000), batchSize = 100, idSelector = { it }) {
+        val flow = paginateBackwards(start = Snowflake(1000u), batchSize = 100, idSelector = { it }) {
             var value = it.value.value
-            if (value <= 0) return@paginateBackwards emptyList<Snowflake>()
-            value -= 1 //don't include the position id
+            if (value <= 0u) return@paginateBackwards emptyList<Snowflake>()
+            value -= 1u //don't include the position id
 
             buildList(100) {
-                ((value - 99 /*reverse until, don't count the lowest value*/)..value).reversed().forEach { snowflake -> //biggest/youngest -> smallest/oldest
+                ((value - 99u /*reverse until, don't count the lowest value*/)..value).reversed().forEach { snowflake -> //biggest/youngest -> smallest/oldest
                     add(Snowflake(snowflake))
                 }
             }

--- a/core/src/test/kotlin/behavior/MessageBehaviorTest.kt
+++ b/core/src/test/kotlin/behavior/MessageBehaviorTest.kt
@@ -6,5 +6,5 @@ import mockKord
 
 internal class MessageBehaviorTest : EntityEqualityTest<MessageBehavior> by EntityEqualityTest({
     val kord = mockKord()
-    MessageBehavior(it, Snowflake(0), kord)
+    MessageBehavior(it, Snowflake(0u), kord)
 })

--- a/core/src/test/kotlin/behavior/RoleBehaviorTest.kt
+++ b/core/src/test/kotlin/behavior/RoleBehaviorTest.kt
@@ -2,7 +2,6 @@ package dev.kord.core.behavior
 
 import dev.kord.common.entity.Snowflake
 import equality.GuildEntityEqualityTest
-import io.mockk.mockk
 import mockKord
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
@@ -16,7 +15,7 @@ internal class RoleBehaviorTest : GuildEntityEqualityTest<RoleBehavior> by Guild
     fun `everyone role mention is properly formatted`(){
         val kord = mockKord()
 
-        val id = Snowflake(1337)
+        val id = Snowflake(1337u)
         val behavior = RoleBehavior(id, id, kord)
 
         assertEquals("@everyone", behavior.mention)

--- a/core/src/test/kotlin/entity/MemberTest.kt
+++ b/core/src/test/kotlin/entity/MemberTest.kt
@@ -29,11 +29,11 @@ internal class MemberTest : GuildEntityEqualityTest<Member> by GuildEntityEquali
     fun `members equal users with the same ID`() {
         val kord = mockKord()
         val memberData = mockk<MemberData>()
-        every { memberData.userId } returns Snowflake(0L)
-        every { memberData.guildId } returns Snowflake(1L)
+        every { memberData.userId } returns Snowflake(0u)
+        every { memberData.guildId } returns Snowflake(1u)
 
         val userData = mockk<UserData>()
-        every { userData.id } returns Snowflake(0L)
+        every { userData.id } returns Snowflake(0u)
         val member = Member(memberData, userData, kord)
         val user = User(userData, kord)
 

--- a/core/src/test/kotlin/equality/EntityEqualityTest.kt
+++ b/core/src/test/kotlin/equality/EntityEqualityTest.kt
@@ -3,11 +3,12 @@ package equality
 import dev.kord.common.entity.Snowflake
 import dev.kord.core.entity.KordEntity
 import kotlin.random.Random
+import kotlin.random.nextULong
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 
-val ids = generateSequence { Random.nextLong() }.distinct().iterator()
+val ids = generateSequence { Random.nextULong() }.distinct().iterator()
 fun randomId() = Snowflake(ids.next())
 
 interface EntityEqualityTest<T : KordEntity> {

--- a/core/src/test/kotlin/equality/GuildEntityEqualityTest.kt
+++ b/core/src/test/kotlin/equality/GuildEntityEqualityTest.kt
@@ -9,7 +9,7 @@ interface GuildEntityEqualityTest<T: KordEntity> : EntityEqualityTest<T> {
 
     fun newEntity(id: Snowflake, guildId: Snowflake): T
 
-    override fun newEntity(id: Snowflake): T = newEntity(id, Snowflake(1))
+    override fun newEntity(id: Snowflake): T = newEntity(id, Snowflake(1u))
 
     @Test
     fun `Guild Entity with different guild ids are not equal`() {

--- a/core/src/test/kotlin/live/AbstractLiveEntityTest.kt
+++ b/core/src/test/kotlin/live/AbstractLiveEntityTest.kt
@@ -20,7 +20,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
-import java.time.Clock
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
@@ -104,7 +103,7 @@ abstract class AbstractLiveEntityTest<LIVE : AbstractLiveKordEntity> {
     protected open fun createKord(): Kord {
         gateway = GatewayMock()
         return Kord(
-            resources = ClientResources("token",Snowflake(0), Shards(1), HttpClient(), EntitySupplyStrategy.cache, Intents.none),
+            resources = ClientResources("token", Snowflake(0u), Shards(1), HttpClient(), EntitySupplyStrategy.cache, Intents.none),
             cache = DataCache.none(),
             MasterGateway(mapOf(0 to gateway)),
             RestClient(KtorRequestHandler(token = "token")),

--- a/core/src/test/kotlin/performance/KordEventDropTest.kt
+++ b/core/src/test/kotlin/performance/KordEventDropTest.kt
@@ -47,7 +47,7 @@ class KordEventDropTest {
     }
 
     val kord = Kord(
-        resources = ClientResources("token",Snowflake(0), Shards(1), HttpClient(), EntitySupplyStrategy.cache, Intents.none),
+        resources = ClientResources("token", Snowflake(0u), Shards(1), HttpClient(), EntitySupplyStrategy.cache, Intents.none),
         cache = DataCache.none(),
         MasterGateway(mapOf(0 to SpammyGateway)),
         RestClient(KtorRequestHandler("token", clock = Clock.System)),

--- a/core/src/test/kotlin/regression/CacheMissRegression.kt
+++ b/core/src/test/kotlin/regression/CacheMissRegression.kt
@@ -29,8 +29,6 @@ import io.ktor.http.*
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.channels.BroadcastChannel
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runBlockingTest
@@ -144,7 +142,7 @@ class CacheMissingRegressions {
 
     @Test
     fun `if data not in cache explode`() {
-        val id = 5L
+        val id = 5uL
         assertThrows<IllegalStateException> {
             runBlocking {
                 kord.getChannel(Snowflake(id))
@@ -155,7 +153,7 @@ class CacheMissingRegressions {
     @Test
     fun `if data in cache don't fetch from rest`() {
         runBlocking {
-            val id = Snowflake(5L)
+            val id = Snowflake(5uL)
             kord.cache.put(ChannelData(id, ChannelType.GuildText))
 
             kord.getChannel(id)

--- a/core/src/test/kotlin/regression/ReactionEmojiTest.kt
+++ b/core/src/test/kotlin/regression/ReactionEmojiTest.kt
@@ -8,7 +8,7 @@ class ReactionEmojiTest {
 
     @Test
     fun `getting the id of a reaction emoji doesn't cause a castException`() {
-        val emoji = ReactionEmoji.Custom(Snowflake(0), "test", false)
+        val emoji = ReactionEmoji.Custom(Snowflake(0u), "test", false)
         emoji.id
     }
 }

--- a/core/src/test/kotlin/rest/RestTest.kt
+++ b/core/src/test/kotlin/rest/RestTest.kt
@@ -41,7 +41,7 @@ fun imageBinary(path: String): Image {
 @EnabledIfEnvironmentVariable(named = "KORD_TEST_TOKEN", matches = ".+")
 class RestServiceTest {
 
-    private val publicGuildId = Snowflake(322850917248663552)
+    private val publicGuildId = Snowflake(322850917248663552u)
 
     private val token = System.getenv("KORD_TEST_TOKEN")
 
@@ -387,7 +387,7 @@ class RestServiceTest {
     @Order(21)
     fun `errors are thrown correctly`() = runBlocking {
         val exception = assertThrows<RestRequestException> {
-            runBlocking { kord.getChannel(Snowflake(-500)) }
+            runBlocking { kord.getChannel(Snowflake((-500).toULong())) }
         }
 
         assert(exception.error != null)

--- a/core/src/test/kotlin/supplier/CacheEntitySupplierTest.kt
+++ b/core/src/test/kotlin/supplier/CacheEntitySupplierTest.kt
@@ -5,7 +5,6 @@ import dev.kord.common.annotation.KordUnsafe
 import dev.kord.common.entity.Snowflake
 import dev.kord.core.ClientResources
 import dev.kord.core.Kord
-import dev.kord.core.Unsafe
 import dev.kord.core.builder.kord.Shards
 import dev.kord.core.cache.KordCacheBuilder
 import dev.kord.core.gateway.MasterGateway
@@ -27,16 +26,16 @@ internal class CacheEntitySupplierTest {
     @OptIn(PrivilegedIntent::class, KordUnsafe::class, KordExperimental::class)
     fun `cache does not throw when accessing unregistered entities`(): Unit = runBlocking {
         val kord = Kord(
-                ClientResources("",Snowflake(0), Shards(0), HttpClient(), EntitySupplyStrategy.cache, Intents.all),
+                ClientResources("", Snowflake(0u), Shards(0), HttpClient(), EntitySupplyStrategy.cache, Intents.all),
                 KordCacheBuilder().build(),
                 MasterGateway(mapOf(0 to Gateway.none())),
                 RestClient(KtorRequestHandler("")),
-                Snowflake(0),
+                Snowflake(0u),
                 MutableSharedFlow(),
                 Dispatchers.Default
         )
 
-        kord.unsafe.guild(Snowflake(0)).regions.toList()
+        kord.unsafe.guild(Snowflake(0u)).regions.toList()
     }
 
 }

--- a/gateway/src/test/kotlin/json/SnowflakeTest.kt
+++ b/gateway/src/test/kotlin/json/SnowflakeTest.kt
@@ -8,6 +8,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.put
+import java.math.BigInteger
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -28,10 +29,32 @@ class SnowflakeTest {
     }
 
     @Test
-    fun `Deserialization of Snowflake as Long completes successfully`() {
+    fun `Deserialization of Snowflake as large String completes successfully`() {
+        val value = ULong.MAX_VALUE.toString()
+        val json = buildJsonObject {
+            put("snowflake", value)
+        }
+
+        val container = Json.decodeFromJsonElement<SnowflakeContainer>(json)
+        assertEquals(value, container.snowflake.asString)
+    }
+
+    @Test
+    fun `Deserialization of Snowflake as Number completes successfully`() {
         val value = 1337L
         val json = buildJsonObject {
             put("snowflake", value)
+        }
+
+        val container = Json.decodeFromJsonElement<SnowflakeContainer>(json)
+        assertEquals(value.toULong(), container.snowflake.value)
+    }
+
+    @Test
+    fun `Deserialization of Snowflake as large Number completes successfully`() {
+        val value = ULong.MAX_VALUE
+        val json = buildJsonObject {
+            put("snowflake", BigInteger(value.toString())) // put only takes Number, ULong does not extend Number
         }
 
         val container = Json.decodeFromJsonElement<SnowflakeContainer>(json)
@@ -46,5 +69,4 @@ class SnowflakeTest {
         val reDecodedContainer = Json.decodeFromString<SnowflakeContainer>(Json.encodeToString(container))
         assertEquals(container, reDecodedContainer)
     }
-
 }

--- a/gateway/src/test/kotlin/json/SnowflakeTest.kt
+++ b/gateway/src/test/kotlin/json/SnowflakeTest.kt
@@ -8,7 +8,6 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.put
-import java.math.BigInteger
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -52,13 +51,14 @@ class SnowflakeTest {
 
     @Test
     fun `Deserialization of Snowflake as large Number completes successfully`() {
-        val value = ULong.MAX_VALUE
+        // ULong is inline class and therefore cannot extend abstract class Number but put only takes Number
+        val value = ULong.MAX_VALUE.toNumber()
         val json = buildJsonObject {
-            put("snowflake", BigInteger(value.toString())) // put only takes Number, ULong does not extend Number
+            put("snowflake", value)
         }
 
         val container = Json.decodeFromJsonElement<SnowflakeContainer>(json)
-        assertEquals(value, container.snowflake.value)
+        assertEquals(value.value, container.snowflake.value)
     }
 
     @Test

--- a/gateway/src/test/kotlin/json/Util.kt
+++ b/gateway/src/test/kotlin/json/Util.kt
@@ -1,7 +1,23 @@
 package json
 
-import org.junit.jupiter.api.Assertions
+import kotlin.test.assertEquals
 
 infix fun <T> T.shouldBe(that: T) {
-    Assertions.assertEquals(that, this)
+    assertEquals(that, this)
+}
+
+fun ULong.toNumber() = ULongNumber(this)
+
+class ULongNumber(val value: ULong) : Number(), Comparable<ULongNumber> {
+    override fun toByte() = value.toByte()
+    override fun toShort() = value.toShort()
+    override fun toInt() = value.toInt()
+    override fun toLong() = value.toLong()
+    override fun toFloat() = value.toFloat()
+    override fun toDouble() = value.toDouble()
+    override fun toChar() = value.toInt().toChar()
+    override fun compareTo(other: ULongNumber) = this.value.compareTo(other.value)
+    override fun equals(other: Any?) = other is ULongNumber && this.value == other.value
+    override fun hashCode() = value.hashCode()
+    override fun toString() = value.toString()
 }

--- a/rest/src/main/kotlin/builder/guild/GuildCreateBuilder.kt
+++ b/rest/src/main/kotlin/builder/guild/GuildCreateBuilder.kt
@@ -21,6 +21,7 @@ import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 import kotlin.random.Random
+import kotlin.random.nextULong
 
 @KordDsl
 class GuildCreateBuilder(var name: String) : RequestBuilder<GuildCreateRequest> {
@@ -29,7 +30,7 @@ class GuildCreateBuilder(var name: String) : RequestBuilder<GuildCreateRequest> 
      * Iterator that generates unique ids for roles and channels.
      */
     val snowflakeGenerator by lazy(LazyThreadSafetyMode.NONE) {
-        generateSequence { Random.nextLong(0, Long.MAX_VALUE) }.filter {
+        generateSequence { Random.nextULong(ULong.MIN_VALUE, ULong.MAX_VALUE) }.filter {
             it !in roles.map { role -> role.id.value?.value }
                     && it !in channels.map { channel -> channel.id.value?.value }
                     && Snowflake(it) != systemChannelId

--- a/rest/src/main/kotlin/builder/guild/GuildCreateBuilder.kt
+++ b/rest/src/main/kotlin/builder/guild/GuildCreateBuilder.kt
@@ -30,7 +30,7 @@ class GuildCreateBuilder(var name: String) : RequestBuilder<GuildCreateRequest> 
      * Iterator that generates unique ids for roles and channels.
      */
     val snowflakeGenerator by lazy(LazyThreadSafetyMode.NONE) {
-        generateSequence { Random.nextULong(ULong.MIN_VALUE, ULong.MAX_VALUE) }.filter {
+        generateSequence { Random.nextULong() }.filter {
             it !in roles.map { role -> role.id.value?.value }
                     && it !in channels.map { channel -> channel.id.value?.value }
                     && Snowflake(it) != systemChannelId


### PR DESCRIPTION
## Fixes for `Snowflake`
- constructor that takes an `Instant` took the epoch milliseconds from the instant, shifted it to the left and *then* substracted the Discord Epoch but it should first subtract and then shift (see https://discord.com/developers/docs/reference#snowflake-ids-in-pagination-generating-a-snowflake-id-from-a-timestamp-example) -- fixed in https://github.com/kordlib/kord/commit/76a35b6024da0d033004e8f9eb46112b357c8265
- `SnowflakeMark.elapsedNow()` returned a `Duration` with the wrong sign (`Snowflake.min.timeMark.hasPassedNow()` returned `false` and `Snowflake.max.timeMark.hasPassedNow()` returned `true`) -- fixed in https://github.com/kordlib/kord/commit/b0bafb82b65817d7efee26a0e4f388b8724cab73
- `Snowflake.timeMark` passed unadjusted milliseconds since Discord Epoch to `SnowflakeMark`'s constructor which e.g. caused `Snowflake(Clock.System.now()).timeMark.elapsedNow()` to return a very long `Duration` where it should return a very short one -- fixed in https://github.com/kordlib/kord/commit/86d1412ccfcfba76bf95ab9cb467de475a835380 (and deduplicated logic from `timeStamp` and `timeMark` in https://github.com/kordlib/kord/commit/c47caa04f99e2bccc3a8054ec908d7651fe377a7)

## Improvements for `Snowflake`
- ~~https://github.com/kordlib/kord/commit/ad0d746239185aae6d9f55b4250cb2732233b05c: using `ushr` instead of `shr` to get correct behavior for `Snowflake`s with a negative `value` - Would it be a good idea to just use `ULong` for `value`? (It would bring a more accurate `Snowflake.max` with `ULong.MAX_VALUE`, avoid confusion with negative `Snowflake` values etc. But I'm not sure if this would break things elsewhere and if/how it would work with serialization.)~~ - replaced by https://github.com/kordlib/kord/commit/c889ff95b87709bfefb126ec42f2a02ba26b3d7f
- https://github.com/kordlib/kord/commit/9c6ba3dbaadbf89407afafa4bfdb33185f62c1fd: Additional documentation for `compareTo()` and `equals()` behavior for `Snowflake`.
- https://github.com/kordlib/kord/commit/3f9ad822c08bbe14fa5744d4fdd68b8f0ccc8ef5: Timestamp related tests, `Snowflake` constructed with `Instant` too far in the past/future has min/max timestamp instead of undefined overflow behavior, `Snowflake.endOfTime` constant and more documentation.
- https://github.com/kordlib/kord/commit/c889ff95b87709bfefb126ec42f2a02ba26b3d7f: Type of `value` is now `ULong` (was `Long` before) - this included modifying the serializer for `Snowflake`s.
- https://github.com/kordlib/kord/commit/361b87a49a31fcdf660f0498514a66329aa28e36: Factory function / pseudo constructor as a replacement for old `Long` constructor (with additional note on negative values).