### PR TITLE
Add previous value to GuildUpdateEvent

### DIFF
--- a/core/src/main/kotlin/event/guild/GuildUpdateEvent.kt
+++ b/core/src/main/kotlin/event/guild/GuildUpdateEvent.kt
@@ -4,7 +4,7 @@ import dev.kord.core.Kord
 import dev.kord.core.entity.Guild
 import dev.kord.core.event.Event
 
-class GuildUpdateEvent(val guild: Guild, override val shard: Int) : Event {
+class GuildUpdateEvent(val guild: Guild, val old: Guild?, override val shard: Int) : Event {
     override val kord: Kord get() = guild.kord
     override fun toString(): String {
         return "GuildUpdateEvent(guild=$guild, shard=$shard)"

--- a/core/src/main/kotlin/gateway/handler/GuildEventHandler.kt
+++ b/core/src/main/kotlin/gateway/handler/GuildEventHandler.kt
@@ -87,10 +87,11 @@ internal class GuildEventHandler(
 
     private suspend fun handle(event: GuildUpdate, shard: Int) {
         val data = GuildData.from(event.guild)
+        val old = cache.query<GuildData> { idEq(GuildData::id, event.guild.id) }.singleOrNull()
         cache.put(data)
         event.guild.cache()
 
-        coreFlow.emit(GuildUpdateEvent(Guild(data, kord), shard))
+        coreFlow.emit(GuildUpdateEvent(Guild(data, kord), old?.let { Guild(it, kord) }, shard))
     }
 
     private suspend fun handle(event: GuildDelete, shard: Int) = with(event.guild) {


### PR DESCRIPTION
Fixes #393 

Adds an `old` field with the previous (hopefully cached) guild to the `GuildUpdateEvent`.

