### PR TITLE
No longer send Authorization header on endpoints without authorization

### DIFF
--- a/core/src/main/kotlin/builder/kord/KordBuilder.kt
+++ b/core/src/main/kotlin/builder/kord/KordBuilder.kt
@@ -26,10 +26,11 @@ import dev.kord.rest.request.RequestHandler
 import dev.kord.rest.request.isError
 import dev.kord.rest.route.Route
 import dev.kord.rest.service.RestClient
-import io.ktor.client.*
-import io.ktor.client.request.*
-import io.ktor.client.statement.*
-import io.ktor.http.*
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.readText
+import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -70,7 +71,7 @@ public class KordBuilder(public val token: String) {
         }
 
     private var handlerBuilder: (resources: ClientResources) -> RequestHandler =
-        { KtorRequestHandler(it.httpClient, ExclusionRequestRateLimiter()) }
+        { KtorRequestHandler(it.httpClient, ExclusionRequestRateLimiter(), token = token) }
     private var cacheBuilder: KordCacheBuilder.(resources: ClientResources) -> Unit = {}
 
     /**
@@ -205,7 +206,7 @@ public class KordBuilder(public val token: String) {
      * @throws KordInitializationException if something went wrong while getting the bot's gateway information.
      */
     public suspend fun build(): Kord {
-        val client = httpClient.configure(token)
+        val client = httpClient.configure()
 
         val recommendedShards = client.getGatewayInfo().shards
         val shardsInfo = shardsBuilder(recommendedShards)

--- a/core/src/main/kotlin/builder/kord/KordBuilderUtil.kt
+++ b/core/src/main/kotlin/builder/kord/KordBuilderUtil.kt
@@ -1,6 +1,12 @@
 package dev.kord.core.builder.kord
 
 import dev.kord.common.entity.Snowflake
+import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.features.json.JsonFeature
+import io.ktor.client.features.json.serializer.KotlinxSerializer
+import io.ktor.client.features.websocket.WebSockets
 import io.ktor.client.*
 import io.ktor.client.engine.cio.*
 import io.ktor.client.features.*
@@ -9,21 +15,18 @@ import io.ktor.client.features.json.serializer.*
 import io.ktor.client.features.websocket.*
 import io.ktor.client.request.*
 import kotlinx.serialization.json.Json
-import java.util.*
+import java.util.Base64
 
-internal fun HttpClientConfig<*>.defaultConfig(token: String) {
+internal fun HttpClientConfig<*>.defaultConfig() {
     expectSuccess = false
-    defaultRequest {
-        header("Authorization", "Bot $token")
-    }
 
     install(JsonFeature)
     install(WebSockets)
 }
 
-internal fun HttpClient?.configure(token: String): HttpClient {
+internal fun HttpClient?.configure(): HttpClient {
     if (this != null) return this.config {
-        defaultConfig(token)
+        defaultConfig()
     }
 
     val json = Json {
@@ -34,7 +37,7 @@ internal fun HttpClient?.configure(token: String): HttpClient {
     }
 
     return HttpClient(CIO) {
-        defaultConfig(token)
+        defaultConfig()
         install(JsonFeature) {
             serializer = KotlinxSerializer(json)
         }

--- a/core/src/main/kotlin/builder/kord/KordRestOnlyBuilder.kt
+++ b/core/src/main/kotlin/builder/kord/KordRestOnlyBuilder.kt
@@ -14,7 +14,7 @@ import dev.kord.rest.ratelimit.ExclusionRequestRateLimiter
 import dev.kord.rest.request.KtorRequestHandler
 import dev.kord.rest.request.RequestHandler
 import dev.kord.rest.service.RestClient
-import io.ktor.client.*
+import io.ktor.client.HttpClient
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -23,7 +23,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 public class KordRestOnlyBuilder(public val token: String) {
 
     private var handlerBuilder: (resources: ClientResources) -> RequestHandler =
-        { KtorRequestHandler(it.httpClient, ExclusionRequestRateLimiter()) }
+        { KtorRequestHandler(it.httpClient, ExclusionRequestRateLimiter(), token = it.token) }
 
     /**
      * The [CoroutineDispatcher] kord uses to launch suspending tasks. [Dispatchers.Default] by default.
@@ -56,7 +56,7 @@ public class KordRestOnlyBuilder(public val token: String) {
      * @throws KordInitializationException if something went wrong while getting the bot's gateway information.
      */
     public fun build(): Kord {
-        val client = httpClient.configure(token)
+        val client = httpClient.configure()
 
         val resources = ClientResources(
             token,

--- a/core/src/test/kotlin/regression/CacheMissRegression.kt
+++ b/core/src/test/kotlin/regression/CacheMissRegression.kt
@@ -23,12 +23,14 @@ import dev.kord.rest.request.Request
 import dev.kord.rest.request.RequestHandler
 import dev.kord.rest.route.Route
 import dev.kord.rest.service.RestClient
-import io.ktor.client.*
-import io.ktor.client.request.*
-import io.ktor.client.request.forms.*
-import io.ktor.client.statement.*
-import io.ktor.content.*
-import io.ktor.http.*
+import io.ktor.client.HttpClient
+import io.ktor.client.request.forms.MultiPartFormDataContent
+import io.ktor.client.request.request
+import io.ktor.client.statement.HttpStatement
+import io.ktor.client.statement.readText
+import io.ktor.content.TextContent
+import io.ktor.http.ContentType
+import io.ktor.http.takeFrom
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -78,7 +80,7 @@ object FakeGateway : Gateway {
     override val coroutineContext: CoroutineContext = SupervisorJob() + EmptyCoroutineContext
 }
 
-class CrashingHandler(val client: HttpClient) : RequestHandler {
+class CrashingHandler(val client: HttpClient, override val token: String) : RequestHandler {
     override suspend fun <B : Any, R> handle(request: Request<B, R>): R {
         if (request.route != Route.CurrentUserGet) throw IllegalStateException("shouldn't do a request")
         val response = client.request<HttpStatement> {
@@ -128,14 +130,14 @@ class CacheMissingRegressions {
             token,
             getBotIdFromToken(token),
             Shards(1),
-            null.configure(token),
+            null.configure(),
             EntitySupplyStrategy.cacheWithRestFallback,
         )
         kord = Kord(
             resources,
             MapDataCache().also { it.registerKordData() },
             DefaultMasterGateway(mapOf(0 to FakeGateway)),
-            RestClient(CrashingHandler(resources.httpClient)),
+            RestClient(CrashingHandler(resources.httpClient, resources.token)),
             getBotIdFromToken(token),
             MutableSharedFlow(extraBufferCapacity = Int.MAX_VALUE),
             Dispatchers.Default

--- a/rest/src/main/kotlin/request/RequestHandler.kt
+++ b/rest/src/main/kotlin/request/RequestHandler.kt
@@ -6,6 +6,11 @@ package dev.kord.rest.request
 interface RequestHandler {
 
     /**
+     * The Discord bot authorization token used on requests.
+     */
+    val token: String
+
+    /**
      * Executes the [request], abiding by the active rate limits and returning the response [R].
      * Throws an [RestRequestException] when a non-rate limit error response is returned.
      */

--- a/rest/src/main/kotlin/service/RestService.kt
+++ b/rest/src/main/kotlin/service/RestService.kt
@@ -1,8 +1,9 @@
 package dev.kord.rest.service
 
-import dev.kord.rest.request.RequestHandler
 import dev.kord.rest.request.RequestBuilder
+import dev.kord.rest.request.RequestHandler
 import dev.kord.rest.route.Route
+import io.ktor.http.HttpHeaders
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -13,7 +14,14 @@ abstract class RestService(@PublishedApi internal val requestHandler: RequestHan
         contract {
             callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
         }
-        val request = RequestBuilder(route).apply(builder).build()
+        val request = RequestBuilder(route)
+            .apply(builder)
+            .apply {
+                if (route.requiresAuthorization) {
+                    header(HttpHeaders.Authorization, "Bot ${requestHandler.token}")
+                }
+            }
+            .build()
         return requestHandler.handle(request)
     }
 


### PR DESCRIPTION
As pointed out by @ByteAlex sending an `Authorization`header on endpoints not requiering it can cause rate-limit issues, this PR changes the current behavior of always sending the header to only sending it when needed﻿
