### PR TITLE
Behaviour improvement

### DIFF
--- a/core/src/main/kotlin/behavior/GuildBehavior.kt
+++ b/core/src/main/kotlin/behavior/GuildBehavior.kt
@@ -259,6 +259,23 @@ interface GuildBehavior : KordEntity, Strategizable {
     suspend fun asGuildOrNull(): Guild? = supplier.getGuildOrNull(id)
 
     /**
+     * Retrieve the [Guild] associated with this behaviour from the provided [EntitySupplier]
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     * @throws [EntityNotFoundException] if the user wasn't present.
+     */
+    suspend fun fetchGuild(): Guild = supplier.getGuild(id)
+
+
+    /**
+     * Retrieve the [Guild] associated with this behaviour from the provided [EntitySupplier]
+     * returns null if the [Guild] isn't present.
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     */
+    suspend fun fetchGuildOrNull(): Guild? = supplier.getGuildOrNull(id)
+
+    /**
      * Requests to delete this guild.
      *
      * @throws [RestRequestException] if something went wrong during the request.

--- a/core/src/main/kotlin/behavior/MemberBehavior.kt
+++ b/core/src/main/kotlin/behavior/MemberBehavior.kt
@@ -58,6 +58,23 @@ interface MemberBehavior : KordEntity, UserBehavior {
     suspend fun asMemberOrNull(): Member? = supplier.getMemberOrNull(guildId, id)
 
     /**
+     * Retrieve the [Member] associated with this behaviour from the provided [EntitySupplier]
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     * @throws [EntityNotFoundException] if the user wasn't present.
+     */
+    suspend fun fetchMember(): Member = supplier.getMember(guildId, id)
+
+
+    /**
+     * Retrieve the [Member] associated with this behaviour from the provided [EntitySupplier]
+     * returns null if the [Member] isn't present.
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     */
+    suspend fun fetchMemberOrNull(): Member? = supplier.getMemberOrNull(guildId, id)
+
+    /**
      * Requests to kick this member from its guild.
      *
      * @param reason the reason showing up in the audit log

--- a/core/src/main/kotlin/behavior/MessageBehavior.kt
+++ b/core/src/main/kotlin/behavior/MessageBehavior.kt
@@ -64,6 +64,22 @@ interface MessageBehavior : KordEntity, Strategizable {
      */
     suspend fun asMessageOrNull(): Message? = supplier.getMessageOrNull(channelId = channelId, messageId = id)
 
+    /**
+     * Retrieve the [Message] associated with this behaviour from the provided [EntitySupplier]
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     * @throws [EntityNotFoundException] if the user wasn't present.
+     */
+    suspend fun fetchMessage(): Message = supplier.getMessage(channelId, id)
+
+
+    /**
+     * Retrieve the [Message] associated with this behaviour from the provided [EntitySupplier]
+     * returns null if the [Message] isn't present.
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     */
+    suspend fun fetchMessageOrNull(): Message? = supplier.getMessageOrNull(channelId, id)
 
     /**
      * Requests to delete this message.

--- a/core/src/main/kotlin/behavior/RoleBehavior.kt
+++ b/core/src/main/kotlin/behavior/RoleBehavior.kt
@@ -1,11 +1,13 @@
 package dev.kord.core.behavior
 
 import dev.kord.common.entity.Snowflake
+import dev.kord.common.exception.RequestException
 import dev.kord.core.Kord
 import dev.kord.core.cache.data.RoleData
 import dev.kord.core.entity.KordEntity
 import dev.kord.core.entity.Role
 import dev.kord.core.entity.Strategizable
+import dev.kord.core.exception.EntityNotFoundException
 import dev.kord.core.indexOfFirstOrNull
 import dev.kord.core.sorted
 import dev.kord.core.supplier.EntitySupplier
@@ -42,6 +44,22 @@ interface RoleBehavior : KordEntity, Strategizable {
             return if (guildId == id) "@everyone"
             else "<@&${id.asString}>"
         }
+
+    /**
+     * Requests to get the this behavior as a [Role] if it's not an instance of a [Role].
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     * @throws [EntityNotFoundException] if the user wasn't present.
+     */
+    suspend fun asRole(): Role = supplier.getRole(guildId, id)
+
+    /**
+     * Requests to get this behavior as a [Role] if its not an instance of a [Role],
+     * returns null if the user isn't present.
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     */
+    suspend fun asRoleOrNull(): Role? = supplier.getRoleOrNull(guildId, id)
 
     /**
      * Requests to change the [position] of this role.

--- a/core/src/main/kotlin/behavior/RoleBehavior.kt
+++ b/core/src/main/kotlin/behavior/RoleBehavior.kt
@@ -7,6 +7,7 @@ import dev.kord.core.cache.data.RoleData
 import dev.kord.core.entity.KordEntity
 import dev.kord.core.entity.Role
 import dev.kord.core.entity.Strategizable
+import dev.kord.core.entity.User
 import dev.kord.core.exception.EntityNotFoundException
 import dev.kord.core.indexOfFirstOrNull
 import dev.kord.core.sorted
@@ -60,6 +61,23 @@ interface RoleBehavior : KordEntity, Strategizable {
      * @throws [RequestException] if anything went wrong during the request.
      */
     suspend fun asRoleOrNull(): Role? = supplier.getRoleOrNull(guildId, id)
+
+    /**
+     * Retrieve the [Role] associated with this behaviour from the provided [EntitySupplier]
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     * @throws [EntityNotFoundException] if the user wasn't present.
+     */
+    suspend fun fetchRole(): Role = supplier.getRole(guildId, id)
+
+
+    /**
+     * Retrieve the [Role] associated with this behaviour from the provided [EntitySupplier]
+     * returns null if the [Role] isn't present.
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     */
+    suspend fun fetchRoleOrNull(): Role? = supplier.getRoleOrNull(guildId, id)
 
     /**
      * Requests to change the [position] of this role.

--- a/core/src/main/kotlin/behavior/StageInstanceBehavior.kt
+++ b/core/src/main/kotlin/behavior/StageInstanceBehavior.kt
@@ -1,11 +1,13 @@
 package dev.kord.core.behavior
 
 import dev.kord.common.entity.Snowflake
+import dev.kord.common.exception.RequestException
 import dev.kord.core.Kord
 import dev.kord.core.cache.data.StageInstanceData
 import dev.kord.core.entity.KordEntity
 import dev.kord.core.entity.StageInstance
 import dev.kord.core.entity.Strategizable
+import dev.kord.core.exception.EntityNotFoundException
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 import dev.kord.rest.json.request.StageInstanceUpdateRequest
@@ -22,7 +24,21 @@ interface StageInstanceBehavior : KordEntity, Strategizable {
         return StageInstance(data, kord, supplier)
     }
 
+    /**
+     * Requests to get the this behavior as a [StageInstance] if it's not an instance of a [StageInstance].
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     * @throws [EntityNotFoundException] if the user wasn't present.
+     */
     suspend fun asStageInstance(): StageInstance = supplier.getStageInstance(channelId)
+
+    /**
+     * Requests to get this behavior as a [StageInstance] if its not an instance of a [StageInstance],
+     * returns null if the user isn't present.
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     */
+    suspend fun asStageInstanceOrNull(): StageInstance? = supplier.getStageInstanceOrNull(channelId)
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): StageInstanceBehavior =
         StageInstanceBehavior(id, channelId, kord, strategy.supply(kord))

