### PR TITLE
Temporary fix for Snowflake.max use in pagination

### DIFF
--- a/core/src/main/kotlin/Util.kt
+++ b/core/src/main/kotlin/Util.kt
@@ -215,7 +215,7 @@ internal fun <C : Collection<T>, T : KordEntity> paginateForwards(
  *  Selects the [Position.Before] the oldest item in the batch.
  */
 internal fun <C : Collection<T>, T> paginateBackwards(
-    start: Snowflake = Snowflake.max,
+    start: Snowflake = Snowflake(Long.MAX_VALUE),
     batchSize: Int,
     idSelector: (T) -> Snowflake,
     request: suspend (position: Position) -> C
@@ -226,7 +226,7 @@ internal fun <C : Collection<T>, T> paginateBackwards(
  *  Selects the [Position.Before] the oldest item in the batch.
  */
 internal fun <C : Collection<T>, T : KordEntity> paginateBackwards(
-    start: Snowflake = Snowflake.max,
+    start: Snowflake = Snowflake(Long.MAX_VALUE),
     batchSize: Int,
     request: suspend (position: Position) -> C
 ): Flow<T> =

--- a/core/src/main/kotlin/behavior/channel/threads/ThreadParentChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/threads/ThreadParentChannelBehavior.kt
@@ -97,7 +97,7 @@ interface PrivateThreadParentChannelBehavior : ThreadParentChannelBehavior {
      * [terminal operators](https://kotlinlang.org/docs/reference/coroutines/flow.html#terminal-flow-operators) instead.
      */
     fun getJoinedPrivateArchivedThreads(
-        before: Snowflake = Snowflake.max,
+        before: Snowflake = Snowflake(Long.MAX_VALUE),
         limit: Int = Int.MAX_VALUE
     ): Flow<ThreadChannel> {
         return supplier.getJoinedPrivateArchivedThreads(id, before, limit)

--- a/core/src/main/kotlin/supplier/RestEntitySupplier.kt
+++ b/core/src/main/kotlin/supplier/RestEntitySupplier.kt
@@ -332,7 +332,7 @@ class RestEntitySupplier(val kord: Kord) : EntitySupplier {
     fun getAuditLogEntries(
         guildId: Snowflake,
         request: AuditLogGetRequest = AuditLogGetRequest()
-    ): Flow<DiscordAuditLogEntry> = paginateBackwards(Snowflake.max, batchSize = 100, DiscordAuditLogEntry::id) {
+    ): Flow<DiscordAuditLogEntry> = paginateBackwards(batchSize = 100, idSelector = DiscordAuditLogEntry::id) {
         auditLog.getAuditLogs(guildId, request.copy(before = it.value)).auditLogEntries
     }
 


### PR DESCRIPTION
Fixes error when using too large `Snowflake` for pagination by not using `Snowflake.max`.
This is just temporary and should be replaced by https://github.com/kordlib/kord/pull/382 but I would want to wait for https://github.com/discord/discord-api-docs/pull/3745 to get merged.