### PR TITLE
Add missing '=' in GuildBehavior.toString()

### DIFF
--- a/core/src/main/kotlin/behavior/GuildBehavior.kt
+++ b/core/src/main/kotlin/behavior/GuildBehavior.kt
@@ -573,7 +573,7 @@ public fun GuildBehavior(
     }
 
     override fun toString(): String {
-        return "GuildBehavior(id=$id, kord=$kord, supplier$supplier)"
+        return "GuildBehavior(id=$id, kord=$kord, supplier=$supplier)"
     }
 }
 


### PR DESCRIPTION
GuildBehavior's `toString()` was missing an `=` after `supplier`:

```kotlin
return "GuildBehavior(id=$id, kord=$kord, supplier$supplier)"
//                                               ^^
```