### PR TITLE
Serialize NumberChoice as a Double, not as a String

### DIFF
--- a/common/src/main/kotlin/entity/Interactions.kt
+++ b/common/src/main/kotlin/entity/Interactions.kt
@@ -169,6 +169,7 @@ sealed class Choice<out T> {
             encoder.encodeStructure(descriptor) {
                 encodeStringElement(descriptor, 0, value.name)
                 if (value is IntChoice) encodeIntElement(descriptor, 1, value.value)
+                if (value is NumberChoice) encodeDoubleElement(descriptor, 1, value.value)
                 else encodeStringElement(descriptor, 1, value.value.toString())
             }
         }

--- a/common/src/main/kotlin/entity/Interactions.kt
+++ b/common/src/main/kotlin/entity/Interactions.kt
@@ -168,9 +168,11 @@ sealed class Choice<out T> {
         override fun serialize(encoder: Encoder, value: Choice<*>) {
             encoder.encodeStructure(descriptor) {
                 encodeStringElement(descriptor, 0, value.name)
-                if (value is IntChoice) encodeIntElement(descriptor, 1, value.value)
-                if (value is NumberChoice) encodeDoubleElement(descriptor, 1, value.value)
-                else encodeStringElement(descriptor, 1, value.value.toString())
+                when (value) {
+                    is IntChoice -> encodeIntElement(descriptor, 1, value.value)
+                    is NumberChoice -> encodeDoubleElement(descriptor, 1, value.value)
+                    else -> encodeStringElement(descriptor, 1, value.value.toString())
+                }
             }
         }
     }


### PR DESCRIPTION
The option generated by Kord
```json
{"type":10,"name":"squish","description":"How much squishness you want in your pet?","required":false,"choices":[{"name":"Am I petting a rock?","value":"0.0"},{"name":"Kinda hard... but it is a bit squishy!","value":"0.25"},{"name":"Normal squishness","value":"0.875"},{"name":"Very squishy","value":"1.5"},{"name":"Pat him so he can feel it","value":"3.0"}]}
```
Discord's response:
```json
{"21":{"options":{"1":{"choices":{"0":{"value":{"_errors":[{"code":"APPLICATION_COMMAND_CHOICES_VALUE_INVALID","message":"Choice values must be of type \"number\""}]}},"1":{"value":{"_errors":[{"code":"APPLICATION_COMMAND_CHOICES_VALUE_INVALID","message":"Choice values must be of type \"number\""}]}},"2":{"value":{"_errors":[{"code":"APPLICATION_COMMAND_CHOICES_VALUE_INVALID","message":"Choice values must be of type \"number\""}]}},"3":{"value":{"_errors":[{"code":"APPLICATION_COMMAND_CHOICES_VALUE_INVALID","message":"Choice values must be of type \"number\""}]}},"4":{"value":{"_errors":[{"code":"APPLICATION_COMMAND_CHOICES_VALUE_INVALID","message":"Choice values must be of type \"number\""}]}}}}}}}
```

![image](https://user-images.githubusercontent.com/9496359/135630374-d6a4d410-e088-478b-a7d6-035bc1d3a1c1.png)
