### PR TITLE
Add missing '=' in TextChannelBehavior.toString()

### DIFF
--- a/core/src/main/kotlin/behavior/channel/TextChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/TextChannelBehavior.kt
@@ -140,7 +140,7 @@ public fun TextChannelBehavior(
     }
 
     override fun toString(): String {
-        return "TextChannelBehavior(id=$id, guildId=$guildId, kord=$kord, supplier$supplier)"
+        return "TextChannelBehavior(id=$id, guildId=$guildId, kord=$kord, supplier=$supplier)"
     }
 }
 


### PR DESCRIPTION
TextChannelBehavior's `toString()` was missing an `=` after `supplier`:

```kotlin
return "TextChannelBehavior(id=$id, guildId=$guildId, kord=$kord, supplier$supplier)"
//                                                                       ^^
```

<hr/>

Same issue as #442. I searched all the .kt files to make sure this problem isn't anywhere else (with the regex `(\w+)\$\1`), and it looks like this is the only place :)