--- a/core/src/main/kotlin/behavior/StageInstanceBehavior.kt
+++ b/core/src/main/kotlin/behavior/StageInstanceBehavior.kt
@@ -7,6 +7,7 @@ import dev.kord.core.cache.data.StageInstanceData
 import dev.kord.core.entity.KordEntity
 import dev.kord.core.entity.StageInstance
 import dev.kord.core.entity.Strategizable
+import dev.kord.core.entity.User
 import dev.kord.core.exception.EntityNotFoundException
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
@@ -39,6 +40,23 @@ interface StageInstanceBehavior : KordEntity, Strategizable {
      * @throws [RequestException] if anything went wrong during the request.
      */
     suspend fun asStageInstanceOrNull(): StageInstance? = supplier.getStageInstanceOrNull(channelId)
+
+    /**
+     * Retrieve the [StageInstance] associated with this behaviour from the provided [EntitySupplier]
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     * @throws [EntityNotFoundException] if the user wasn't present.
+     */
+    suspend fun fetchStageInstance(): StageInstance = supplier.getStageInstance(id)
+
+
+    /**
+     * Retrieve the [StageInstance] associated with this behaviour from the provided [EntitySupplier]
+     * returns null if the [StageInstance] isn't present.
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     */
+    suspend fun fetchStageInstanceOrNull(): StageInstance? = supplier.getStageInstanceOrNull(id)
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): StageInstanceBehavior =
         StageInstanceBehavior(id, channelId, kord, strategy.supply(kord))

