### PR TITLE
Added old channel on ChannelUpdateEvent

### DIFF
--- a/core/src/main/kotlin/event/channel/ChannelUpdateEvent.kt
+++ b/core/src/main/kotlin/event/channel/ChannelUpdateEvent.kt
@@ -17,81 +17,89 @@ public interface ChannelUpdateEvent : Event {
 
 public class CategoryUpdateEvent(
     override val channel: Category,
+    public val old: Category?,
     override val shard: Int,
     public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
 ) : ChannelUpdateEvent, CoroutineScope by coroutineScope {
     override fun toString(): String {
-        return "CategoryUpdateEvent(channel=$channel, shard=$shard)"
+        return "CategoryUpdateEvent(channel=$channel, old=$old, shard=$shard)"
     }
 }
 
 public class DMChannelUpdateEvent(
     override val channel: DmChannel,
+    public val old: DmChannel?,
     override val shard: Int,
     public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
 ) : ChannelUpdateEvent, CoroutineScope by coroutineScope {
     override fun toString(): String {
-        return "DMChannelUpdateEvent(channel=$channel, shard=$shard)"
+        return "DMChannelUpdateEvent(channel=$channel, old=$old, shard=$shard)"
     }
 }
 
 public class NewsChannelUpdateEvent(
     override val channel: NewsChannel,
+    public val old: NewsChannel?,
     override val shard: Int,
     public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
 ) : ChannelUpdateEvent, CoroutineScope by coroutineScope {
     override fun toString(): String {
-        return "NewsChannelUpdateEvent(channel=$channel, shard=$shard)"
+        return "NewsChannelUpdateEvent(channel=$channel, old=$old, shard=$shard)"
     }
 }
 
 public class StoreChannelUpdateEvent(
     override val channel: StoreChannel,
+    public val old: StoreChannel?,
     override val shard: Int,
     public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
 ) : ChannelUpdateEvent, CoroutineScope by coroutineScope {
     override fun toString(): String {
-        return "StoreChannelUpdateEvent(channel=$channel, shard=$shard)"
+        return "StoreChannelUpdateEvent(channel=$channel, old=$old, shard=$shard)"
     }
 }
 
 public class TextChannelUpdateEvent(
     override val channel: TextChannel,
+    public val old: TextChannel?,
     override val shard: Int,
     public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
 ) : ChannelUpdateEvent, CoroutineScope by coroutineScope {
     override fun toString(): String {
-        return "TextChannelUpdateEvent(channel=$channel, shard=$shard)"
+        return "TextChannelUpdateEvent(channel=$channel, old=$old, shard=$shard)"
     }
 }
 
 public class VoiceChannelUpdateEvent(
     override val channel: VoiceChannel,
+    public val old: VoiceChannel?,
     override val shard: Int,
     public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
 ) : ChannelUpdateEvent, CoroutineScope by coroutineScope{
     override fun toString(): String {
-        return "VoiceChannelUpdateEvent(channel=$channel, shard=$shard)"
+        return "VoiceChannelUpdateEvent(channel=$channel, old=$old, shard=$shard)"
     }
 }
 
 
 public class StageChannelUpdateEvent(
     override val channel: StageChannel,
+    public val old: StageChannel?,
     override val shard: Int,
     public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
 ) : ChannelUpdateEvent, CoroutineScope by coroutineScope {
     override fun toString(): String {
-        return "StageChannelUpdateEvent(channel=$channel, shard=$shard)"
+        return "StageChannelUpdateEvent(channel=$channel, old=$old, shard=$shard)"
     }
 }
 
 public class UnknownChannelUpdateEvent(
     override val channel: Channel,
+    public val old: Channel?,
     override val shard: Int,
     public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
 ) : ChannelUpdateEvent, CoroutineScope by coroutineScope {
     override fun toString(): String {
-        return "UnknownChannelUpdateEvent(channel=$channel, shard=$shard)"
+        return "UnknownChannelUpdateEvent(channel=$channel, old=$old, shard=$shard)"
     }
 }

--- a/core/src/main/kotlin/gateway/handler/ChannelEventHandler.kt
+++ b/core/src/main/kotlin/gateway/handler/ChannelEventHandler.kt
@@ -15,6 +15,8 @@ import dev.kord.core.event.channel.data.ChannelPinsUpdateEventData
 import dev.kord.core.event.channel.data.TypingStartEventData
 import dev.kord.gateway.*
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.singleOrNull
 import kotlin.coroutines.CoroutineContext
 import dev.kord.core.event.Event as CoreEvent
 
@@ -59,20 +61,26 @@ internal class ChannelEventHandler(
 
     private suspend fun handle(event: ChannelUpdate, shard: Int, kord: Kord, coroutineScope: CoroutineScope): CoreEvent? {
         val data = ChannelData.from(event.channel)
-        cache.put(data)
+
+        val query = cache.query<ChannelData> {
+            idEq(ChannelData::id, event.channel.id)
+        }
+        val old = query.asFlow().map { Channel.from(it, kord) }.singleOrNull()
 
         val coreEvent = when (val channel = Channel.from(data, kord)) {
-            is NewsChannel -> NewsChannelUpdateEvent(channel, shard, coroutineScope)
-            is StoreChannel -> StoreChannelUpdateEvent(channel, shard, coroutineScope)
-            is DmChannel -> DMChannelUpdateEvent(channel, shard, coroutineScope)
-            is TextChannel -> TextChannelUpdateEvent(channel, shard, coroutineScope)
-            is StageChannel -> StageChannelUpdateEvent(channel, shard, coroutineScope)
-            is VoiceChannel -> VoiceChannelUpdateEvent(channel, shard, coroutineScope)
-            is Category -> CategoryUpdateEvent(channel, shard, coroutineScope)
+            is NewsChannel -> NewsChannelUpdateEvent(channel, old as NewsChannel, shard, coroutineScope)
+            is StoreChannel -> StoreChannelUpdateEvent(channel, old as StoreChannel, shard, coroutineScope)
+            is DmChannel -> DMChannelUpdateEvent(channel, old as DmChannel, shard, coroutineScope)
+            is TextChannel -> TextChannelUpdateEvent(channel, old as TextChannel, shard, coroutineScope)
+            is StageChannel -> StageChannelUpdateEvent(channel, old as StageChannel, shard, coroutineScope)
+            is VoiceChannel -> VoiceChannelUpdateEvent(channel, old as VoiceChannel, shard, coroutineScope)
+            is Category -> CategoryUpdateEvent(channel, old as Category, shard, coroutineScope)
             is ThreadChannel -> return null
-            else -> UnknownChannelUpdateEvent(channel, shard, coroutineScope)
+            else -> UnknownChannelUpdateEvent(channel, old, shard, coroutineScope)
 
         }
+
+        cache.put(data)
 
         return coreEvent
     }


### PR DESCRIPTION
Refers to the https://github.com/kordlib/kord/issues/436, I don't know if there should be an "old" property in RoleUpdateEvent, the only way not to be null (from what I've seen) is by using cachingRest