### PR TITLE
Implement all supported Encryption Modes

### DIFF
--- a/voice/src/main/kotlin/VoiceConnection.kt
+++ b/voice/src/main/kotlin/VoiceConnection.kt
@@ -4,6 +4,7 @@ import dev.kord.common.annotation.KordVoice
 import dev.kord.common.entity.Snowflake
 import dev.kord.gateway.Gateway
 import dev.kord.gateway.UpdateVoiceStatus
+import dev.kord.voice.encryption.strategies.NonceStrategy
 import dev.kord.voice.gateway.VoiceGateway
 import dev.kord.voice.gateway.VoiceGatewayConfiguration
 import dev.kord.voice.handlers.StreamsHandler
@@ -40,6 +41,8 @@ data class VoiceConnectionData(
  * @param data the data representing this [VoiceConnection].
  * @param voiceGatewayConfiguration the configuration used on each new [connect] for the [voiceGateway].
  * @param audioProvider a [AudioProvider] that will provide [AudioFrame] when required.
+ * @param frameSender the [AudioFrameSender] that will handle the sending of audio packets.
+ * @param nonceStrategy the [NonceStrategy] that is used during encryption of audio.
  * @param frameInterceptorFactory a factory for [FrameInterceptor]s that is used whenever audio is ready to be sent. See [FrameInterceptor] and [DefaultFrameInterceptor].
  */
 @KordVoice
@@ -52,6 +55,7 @@ class VoiceConnection(
     val streams: Streams,
     val audioProvider: AudioProvider,
     val frameSender: AudioFrameSender,
+    val nonceStrategy: NonceStrategy,
     val frameInterceptorFactory: (FrameInterceptorContext) -> FrameInterceptor,
 ) {
     val scope: CoroutineScope =

--- a/voice/src/main/kotlin/VoiceConnectionBuilder.kt
+++ b/voice/src/main/kotlin/VoiceConnectionBuilder.kt
@@ -8,6 +8,8 @@ import dev.kord.gateway.Gateway
 import dev.kord.gateway.UpdateVoiceStatus
 import dev.kord.gateway.VoiceServerUpdate
 import dev.kord.gateway.VoiceStateUpdate
+import dev.kord.voice.encryption.strategies.LiteNonceStrategy
+import dev.kord.voice.encryption.strategies.NonceStrategy
 import dev.kord.voice.exception.VoiceConnectionInitializationException
 import dev.kord.voice.gateway.DefaultVoiceGatewayBuilder
 import dev.kord.voice.gateway.VoiceGateway
@@ -45,6 +47,12 @@ class VoiceConnectionBuilder(
      * will be used.
      */
     var audioSender: AudioFrameSender? = null
+
+    /**
+     * The nonce strategy to be used for the encryption of audio packets.
+     * If `null`, [dev.kord.voice.encryption.strategies.LiteNonceStrategy] will be used.
+     */
+    var nonceStrategy: NonceStrategy? = null
 
     fun audioProvider(provider: AudioProvider) {
         this.audioProvider = provider
@@ -154,9 +162,10 @@ class VoiceConnectionBuilder(
         val audioProvider = audioProvider ?: EmptyAudioPlayerProvider
         val audioSender =
             audioSender ?: DefaultAudioFrameSender(DefaultAudioFrameSenderData(udpSocket))
+        val nonceStrategy = nonceStrategy ?: LiteNonceStrategy()
         val frameInterceptorFactory = frameInterceptorFactory ?: { DefaultFrameInterceptor(it) }
         val streams =
-            streams ?: if (receiveVoice) DefaultStreams(voiceGateway, udpSocket) else NOPStreams
+            streams ?: if (receiveVoice) DefaultStreams(voiceGateway, udpSocket, nonceStrategy) else NOPStreams
 
         return VoiceConnection(
             voiceConnectionData,
@@ -167,6 +176,7 @@ class VoiceConnectionBuilder(
             streams,
             audioProvider,
             audioSender,
+            nonceStrategy,
             frameInterceptorFactory,
         )
     }

--- a/voice/src/main/kotlin/encryption/XSalsa20Poly1305Encryption.kt
+++ b/voice/src/main/kotlin/encryption/XSalsa20Poly1305Encryption.kt
@@ -23,9 +23,6 @@ internal class XSalsa20Poly1305Encryption(private val key: ByteArray) {
 
             output.writeByteArray(c, boxzerobytesLength, messageBufferLength - boxzerobytesLength)
 
-            // TODO: implement a nonce strategy
-            output.writeByteArray(nonce, length = 4)
-
             return true
         }
 

--- a/voice/src/main/kotlin/encryption/strategies/LiteNonceStrategy.kt
+++ b/voice/src/main/kotlin/encryption/strategies/LiteNonceStrategy.kt
@@ -1,0 +1,36 @@
+package dev.kord.voice.encryption.strategies
+
+import dev.kord.voice.io.ByteArrayView
+import dev.kord.voice.io.MutableByteArrayCursor
+import dev.kord.voice.io.mutableCursor
+import dev.kord.voice.io.view
+import dev.kord.voice.udp.RTPPacket
+import kotlinx.atomicfu.atomic
+
+class LiteNonceStrategy : NonceStrategy {
+    override val nonceLength: Int = 4
+
+    private var count: Int by atomic(0)
+    private val nonceBuffer: ByteArray = ByteArray(4)
+    private val nonceView = nonceBuffer.view()
+    private val nonceCursor = nonceBuffer.mutableCursor()
+
+    override fun strip(packet: RTPPacket): ByteArrayView {
+        return with(packet.payload) {
+            val nonce = view(dataEnd - 4, dataEnd)!!
+            resize(dataStart, dataEnd - 4)
+            nonce
+        }
+    }
+
+    override fun generate(header: () -> ByteArrayView): ByteArrayView {
+        count++
+        nonceCursor.reset()
+        nonceCursor.writeInt(count)
+        return nonceView
+    }
+
+    override fun append(nonce: ByteArrayView, cursor: MutableByteArrayCursor) {
+        cursor.writeByteView(nonce)
+    }
+}

--- a/voice/src/main/kotlin/encryption/strategies/NonceStrategy.kt
+++ b/voice/src/main/kotlin/encryption/strategies/NonceStrategy.kt
@@ -1,0 +1,30 @@
+package dev.kord.voice.encryption.strategies
+
+import dev.kord.voice.io.ByteArrayView
+import dev.kord.voice.io.MutableByteArrayCursor
+import dev.kord.voice.udp.RTPPacket
+
+/**
+ * An [encryption mode, regarding the nonce](https://discord.com/developers/docs/topics/voice-connections#establishing-a-voice-udp-connection-encryption-modes), supported by Discord.
+ */
+sealed interface NonceStrategy {
+    /**
+     * The amount of bytes this nonce will take up.
+     */
+    val nonceLength: Int
+
+    /**
+     * Reads the nonce from this [packet] (also removes it if it resides in the payload), and returns a [ByteArrayView] of it.
+     */
+    fun strip(packet: RTPPacket): ByteArrayView
+
+    /**
+     * Generates a nonce, may use the provided information.
+     */
+    fun generate(header: () -> ByteArrayView): ByteArrayView
+
+    /**
+     * Writes the [nonce] to [cursor] in the correct relative position.
+     */
+    fun append(nonce: ByteArrayView, cursor: MutableByteArrayCursor)
+}

--- a/voice/src/main/kotlin/encryption/strategies/NormalNonceStrategy.kt
+++ b/voice/src/main/kotlin/encryption/strategies/NormalNonceStrategy.kt
@@ -1,0 +1,31 @@
+package dev.kord.voice.encryption.strategies
+
+import dev.kord.voice.io.ByteArrayView
+import dev.kord.voice.io.MutableByteArrayCursor
+import dev.kord.voice.io.mutableCursor
+import dev.kord.voice.io.view
+import dev.kord.voice.udp.RTPPacket
+import dev.kord.voice.udp.RTP_HEADER_LENGTH
+
+class NormalNonceStrategy : NonceStrategy {
+    // the nonce is already a part of the rtp header, which means this will take up no extra space.
+    override val nonceLength: Int = 0
+
+    private val rtpHeaderBuffer = ByteArray(RTP_HEADER_LENGTH)
+    private val rtpHeaderCursor = rtpHeaderBuffer.mutableCursor()
+    private val rtpHeaderView = rtpHeaderBuffer.view()
+
+    override fun strip(packet: RTPPacket): ByteArrayView {
+        rtpHeaderCursor.reset()
+        packet.writeHeader(rtpHeaderCursor)
+        return rtpHeaderView
+    }
+
+    override fun generate(header: () -> ByteArrayView): ByteArrayView {
+        return header()
+    }
+
+    override fun append(nonce: ByteArrayView, cursor: MutableByteArrayCursor) {
+        /* the nonce is the rtp header which means this should do nothing */
+    }
+}

--- a/voice/src/main/kotlin/encryption/strategies/SuffixNonceStrategy.kt
+++ b/voice/src/main/kotlin/encryption/strategies/SuffixNonceStrategy.kt
@@ -1,0 +1,33 @@
+package dev.kord.voice.encryption.strategies
+
+import dev.kord.voice.io.ByteArrayView
+import dev.kord.voice.io.MutableByteArrayCursor
+import dev.kord.voice.io.view
+import dev.kord.voice.udp.RTPPacket
+import kotlin.random.Random
+
+private const val SUFFIX_NONCE_LENGTH = 24
+
+class SuffixNonceStrategy : NonceStrategy {
+    override val nonceLength: Int = SUFFIX_NONCE_LENGTH
+
+    private val nonceBuffer: ByteArray = ByteArray(SUFFIX_NONCE_LENGTH)
+    private val nonceView = nonceBuffer.view()
+
+    override fun strip(packet: RTPPacket): ByteArrayView {
+        return with(packet.payload) {
+            val nonce = view(dataEnd - SUFFIX_NONCE_LENGTH, dataEnd)!!
+            resize(dataStart, dataEnd - SUFFIX_NONCE_LENGTH)
+            nonce
+        }
+    }
+
+    override fun generate(header: () -> ByteArrayView): ByteArrayView {
+        Random.Default.nextBytes(nonceBuffer)
+        return nonceView
+    }
+
+    override fun append(nonce: ByteArrayView, cursor: MutableByteArrayCursor) {
+        cursor.writeByteView(nonce)
+    }
+}

--- a/voice/src/main/kotlin/udp/AudioFrameSender.kt
+++ b/voice/src/main/kotlin/udp/AudioFrameSender.kt
@@ -7,6 +7,7 @@ import dev.kord.voice.AudioProvider
 import dev.kord.voice.FrameInterceptor
 import dev.kord.voice.FrameInterceptorContext
 import dev.kord.voice.FrameInterceptorContextBuilder
+import dev.kord.voice.encryption.strategies.NonceStrategy
 import io.ktor.util.network.*
 
 @KordVoice
@@ -14,6 +15,7 @@ data class AudioFrameSenderConfiguration(
     val server: NetworkAddress,
     val ssrc: UInt,
     val key: ByteArray,
+    val nonceStrategy: NonceStrategy,
     val provider: AudioProvider,
     val baseFrameInterceptorContext: FrameInterceptorContextBuilder,
     val interceptorFactory: (FrameInterceptorContext) -> FrameInterceptor

--- a/voice/src/main/kotlin/udp/DefaultAudioFrameSender.kt
+++ b/voice/src/main/kotlin/udp/DefaultAudioFrameSender.kt
@@ -33,7 +33,7 @@ class DefaultAudioFrameSender(
         val interceptor: FrameInterceptor = createFrameInterceptor(configuration)
         var sequence: UShort = Random.nextBits(UShort.SIZE_BITS).toUShort()
 
-        val packetProvider = DefaultAudioPackerProvider(configuration.key)
+        val packetProvider = DefaultAudioPackerProvider(configuration.key, configuration.nonceStrategy)
 
         val frames = Channel<AudioFrame?>(Channel.RENDEZVOUS)
         with(configuration.provider) { launch { provideFrames(frames) } }


### PR DESCRIPTION
This PR adds the ability for the user to choose one of the [supported encryption modes](https://discord.com/developers/docs/topics/voice-connections#establishing-a-voice-udp-connection-encryption-modes). These are implemented as `NonceStrategy`s, and can be set in the `VoiceConnectionBuilder`.