### PR TITLE
voice connect use behavior over entity

### DIFF
--- a/core/src/main/kotlin/behavior/channel/BaseVoiceChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/BaseVoiceChannelBehavior.kt
@@ -39,7 +39,7 @@ public interface BaseVoiceChannelBehavior : TopGuildChannelBehavior {
     @KordVoice
     public suspend fun connect(builder: VoiceConnectionBuilder.() -> Unit): VoiceConnection {
         val voiceConnection = VoiceConnection(
-            getGuild().gateway ?: GatewayNotFoundException.voiceConnectionGatewayNotFound(guildId),
+            guild.gateway ?: GatewayNotFoundException.voiceConnectionGatewayNotFound(guildId),
             kord.selfId,
             id,
             guildId,


### PR DESCRIPTION
In the current connect method, it uses the supplier to return a guild entity, when a guild behavior is just fine.

depends on #425 