### PR TITLE
Add bill of materials

### DIFF
--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -1,0 +1,37 @@
+plugins {
+    `java-platform`
+    `kord-publishing`
+}
+
+javaPlatform {
+    allowDependencies()
+}
+
+val me = project
+rootProject.subprojects {
+    if (name != me.name) {
+        me.evaluationDependsOn(path)
+    }
+}
+
+dependencies {
+    constraints {
+        rootProject.subprojects.forEach { subproject ->
+            if (subproject.plugins.hasPlugin("maven-publish") && subproject.name != name) {
+                subproject.publishing.publications.withType<MavenPublication> {
+                    if (!artifactId.endsWith("-metadata") &&
+                        !artifactId.endsWith("-kotlinMultiplatform")
+                    ) {
+                        api(groupId, artifactId, version)
+                    }
+                }
+            }
+        }
+    }
+}
+
+publishing {
+    publications.withType<MavenPublication> {
+        from(components["javaPlatform"])
+    }
+}

--- a/buildSrc/src/main/kotlin/kord-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/kord-module.gradle.kts
@@ -1,14 +1,11 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import java.util.Base64
 
 plugins {
     kotlin("jvm")
     kotlin("plugin.serialization")
     id("org.jetbrains.dokka")
     id("kotlinx-atomicfu")
-
     `maven-publish`
-    signing
 }
 
 repositories {
@@ -80,75 +77,10 @@ tasks {
     }
 
     publishing {
-        publications {
-            create<MavenPublication>(Library.name) {
-                from(components["kotlin"])
-                groupId = Library.group
-                artifactId = "kord-${project.name}"
-                version = Library.version
-
-                artifact(sourcesJar.get())
-                artifact(dokkaJar.get())
-
-                pom {
-                    name.set(Library.name)
-                    description.set(Library.description)
-                    url.set(Library.description)
-
-                    organization {
-                        name.set("Kord")
-                        url.set("https://github.com/kordlib")
-                    }
-
-                    developers {
-                        developer {
-                            name.set("The Kord Team")
-                        }
-                    }
-
-                    issueManagement {
-                        system.set("GitHub")
-                        url.set("https://github.com/kordlib/kord/issues")
-                    }
-
-                    licenses {
-                        license {
-                            name.set("MIT")
-                            url.set("https://opensource.org/licenses/MIT")
-                        }
-                    }
-                    scm {
-                        connection.set("scm:git:ssh://github.com/kordlib/kord.git")
-                        developerConnection.set("scm:git:ssh://git@github.com:kordlib/kord.git")
-                        url.set(Library.projectUrl)
-                    }
-                }
-
-                if (!isJitPack) {
-                    repositories {
-                        maven {
-                            url = if (Library.isSnapshot) uri(Repo.snapshotsUrl)
-                            else uri(Repo.releasesUrl)
-
-                            credentials {
-                                username = System.getenv("NEXUS_USER")
-                                password = System.getenv("NEXUS_PASSWORD")
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    if (!isJitPack && Library.isRelease) {
-        signing {
-            val signingKey = findProperty("signingKey")?.toString()
-            val signingPassword = findProperty("signingPassword")?.toString()
-            if (signingKey != null && signingPassword != null) {
-                useInMemoryPgpKeys(Base64.getDecoder().decode(signingKey).toString(), signingPassword)
-            }
-            sign(publishing.publications[Library.name])
+        publications.withType<MavenPublication> {
+            from(components["kotlin"])
+            artifact(sourcesJar.get())
+            artifact(dokkaJar.get())
         }
     }
 }

--- a/buildSrc/src/main/kotlin/kord-publishing.gradle.kts
+++ b/buildSrc/src/main/kotlin/kord-publishing.gradle.kts
@@ -1,0 +1,77 @@
+import java.util.Base64
+
+plugins {
+    `maven-publish`
+    signing
+}
+
+tasks {
+    publishing {
+        publications {
+            create<MavenPublication>(Library.name) {
+                groupId = Library.group
+                artifactId = "kord-${project.name}"
+                version = Library.version
+
+                pom {
+                    name.set(Library.name)
+                    description.set(Library.description)
+                    url.set(Library.description)
+
+                    organization {
+                        name.set("Kord")
+                        url.set("https://github.com/kordlib")
+                    }
+
+                    developers {
+                        developer {
+                            name.set("The Kord Team")
+                        }
+                    }
+
+                    issueManagement {
+                        system.set("GitHub")
+                        url.set("https://github.com/kordlib/kord/issues")
+                    }
+
+                    licenses {
+                        license {
+                            name.set("MIT")
+                            url.set("http://opensource.org/licenses/MIT")
+                        }
+                    }
+                    scm {
+                        connection.set("scm:git:ssh://github.com/kordlib/kord.git")
+                        developerConnection.set("scm:git:ssh://git@github.com:kordlib/kord.git")
+                        url.set(Library.projectUrl)
+                    }
+                }
+
+                if (!isJitPack) {
+                    repositories {
+                        maven {
+                            url = if (Library.isSnapshot) uri(Repo.snapshotsUrl)
+                            else uri(Repo.releasesUrl)
+
+                            credentials {
+                                username = System.getenv("NEXUS_USER")
+                                password = System.getenv("NEXUS_PASSWORD")
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (!isJitPack && Library.isRelease) {
+        signing {
+            val signingKey = findProperty("signingKey")?.toString()
+            val signingPassword = findProperty("signingPassword")?.toString()
+            if (signingKey != null && signingPassword != null) {
+                useInMemoryPgpKeys(Base64.getDecoder().decode(signingKey).toString(), signingPassword)
+            }
+            sign(publishing.publications[Library.name])
+        }
+    }
+}

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     `kord-module`
     `kord-sampled-module`
+    `kord-publishing`
 }
 
 dependencies {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     `kord-module`
     `kord-sampled-module`
+    `kord-publishing`
 }
 
 dependencies {

--- a/gateway/build.gradle.kts
+++ b/gateway/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     `kord-module`
     `kord-sampled-module`
+    `kord-publishing`
 }
 
 dependencies {

--- a/rest/build.gradle.kts
+++ b/rest/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     `kord-module`
     `kord-sampled-module`
+    `kord-publishing`
 }
 
 dependencies {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,6 +20,7 @@ include("common")
 include("rest")
 include("core")
 include("voice")
+include("bom")
 
 enableFeaturePreview("VERSION_CATALOGS")
 

--- a/voice/build.gradle.kts
+++ b/voice/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     `kord-module`
     `kord-sampled-module`
+    `kord-publishing`
 }
 
 dependencies {


### PR DESCRIPTION
- Extract publishing into its own gradle script plugin
- Add bill of materials

This allows aligning kord dependency versions via [Maven BOMS](https://docs.gradle.org/current/userguide/platforms.html#sub:bom_import)
