### PR TITLE
Old properties for Update events

### DIFF
--- a/core/src/main/kotlin/entity/channel/thread/ThreadChannel.kt
+++ b/core/src/main/kotlin/entity/channel/thread/ThreadChannel.kt
@@ -108,7 +108,7 @@ public interface ThreadChannel : GuildMessageChannel, ThreadChannelBehavior {
 
 }
 
-internal fun ThreadChannel(data: ChannelData, kord: Kord, supplier: EntitySupplier): ThreadChannel {
+internal fun ThreadChannel(data: ChannelData, kord: Kord, supplier: EntitySupplier = kord.defaultSupplier): ThreadChannel {
     return object : ThreadChannel {
 
         override val data: ChannelData

--- a/core/src/main/kotlin/event/channel/ChannelDeleteEvent.kt
+++ b/core/src/main/kotlin/event/channel/ChannelDeleteEvent.kt
@@ -95,7 +95,7 @@ public class UnknownChannelDeleteEvent(
     override val shard: Int,
     public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
 
-) : ChannelCreateEvent, CoroutineScope by coroutineScope {
+) : ChannelDeleteEvent, CoroutineScope by coroutineScope {
     override fun toString(): String {
         return "UnknownChannelDeleteEvent(channel=$channel, shard=$shard)"
     }

--- a/core/src/main/kotlin/event/channel/ChannelUpdateEvent.kt
+++ b/core/src/main/kotlin/event/channel/ChannelUpdateEvent.kt
@@ -9,7 +9,7 @@ import dev.kord.core.event.kordCoroutineScope
 import kotlinx.coroutines.CoroutineScope
 import kotlin.coroutines.CoroutineContext
 
-//TODO("Update the toString representation")
+
 public interface ChannelUpdateEvent : Event {
     public val channel: Channel
     public val old: Channel?
@@ -24,7 +24,7 @@ public class CategoryUpdateEvent(
     public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
 ) : ChannelUpdateEvent, CoroutineScope by coroutineScope {
     override fun toString(): String {
-        return "CategoryUpdateEvent(channel=$channel, shard=$shard)"
+        return "CategoryUpdateEvent(channel=$channel, old=$old, shard=$shard)"
     }
 }
 
@@ -35,7 +35,7 @@ public class DMChannelUpdateEvent(
     public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
 ) : ChannelUpdateEvent, CoroutineScope by coroutineScope {
     override fun toString(): String {
-        return "DMChannelUpdateEvent(channel=$channel, shard=$shard)"
+        return "DMChannelUpdateEvent(channel=$channel, old=$old, shard=$shard)"
     }
 }
 
@@ -46,7 +46,7 @@ public class NewsChannelUpdateEvent(
     public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
 ) : ChannelUpdateEvent, CoroutineScope by coroutineScope {
     override fun toString(): String {
-        return "NewsChannelUpdateEvent(channel=$channel, shard=$shard)"
+        return "NewsChannelUpdateEvent(channel=$channel, old=$old, shard=$shard)"
     }
 }
 
@@ -57,7 +57,7 @@ public class StoreChannelUpdateEvent(
     public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
 ) : ChannelUpdateEvent, CoroutineScope by coroutineScope {
     override fun toString(): String {
-        return "StoreChannelUpdateEvent(channel=$channel, shard=$shard)"
+        return "StoreChannelUpdateEvent(channel=$channel, old=$old, shard=$shard)"
     }
 }
 
@@ -68,7 +68,7 @@ public class TextChannelUpdateEvent(
     public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
 ) : ChannelUpdateEvent, CoroutineScope by coroutineScope {
     override fun toString(): String {
-        return "TextChannelUpdateEvent(channel=$channel, shard=$shard)"
+        return "TextChannelUpdateEvent(channel=$channel, old=$old, shard=$shard)"
     }
 }
 
@@ -79,7 +79,7 @@ public class VoiceChannelUpdateEvent(
     public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
 ) : ChannelUpdateEvent, CoroutineScope by coroutineScope{
     override fun toString(): String {
-        return "VoiceChannelUpdateEvent(channel=$channel, shard=$shard)"
+        return "VoiceChannelUpdateEvent(channel=$channel, old=$old, shard=$shard)"
     }
 }
 
@@ -91,7 +91,7 @@ public class StageChannelUpdateEvent(
     public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
 ) : ChannelUpdateEvent, CoroutineScope by coroutineScope {
     override fun toString(): String {
-        return "StageChannelUpdateEvent(channel=$channel, shard=$shard)"
+        return "StageChannelUpdateEvent(channel=$channel, old=$old, shard=$shard)"
     }
 }
 
@@ -102,6 +102,6 @@ public class UnknownChannelUpdateEvent(
     public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
 ) : ChannelUpdateEvent, CoroutineScope by coroutineScope {
     override fun toString(): String {
-        return "UnknownChannelUpdateEvent(channel=$channel, shard=$shard)"
+        return "UnknownChannelUpdateEvent(channel=$channel, old=$old, shard=$shard)"
     }
 }

--- a/core/src/main/kotlin/event/channel/ChannelUpdateEvent.kt
+++ b/core/src/main/kotlin/event/channel/ChannelUpdateEvent.kt
@@ -9,14 +9,17 @@ import dev.kord.core.event.kordCoroutineScope
 import kotlinx.coroutines.CoroutineScope
 import kotlin.coroutines.CoroutineContext
 
+//TODO("Update the toString representation")
 public interface ChannelUpdateEvent : Event {
     public val channel: Channel
+    public val old: Channel?
     override val kord: Kord
         get() = channel.kord
 }
 
 public class CategoryUpdateEvent(
     override val channel: Category,
+    override val old: Category?,
     override val shard: Int,
     public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
 ) : ChannelUpdateEvent, CoroutineScope by coroutineScope {
@@ -27,6 +30,7 @@ public class CategoryUpdateEvent(
 
 public class DMChannelUpdateEvent(
     override val channel: DmChannel,
+    override val old: DmChannel?,
     override val shard: Int,
     public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
 ) : ChannelUpdateEvent, CoroutineScope by coroutineScope {
@@ -37,6 +41,7 @@ public class DMChannelUpdateEvent(
 
 public class NewsChannelUpdateEvent(
     override val channel: NewsChannel,
+    override val old: NewsChannel?,
     override val shard: Int,
     public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
 ) : ChannelUpdateEvent, CoroutineScope by coroutineScope {
@@ -47,6 +52,7 @@ public class NewsChannelUpdateEvent(
 
 public class StoreChannelUpdateEvent(
     override val channel: StoreChannel,
+    override val old: StoreChannel?,
     override val shard: Int,
     public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
 ) : ChannelUpdateEvent, CoroutineScope by coroutineScope {
@@ -57,6 +63,7 @@ public class StoreChannelUpdateEvent(
 
 public class TextChannelUpdateEvent(
     override val channel: TextChannel,
+    override val old: TextChannel?,
     override val shard: Int,
     public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
 ) : ChannelUpdateEvent, CoroutineScope by coroutineScope {
@@ -67,6 +74,7 @@ public class TextChannelUpdateEvent(
 
 public class VoiceChannelUpdateEvent(
     override val channel: VoiceChannel,
+    override val old: VoiceChannel?,
     override val shard: Int,
     public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
 ) : ChannelUpdateEvent, CoroutineScope by coroutineScope{
@@ -78,6 +86,7 @@ public class VoiceChannelUpdateEvent(
 
 public class StageChannelUpdateEvent(
     override val channel: StageChannel,
+    override val old: StageChannel?,
     override val shard: Int,
     public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
 ) : ChannelUpdateEvent, CoroutineScope by coroutineScope {
@@ -88,6 +97,7 @@ public class StageChannelUpdateEvent(
 
 public class UnknownChannelUpdateEvent(
     override val channel: Channel,
+    override val old: Channel?,
     override val shard: Int,
     public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
 ) : ChannelUpdateEvent, CoroutineScope by coroutineScope {

--- a/core/src/main/kotlin/event/channel/thread/ThreadUpdateEvent.kt
+++ b/core/src/main/kotlin/event/channel/thread/ThreadUpdateEvent.kt
@@ -6,7 +6,6 @@ import dev.kord.core.entity.channel.thread.ThreadChannel
 import dev.kord.core.event.channel.ChannelUpdateEvent
 import dev.kord.core.event.kordCoroutineScope
 import kotlinx.coroutines.CoroutineScope
-import kotlin.coroutines.CoroutineContext
 
 public sealed interface ThreadUpdateEvent : ChannelUpdateEvent {
     override val channel: ThreadChannel
@@ -21,7 +20,7 @@ public class TextChannelThreadUpdateEvent(
 ) :
     ThreadUpdateEvent, CoroutineScope by coroutineScope {
     override fun toString(): String {
-        return "TextThreadChannelUpdateEvent(channel=$channel, shard=$shard)"
+        return "TextThreadChannelUpdateEvent(channel=$channel, old=$old, shard=$shard)"
     }
 }
 
@@ -33,7 +32,7 @@ public class NewsChannelThreadUpdateEvent(
     public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
 ) : ThreadUpdateEvent, CoroutineScope by coroutineScope {
     override fun toString(): String {
-        return "NewsThreadChannelUpdateEvent(channel=$channel, shard=$shard)"
+        return "NewsThreadChannelUpdateEvent(channel=$channel, old=$old, shard=$shard)"
     }
 }
 
@@ -45,6 +44,6 @@ public class UnknownChannelThreadUpdateEvent(
     public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
 ) : ThreadUpdateEvent, CoroutineScope by coroutineScope {
     override fun toString(): String {
-        return "UnknownChannelThreadUpdateEvent(channel=$channel, shard=$shard)"
+        return "UnknownChannelThreadUpdateEvent(channel=$channel, old=$old, shard=$shard)"
     }
 }

--- a/core/src/main/kotlin/event/channel/thread/ThreadUpdateEvent.kt
+++ b/core/src/main/kotlin/event/channel/thread/ThreadUpdateEvent.kt
@@ -15,6 +15,7 @@ public sealed interface ThreadUpdateEvent : ChannelUpdateEvent {
 
 public class TextChannelThreadUpdateEvent(
     override val channel: TextChannelThread,
+    override val old: TextChannelThread?,
     override val shard: Int,
     public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
 ) :
@@ -27,6 +28,7 @@ public class TextChannelThreadUpdateEvent(
 
 public class NewsChannelThreadUpdateEvent(
     override val channel: NewsChannelThread,
+    override val old: NewsChannelThread?,
     override val shard: Int,
     public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
 ) : ThreadUpdateEvent, CoroutineScope by coroutineScope {
@@ -38,6 +40,7 @@ public class NewsChannelThreadUpdateEvent(
 
 public class UnknownChannelThreadUpdateEvent(
     override val channel: ThreadChannel,
+    override val old: ThreadChannel?,
     override val shard: Int,
     public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
 ) : ThreadUpdateEvent, CoroutineScope by coroutineScope {

--- a/core/src/main/kotlin/event/guild/EmojisUpdateEvent.kt
+++ b/core/src/main/kotlin/event/guild/EmojisUpdateEvent.kt
@@ -16,6 +16,7 @@ import kotlin.coroutines.CoroutineContext
 public class EmojisUpdateEvent(
     public val guildId: Snowflake,
     public val emojis: Set<GuildEmoji>,
+    public val old: Set<GuildEmoji>?,
     override val kord: Kord,
     override val shard: Int,
     override val supplier: EntitySupplier = kord.defaultSupplier,
@@ -29,7 +30,7 @@ public class EmojisUpdateEvent(
     public suspend fun getGuildOrNull(): Guild? = supplier.getGuildOrNull(guildId)
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): EmojisUpdateEvent =
-        EmojisUpdateEvent(guildId, emojis, kord, shard, strategy.supply(kord))
+        EmojisUpdateEvent(guildId, emojis, old, kord, shard, strategy.supply(kord))
 
     override fun toString(): String {
         return "EmojisUpdateEvent(guildId=$guildId, emojis=$emojis, kord=$kord, shard=$shard, supplier=$supplier)"

--- a/core/src/main/kotlin/event/guild/EmojisUpdateEvent.kt
+++ b/core/src/main/kotlin/event/guild/EmojisUpdateEvent.kt
@@ -33,6 +33,6 @@ public class EmojisUpdateEvent(
         EmojisUpdateEvent(guildId, emojis, old, kord, shard, strategy.supply(kord))
 
     override fun toString(): String {
-        return "EmojisUpdateEvent(guildId=$guildId, emojis=$emojis, kord=$kord, shard=$shard, supplier=$supplier)"
+        return "EmojisUpdateEvent(guildId=$guildId, emojis=$emojis, old=$old, kord=$kord, shard=$shard, supplier=$supplier)"
     }
 }

--- a/core/src/main/kotlin/event/guild/MemberLeaveEvent.kt
+++ b/core/src/main/kotlin/event/guild/MemberLeaveEvent.kt
@@ -4,6 +4,7 @@ import dev.kord.common.entity.Snowflake
 import dev.kord.core.Kord
 import dev.kord.core.behavior.GuildBehavior
 import dev.kord.core.entity.Guild
+import dev.kord.core.entity.Member
 import dev.kord.core.entity.User
 import dev.kord.core.event.Event
 import dev.kord.core.event.kordCoroutineScope
@@ -12,6 +13,7 @@ import kotlin.coroutines.CoroutineContext
 
 public class MemberLeaveEvent(
     public val user: User,
+    public val old: Member?,
     public val guildId: Snowflake,
     override val shard: Int,
     public val coroutineScope: CoroutineScope = kordCoroutineScope(user.kord)

--- a/core/src/main/kotlin/event/guild/MemberLeaveEvent.kt
+++ b/core/src/main/kotlin/event/guild/MemberLeaveEvent.kt
@@ -28,7 +28,7 @@ public class MemberLeaveEvent(
     public suspend fun getGuildOrNull(): Guild? = guild.asGuildOrNull()
 
     override fun toString(): String {
-        return "MemberLeaveEvent(user=$user, guildId=$guildId, shard=$shard)"
+        return "MemberLeaveEvent(user=$user, old=$old, guildId=$guildId, shard=$shard)"
     }
 
 }

--- a/core/src/main/kotlin/event/role/RoleUpdateEvent.kt
+++ b/core/src/main/kotlin/event/role/RoleUpdateEvent.kt
@@ -15,6 +15,7 @@ import kotlin.coroutines.CoroutineContext
 
 public class RoleUpdateEvent(
     public val role: Role,
+    public val old: Role?,
     override val shard: Int,
     override val supplier: EntitySupplier = role.kord.defaultSupplier,
     public val coroutineScope: CoroutineScope = kordCoroutineScope(role.kord)
@@ -31,7 +32,7 @@ public class RoleUpdateEvent(
     public suspend fun getGuildOrNull(): Guild? = supplier.getGuildOrNull(guildId)
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): RoleUpdateEvent =
-        RoleUpdateEvent(role, shard, strategy.supply(kord))
+        RoleUpdateEvent(role, old, shard, strategy.supply(kord))
 
     override fun toString(): String {
         return "RoleUpdateEvent(role=$role, shard=$shard, supplier=$supplier)"

--- a/core/src/main/kotlin/event/role/RoleUpdateEvent.kt
+++ b/core/src/main/kotlin/event/role/RoleUpdateEvent.kt
@@ -35,6 +35,6 @@ public class RoleUpdateEvent(
         RoleUpdateEvent(role, old, shard, strategy.supply(kord))
 
     override fun toString(): String {
-        return "RoleUpdateEvent(role=$role, shard=$shard, supplier=$supplier)"
+        return "RoleUpdateEvent(role=$role, old=$old, shard=$shard, supplier=$supplier)"
     }
 }


### PR DESCRIPTION
* ThreadChannel factory function defaults to the Kord supplier now.
* Add `old` properties to update events where appropriate 