### PR TITLE
Make Snowflake -> String conversion more idiomatic

### DIFF
--- a/common/src/main/kotlin/entity/DiscordMessage.kt
+++ b/common/src/main/kotlin/entity/DiscordMessage.kt
@@ -332,7 +332,7 @@ class MessageFlags internal constructor(val code: Int) {
         return builder.flags()
     }
 
-    override fun toString(): String = "MessageFlags(flags=${flags.toString()})"
+    override fun toString(): String = "MessageFlags(flags=$flags)"
 
     internal object Serializer : KSerializer<MessageFlags> {
 

--- a/common/src/main/kotlin/entity/Presence.kt
+++ b/common/src/main/kotlin/entity/Presence.kt
@@ -52,7 +52,7 @@ data class DiscordPresenceUser(
         override fun serialize(encoder: Encoder, value: DiscordPresenceUser) {
             val jsonEncoder = encoder as? JsonEncoder ?: error("Can be serialized only by JSON")
             val details = value.details.toMutableMap()
-            details["id"] = JsonPrimitive(value.id.asString)
+            details["id"] = JsonPrimitive(value.id.toString())
 
             jsonEncoder.encodeJsonElement(JsonObject(details))
         }

--- a/common/src/main/kotlin/entity/Snowflake.kt
+++ b/common/src/main/kotlin/entity/Snowflake.kt
@@ -68,6 +68,7 @@ class Snowflake : Comparable<Snowflake> {
     /**
      * A [String] representation of this Snowflake's [value].
      */
+    @Deprecated("Use toString() instead", ReplaceWith("toString()"))
     val asString get() = value.toString()
 
     /**
@@ -91,7 +92,10 @@ class Snowflake : Comparable<Snowflake> {
     override fun compareTo(other: Snowflake): Int =
         millisecondsSinceDiscordEpoch.compareTo(other.millisecondsSinceDiscordEpoch)
 
-    override fun toString(): String = "Snowflake(value=$value)"
+    /**
+     * A [String] representation of this Snowflake's [value].
+     */
+    override fun toString(): String = value.toString()
 
     override fun hashCode(): Int = value.hashCode()
 

--- a/common/src/test/kotlin/json/ChannelTest.kt
+++ b/common/src/test/kotlin/json/ChannelTest.kt
@@ -19,14 +19,14 @@ class ChannelTest {
         val channel = Json.decodeFromString(DiscordChannel.serializer(), file("dmchannel"))
 
         with(channel) {
-            lastMessageId.value!!.asString shouldBe "3343820033257021450"
+            lastMessageId.value!!.toString() shouldBe "3343820033257021450"
             type.value shouldBe 1
-            id.asString shouldBe "319674150115610528"
+            id.toString() shouldBe "319674150115610528"
             recipients.value!!.size shouldBe 1
             with(recipients.value!!.first()) {
                 username shouldBe "test"
                 discriminator shouldBe "9999"
-                id.asString shouldBe "82198898841029460"
+                id.toString() shouldBe "82198898841029460"
                 avatar shouldBe "33ecab261d4681afa4d85a04691c4a01"
             }
         }
@@ -43,9 +43,9 @@ class ChannelTest {
             name.value shouldBe "Test"
             nsfw.asNullable shouldBe false
             position.value shouldBe 0
-            guildId.value?.asString shouldBe "290926798629997250"
+            guildId.value?.toString() shouldBe "290926798629997250"
             type.value shouldBe 4
-            id.asString shouldBe "399942396007890945"
+            id.toString() shouldBe "399942396007890945"
         }
     }
 
@@ -61,19 +61,19 @@ class ChannelTest {
             with(recipients.value!!.first()) {
                 username shouldBe "test"
                 discriminator shouldBe "9999"
-                id.asString shouldBe "82198898841029460"
+                id.toString() shouldBe "82198898841029460"
                 avatar shouldBe "33ecab261d4681afa4d85a04691c4a01"
             }
             with(recipients.value!![1]) {
                 username shouldBe "test2"
                 discriminator shouldBe "9999"
-                id.asString shouldBe "82198810841029460"
+                id.toString() shouldBe "82198810841029460"
                 avatar shouldBe "33ecab261d4681afa4d85a10691c4a01"
             }
-            lastMessageId.value?.asString shouldBe "3343820033257021450"
+            lastMessageId.value?.toString() shouldBe "3343820033257021450"
             type.value shouldBe 3
-            id.asString shouldBe "319674150115710528"
-            ownerId.value?.asString shouldBe "82198810841029460"
+            id.toString() shouldBe "319674150115710528"
+            ownerId.value?.toString() shouldBe "82198810841029460"
         }
     }
 
@@ -83,16 +83,16 @@ class ChannelTest {
         val channel = Json.decodeFromString(DiscordChannel.serializer(), file("guildnewschannel"))
 
         with(channel) {
-            id.asString shouldBe "41771983423143937"
-            guildId.value!!.asString shouldBe "41771983423143937"
+            id.toString() shouldBe "41771983423143937"
+            guildId.value!!.toString() shouldBe "41771983423143937"
             name.value shouldBe "important-news"
             type.value shouldBe 5
             position.value shouldBe 6
             permissionOverwrites.value!! shouldBe emptyList()
             nsfw.value shouldBe true
             topic.value shouldBe "Rumors about Half Life 3"
-            lastMessageId.value?.asString shouldBe "155117677105512449"
-            parentId.value?.asString shouldBe "399942396007890945"
+            lastMessageId.value?.toString() shouldBe "155117677105512449"
+            parentId.value?.toString() shouldBe "399942396007890945"
         }
     }
 
@@ -102,8 +102,8 @@ class ChannelTest {
         val channel = Json.decodeFromString(DiscordChannel.serializer(), file("guildtextchannel"))
 
         with(channel) {
-            id.asString shouldBe "41771983423143937"
-            guildId.value!!.asString shouldBe "41771983423143937"
+            id.toString() shouldBe "41771983423143937"
+            guildId.value!!.toString() shouldBe "41771983423143937"
             name.value shouldBe "general"
             type.value shouldBe 0
             position.asNullable!! shouldBe 6
@@ -111,8 +111,8 @@ class ChannelTest {
             rateLimitPerUser.asNullable shouldBe 2
             nsfw.value shouldBe true
             topic.value shouldBe "24/7 chat about how to gank Mike #2"
-            lastMessageId.value?.asString shouldBe "155117677105512449"
-            parentId.value?.asString shouldBe "399942396007890945"
+            lastMessageId.value?.toString() shouldBe "155117677105512449"
+            parentId.value?.toString() shouldBe "399942396007890945"
         }
     }
 
@@ -122,8 +122,8 @@ class ChannelTest {
         val channel = Json.decodeFromString(DiscordChannel.serializer(), file("guildvoicechannel"))
 
         with(channel) {
-            id.asString shouldBe "155101607195836416"
-            guildId.value!!.asString shouldBe "41771983423143937"
+            id.toString() shouldBe "155101607195836416"
+            guildId.value!!.toString() shouldBe "41771983423143937"
             name.value shouldBe "ROCKET CHEESE"
             type.value shouldBe 2
             nsfw.asNullable shouldBe false
@@ -131,7 +131,7 @@ class ChannelTest {
             permissionOverwrites.value!! shouldBe emptyList()
             bitrate.value shouldBe 64000
             userLimit.value shouldBe 0
-            parentId.value?.asString shouldBe null
+            parentId.value?.toString() shouldBe null
         }
     }
 
@@ -141,8 +141,8 @@ class ChannelTest {
         val channel = Json.decodeFromString(DiscordChannel.serializer(), file("storechannel"))
 
         with(channel) {
-            id.asString shouldBe "41771983423143937"
-            guildId.value!!.asString shouldBe "41771983423143937"
+            id.toString() shouldBe "41771983423143937"
+            guildId.value!!.toString() shouldBe "41771983423143937"
             name.value shouldBe "buy dota-2"
             type.value shouldBe 6
             position.asNullable shouldBe 0

--- a/common/src/test/kotlin/json/EmojiTest.kt
+++ b/common/src/test/kotlin/json/EmojiTest.kt
@@ -19,7 +19,7 @@ class EmojiTest {
         val emoji = Json.decodeFromString(DiscordEmoji.serializer(), file("customemoji"))
 
         with(emoji) {
-            id!!.asString shouldBe "41771983429993937"
+            id!!.toString() shouldBe "41771983429993937"
             name shouldBe "LUL"
         }
 

--- a/common/src/test/kotlin/json/MessageTest.kt
+++ b/common/src/test/kotlin/json/MessageTest.kt
@@ -33,7 +33,7 @@ class MessageTest {
             embeds shouldBe emptyList()
             timestamp shouldBe "2017-07-11T17:27:07.299000+00:00"
             mentionEveryone shouldBe false
-            id.asString shouldBe "334385199974967042"
+            id.toString() shouldBe "334385199974967042"
             pinned shouldBe false
             editedTimestamp shouldBe null
             with(author) {
@@ -71,25 +71,25 @@ fun `User serialization`() {
         embeds shouldBe emptyList()
         timestamp shouldBe "2017-07-11T17:27:07.299000+00:00"
         mentionEveryone shouldBe false
-        id.asString shouldBe "334385199974967042"
+        id.toString() shouldBe "334385199974967042"
         pinned shouldBe false
         editedTimestamp shouldBe null
         with(author) {
             username shouldBe "Mason"
             discriminator shouldBe "9999"
-            id.asString shouldBe "53908099506183680"
+            id.toString() shouldBe "53908099506183680"
             avatar shouldBe "a_bab14f271d565501444b2ca3be944b25"
         }
         mentionRoles shouldBe emptyList()
         content shouldBe "Big news! In this <#278325129692446722> channel!"
-        channelId.asString shouldBe "290926798999357250"
+        channelId.toString() shouldBe "290926798999357250"
         mentions shouldBe emptyList()
         type.code shouldBe 0
         flags shouldBe MessageFlags(MessageFlag.IsCrossPost.code)
         with(messageReference.value!!) {
-            channelId.value?.asString shouldBe "278325129692446722"
-            guildId.value!!.asString shouldBe "278325129692446720"
-            id.value!!.asString shouldBe "306588351130107906"
+            channelId.value?.toString() shouldBe "278325129692446722"
+            guildId.value!!.toString() shouldBe "278325129692446720"
+            id.value!!.toString() shouldBe "306588351130107906"
         }
     }
 

--- a/common/src/test/kotlin/json/UserTest.kt
+++ b/common/src/test/kotlin/json/UserTest.kt
@@ -19,7 +19,7 @@ class UserTest {
         val user = Json.decodeFromString(DiscordUser.serializer(), file("user"))
 
         with(user) {
-            id.asString shouldBe "80351110224678912"
+            id.toString() shouldBe "80351110224678912"
             username shouldBe "Nelly"
             discriminator shouldBe "1337"
             avatar shouldBe "8342729096ea3675442027381ff50dfe"

--- a/common/src/test/kotlin/json/Util.kt
+++ b/common/src/test/kotlin/json/Util.kt
@@ -17,11 +17,11 @@ infix fun OptionalBoolean.shouldBe(value: Boolean){
 }
 
 infix fun Snowflake?.shouldBe(value: String?){
-    Assertions.assertEquals(value, this?.asString)
+    Assertions.assertEquals(value, this?.toString())
 }
 
 infix fun OptionalSnowflake?.shouldBe(value: String?){
-    Assertions.assertEquals(value, this?.value?.asString)
+    Assertions.assertEquals(value, this?.value?.toString())
 }
 
 infix fun VerificationLevel?.shouldBe(value: VerificationLevel?){

--- a/common/src/test/kotlin/json/VoiceStateTest.kt
+++ b/common/src/test/kotlin/json/VoiceStateTest.kt
@@ -20,8 +20,8 @@ class VoiceStateTest {
         val state = Json.decodeFromString(DiscordVoiceState.serializer(), file("voicestate"))
 
         with(state) {
-            channelId!!.asString shouldBe "157733188964188161"
-            userId.asString shouldBe "80351110224678912"
+            channelId!!.toString() shouldBe "157733188964188161"
+            userId.toString() shouldBe "80351110224678912"
             sessionId shouldBe "90326bd25d71d39b9ef95b299e3872ff"
             deaf shouldBe false
             mute shouldBe false

--- a/core/src/main/kotlin/behavior/MemberBehavior.kt
+++ b/core/src/main/kotlin/behavior/MemberBehavior.kt
@@ -39,7 +39,7 @@ public interface MemberBehavior : KordEntity, UserBehavior {
     /**
      * The raw mention for this member's nickname.
      */
-    public val nicknameMention: String get() = "<@!${id.asString}>"
+    public val nicknameMention: String get() = "<@!$id>"
 
     /**
      * Requests to get the this behavior as a [Member].

--- a/core/src/main/kotlin/behavior/RoleBehavior.kt
+++ b/core/src/main/kotlin/behavior/RoleBehavior.kt
@@ -43,7 +43,7 @@ public interface RoleBehavior : KordEntity, Strategizable {
     public val mention: String
         get() {
             return if (guildId == id) "@everyone"
-            else "<@&${id.asString}>"
+            else "<@&$id>"
         }
 
     /**

--- a/core/src/main/kotlin/behavior/UserBehavior.kt
+++ b/core/src/main/kotlin/behavior/UserBehavior.kt
@@ -22,7 +22,7 @@ import java.util.*
  */
 public interface UserBehavior : KordEntity, Strategizable {
 
-    public val mention: String get() = "<@${id.asString}>"
+    public val mention: String get() = "<@$id>"
 
     /**
      * Requests to get the this behavior as a [Member] in the [Guild] with the [guildId].

--- a/core/src/main/kotlin/entity/Guild.kt
+++ b/core/src/main/kotlin/entity/Guild.kt
@@ -363,7 +363,7 @@ public class Guild(
      * Gets the banner url in the specified format.
      */
     public fun getBannerUrl(format: Image.Format): String? =
-        data.banner?.let { "https://cdn.discordapp.com/banners/${id.asString}/$it.${format.extension}" }
+        data.banner?.let { "https://cdn.discordapp.com/banners/$id/$it.${format.extension}" }
 
     /**
      * Requests to get the banner image in the specified [format], if present.
@@ -421,7 +421,7 @@ public class Guild(
      * Gets the discovery splash url in the specified [format], if present.
      */
     public fun getDiscoverySplashUrl(format: Image.Format): String? =
-        data.splash.value?.let { "discovery-splashes/${id.asString}/${it}.${format.extension}" }
+        data.splash.value?.let { "discovery-splashes/$id/${it}.${format.extension}" }
 
     /**
      * Requests to get the splash image in the specified [format], if present.
@@ -438,7 +438,7 @@ public class Guild(
      * Gets the icon url, if present.
      */
     public fun getIconUrl(format: Image.Format): String? =
-        data.icon?.let { "https://cdn.discordapp.com/icons/${id.asString}/$it.${format.extension}" }
+        data.icon?.let { "https://cdn.discordapp.com/icons/$id/$it.${format.extension}" }
 
     /**
      * Requests to get the icon image in the specified [format], if present.
@@ -482,7 +482,7 @@ public class Guild(
      * Gets the splash url in the specified [format], if present.
      */
     public fun getSplashUrl(format: Image.Format): String? =
-        data.splash.value?.let { "https://cdn.discordapp.com/splashes/${id.asString}/$it.${format.extension}" }
+        data.splash.value?.let { "https://cdn.discordapp.com/splashes/$id/$it.${format.extension}" }
 
     /**
      * Requests to get the splash image in the specified [format], if present.

--- a/core/src/main/kotlin/entity/GuildEmoji.kt
+++ b/core/src/main/kotlin/entity/GuildEmoji.kt
@@ -35,7 +35,7 @@ public class GuildEmoji(
         get() = data.guildId
 
     public val mention: String
-        get() = if (isAnimated) "<a:$name:${id.asString}>" else "<:$name:${id.asString}>"
+        get() = if (isAnimated) "<a:$name:$id>" else "<:$name:$id>"
 
     /**
      * Whether this emoji can be used, may be false due to loss of Server Boosts.

--- a/core/src/main/kotlin/entity/PartialGuild.kt
+++ b/core/src/main/kotlin/entity/PartialGuild.kt
@@ -57,7 +57,7 @@ public class PartialGuild(
      * Gets the icon url, if present.
      */
     public fun getIconUrl(format: Image.Format): String? =
-        data.icon?.let { "https://cdn.discordapp.com/icons/${id.asString}/$it.${format.extension}" }
+        data.icon?.let { "https://cdn.discordapp.com/icons/$id/$it.${format.extension}" }
 
     /**
      * Requests to get the icon image in the specified [format], if present.

--- a/core/src/main/kotlin/entity/ReactionEmoji.kt
+++ b/core/src/main/kotlin/entity/ReactionEmoji.kt
@@ -20,10 +20,10 @@ public sealed class ReactionEmoji {
     public data class Custom(val id: Snowflake, override val name: String, val isAnimated: Boolean) : ReactionEmoji() {
 
         override val urlFormat: String
-            get() = "$name:${id.asString}"
+            get() = "$name:$id"
 
         override val mention: String
-            get() = if (isAnimated) "<a:$name:${id.asString}>" else "<:$name:${id.asString}>"
+            get() = if (isAnimated) "<a:$name:$id>" else "<:$name:$id>"
 
 
         override fun toString(): String = "Custom(id=$id, name=$name, isAnimated=$isAnimated)"

--- a/core/src/main/kotlin/entity/User.kt
+++ b/core/src/main/kotlin/entity/User.kt
@@ -84,7 +84,7 @@ public open class User(
     public val accentColor: Color? get() = data.accentColor?.let { Color(it) }
 
     public fun getBannerUrl(format: Image.Format): String? =
-        data.banner?.let { "https://cdn.discordapp.com/banners/${id.asString}/$it.${format.extension}" }
+        data.banner?.let { "https://cdn.discordapp.com/banners/$id/$it.${format.extension}" }
 
 
     override fun hashCode(): Int = id.hashCode()

--- a/core/src/main/kotlin/entity/channel/TopGuildChannel.kt
+++ b/core/src/main/kotlin/entity/channel/TopGuildChannel.kt
@@ -44,7 +44,7 @@ public interface TopGuildChannel : GuildChannel, TopGuildChannelBehavior {
     public suspend fun getEffectivePermissions(memberId: Snowflake): Permissions {
         val member = supplier.getMemberOrNull(guildId, memberId)
         require(member != null) {
-            "member ${memberId.asString} is not in guild ${guildId.asString}"
+            "member $memberId is not in guild $guildId"
         }
 
         val base = member.getPermissions()

--- a/core/src/main/kotlin/exception/EntityNotFoundException.kt
+++ b/core/src/main/kotlin/exception/EntityNotFoundException.kt
@@ -15,11 +15,11 @@ public class EntityNotFoundException : Exception {
 
         @PublishedApi
         internal inline fun entityNotFound(entityType: String, id: Snowflake): Nothing =
-            throw EntityNotFoundException("$entityType with id ${id.asString} was not found.")
+            throw EntityNotFoundException("$entityType with id $id was not found.")
 
         @PublishedApi
         internal inline fun guildEntityNotFound(entityType: String, guildId: Snowflake, id: Snowflake): Nothing =
-            throw EntityNotFoundException("$entityType with id ${id.asString} in guild ${guildId.asString} was not found.")
+            throw EntityNotFoundException("$entityType with id $id in guild $guildId was not found.")
 
 
         public inline fun guildNotFound(guildId: Snowflake): Nothing =
@@ -32,7 +32,7 @@ public class EntityNotFoundException : Exception {
             guildEntityNotFound("Member", guildId = guildId, id = userId)
 
         public inline fun messageNotFound(channelId: Snowflake, messageId: Snowflake): Nothing =
-            throw EntityNotFoundException("Message with id ${messageId.asString} in channel ${channelId.asString} was not found")
+            throw EntityNotFoundException("Message with id $messageId in channel $channelId was not found")
 
         public inline fun userNotFound(userId: Snowflake): Nothing =
             entityNotFound("User", userId)

--- a/gateway/src/test/kotlin/json/SerializationTest.kt
+++ b/gateway/src/test/kotlin/json/SerializationTest.kt
@@ -47,10 +47,10 @@ class SerializationTest {
             with(event.data.guilds) {
                 val guild = get(0)
                 with(guild) {
-                    id.asString shouldBe "41771983423143937"
+                    id.toString() shouldBe "41771983423143937"
                 }
                 with(user) {
-                    id.asString shouldBe "80351110224678912"
+                    id.toString() shouldBe "80351110224678912"
                     username shouldBe "Nelly"
                     discriminator shouldBe "1337"
                     avatar shouldBe "8342729096ea3675442027381ff50dfe"
@@ -87,8 +87,8 @@ class SerializationTest {
     fun `ChannelPinsUpdate Event serialization`() {
         val event = Json.decodeFromString(Event.Companion, file("channelpinsupdate")) as ChannelPinsUpdate
         with(event.pins) {
-            guildId.value?.asString shouldBe "41771983423143937"
-            channelId.asString shouldBe "399942396007890945"
+            guildId.value?.toString() shouldBe "41771983423143937"
+            channelId.toString() shouldBe "399942396007890945"
             lastPinTimestamp.value shouldBe "2015-04-26T06:26:56.936000+00:00"
 
         }
@@ -99,8 +99,8 @@ class SerializationTest {
     fun `ChannelCreate Event serialization`() {
         val event = Json.decodeFromString(Event.Companion, file("channelcreate")) as ChannelCreate
         with(event.channel) {
-            id.asString shouldBe "41771983423143937"
-            guildId.value?.asString shouldBe "41771983423143937"
+            id.toString() shouldBe "41771983423143937"
+            guildId.value?.toString() shouldBe "41771983423143937"
             name.value shouldBe "general"
             type.value shouldBe 0
             position.value shouldBe 6
@@ -108,8 +108,8 @@ class SerializationTest {
             rateLimitPerUser.value shouldBe 2
             nsfw.value shouldBe true
             topic.value shouldBe "24/7 chat about how to gank Mike #2"
-            lastMessageId.value?.asString shouldBe "155117677105512449"
-            parentId.value?.asString shouldBe "399942396007890945"
+            lastMessageId.value?.toString() shouldBe "155117677105512449"
+            parentId.value?.toString() shouldBe "399942396007890945"
         }
     }
 
@@ -118,8 +118,8 @@ class SerializationTest {
     fun `ChannelUpdate Event serialization`() {
         val event = Json.decodeFromString(Event.Companion, file("channelupdate")) as ChannelUpdate
         with(event.channel) {
-            id.asString shouldBe "41771983423143937"
-            guildId.value?.asString shouldBe "41771983423143937"
+            id.toString() shouldBe "41771983423143937"
+            guildId.value?.toString() shouldBe "41771983423143937"
             name.value shouldBe "general"
             type.value shouldBe 0
             position.value shouldBe 6
@@ -127,8 +127,8 @@ class SerializationTest {
             rateLimitPerUser.value shouldBe 2
             nsfw.value shouldBe true
             topic.value shouldBe "24/7 chat about how to gank Mike #2"
-            lastMessageId.value?.asString shouldBe "155117677105512449"
-            parentId.value?.asString shouldBe "399942396007890945"
+            lastMessageId.value?.toString() shouldBe "155117677105512449"
+            parentId.value?.toString() shouldBe "399942396007890945"
         }
     }
 
@@ -136,8 +136,8 @@ class SerializationTest {
     fun `ChannelDelete Event serialization`() {
         val event = Json.decodeFromString(Event.Companion, file("channeldelete")) as ChannelDelete
         with(event.channel) {
-            id.asString shouldBe "41771983423143937"
-            guildId.value?.asString shouldBe "41771983423143937"
+            id.toString() shouldBe "41771983423143937"
+            guildId.value?.toString() shouldBe "41771983423143937"
             name.value shouldBe "general"
             type.value shouldBe 0
             position.value shouldBe 6
@@ -145,8 +145,8 @@ class SerializationTest {
             rateLimitPerUser.value shouldBe 2
             nsfw.value shouldBe true
             topic.value shouldBe "24/7 chat about how to gank Mike #2"
-            lastMessageId.value?.asString shouldBe "155117677105512449"
-            parentId?.value?.asString shouldBe "399942396007890945"
+            lastMessageId.value?.toString() shouldBe "155117677105512449"
+            parentId?.value?.toString() shouldBe "399942396007890945"
         }
     }
 

--- a/gateway/src/test/kotlin/json/SnowflakeTest.kt
+++ b/gateway/src/test/kotlin/json/SnowflakeTest.kt
@@ -24,7 +24,7 @@ class SnowflakeTest {
         }
 
         val container = Json.decodeFromJsonElement<SnowflakeContainer>(json)
-        assertEquals(value, container.snowflake.asString)
+        assertEquals(value, container.snowflake.toString())
     }
 
     @Test
@@ -35,7 +35,7 @@ class SnowflakeTest {
         }
 
         val container = Json.decodeFromJsonElement<SnowflakeContainer>(json)
-        assertEquals(value, container.snowflake.asString)
+        assertEquals(value, container.snowflake.toString())
     }
 
     @Test

--- a/rest/src/main/kotlin/builder/message/AllowedMentionsBuilder.kt
+++ b/rest/src/main/kotlin/builder/message/AllowedMentionsBuilder.kt
@@ -53,8 +53,8 @@ class AllowedMentionsBuilder {
 
     fun build(): AllowedMentions = AllowedMentions(
         parse = types.toList(),
-        users = users.map { it.asString },
-        roles = roles.map { it.asString },
+        users = users.map { it.toString() },
+        roles = roles.map { it.toString() },
         repliedUser = _repliedUser
     )
 

--- a/rest/src/main/kotlin/request/RequestBuilder.kt
+++ b/rest/src/main/kotlin/request/RequestBuilder.kt
@@ -10,7 +10,7 @@ class RequestBuilder<T>(private val route: Route<T>, keySize: Int = 2) {
 
     val keys: MutableMap<Route.Key, String> = HashMap(keySize, 1f)
 
-    operator fun MutableMap<Route.Key, String>.set(key: Route.Key, value: Snowflake) = set(key, value.asString)
+    operator fun MutableMap<Route.Key, String>.set(key: Route.Key, value: Snowflake) = set(key, value.toString())
 
     private val headers = HeadersBuilder()
     private val parameters = ParametersBuilder()

--- a/rest/src/main/kotlin/route/DiscordCdn.kt
+++ b/rest/src/main/kotlin/route/DiscordCdn.kt
@@ -6,14 +6,14 @@ object DiscordCdn {
 
     private const val BASE_URL = "https://cdn.discordapp.com"
 
-    fun emoji(emojiId: Snowflake): CdnUrl = CdnUrl("$BASE_URL/emojis/${emojiId.asString}")
+    fun emoji(emojiId: Snowflake): CdnUrl = CdnUrl("$BASE_URL/emojis/$emojiId")
 
     fun defaultAvatar(discriminator: Int): CdnUrl = CdnUrl("$BASE_URL/embed/avatars/${discriminator % 5}")
 
-    fun userAvatar(userId: Snowflake, hash: String): CdnUrl = CdnUrl("$BASE_URL/avatars/${userId.asString}/$hash")
+    fun userAvatar(userId: Snowflake, hash: String): CdnUrl = CdnUrl("$BASE_URL/avatars/$userId/$hash")
 
     fun memberAvatar(guildId: Snowflake, userId: Snowflake, hash: String) =
-        CdnUrl("$BASE_URL/guilds/${guildId.asString}/users/${userId.asString}/avatars/$hash")
+        CdnUrl("$BASE_URL/guilds/$guildId/users/$userId/avatars/$hash")
 
-    fun roleIcon(roleId: Snowflake, hash: String) = CdnUrl("$BASE_URL/role-icons/${roleId.asString}/$hash")
+    fun roleIcon(roleId: Snowflake, hash: String) = CdnUrl("$BASE_URL/role-icons/$roleId/$hash")
 }

--- a/rest/src/main/kotlin/service/WebhookService.kt
+++ b/rest/src/main/kotlin/service/WebhookService.kt
@@ -119,7 +119,7 @@ class WebhookService(requestHandler: RequestHandler) : RestService(requestHandle
             keys[Route.WebhookId] = webhookId
             keys[Route.WebhookToken] = token
             if(wait != null) parameter("wait", "$wait")
-            if(threadId != null) parameter("thread_id", threadId.asString)
+            if(threadId != null) parameter("thread_id", threadId.toString())
             val request = WebhookMessageCreateBuilder().apply(builder).toRequest()
             body(WebhookExecuteRequest.serializer(), request.request)
             request.files.forEach { file(it) }


### PR DESCRIPTION
This PR deprecates `Snowflake.asString`, and gives its functionality to `Snowflake.toString()` instead.
(And migrates all usages of `.asString` in the repo to `.toString()`)

With this change, `"$snowflake"` can be done instead of `"${snowflake.asString}"`.

The main changes are in Snowflake.kt, with all the other changes being the migrations.

<hr>

Thinking this is more idiomatic is mostly based on intuition, but I have some rationale:
- Can't think of a use case needing the string `"Snowflake(value=...)"` outside of println debugging
  - `Snowflake.toString()` is never used in this repo
  - `"...${snowflake.asString}..." is used 26 times`, when `"...$snowflake..."` would be more convenient
- `asString` being a property feels out of place, since semantically it's a conversion, not an attribute of Discord snowflakes
  - Although I can think of kotlinx libraries that use properties for convenience conversions (e.g. [JSON](https://github.com/Kotlin/kotlinx.serialization/blob/f6a34325e557c51ed472f9f4c98497ccc035e39e/formats/json/commonMain/src/kotlinx/serialization/json/JsonElement.kt#L148-L229))
- I expect symmetry when a value type has a String constructor: `snowflake == Snowflake(snowflake.toString())`
- I expect symmetry between `.to*()` and `.as*()` functions: `snowflake.asString == snowflake.toString()`