### PR TITLE
Update embed description limit

### DIFF
--- a/rest/src/main/kotlin/builder/message/EmbedBuilder.kt
+++ b/rest/src/main/kotlin/builder/message/EmbedBuilder.kt
@@ -286,7 +286,7 @@ class EmbedBuilder : RequestBuilder<EmbedRequest> {
         /**
          * The maximum length of the [EmbedBuilder.description] field.
          */
-        const val description = 2048
+        const val description = 4096
 
         /**
          * The maximum amount of [EmbedBuilder.Field] in an [EmbedBuilder].


### PR DESCRIPTION
The limit was raised back in July after the message limit for Nitro users was raised.

Docs Source:
https://discord.com/developers/docs/resources/channel#embed-limits-limits