### PR TITLE
Restrict Snowflake range, type changes, consistent naming

### DIFF
--- a/common/src/main/kotlin/entity/DiscordActivity.kt
+++ b/common/src/main/kotlin/entity/DiscordActivity.kt
@@ -25,7 +25,7 @@ data class DiscordActivity(
     val url: Optional<String?> = Optional.Missing(),
     @SerialName("created_at")
     val createdAt: Long,
-    val timestamps: Optional<DiscordActivityTimeStamps> = Optional.Missing(),
+    val timestamps: Optional<DiscordActivityTimestamps> = Optional.Missing(),
     @SerialName("application_id")
     val applicationId: OptionalSnowflake = OptionalSnowflake.Missing,
     val details: Optional<String?> = Optional.Missing(),
@@ -67,9 +67,15 @@ class ActivityFlags(val value: Int) {
     }
 }
 
+@Deprecated(
+    "DiscordActivityTimeStamps was renamed to DiscordActivityTimestamps.",
+    ReplaceWith("DiscordActivityTimestamps"),
+    DeprecationLevel.ERROR,
+)
+typealias DiscordActivityTimeStamps = DiscordActivityTimestamps
 
 @Serializable
-data class DiscordActivityTimeStamps(
+data class DiscordActivityTimestamps(
     val start: OptionalLong = OptionalLong.Missing,
     val end: OptionalLong = OptionalLong.Missing
 )

--- a/common/src/main/kotlin/entity/DiscordGuild.kt
+++ b/common/src/main/kotlin/entity/DiscordGuild.kt
@@ -155,8 +155,8 @@ data class DiscordGuild(
     @SerialName("welcome_screen")
     val welcomeScreen: Optional<DiscordWelcomeScreen> = Optional.Missing(),
     @SerialName("nsfw_level")
-    val nsfwLevel: NsfwLevel
-    )
+    val nsfwLevel: NsfwLevel,
+)
 
 /**
  * A partial representation of a [Discord Guild structure](https://discord.com/developers/docs/resources/guild#guild-object
@@ -176,7 +176,7 @@ class DiscordPartialGuild(
     val permissions: Optional<Permissions> = Optional.Missing(),
     val features: List<GuildFeature>,
     @SerialName("welcome_screen")
-    val welcomeScreen: Optional<DiscordWelcomeScreen> = Optional.Missing()
+    val welcomeScreen: Optional<DiscordWelcomeScreen> = Optional.Missing(),
 )
 
 /**
@@ -242,7 +242,7 @@ sealed class GuildFeature(val value: String) {
 
     /** Guild has access to the seven day archive time for threads */
     object SevenDayThreadArchive : GuildFeature("SEVEN_DAY_THREAD_ARCHIVE")
-    
+
     /** Guild has access to create private threads */
     object PrivateThreads : GuildFeature("PRIVATE_THREADS")
 
