### PR TITLE
Small fix on TopGuildChannel 

### DIFF
--- a/core/src/main/kotlin/entity/channel/TopGuildChannel.kt
+++ b/core/src/main/kotlin/entity/channel/TopGuildChannel.kt
@@ -61,7 +61,7 @@ interface TopGuildChannel : GuildChannel, TopGuildChannelBehavior {
                 +it.allowed
                 -it.denied
             }
-            roleOverwrites.map {
+            roleOverwrites.forEach {
                 +it.allowed
                 -it.denied
             }


### PR DESCRIPTION
Effective permissions calculation uses a map, but should effectivly use a loop.