--- a/core/src/main/kotlin/behavior/UserBehavior.kt
+++ b/core/src/main/kotlin/behavior/UserBehavior.kt
@@ -57,6 +57,39 @@ interface UserBehavior : KordEntity, Strategizable {
      */
     suspend fun asUserOrNull(): User? = supplier.getUserOrNull(id)
 
+    /**
+     * Retrieve the [Member] associated with this behaviour from the provided [EntitySupplier]
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     * @throws [EntityNotFoundException] if the user wasn't present.
+     */
+    suspend fun fetchMember(guildId: Snowflake): Member = supplier.getMember(guildId, id)
+
+    /**
+     * Retrieve the [Member] associated with this behaviour from the provided [EntitySupplier]
+     * returns null if the [Member] isn't present.
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     */
+    suspend fun fetchMemberOrNull(guildId: Snowflake): Member? = supplier.getMemberOrNull(guildId, id)
+
+    /**
+     * Retrieve the [User] associated with this behaviour from the provided [EntitySupplier]
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     * @throws [EntityNotFoundException] if the user wasn't present.
+     */
+    suspend fun fetchUser(): User = supplier.getUser(id)
+
+
+    /**
+     * Retrieve the [User] associated with this behaviour from the provided [EntitySupplier]
+     * returns null if the [User] isn't present.
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     */
+    suspend fun fetchUserOrNull(): User? = supplier.getUserOrNull(id)
+
 
     /**
      * Requests to get or create a [DmChannel] between this bot and the user.

--- a/core/src/main/kotlin/behavior/channel/CategoryBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/CategoryBehavior.kt
@@ -9,6 +9,7 @@ import dev.kord.core.exception.EntityNotFoundException
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 import dev.kord.core.supplier.getChannelOf
+import dev.kord.core.supplier.getChannelOfOrNull
 import dev.kord.rest.builder.channel.CategoryModifyBuilder
 import dev.kord.rest.builder.channel.NewsChannelCreateBuilder
 import dev.kord.rest.builder.channel.TextChannelCreateBuilder
@@ -48,7 +49,24 @@ interface CategoryBehavior : TopGuildChannelBehavior {
      * @throws [EntityNotFoundException] if the channel wasn't present.
      * @throws [ClassCastException] if the channel wasn't a category.
      */
-    override suspend fun asChannelOrNull(): Category? = supplier.getChannelOf(id)
+    override suspend fun asChannelOrNull(): Category? = supplier.getChannelOfOrNull(id)
+
+    /**
+     * Retrieve the [Category] associated with this behaviour from the provided [EntitySupplier]
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     * @throws [EntityNotFoundException] if the user wasn't present.
+     */
+    override suspend fun fetchChannel(): Category = supplier.getChannelOf(id)
+
+
+    /**
+     * Retrieve the [Category] associated with this behaviour from the provided [EntitySupplier]
+     * returns null if the [Category] isn't present.
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     */
+    override suspend fun fetchChannelOrNull(): Category? = supplier.getChannelOfOrNull(id)
 
 
     /**

--- a/core/src/main/kotlin/behavior/channel/ChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/ChannelBehavior.kt
@@ -3,6 +3,7 @@ package dev.kord.core.behavior.channel
 import dev.kord.common.entity.Snowflake
 import dev.kord.common.exception.RequestException
 import dev.kord.core.Kord
+import dev.kord.core.entity.Guild
 import dev.kord.core.entity.KordEntity
 import dev.kord.core.entity.Strategizable
 import dev.kord.core.entity.channel.Channel
@@ -42,6 +43,23 @@ interface ChannelBehavior : KordEntity, Strategizable {
      * @throws [RequestException] if something went wrong during the request.
      */
     suspend fun asChannelOrNull(): Channel? = supplier.getChannelOrNull(id)
+
+    /**
+     * Retrieve the [Channel] associated with this behaviour from the provided [EntitySupplier]
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     * @throws [EntityNotFoundException] if the user wasn't present.
+     */
+    suspend fun fetchChannel(): Channel = supplier.getChannel(id)
+
+
+    /**
+     * Retrieve the [Channel] associated with this behaviour from the provided [EntitySupplier]
+     * returns null if the [Channel] isn't present.
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     */
+    suspend fun fetchChannelOrNull(): Channel? = supplier.getChannelOrNull(id)
 
     /**
      * Requests to delete a channel (or close it if this is a dm channel).

--- a/core/src/main/kotlin/behavior/channel/GuildChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/GuildChannelBehavior.kt
@@ -5,11 +5,14 @@ import dev.kord.common.exception.RequestException
 import dev.kord.core.Kord
 import dev.kord.core.behavior.GuildBehavior
 import dev.kord.core.entity.*
+import dev.kord.core.entity.channel.Category
 import dev.kord.core.entity.channel.GuildChannel
 import dev.kord.core.entity.channel.TopGuildChannel
 import dev.kord.core.exception.EntityNotFoundException
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
+import dev.kord.core.supplier.getChannelOf
+import dev.kord.core.supplier.getChannelOfOrNull
 import java.util.*
 
 /**
@@ -43,6 +46,23 @@ interface GuildChannelBehavior : ChannelBehavior, Strategizable {
      * @throws [RequestException] if something went wrong during the request.
      */
     override suspend fun asChannelOrNull(): GuildChannel? = super.asChannelOrNull() as? GuildChannel
+
+    /**
+     * Retrieve the [GuildChannel] associated with this behaviour from the provided [EntitySupplier]
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     * @throws [EntityNotFoundException] if the user wasn't present.
+     */
+    override suspend fun fetchChannel(): GuildChannel = super.fetchChannel() as GuildChannel
+
+
+    /**
+     * Retrieve the [GuildChannel] associated with this behaviour from the provided [EntitySupplier]
+     * returns null if the [GuildChannel] isn't present.
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     */
+    override suspend fun fetchChannelOrNull(): GuildChannel? = super.fetchChannelOrNull() as? GuildChannel
 
     /**
      * Requests to get this channel's [Guild].

--- a/core/src/main/kotlin/behavior/channel/GuildMessageChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/GuildMessageChannelBehavior.kt
@@ -1,8 +1,11 @@
 package dev.kord.core.behavior.channel
 
 import dev.kord.common.entity.Snowflake
+import dev.kord.common.exception.RequestException
 import dev.kord.core.Kord
+import dev.kord.core.entity.channel.GuildChannel
 import dev.kord.core.entity.channel.GuildMessageChannel
+import dev.kord.core.exception.EntityNotFoundException
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 import dev.kord.rest.json.request.BulkDeleteRequest
@@ -45,6 +48,26 @@ interface GuildMessageChannelBehavior : GuildChannelBehavior, MessageChannelBeha
     override suspend fun asChannelOrNull(): GuildMessageChannel? {
         return super<GuildChannelBehavior>.asChannelOrNull() as? GuildMessageChannel
     }
+
+
+    /**
+     * Retrieve the [GuildMessageChannel] associated with this behaviour from the provided [EntitySupplier]
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     * @throws [EntityNotFoundException] if the user wasn't present.
+     */
+    override suspend fun fetchChannel(): GuildMessageChannel =
+        super<GuildChannelBehavior>.fetchChannel() as GuildMessageChannel
+
+
+    /**
+     * Retrieve the [GuildMessageChannel] associated with this behaviour from the provided [EntitySupplier]
+     * returns null if the [GuildMessageChannel] isn't present.
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     */
+    override suspend fun fetchChannelOrNull(): GuildMessageChannel? =
+        super<GuildChannelBehavior>.fetchChannelOrNull() as? GuildMessageChannel
 
     /**
      * Returns a new [GuildMessageChannelBehavior] with the given [strategy].

--- a/core/src/main/kotlin/behavior/channel/MessageChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/MessageChannelBehavior.kt
@@ -6,6 +6,7 @@ import dev.kord.core.Kord
 import dev.kord.core.cache.data.MessageData
 import dev.kord.core.entity.Message
 import dev.kord.core.entity.Strategizable
+import dev.kord.core.entity.channel.GuildChannel
 import dev.kord.core.entity.channel.MessageChannel
 import dev.kord.core.exception.EntityNotFoundException
 import dev.kord.core.supplier.EntitySupplier
@@ -53,6 +54,23 @@ interface MessageChannelBehavior : ChannelBehavior, Strategizable {
      * @throws [RequestException] if something went wrong during the request.
      */
     override suspend fun asChannelOrNull(): MessageChannel? = super.asChannelOrNull() as? MessageChannel
+
+    /**
+     * Retrieve the [MessageChannel] associated with this behaviour from the provided [EntitySupplier]
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     * @throws [EntityNotFoundException] if the user wasn't present.
+     */
+    override suspend fun fetchChannel(): MessageChannel = super.fetchChannel() as MessageChannel
+
+
+    /**
+     * Retrieve the [MessageChannel] associated with this behaviour from the provided [EntitySupplier]
+     * returns null if the [MessageChannel] isn't present.
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     */
+    override suspend fun fetchChannelOrNull(): MessageChannel? = super.fetchChannelOrNull() as? MessageChannel
 
     /**
      * Requests to get all messages in this channel.

--- a/core/src/main/kotlin/behavior/channel/NewsChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/NewsChannelBehavior.kt
@@ -11,6 +11,7 @@ import dev.kord.core.behavior.channel.threads.unsafeStartPublicThreadWithMessage
 import dev.kord.core.behavior.channel.threads.unsafeStartThread
 import dev.kord.core.cache.data.ChannelData
 import dev.kord.core.entity.channel.Channel
+import dev.kord.core.entity.channel.GuildChannel
 import dev.kord.core.entity.channel.NewsChannel
 import dev.kord.core.entity.channel.thread.NewsChannelThread
 import dev.kord.core.exception.EntityNotFoundException
@@ -52,6 +53,23 @@ interface NewsChannelBehavior : ThreadParentChannelBehavior {
      * @throws [RequestException] if something went wrong during the request.
      */
     override suspend fun asChannelOrNull(): NewsChannel? = super.asChannelOrNull() as? NewsChannel
+
+    /**
+     * Retrieve the [NewsChannel] associated with this behaviour from the provided [EntitySupplier]
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     * @throws [EntityNotFoundException] if the user wasn't present.
+     */
+    override suspend fun fetchChannel(): NewsChannel = super.fetchChannel() as NewsChannel
+
+
+    /**
+     * Retrieve the [NewsChannel] associated with this behaviour from the provided [EntitySupplier]
+     * returns null if the [NewsChannel] isn't present.
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     */
+    override suspend fun fetchChannelOrNull(): NewsChannel? = super.fetchChannelOrNull() as? NewsChannel
 
 
     /**

--- a/core/src/main/kotlin/behavior/channel/StoreChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/StoreChannelBehavior.kt
@@ -5,6 +5,7 @@ import dev.kord.common.exception.RequestException
 import dev.kord.core.Kord
 import dev.kord.core.cache.data.ChannelData
 import dev.kord.core.entity.channel.Channel
+import dev.kord.core.entity.channel.GuildChannel
 import dev.kord.core.entity.channel.StoreChannel
 import dev.kord.core.exception.EntityNotFoundException
 import dev.kord.core.supplier.EntitySupplier
@@ -38,6 +39,23 @@ interface StoreChannelBehavior : TopGuildChannelBehavior {
      * @throws [RequestException] if anything went wrong during the request.
      */
     override suspend fun asChannelOrNull(): StoreChannel? = super.asChannelOrNull() as? StoreChannel
+
+    /**
+     * Retrieve the [StoreChannel] associated with this behaviour from the provided [EntitySupplier]
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     * @throws [EntityNotFoundException] if the user wasn't present.
+     */
+    override suspend fun fetchChannel(): StoreChannel = super.fetchChannel() as StoreChannel
+
+
+    /**
+     * Retrieve the [StoreChannel] associated with this behaviour from the provided [EntitySupplier]
+     * returns null if the [StoreChannel] isn't present.
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     */
+    override suspend fun fetchChannelOrNull(): StoreChannel? = super.fetchChannelOrNull() as? StoreChannel
 
     /**
      * returns a new [StoreChannelBehavior] with the given [strategy].

--- a/core/src/main/kotlin/behavior/channel/TextChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/TextChannelBehavior.kt
@@ -10,6 +10,7 @@ import dev.kord.core.behavior.channel.threads.unsafeStartPublicThreadWithMessage
 import dev.kord.core.behavior.channel.threads.unsafeStartThread
 import dev.kord.core.cache.data.ChannelData
 import dev.kord.core.entity.channel.Channel
+import dev.kord.core.entity.channel.GuildChannel
 import dev.kord.core.entity.channel.TextChannel
 import dev.kord.core.entity.channel.thread.TextChannelThread
 import dev.kord.core.exception.EntityNotFoundException
@@ -47,6 +48,23 @@ interface TextChannelBehavior : PrivateThreadParentChannelBehavior {
      * @throws [RequestException] if anything went wrong during the request.
      */
     override suspend fun asChannelOrNull(): TextChannel? = super.asChannelOrNull() as? TextChannel
+
+    /**
+     * Retrieve the [TextChannel] associated with this behaviour from the provided [EntitySupplier]
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     * @throws [EntityNotFoundException] if the user wasn't present.
+     */
+    override suspend fun fetchChannel(): TextChannel = super.fetchChannel() as TextChannel
+
+
+    /**
+     * Retrieve the [TextChannel] associated with this behaviour from the provided [EntitySupplier]
+     * returns null if the [TextChannel] isn't present.
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     */
+    override suspend fun fetchChannelOrNull(): TextChannel? = super.fetchChannelOrNull() as? TextChannel
 
     suspend fun startPublicThread(
         name: String,

--- a/core/src/main/kotlin/behavior/channel/TopGuildChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/TopGuildChannelBehavior.kt
@@ -5,6 +5,7 @@ import dev.kord.common.exception.RequestException
 import dev.kord.core.Kord
 import dev.kord.core.cache.data.InviteData
 import dev.kord.core.entity.*
+import dev.kord.core.entity.channel.TextChannel
 import dev.kord.core.entity.channel.TopGuildChannel
 import dev.kord.core.exception.EntityNotFoundException
 import dev.kord.core.supplier.EntitySupplier
@@ -65,6 +66,23 @@ interface TopGuildChannelBehavior : GuildChannelBehavior {
      * @throws [RequestException] if something went wrong during the request.
      */
     override suspend fun asChannelOrNull(): TopGuildChannel? = super.asChannelOrNull() as? TopGuildChannel
+
+    /**
+     * Retrieve the [TopGuildChannel] associated with this behaviour from the provided [EntitySupplier]
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     * @throws [EntityNotFoundException] if the user wasn't present.
+     */
+    override suspend fun fetchChannel(): TopGuildChannel = super.fetchChannel() as TopGuildChannel
+
+
+    /**
+     * Retrieve the [TopGuildChannel] associated with this behaviour from the provided [EntitySupplier]
+     * returns null if the [TopGuildChannel] isn't present.
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     */
+    override suspend fun fetchChannelOrNull(): TopGuildChannel? = super.fetchChannelOrNull() as? TopGuildChannel
 
     /**
      * Requests to add or replace a [PermissionOverwrite] to this entity.

--- a/core/src/main/kotlin/behavior/channel/TopGuildMessageChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/TopGuildMessageChannelBehavior.kt
@@ -63,6 +63,25 @@ interface TopGuildMessageChannelBehavior : TopGuildChannelBehavior, GuildMessage
         super<TopGuildChannelBehavior>.asChannelOrNull() as? TopGuildMessageChannel
 
     /**
+     * Retrieve the [TopGuildMessageChannel] associated with this behaviour from the provided [EntitySupplier]
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     * @throws [EntityNotFoundException] if the user wasn't present.
+     */
+    override suspend fun fetchChannel(): TopGuildMessageChannel =
+        super<TopGuildChannelBehavior>.fetchChannel() as TopGuildMessageChannel
+
+
+    /**
+     * Retrieve the [TopGuildMessageChannel] associated with this behaviour from the provided [EntitySupplier]
+     * returns null if the [TopGuildMessageChannel] isn't present.
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     */
+    override suspend fun fetchChannelOrNull(): TopGuildMessageChannel? =
+        super<TopGuildChannelBehavior>.fetchChannelOrNull() as? TopGuildMessageChannel
+
+    /**
      * Returns a new [TopGuildMessageChannelBehavior] with the given [strategy].
      */
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): TopGuildMessageChannelBehavior =

--- a/core/src/main/kotlin/behavior/channel/VoiceChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/VoiceChannelBehavior.kt
@@ -5,6 +5,7 @@ import dev.kord.common.exception.RequestException
 import dev.kord.core.Kord
 import dev.kord.core.cache.data.ChannelData
 import dev.kord.core.entity.channel.Channel
+import dev.kord.core.entity.channel.TopGuildChannel
 import dev.kord.core.entity.channel.VoiceChannel
 import dev.kord.core.exception.EntityNotFoundException
 import dev.kord.core.supplier.EntitySupplier
@@ -38,6 +39,23 @@ interface VoiceChannelBehavior : BaseVoiceChannelBehavior {
      * @throws [RequestException] if anything went wrong during the request.
      */
     override suspend fun asChannelOrNull(): VoiceChannel? = super.asChannelOrNull() as? VoiceChannel
+
+    /**
+     * Retrieve the [VoiceChannel] associated with this behaviour from the provided [EntitySupplier]
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     * @throws [EntityNotFoundException] if the user wasn't present.
+     */
+    override suspend fun fetchChannel(): VoiceChannel = super.fetchChannel() as VoiceChannel
+
+
+    /**
+     * Retrieve the [VoiceChannel] associated with this behaviour from the provided [EntitySupplier]
+     * returns null if the [VoiceChannel] isn't present.
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     */
+    override suspend fun fetchChannelOrNull(): VoiceChannel? = super.fetchChannelOrNull() as? VoiceChannel
 
     /**
      * Returns a new [VoiceChannelBehavior] with the given [strategy].

--- a/core/src/main/kotlin/behavior/channel/threads/ThreadParentChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/threads/ThreadParentChannelBehavior.kt
@@ -13,6 +13,7 @@ import dev.kord.core.cache.data.ChannelData
 import dev.kord.core.entity.channel.Channel
 import dev.kord.core.entity.channel.ThreadParentChannel
 import dev.kord.core.entity.channel.thread.ThreadChannel
+import dev.kord.core.exception.EntityNotFoundException
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 import dev.kord.rest.json.request.StartThreadRequest
@@ -59,6 +60,23 @@ interface ThreadParentChannelBehavior : TopGuildMessageChannelBehavior {
     override suspend fun asChannelOrNull(): ThreadParentChannel? {
         return super.asChannelOrNull() as? ThreadParentChannel
     }
+
+    /**
+     * Retrieve the [ThreadParentChannel] associated with this behaviour from the provided [EntitySupplier]
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     * @throws [EntityNotFoundException] if the user wasn't present.
+     */
+    override suspend fun fetchChannel(): ThreadParentChannel = super.fetchChannel() as ThreadParentChannel
+
+
+    /**
+     * Retrieve the [ThreadParentChannel] associated with this behaviour from the provided [EntitySupplier]
+     * returns null if the [ThreadParentChannel] isn't present.
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     */
+    override suspend fun fetchChannelOrNull(): ThreadParentChannel? = super.fetchChannelOrNull() as? ThreadParentChannel
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): ThreadParentChannelBehavior
 

--- a/core/src/main/kotlin/entity/Guild.kt
+++ b/core/src/main/kotlin/entity/Guild.kt
@@ -46,6 +46,10 @@ class Guild(
      */
     val afkChannelId: Snowflake? get() = data.afkChannelId
 
+    override suspend fun asGuild(): Guild = this
+
+    override suspend fun asGuildOrNull(): Guild = this
+
     val afkChannel: VoiceChannelBehavior?
         get() = afkChannelId?.let { VoiceChannelBehavior(guildId = id, id = it, kord = kord) }
 

--- a/core/src/main/kotlin/entity/Member.kt
+++ b/core/src/main/kotlin/entity/Member.kt
@@ -13,8 +13,8 @@ import dev.kord.core.cache.data.UserData
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 import kotlinx.coroutines.flow.*
-import kotlinx.datetime.toInstant
 import kotlinx.datetime.Instant
+import kotlinx.datetime.toInstant
 import java.util.*
 
 /**
@@ -110,6 +110,18 @@ class Member(
      */
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): Member =
         Member(memberData, data, kord, strategy.supply(kord))
+
+    override suspend fun asUser(): User = this
+
+    override suspend fun asUserOrNull(): User = this
+
+    override suspend fun asMember(guildId: Snowflake): Member = this
+
+    override suspend fun asMember(): Member = this
+
+    override suspend fun asMemberOrNull(guildId: Snowflake): Member = this
+
+    override suspend fun asMemberOrNull(): Member = this
 
 
     override fun hashCode(): Int = Objects.hash(id, guildId)

--- a/core/src/main/kotlin/entity/Message.kt
+++ b/core/src/main/kotlin/entity/Message.kt
@@ -47,6 +47,8 @@ class Message(
     override val channelId: Snowflake
         get() = data.channelId
 
+    override suspend fun asMessageOrNull(): Message = this
+
     /**
      * The files attached to this message.
      */

--- a/core/src/main/kotlin/entity/Role.kt
+++ b/core/src/main/kotlin/entity/Role.kt
@@ -37,6 +37,10 @@ data class Role(
 
     val rawPosition: Int get() = data.position
 
+    override suspend fun asRole(): Role = this
+
+    override suspend fun asRoleOrNull(): Role = this
+
     /**
      * The tags of this role, if present.
      */

--- a/core/src/main/kotlin/entity/StageInstance.kt
+++ b/core/src/main/kotlin/entity/StageInstance.kt
@@ -7,7 +7,8 @@ import dev.kord.core.cache.data.StageInstanceData
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 
-class StageInstance(val data: StageInstanceData, override val kord: Kord, override val supplier: EntitySupplier) : StageInstanceBehavior {
+class StageInstance(val data: StageInstanceData, override val kord: Kord, override val supplier: EntitySupplier) :
+    StageInstanceBehavior {
     override val id: Snowflake get() = data.id
     val guildId: Snowflake get() = data.guildId
     override val channelId: Snowflake get() = data.channelId
@@ -16,4 +17,7 @@ class StageInstance(val data: StageInstanceData, override val kord: Kord, overri
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): StageInstanceBehavior =
         StageInstance(data, kord, strategy.supply(kord))
 
+    override suspend fun asStageInstance(): StageInstance = this
+
+    override suspend fun asStageInstanceOrNull(): StageInstance = this
 }

--- a/core/src/main/kotlin/entity/User.kt
+++ b/core/src/main/kotlin/entity/User.kt
@@ -43,6 +43,14 @@ open class User(
     @DeprecatedSinceKord("0.7.0")
     val flags: UserFlags? by ::publicFlags
 
+    override suspend fun asUser(): User {
+        return this
+    }
+
+    override suspend fun asUserOrNull(): User {
+        return this
+    }
+
     /**
      * The flags on a user's account, if present.
      */

--- a/core/src/main/kotlin/entity/channel/Category.kt
+++ b/core/src/main/kotlin/entity/channel/Category.kt
@@ -28,6 +28,8 @@ class Category(
 
     override suspend fun asChannel(): Category = this
 
+    override suspend fun asChannelOrNull(): Category = this
+
     override fun compareTo(other: Entity): Int {
         return super<TopGuildChannel>.compareTo(other)
     }

--- a/core/src/main/kotlin/entity/channel/DmChannel.kt
+++ b/core/src/main/kotlin/entity/channel/DmChannel.kt
@@ -49,6 +49,10 @@ data class DmChannel(
             .map { supplier.getUserOrNull(it) }
             .filterNotNull()
 
+    override suspend fun asChannel(): MessageChannel = this
+
+    override suspend fun asChannelOrNull(): MessageChannel = this
+
     /**
      * returns a new [DmChannel] with the given [strategy].
      */

--- a/core/src/main/kotlin/entity/channel/NewsChannel.kt
+++ b/core/src/main/kotlin/entity/channel/NewsChannel.kt
@@ -18,8 +18,6 @@ class NewsChannel(
     override val supplier: EntitySupplier = kord.defaultSupplier
 ) : CategorizableChannel, TopGuildMessageChannel, ThreadParentChannel,  NewsChannelBehavior {
 
-    override suspend fun asChannel(): NewsChannel = this
-
     override fun hashCode(): Int = Objects.hash(id, guildId)
 
     override fun equals(other: Any?): Boolean = when (other) {
@@ -27,6 +25,10 @@ class NewsChannel(
         is ChannelBehavior -> other.id == id
         else -> false
     }
+
+    override suspend fun asChannel(): NewsChannel = this
+
+    override suspend fun asChannelOrNull(): NewsChannel = this
 
     /**
      * Returns a new [NewsChannel] with the given [strategy].

--- a/core/src/main/kotlin/entity/channel/ResolvedChannel.kt
+++ b/core/src/main/kotlin/entity/channel/ResolvedChannel.kt
@@ -1,6 +1,5 @@
 package dev.kord.core.entity.channel
 
-import dev.kord.common.annotation.KordPreview
 import dev.kord.common.entity.Permissions
 import dev.kord.core.Kord
 import dev.kord.core.cache.data.ChannelData
@@ -18,6 +17,10 @@ class ResolvedChannel(
     val name: String get() = data.name.value!!
 
     val permissions: Permissions get() = data.permissions.value!!
+
+    override suspend fun asChannel(): Channel = this
+
+    override suspend fun asChannelOrNull(): Channel = this
 
     override val supplier: EntitySupplier
         get() = strategy.supply(kord)

--- a/core/src/main/kotlin/entity/channel/StageVoiceChannel.kt
+++ b/core/src/main/kotlin/entity/channel/StageVoiceChannel.kt
@@ -5,7 +5,6 @@ import dev.kord.common.entity.optional.getOrThrow
 import dev.kord.core.Kord
 import dev.kord.core.behavior.channel.ChannelBehavior
 import dev.kord.core.behavior.channel.GuildChannelBehavior
-import dev.kord.core.behavior.channel.TopGuildChannelBehavior
 import dev.kord.core.behavior.channel.StageChannelBehavior
 import dev.kord.core.cache.data.ChannelData
 import dev.kord.core.exception.GatewayNotFoundException
@@ -44,6 +43,8 @@ class StageChannel(
         StageChannel(data, kord, strategy.supply(kord))
 
     override suspend fun asChannel(): StageChannel = this
+
+    override suspend fun asChannelOrNull(): StageChannel = this
 
     override fun hashCode(): Int = Objects.hash(id, guildId)
 

--- a/core/src/main/kotlin/entity/channel/StoreChannel.kt
+++ b/core/src/main/kotlin/entity/channel/StoreChannel.kt
@@ -22,6 +22,8 @@ data class StoreChannel(
 
     override suspend fun asChannel(): StoreChannel = this
 
+    override suspend fun asChannelOrNull(): StoreChannel = this
+
     /**
      * Returns a new [StoreChannel] with the given [strategy].
      */

--- a/core/src/main/kotlin/entity/channel/TextChannel.kt
+++ b/core/src/main/kotlin/entity/channel/TextChannel.kt
@@ -38,6 +38,10 @@ class TextChannel(
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): TextChannel =
         TextChannel(data, kord, strategy.supply(kord))
 
+    override suspend fun asChannel(): TextChannel = this
+
+    override suspend fun asChannelOrNull(): TextChannel = this
+
     override fun hashCode(): Int = Objects.hash(id, guildId)
 
     override fun equals(other: Any?): Boolean = when (other) {

--- a/core/src/main/kotlin/entity/channel/VoiceChannel.kt
+++ b/core/src/main/kotlin/entity/channel/VoiceChannel.kt
@@ -44,6 +44,8 @@ class VoiceChannel(
         VoiceChannel(data, kord, strategy.supply(kord))
 
     override suspend fun asChannel(): VoiceChannel = this
+    
+    override suspend fun asChannelOrNull(): VoiceChannel = this
 
     override fun hashCode(): Int = Objects.hash(id, guildId)
 

--- a/core/src/main/kotlin/entity/channel/thread/NewsChannelThread.kt
+++ b/core/src/main/kotlin/entity/channel/thread/NewsChannelThread.kt
@@ -19,9 +19,9 @@ class NewsChannelThread(
 ) : ThreadChannel {
 
 
-    override suspend fun asChannel(): NewsChannelThread = super.asChannel() as NewsChannelThread
+    override suspend fun asChannel(): NewsChannelThread = this
 
-    override suspend fun asChannelOrNull(): NewsChannelThread? = super.asChannelOrNull() as? NewsChannelThread
+    override suspend fun asChannelOrNull(): NewsChannelThread? = this
 
 
     override suspend fun getParent(): NewsChannel {

--- a/core/src/main/kotlin/entity/channel/thread/TextChannelThread.kt
+++ b/core/src/main/kotlin/entity/channel/thread/TextChannelThread.kt
@@ -34,9 +34,9 @@ class TextChannelThread(
     override val guildId: Snowflake
         get() = data.guildId.value!!
 
-    override suspend fun asChannel(): TextChannelThread = super.asChannel() as TextChannelThread
+    override suspend fun asChannel(): TextChannelThread = this
 
-    override suspend fun asChannelOrNull(): TextChannelThread? = super.asChannelOrNull() as? TextChannelThread
+    override suspend fun asChannelOrNull(): TextChannelThread = this
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): TextChannelThread {
         return TextChannelThread(data, kord, strategy.supply(kord))


### PR DESCRIPTION
Kord entities inherit from their Behaviours, so to keep generic in some places you use a behaviour.

When calling as{Entity} on a Behaviour, I'd expect it to return itself when it's already an entity, but it's doing a cache-lookup instead.

This PR fixes that and returns the Entity in case the Behaviour is an Entity already.