@@ -320,7 +320,7 @@ enum class SystemChannelFlag(val code: Int) {
 @Serializable
 data class DiscordGuildBan(
     @SerialName("guild_id")
-    val guildId: String,
+    val guildId: Snowflake,
     val user: DiscordUser,
 )
 
@@ -402,7 +402,7 @@ data class DiscordVoiceState(
     val selfStream: OptionalBoolean = OptionalBoolean.Missing,
     val suppress: Boolean,
     @SerialName("request_to_speak_timestamp")
-    val requestToSpeakTimestamp: String?
+    val requestToSpeakTimestamp: String?,
 )
 
 /**
@@ -526,6 +526,7 @@ sealed class MFALevel(val value: Int) {
         }
     }
 }
+
 /**
  * A representation of a [Discord Guild NSFW Level](https://discord.com/developers/docs/resources/guild#guild-object-guild-nsfw-level).
  */
@@ -613,12 +614,12 @@ data class DiscordWelcomeScreenChannel(
     @SerialName("emoji_id")
     val emojiId: Snowflake?,
     @SerialName("emoji_name")
-    val emojiName: String?
+    val emojiName: String?,
 )
 
 @Serializable
 data class DiscordWelcomeScreen(
     val description: String?,
     @SerialName("welcome_channels")
-    val welcomeChannels: List<DiscordWelcomeScreenChannel>
+    val welcomeChannels: List<DiscordWelcomeScreenChannel>,
 )

--- a/common/src/main/kotlin/entity/DiscordGuild.kt
+++ b/common/src/main/kotlin/entity/DiscordGuild.kt
@@ -155,7 +155,7 @@ data class DiscordGuild(
     @SerialName("welcome_screen")
     val welcomeScreen: Optional<DiscordWelcomeScreen> = Optional.Missing(),
     @SerialName("nsfw_level")
-    val nsfwLevel: NsfwLevel,
+    val nsfwLevel: NsfwLevel
 )
 
 /**
@@ -176,7 +176,7 @@ class DiscordPartialGuild(
     val permissions: Optional<Permissions> = Optional.Missing(),
     val features: List<GuildFeature>,
     @SerialName("welcome_screen")
-    val welcomeScreen: Optional<DiscordWelcomeScreen> = Optional.Missing(),
+    val welcomeScreen: Optional<DiscordWelcomeScreen> = Optional.Missing()
 )
 
 /**
@@ -402,7 +402,7 @@ data class DiscordVoiceState(
     val selfStream: OptionalBoolean = OptionalBoolean.Missing,
     val suppress: Boolean,
     @SerialName("request_to_speak_timestamp")
-    val requestToSpeakTimestamp: String?,
+    val requestToSpeakTimestamp: String?
 )
 
 /**
@@ -614,12 +614,12 @@ data class DiscordWelcomeScreenChannel(
     @SerialName("emoji_id")
     val emojiId: Snowflake?,
     @SerialName("emoji_name")
-    val emojiName: String?,
+    val emojiName: String?
 )
 
 @Serializable
 data class DiscordWelcomeScreen(
     val description: String?,
     @SerialName("welcome_channels")
-    val welcomeChannels: List<DiscordWelcomeScreenChannel>,
+    val welcomeChannels: List<DiscordWelcomeScreenChannel>
 )

--- a/common/src/main/kotlin/entity/Snowflake.kt
+++ b/common/src/main/kotlin/entity/Snowflake.kt
@@ -15,7 +15,7 @@ import kotlin.time.TimeMark
 
 /**
  * A unique identifier for entities [used by discord](https://discord.com/developers/docs/reference#snowflakes).
- * Snowflakes are IDs with a [timeStamp], which makes them [comparable][Comparable] based on their timestamp.
+ * Snowflakes are IDs with a [timestamp], which makes them [comparable][Comparable] based on their timestamp.
  *
  * Note: this class has a natural ordering that is inconsistent with [equals],
  * since [compareTo] only compares the first 42 bits of the ULong [value] (comparing the timestamp),
@@ -49,13 +49,13 @@ class Snowflake : Comparable<Snowflake> {
     constructor(value: String) : this(value.toULong())
 
     /**
-     * Creates a Snowflake from a given [instant].
+     * Creates a Snowflake from a given [timestamp].
      *
-     * If the given [instant] is too far in the past / future, this constructor will create
-     * an instance with a [timeStamp] equal to the timeStamp of [Snowflake.min] / [Snowflake.max].
+     * If the given timestamp is too far in the past / future, this constructor will create an instance with a
+     * [timestamp][Snowflake.timestamp] equal to the timestamp of [Snowflake.min] / [Snowflake.max].
      */
-    constructor(instant: Instant) : this(
-        instant.toEpochMilliseconds()
+    constructor(timestamp: Instant) : this(
+        timestamp.toEpochMilliseconds()
             .coerceAtLeast(discordEpochLong) // time before is unknown to Snowflakes
             .minus(discordEpochLong)
             .coerceAtMost(maxMillisecondsSinceDiscordEpoch) // time after is unknown to Snowflakes
@@ -71,13 +71,20 @@ class Snowflake : Comparable<Snowflake> {
     /**
      * The point in time this Snowflake represents.
      */
+    @Deprecated("timeStamp was renamed to timestamp.", ReplaceWith("timestamp"), DeprecationLevel.ERROR)
     val timeStamp: Instant
+        get() = timestamp
+
+    /**
+     * The point in time this Snowflake represents.
+     */
+    val timestamp: Instant
         get() = Instant.fromEpochMilliseconds(value.shr(nonTimestampBitCount).toLong().plus(discordEpochLong))
 
     /**
      * A [TimeMark] for the point in time this Snowflake represents.
      */
-    val timeMark: TimeMark get() = SnowflakeTimeMark(timeStamp)
+    val timeMark: TimeMark get() = SnowflakeTimeMark(timestamp)
 
     override fun compareTo(other: Snowflake): Int =
         value.shr(nonTimestampBitCount).compareTo(other.value.shr(nonTimestampBitCount))
@@ -151,9 +158,9 @@ class Snowflake : Comparable<Snowflake> {
     }
 }
 
-private class SnowflakeTimeMark(private val timeStamp: Instant) : TimeMark() {
+private class SnowflakeTimeMark(private val timestamp: Instant) : TimeMark() {
 
-    override fun elapsedNow(): Duration = Clock.System.now() - timeStamp
+    override fun elapsedNow(): Duration = Clock.System.now() - timestamp
 }
 
 /**

--- a/common/src/main/kotlin/entity/Snowflake.kt
+++ b/common/src/main/kotlin/entity/Snowflake.kt
@@ -1,6 +1,6 @@
 package dev.kord.common.entity
 
-import dev.kord.common.entity.Snowflake.Companion.validULongRange
+import dev.kord.common.entity.Snowflake.Companion.validValues
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlinx.serialization.ExperimentalSerializationApi
@@ -35,16 +35,16 @@ class Snowflake : Comparable<Snowflake> {
     /**
      * Creates a Snowflake from a given ULong [value].
      *
-     * Values are [coerced in][coerceIn] [validULongRange].
+     * Values are [coerced in][coerceIn] [validValues].
      */
     constructor(value: ULong) {
-        this.value = value.coerceIn(validULongRange)
+        this.value = value.coerceIn(validValues)
     }
 
     /**
      * Creates a Snowflake from a given String [value], parsing it as a [ULong] value.
      *
-     * Values are [coerced in][coerceIn] [validULongRange].
+     * Values are [coerced in][coerceIn] [validValues].
      */
     constructor(value: String) : this(value.toULong())
 
@@ -102,13 +102,13 @@ class Snowflake : Comparable<Snowflake> {
         private const val discordEpochLong = 1420070400000L
 
         /**
-         * The range that contains all valid raw Snowflake [value]s.
+         * A range that contains all valid raw Snowflake [value]s.
          *
          * Note that this range might change in the future.
          */
-        val validULongRange: ULongRange = ULong.MIN_VALUE..Long.MAX_VALUE.toULong() // 0..9223372036854775807
+        val validValues: ULongRange = ULong.MIN_VALUE..Long.MAX_VALUE.toULong() // 0..9223372036854775807
 
-        private val maxMillisecondsSinceDiscordEpoch = validULongRange.last.shr(nonTimestampBitCount).toLong()
+        private val maxMillisecondsSinceDiscordEpoch = validValues.last.shr(nonTimestampBitCount).toLong()
 
         /**
          * The point in time that marks the Discord Epoch (the first second of 2015).
@@ -135,13 +135,13 @@ class Snowflake : Comparable<Snowflake> {
          * The maximum value a Snowflake can hold.
          * Useful when requesting paginated entities.
          */
-        val max: Snowflake = Snowflake(validULongRange.last)
+        val max: Snowflake = Snowflake(validValues.last)
 
         /**
          * The minimum value a Snowflake can hold.
          * Useful when requesting paginated entities.
          */
-        val min: Snowflake = Snowflake(validULongRange.first)
+        val min: Snowflake = Snowflake(validValues.first)
     }
 
     @OptIn(ExperimentalSerializationApi::class)
@@ -166,6 +166,6 @@ private class SnowflakeTimeMark(private val timestamp: Instant) : TimeMark() {
 /**
  * Creates a [Snowflake] from a given Long [value].
  *
- * Values are [coerced in][coerceIn] [validULongRange].
+ * Values are [coerced in][coerceIn] [validValues].
  */
 fun Snowflake(value: Long): Snowflake = Snowflake(value.coerceAtLeast(0).toULong())

--- a/common/src/main/kotlin/entity/Snowflake.kt
+++ b/common/src/main/kotlin/entity/Snowflake.kt
@@ -106,7 +106,18 @@ class Snowflake : Comparable<Snowflake> {
         /**
          * The point in time that marks the Discord Epoch (the first second of 2015).
          */
-        val discordEpochStart: Instant = Instant.fromEpochMilliseconds(discordEpochLong)
+        @Deprecated(
+            "Snowflake.discordEpochStart was renamed to Snowflake.discordEpoch.",
+            ReplaceWith("Snowflake.discordEpoch"),
+            DeprecationLevel.ERROR,
+        )
+        val discordEpochStart: Instant
+            get() = discordEpoch
+
+        /**
+         * The point in time that marks the Discord Epoch (the first second of 2015).
+         */
+        val discordEpoch: Instant = Instant.fromEpochMilliseconds(discordEpochLong)
 
         /**
          * The last point in time a Snowflake can represent.

--- a/common/src/main/kotlin/entity/optional/OptionalSnowflake.kt
+++ b/common/src/main/kotlin/entity/optional/OptionalSnowflake.kt
@@ -69,7 +69,7 @@ sealed class OptionalSnowflake {
      * Equality and hashcode is implemented through its [value].
      *
      * @param uLongValue the raw value this optional wraps.
-     * See [Snowflake.value] and [Snowflake.validULongRange] for more details.
+     * See [Snowflake.value] and [Snowflake.validValues] for more details.
      */
     class Value(private val uLongValue: ULong) : OptionalSnowflake() {
 

--- a/common/src/test/kotlin/entity/SnowflakeTest.kt
+++ b/common/src/test/kotlin/entity/SnowflakeTest.kt
@@ -11,8 +11,8 @@ import kotlin.test.*
 class SnowflakeTest {
 
     @Test
-    fun `min Snowflake's timeStamp is equal to discordEpochStart`() {
-        assertEquals(Snowflake.discordEpochStart, Snowflake.min.timeStamp)
+    fun `min Snowflake's timeStamp is equal to discordEpoch`() {
+        assertEquals(Snowflake.discordEpoch, Snowflake.min.timeStamp)
     }
 
     @Test
@@ -21,9 +21,9 @@ class SnowflakeTest {
     }
 
     @Test
-    fun `Snowflake created from ULong MIN_VALUE has timeStamp equal to discordEpochStart`() {
+    fun `Snowflake created from ULong MIN_VALUE has timeStamp equal to discordEpoch`() {
         val snowflake = Snowflake(ULong.MIN_VALUE)
-        assertEquals(Snowflake.discordEpochStart, snowflake.timeStamp)
+        assertEquals(Snowflake.discordEpoch, snowflake.timeStamp)
     }
 
     @Test
@@ -33,15 +33,15 @@ class SnowflakeTest {
     }
 
     @Test
-    fun `Snowflake created from Long MIN_VALUE has timeStamp equal to discordEpochStart`() {
+    fun `Snowflake created from Long MIN_VALUE has timeStamp equal to discordEpoch`() {
         val snowflake = Snowflake(Long.MIN_VALUE)
-        assertEquals(Snowflake.discordEpochStart, snowflake.timeStamp)
+        assertEquals(Snowflake.discordEpoch, snowflake.timeStamp)
     }
 
     @Test
-    fun `Snowflake created from instant far in the past has timeStamp equal to discordEpochStart`() {
+    fun `Snowflake created from instant far in the past has timeStamp equal to discordEpoch`() {
         val snowflake = Snowflake(Instant.DISTANT_PAST)
-        assertEquals(Snowflake.discordEpochStart, snowflake.timeStamp)
+        assertEquals(Snowflake.discordEpoch, snowflake.timeStamp)
     }
 
     @Test

--- a/common/src/test/kotlin/entity/SnowflakeTest.kt
+++ b/common/src/test/kotlin/entity/SnowflakeTest.kt
@@ -11,54 +11,54 @@ import kotlin.test.*
 class SnowflakeTest {
 
     @Test
-    fun `min Snowflake's timeStamp is equal to discordEpoch`() {
-        assertEquals(Snowflake.discordEpoch, Snowflake.min.timeStamp)
+    fun `min Snowflake's timestamp is equal to discordEpoch`() {
+        assertEquals(Snowflake.discordEpoch, Snowflake.min.timestamp)
     }
 
     @Test
-    fun `max Snowflake's timeStamp is equal to endOfTime`() {
-        assertEquals(Snowflake.endOfTime, Snowflake.max.timeStamp)
+    fun `max Snowflake's timestamp is equal to endOfTime`() {
+        assertEquals(Snowflake.endOfTime, Snowflake.max.timestamp)
     }
 
     @Test
-    fun `Snowflake created from ULong MIN_VALUE has timeStamp equal to discordEpoch`() {
+    fun `Snowflake created from ULong MIN_VALUE has timestamp equal to discordEpoch`() {
         val snowflake = Snowflake(ULong.MIN_VALUE)
-        assertEquals(Snowflake.discordEpoch, snowflake.timeStamp)
+        assertEquals(Snowflake.discordEpoch, snowflake.timestamp)
     }
 
     @Test
-    fun `Snowflake created from ULong MAX_VALUE has timeStamp equal to endOfTime`() {
+    fun `Snowflake created from ULong MAX_VALUE has timestamp equal to endOfTime`() {
         val snowflake = Snowflake(ULong.MAX_VALUE)
-        assertEquals(Snowflake.endOfTime, snowflake.timeStamp)
+        assertEquals(Snowflake.endOfTime, snowflake.timestamp)
     }
 
     @Test
-    fun `Snowflake created from Long MIN_VALUE has timeStamp equal to discordEpoch`() {
+    fun `Snowflake created from Long MIN_VALUE has timestamp equal to discordEpoch`() {
         val snowflake = Snowflake(Long.MIN_VALUE)
-        assertEquals(Snowflake.discordEpoch, snowflake.timeStamp)
+        assertEquals(Snowflake.discordEpoch, snowflake.timestamp)
     }
 
     @Test
-    fun `Snowflake created from instant far in the past has timeStamp equal to discordEpoch`() {
+    fun `Snowflake created from instant far in the past has timestamp equal to discordEpoch`() {
         val snowflake = Snowflake(Instant.DISTANT_PAST)
-        assertEquals(Snowflake.discordEpoch, snowflake.timeStamp)
+        assertEquals(Snowflake.discordEpoch, snowflake.timestamp)
     }
 
     @Test
-    fun `Snowflake created from instant far in the future has timeStamp equal to endOfTime`() {
+    fun `Snowflake created from instant far in the future has timestamp equal to endOfTime`() {
         val snowflake = Snowflake(Instant.DISTANT_FUTURE)
-        assertEquals(Snowflake.endOfTime, snowflake.timeStamp)
+        assertEquals(Snowflake.endOfTime, snowflake.timestamp)
     }
 
     @Test
-    fun `Snowflake's timeStamp calculates an Instant close to the Instant the Snowflake was created from`() {
+    fun `Snowflake's timestamp calculates an Instant close to the Instant the Snowflake was created from`() {
         val instant = Clock.System.now()
         val snowflake = Snowflake(instant)
 
         // snowflake timestamps have a millisecond accuracy -> allow +/-1 millisecond from original instant
         val validTimeRange = instant.minus(1, MILLISECOND)..instant.plus(1, MILLISECOND)
 
-        assertContains(validTimeRange, snowflake.timeStamp)
+        assertContains(validTimeRange, snowflake.timestamp)
     }
 
     @Test

--- a/core/src/main/kotlin/Kord.kt
+++ b/core/src/main/kotlin/Kord.kt
@@ -3,6 +3,7 @@ package dev.kord.core
 import dev.kord.cache.api.DataCache
 import dev.kord.common.annotation.DeprecatedSinceKord
 import dev.kord.common.annotation.KordExperimental
+import dev.kord.common.annotation.KordPreview
 import dev.kord.common.annotation.KordUnsafe
 import dev.kord.common.entity.DiscordShard
 import dev.kord.common.entity.PresenceStatus
@@ -210,6 +211,7 @@ class Kord(
      * returns null if the [Channel] isn't present.
      *
      * @throws [RequestException] if anything went wrong during the request.
+     * @throws [EntityNotFoundException] if the channel wasn't present.
      */
     suspend fun getChannel(
         id: Snowflake,
@@ -297,9 +299,9 @@ class Kord(
 
     /**
      * Requests to get the [User] that with the [id] through the [strategy],
-     * returns null if the [User] isn't present.
      *
      * @throws [RequestException] if anything went wrong during the request.
+     * @throws [EntityNotFoundException] if the user wasn't present.
      */
     suspend fun getUser(id: Snowflake, strategy: EntitySupplyStrategy<*> = resources.defaultStrategy): User? =
         strategy.supply(this).getUserOrNull(id)

--- a/core/src/main/kotlin/Util.kt
+++ b/core/src/main/kotlin/Util.kt
@@ -271,7 +271,7 @@ internal fun paginateThreads(
     paginateByDate(
         start,
         batchSize,
-        { threads -> threads.minOfOrNull { it.archiveTimeStamp } },
+        { threads -> threads.minOfOrNull { it.archiveTimestamp } },
         request
     )
 

--- a/core/src/main/kotlin/behavior/UserBehavior.kt
+++ b/core/src/main/kotlin/behavior/UserBehavior.kt
@@ -106,7 +106,7 @@ interface UserBehavior : KordEntity, Strategizable {
 fun UserBehavior(
     id: Snowflake,
     kord: Kord,
-    strategy: EntitySupplyStrategy<*> = kord.resources.defaultStrategy,
+    strategy: EntitySupplyStrategy<*> = kord.resources.defaultStrategy
 ): UserBehavior = object : UserBehavior {
     override val id: Snowflake = id
     override val kord: Kord = kord

--- a/core/src/main/kotlin/behavior/UserBehavior.kt
+++ b/core/src/main/kotlin/behavior/UserBehavior.kt
@@ -69,7 +69,7 @@ interface UserBehavior : KordEntity, Strategizable {
      * @throws [RestRequestException] if something went wrong during the request.
      */
     suspend fun getDmChannel(): DmChannel {
-        val response = kord.rest.user.createDM(DMCreateRequest(id.asString))
+        val response = kord.rest.user.createDM(DMCreateRequest(id))
         val data = ChannelData.from(response)
 
         return Channel.from(data, kord) as DmChannel
@@ -106,7 +106,7 @@ interface UserBehavior : KordEntity, Strategizable {
 fun UserBehavior(
     id: Snowflake,
     kord: Kord,
-    strategy: EntitySupplyStrategy<*> = kord.resources.defaultStrategy
+    strategy: EntitySupplyStrategy<*> = kord.resources.defaultStrategy,
 ): UserBehavior = object : UserBehavior {
     override val id: Snowflake = id
     override val kord: Kord = kord

--- a/core/src/main/kotlin/behavior/channel/GuildMessageChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/GuildMessageChannelBehavior.kt
@@ -1,18 +1,13 @@
 package dev.kord.core.behavior.channel
 
 import dev.kord.common.entity.Snowflake
-import dev.kord.common.exception.RequestException
 import dev.kord.core.Kord
-import dev.kord.core.entity.channel.GuildChannel
 import dev.kord.core.entity.channel.GuildMessageChannel
-import dev.kord.core.entity.channel.TopGuildMessageChannel
-import dev.kord.core.exception.EntityNotFoundException
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 import dev.kord.rest.json.request.BulkDeleteRequest
 import dev.kord.rest.request.RestRequestException
 import kotlinx.datetime.Clock
-import java.util.*
 import kotlin.time.Duration
 
 /**
@@ -33,7 +28,7 @@ interface GuildMessageChannelBehavior : GuildChannelBehavior, MessageChannelBeha
         //split up in bulk delete and manual delete
         // if message.timeMark + 14 days > now, then the message isn't 14 days old yet, and we can add it to the bulk delete
         // if message.timeMark + 14 days < now, then the message is more than 14 days old, and we'll have to manually delete them
-        val (younger, older) = messages.partition { it.timeStamp > daysLimit }
+        val (younger, older) = messages.partition { it.timestamp > daysLimit }
 
         younger.chunked(100).forEach {
             if (it.size < 2) kord.rest.channel.deleteMessage(id, it.first(), reason)

--- a/core/src/main/kotlin/behavior/channel/NewsChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/NewsChannelBehavior.kt
@@ -69,7 +69,7 @@ interface NewsChannelBehavior : ThreadParentChannelBehavior {
     suspend fun startPublicThread(
         name: String,
         archiveDuration: ArchiveDuration = ArchiveDuration.Day,
-        reason: String? = null,
+        reason: String? = null
     ): NewsChannelThread {
         return unsafeStartThread(name, archiveDuration, ChannelType.PublicNewsThread, reason) as NewsChannelThread
     }
@@ -78,7 +78,7 @@ interface NewsChannelBehavior : ThreadParentChannelBehavior {
         messageId: Snowflake,
         name: String,
         archiveDuration: ArchiveDuration = ArchiveDuration.Day,
-        reason: String? = null,
+        reason: String? = null
     ): NewsChannelThread {
         return unsafeStartPublicThreadWithMessage(messageId, name, archiveDuration, reason) as NewsChannelThread
     }
@@ -100,7 +100,7 @@ fun NewsChannelBehavior(
     guildId: Snowflake,
     id: Snowflake,
     kord: Kord,
-    strategy: EntitySupplyStrategy<*> = kord.resources.defaultStrategy,
+    strategy: EntitySupplyStrategy<*> = kord.resources.defaultStrategy
 ): NewsChannelBehavior = object : NewsChannelBehavior {
     override val guildId: Snowflake = guildId
     override val id: Snowflake = id

--- a/core/src/main/kotlin/behavior/channel/NewsChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/NewsChannelBehavior.kt
@@ -1,6 +1,5 @@
 package dev.kord.core.behavior.channel
 
-import dev.kord.common.annotation.KordPreview
 import dev.kord.common.entity.ArchiveDuration
 import dev.kord.common.entity.ChannelType
 import dev.kord.common.entity.Permission
@@ -63,14 +62,14 @@ interface NewsChannelBehavior : ThreadParentChannelBehavior {
      * @throws [RequestException] if something went wrong during the request.
      */
     suspend fun follow(target: Snowflake) {
-        kord.rest.channel.followNewsChannel(id, ChannelFollowRequest(webhookChannelId = target.asString))
+        kord.rest.channel.followNewsChannel(id, ChannelFollowRequest(webhookChannelId = target))
     }
 
 
     suspend fun startPublicThread(
         name: String,
         archiveDuration: ArchiveDuration = ArchiveDuration.Day,
-        reason: String? = null
+        reason: String? = null,
     ): NewsChannelThread {
         return unsafeStartThread(name, archiveDuration, ChannelType.PublicNewsThread, reason) as NewsChannelThread
     }
@@ -79,7 +78,7 @@ interface NewsChannelBehavior : ThreadParentChannelBehavior {
         messageId: Snowflake,
         name: String,
         archiveDuration: ArchiveDuration = ArchiveDuration.Day,
-        reason: String? = null
+        reason: String? = null,
     ): NewsChannelThread {
         return unsafeStartPublicThreadWithMessage(messageId, name, archiveDuration, reason) as NewsChannelThread
     }
@@ -101,7 +100,7 @@ fun NewsChannelBehavior(
     guildId: Snowflake,
     id: Snowflake,
     kord: Kord,
-    strategy: EntitySupplyStrategy<*> = kord.resources.defaultStrategy
+    strategy: EntitySupplyStrategy<*> = kord.resources.defaultStrategy,
 ): NewsChannelBehavior = object : NewsChannelBehavior {
     override val guildId: Snowflake = guildId
     override val id: Snowflake = id

--- a/core/src/main/kotlin/behavior/channel/threads/ThreadParentChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/threads/ThreadParentChannelBehavior.kt
@@ -38,7 +38,7 @@ interface ThreadParentChannelBehavior : TopGuildMessageChannelBehavior {
 
     /**
      * Returns archived threads in the channel that are public.
-     * Threads are ordered by [ThreadChannel.archiveTimeStamp] in descending order.
+     * Threads are ordered by [ThreadChannel.archiveTimestamp] in descending order.
      * Requires the [Read Message History Permission][dev.kord.common.entity.Permission.ReadMessageHistory]
      *
      * The returned flow is lazily executed, any [RequestException] will be thrown on
@@ -73,7 +73,7 @@ interface PrivateThreadParentChannelBehavior : ThreadParentChannelBehavior {
 
     /**
      * Returns archived threads in the channel that are private.
-     * Threads are ordered by [archive timestamp][ThreadChannel.archiveTimeStamp] in descending order.
+     * Threads are ordered by [archive timestamp][ThreadChannel.archiveTimestamp] in descending order.
      * Requires the [Read Message History Permission][dev.kord.common.entity.Permission.ReadMessageHistory] and
      * [Manage Threads Permission][dev.kord.common.entity.Permission.ManageThreads]
      *

--- a/core/src/main/kotlin/cache/data/ActivityData.kt
+++ b/core/src/main/kotlin/cache/data/ActivityData.kt
@@ -12,7 +12,7 @@ data class ActivityData(
     val type: ActivityType,
     val url: Optional<String?> = Optional.Missing(),
     val createdAt: Long,
-    val timestamps: Optional<DiscordActivityTimeStamps> = Optional.Missing(),
+    val timestamps: Optional<DiscordActivityTimestamps> = Optional.Missing(),
     val applicationId: OptionalSnowflake = OptionalSnowflake.Missing,
     val details: Optional<String?> = Optional.Missing(),
     val state: Optional<String?> = Optional.Missing(),

--- a/core/src/main/kotlin/entity/channel/MessageChannel.kt
+++ b/core/src/main/kotlin/entity/channel/MessageChannel.kt
@@ -28,8 +28,18 @@ interface MessageChannel : Channel, MessageChannelBehavior {
     /**
      * The timestamp of the last pin
      */
+    @Deprecated(
+        "lastPinTimeStamp was renamed to lastPinTimestamp.",
+        ReplaceWith("lastPinTimestamp"),
+        DeprecationLevel.ERROR,
+    )
     val lastPinTimeStamp: Instant?
-        get() = data.lastPinTimestamp.value?.toInstant()
+        get() = lastPinTimestamp
+
+    /**
+     * The timestamp of the last pin
+     */
+    val lastPinTimestamp: Instant? get() = data.lastPinTimestamp.value?.toInstant()
 
     /**
      * Requests to get the last message sent to this channel,

--- a/core/src/main/kotlin/entity/channel/thread/ThreadChannel.kt
+++ b/core/src/main/kotlin/entity/channel/thread/ThreadChannel.kt
@@ -53,7 +53,18 @@ interface ThreadChannel : GuildMessageChannel, ThreadChannelBehavior {
     /**
      * timestamp when the thread's archive status was last changed.
      */
-    val archiveTimeStamp: Instant get() = threadData.archiveTimestamp.toInstant()
+    @Deprecated(
+        "archiveTimeStamp was renamed to archiveTimestamp.",
+        ReplaceWith("archiveTimestamp"),
+        DeprecationLevel.ERROR,
+    )
+    val archiveTimeStamp: Instant
+        get() = archiveTimestamp
+
+    /**
+     * timestamp when the thread's archive status was last changed.
+     */
+    val archiveTimestamp: Instant get() = threadData.archiveTimestamp.toInstant()
 
     /**
      * The time in which the thread will be auto archived after inactivity.

--- a/core/src/main/kotlin/gateway/handler/GuildEventHandler.kt
+++ b/core/src/main/kotlin/gateway/handler/GuildEventHandler.kt
@@ -27,7 +27,7 @@ internal class GuildEventHandler(
     kord: Kord,
     gateway: MasterGateway,
     cache: DataCache,
-    coreFlow: MutableSharedFlow<CoreEvent>
+    coreFlow: MutableSharedFlow<CoreEvent>,
 ) : BaseGatewayEventHandler(kord, gateway, cache, coreFlow) {
 
     override suspend fun handle(event: Event, shard: Int) = when (event) {
@@ -107,7 +107,7 @@ internal class GuildEventHandler(
         cache.put(user)
         val user = User(data, kord)
 
-        coreFlow.emit(BanAddEvent(user, Snowflake(guildId), shard))
+        coreFlow.emit(BanAddEvent(user, guildId, shard))
     }
 
     private suspend fun handle(event: GuildBanRemove, shard: Int) = with(event.ban) {
@@ -115,7 +115,7 @@ internal class GuildEventHandler(
         cache.put(user)
         val user = User(data, kord)
 
-        coreFlow.emit(BanRemoveEvent(user, Snowflake(guildId), shard))
+        coreFlow.emit(BanRemoveEvent(user, guildId, shard))
     }
 
     private suspend fun handle(event: GuildEmojisUpdate, shard: Int) = with(event.emoji) {
@@ -243,5 +243,4 @@ internal class GuildEventHandler(
         val data = InviteDeleteData.from(invite)
         coreFlow.emit(InviteDeleteEvent(data, kord, shard))
     }
-
 }

--- a/core/src/main/kotlin/gateway/handler/GuildEventHandler.kt
+++ b/core/src/main/kotlin/gateway/handler/GuildEventHandler.kt
@@ -27,7 +27,7 @@ internal class GuildEventHandler(
     kord: Kord,
     gateway: MasterGateway,
     cache: DataCache,
-    coreFlow: MutableSharedFlow<CoreEvent>,
+    coreFlow: MutableSharedFlow<CoreEvent>
 ) : BaseGatewayEventHandler(kord, gateway, cache, coreFlow) {
 
     override suspend fun handle(event: Event, shard: Int) = when (event) {

--- a/core/src/test/kotlin/equality/EntityEqualityTest.kt
+++ b/core/src/test/kotlin/equality/EntityEqualityTest.kt
@@ -9,7 +9,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 
 val ids = generateSequence {
-    Random.nextULong(Snowflake.validULongRange) // limit to valid range to guarantee distinct generated Snowflakes
+    Random.nextULong(Snowflake.validValues) // limit to valid range to guarantee distinct generated Snowflakes
 }.distinct().iterator()
 
 fun randomId() = Snowflake(ids.next())

--- a/core/src/test/kotlin/live/LiveGuildTest.kt
+++ b/core/src/test/kotlin/live/LiveGuildTest.kt
@@ -104,7 +104,7 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
             sendEventValidAndRandomId(guildId) {
                 GuildBanAdd(
                     DiscordGuildBan(
-                        guildId = it.asString,
+                        guildId = it,
                         user = DiscordUser(
                             id = randomId(),
                             username = "",
@@ -129,7 +129,7 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
             sendEventValidAndRandomId(guildId) {
                 GuildBanRemove(
                     DiscordGuildBan(
-                        guildId = it.asString,
+                        guildId = it,
                         user = DiscordUser(
                             id = randomId(),
                             username = "",

--- a/core/src/test/kotlin/live/LiveKordEntityTest.kt
+++ b/core/src/test/kotlin/live/LiveKordEntityTest.kt
@@ -132,7 +132,7 @@ class LiveKordEntityTest : AbstractLiveEntityTest<LiveKordEntityTest.LiveEntityM
 
             val eventGuildBan = GuildBanAdd(
                 DiscordGuildBan(
-                    guildId = guildId.asString,
+                    guildId = guildId,
                     user = DiscordUser(
                         id = randomId(),
                         username = "",

--- a/core/src/test/kotlin/live/LiveMemberTest.kt
+++ b/core/src/test/kotlin/live/LiveMemberTest.kt
@@ -128,7 +128,7 @@ class LiveMemberTest : AbstractLiveEntityTest<LiveMember>() {
             sendEventValidAndRandomIdCheckLiveActive(userId) {
                 GuildBanAdd(
                     DiscordGuildBan(
-                        guildId = randomId().asString,
+                        guildId = randomId(),
                         user = DiscordUser(
                             id = it,
                             username = "",

--- a/gateway/src/test/kotlin/json/SnowflakeTest.kt
+++ b/gateway/src/test/kotlin/json/SnowflakeTest.kt
@@ -29,7 +29,7 @@ class SnowflakeTest {
 
     @Test
     fun `Deserialization of Snowflake as large String completes successfully`() {
-        val value = Snowflake.validULongRange.last.toString()
+        val value = Snowflake.validValues.last.toString()
         val json = buildJsonObject {
             put("snowflake", value)
         }
@@ -52,7 +52,7 @@ class SnowflakeTest {
     @Test
     fun `Deserialization of Snowflake as large Number completes successfully`() {
         // ULong is inline class and therefore cannot extend abstract class Number but put only takes Number
-        val value = Snowflake.validULongRange.last.toNumber()
+        val value = Snowflake.validValues.last.toNumber()
         val json = buildJsonObject {
             put("snowflake", value)
         }

--- a/rest/src/main/kotlin/builder/guild/GuildCreateBuilder.kt
+++ b/rest/src/main/kotlin/builder/guild/GuildCreateBuilder.kt
@@ -30,7 +30,7 @@ class GuildCreateBuilder(var name: String) : RequestBuilder<GuildCreateRequest> 
      * Iterator that generates unique ids for roles and channels.
      */
     val snowflakeGenerator by lazy(LazyThreadSafetyMode.NONE) {
-        generateSequence { Random.nextULong(Snowflake.validULongRange) }.filter {
+        generateSequence { Random.nextULong(Snowflake.validValues) }.filter {
             it !in roles.map { role -> role.id.value?.value }
                     && it !in channels.map { channel -> channel.id.value?.value }
                     && Snowflake(it) != systemChannelId

--- a/rest/src/main/kotlin/json/request/ChannelFollowRequest.kt
+++ b/rest/src/main/kotlin/json/request/ChannelFollowRequest.kt
@@ -1,10 +1,11 @@
 package dev.kord.rest.json.request
 
+import dev.kord.common.entity.Snowflake
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 class ChannelFollowRequest(
     @SerialName("webhook_channel_id")
-    val webhookChannelId: String
+    val webhookChannelId: Snowflake,
 )

--- a/rest/src/main/kotlin/json/request/UserRequests.kt
+++ b/rest/src/main/kotlin/json/request/UserRequests.kt
@@ -1,5 +1,6 @@
 package dev.kord.rest.json.request
 
+import dev.kord.common.entity.Snowflake
 import dev.kord.common.entity.optional.Optional
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -7,25 +8,25 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class DMCreateRequest(
     @SerialName("recipient_id")
-    val userId: String
+    val userId: Snowflake,
 )
 
 @Serializable
 data class GroupDMCreateRequest(
     @SerialName("access_tokens")
     val tokens: List<String>,
-    val nick: Map<String, String>
+    val nick: Map<String, String>,
 )
 
 @Serializable
 data class CurrentUserModifyRequest(
     val username: Optional<String> = Optional.Missing(),
-    val avatar: Optional<String?> = Optional.Missing()
+    val avatar: Optional<String?> = Optional.Missing(),
 )
 
 @Serializable
 data class UserAddDMRequest(
     @SerialName("access_token")
     val token: String,
-    val nick: String
+    val nick: String,
 )

--- a/rest/src/main/kotlin/json/request/UserRequests.kt
+++ b/rest/src/main/kotlin/json/request/UserRequests.kt
@@ -15,18 +15,18 @@ data class DMCreateRequest(
 data class GroupDMCreateRequest(
     @SerialName("access_tokens")
     val tokens: List<String>,
-    val nick: Map<String, String>,
+    val nick: Map<String, String>
 )
 
 @Serializable
 data class CurrentUserModifyRequest(
     val username: Optional<String> = Optional.Missing(),
-    val avatar: Optional<String?> = Optional.Missing(),
+    val avatar: Optional<String?> = Optional.Missing()
 )
 
 @Serializable
 data class UserAddDMRequest(
     @SerialName("access_token")
     val token: String,
-    val nick: String,
+    val nick: String
 )

--- a/rest/src/main/kotlin/json/request/VoiceStateRequests.kt
+++ b/rest/src/main/kotlin/json/request/VoiceStateRequests.kt
@@ -12,8 +12,16 @@ data class CurrentVoiceStateModifyRequest(
     val channelId: Snowflake,
     val suppress: OptionalBoolean = OptionalBoolean.Missing,
     @SerialName("request_to_speak_timestamp")
-    val requestToSpeakTimeStamp: Optional<String> = Optional.Missing()
-)
+    val requestToSpeakTimestamp: Optional<String> = Optional.Missing(),
+) {
+    @Deprecated(
+        "requestToSpeakTimeStamp was renamed to requestToSpeakTimestamp.",
+        ReplaceWith("requestToSpeakTimestamp"),
+        DeprecationLevel.ERROR,
+    )
+    val requestToSpeakTimeStamp: Optional<String>
+        get() = requestToSpeakTimestamp
+}
 
 
 @Serializable


### PR DESCRIPTION
This PR combines https://github.com/kordlib/kord/pull/380, https://github.com/kordlib/kord/pull/382 and some additional changes. I would want to keep this PR open until https://github.com/discord/discord-api-docs/pull/3745 gets accepted.

## Change some types from `String` to `Snowflake` (https://github.com/kordlib/kord/pull/380)

- https://github.com/kordlib/kord/commit/d109712a47579a20ea2a8233f1bb1a77c592f28b: `DiscordGuildBan.guildId`
  see:
  https://discord.com/developers/docs/topics/gateway#guild-ban-add-guild-ban-add-event-fields
  https://discord.com/developers/docs/topics/gateway#guild-ban-remove-guild-ban-remove-event-fields
- https://github.com/kordlib/kord/commit/9784b5a095404a1ddd7d9618e384e39548513c7e: `DMCreatRequest.userId`
  see: https://discord.com/developers/docs/resources/user#create-dm
-  https://github.com/kordlib/kord/commit/6dfd86167b0c3e2fa30dee88c86b44d6f9b03f96: `ChannelFollowRequest.webhookChannelId`
  see: https://discord.com/developers/docs/resources/channel#follow-news-channel

## Restrict `Snowflake`s to valid range (https://github.com/kordlib/kord/pull/382)

Implement the Snowflake limitations described in https://github.com/discord/discord-api-docs/pull/3745. This will e.g. fix an error in pagination (invalid Snowflakes were used before).

The valid range for a `Snowflake`'s raw value is represented by the new `validValues` property of `Snowflake`'s companion object. All constructors will [coerce their input in that range](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.ranges/coerce-in.html) so there is no way to create an invalid `Snowflake`.
If Discord ever decides to widen the valid range, it would just be a matter of adjusting `validValues` accordingly to support that. (I intended this range to be the single point of truth).

https://github.com/kordlib/kord/commit/b96f3bbf081ceae1227349efc1a5e92cfe47c102 removes a test that was depending on an invalid `Snowflake` to pass. Since there is no longer a way to create such invalid `Snowflake`s, it is impossible to make this test pass.

## Consistent naming

- https://github.com/kordlib/kord/commit/957fcc47a71abd18531a94be0cc21a48d3661bbb renames `Snowflake.discordEpochStart` to `Snowflake.discordEpoch` as it is the term used in Discord's documentation
- https://github.com/kordlib/kord/commit/fd4f387a6b8d7daddcff7cd765abf93def7f9d61 brings consistent naming to all `XxxTimestamp` classes and properties