### PR TITLE
Cleanup: remove unnecessary opt-ins, fix top-level tests, experimental contracts everywhere

### DIFF
--- a/buildSrc/src/main/kotlin/Compiler.kt
+++ b/buildSrc/src/main/kotlin/Compiler.kt
@@ -3,6 +3,7 @@ object CompilerArguments {
     const val time = "-Xopt-in=kotlin.time.ExperimentalTime"
     const val stdLib = "-Xopt-in=kotlin.ExperimentalStdlibApi"
     const val optIn = "-Xopt-in=kotlin.RequiresOptIn"
+    const val contracts = "-Xopt-in=kotlin.contracts.ExperimentalContracts"
 }
 
 object Jvm {

--- a/buildSrc/src/main/kotlin/kord-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/kord-module.gradle.kts
@@ -35,7 +35,8 @@ tasks {
             freeCompilerArgs = listOf(
                 CompilerArguments.coroutines,
                 CompilerArguments.time,
-                CompilerArguments.optIn
+                CompilerArguments.optIn,
+                CompilerArguments.contracts,
             )
         }
     }

--- a/common/src/main/kotlin/entity/DiscordGuild.kt
+++ b/common/src/main/kotlin/entity/DiscordGuild.kt
@@ -160,7 +160,9 @@ data class DiscordGuild(
 )
 
 /**
- * A partial representation of a [Discord Guild structure](https://discord.com/developers/docs/resources/guild#guild-object
+ * A partial representation of a [Discord Guild structure](https://discord.com/developers/docs/resources/guild#guild-object)
+ *
+ * see [Get Current User Guilds](https://discord.com/developers/docs/resources/user#get-current-user-guilds)
  *
  * @param id The guild id.
  * @param name The guild name (2-100 characters, excluding trailing and leading whitespace)
@@ -169,7 +171,7 @@ data class DiscordGuild(
  * @param features The enabled guild features.
  */
 @Serializable
-class DiscordPartialGuild(
+data class DiscordPartialGuild(
     val id: Snowflake,
     val name: String,
     val icon: String?,

--- a/common/src/main/kotlin/entity/DiscordMessage.kt
+++ b/common/src/main/kotlin/entity/DiscordMessage.kt
@@ -1,6 +1,5 @@
 package dev.kord.common.entity
 
-import dev.kord.common.annotation.KordPreview
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
 import dev.kord.common.entity.optional.OptionalInt
@@ -309,7 +308,7 @@ enum class MessageFlag(val code: Int) {
 }
 
 @Serializable(with = MessageFlags.Serializer::class)
-class MessageFlags internal constructor(val code: Int) {
+data class MessageFlags internal constructor(val code: Int) {
 
     val flags = MessageFlag.values().filter { code and it.code != 0 }
 

--- a/common/src/main/kotlin/entity/DiscordMessage.kt
+++ b/common/src/main/kotlin/entity/DiscordMessage.kt
@@ -12,7 +12,6 @@ import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -373,7 +372,6 @@ data class MessageFlags internal constructor(val code: Int) {
 
 }
 
-@OptIn(ExperimentalContracts::class)
 inline fun MessageFlags(builder: MessageFlags.Builder.() -> Unit): MessageFlags {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
     return MessageFlags.Builder().apply(builder).flags()

--- a/common/src/main/kotlin/entity/DiscordUser.kt
+++ b/common/src/main/kotlin/entity/DiscordUser.kt
@@ -12,7 +12,6 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.JsonNames
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -133,7 +132,6 @@ data class UserFlags constructor(val code: Int) {
         else -> this
     }
 
-    @OptIn(ExperimentalContracts::class)
     inline fun copy(block: UserFlagsBuilder.() -> Unit): UserFlags {
         contract {
             callsInPlace(block, InvocationKind.EXACTLY_ONCE)
@@ -176,7 +174,6 @@ data class UserFlags constructor(val code: Int) {
 }
 
 
-@OptIn(ExperimentalContracts::class)
 inline fun UserFlags(builder: UserFlags.UserFlagsBuilder.() -> Unit): UserFlags {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
     return UserFlags.UserFlagsBuilder().apply(builder).flags()

--- a/common/src/main/kotlin/entity/Permission.kt
+++ b/common/src/main/kotlin/entity/Permission.kt
@@ -15,7 +15,7 @@ import kotlin.contracts.contract
 
 
 @Serializable(with = Permissions.Companion::class)
-class Permissions constructor(val code: DiscordBitSet) {
+data class Permissions constructor(val code: DiscordBitSet) {
     /**
      *  Returns this [Permissions] as a [Set] of [Permission]
      */

--- a/common/src/main/kotlin/entity/Permission.kt
+++ b/common/src/main/kotlin/entity/Permission.kt
@@ -9,7 +9,6 @@ import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -41,7 +40,6 @@ data class Permissions constructor(val code: DiscordBitSet) {
         return permission.code in code
     }
 
-    @OptIn(ExperimentalContracts::class)
     inline fun copy(block: PermissionsBuilder.() -> Unit): Permissions {
         contract {
             callsInPlace(block, InvocationKind.EXACTLY_ONCE)

--- a/common/src/main/kotlin/ratelimit/RateLimiter.kt
+++ b/common/src/main/kotlin/ratelimit/RateLimiter.kt
@@ -1,6 +1,5 @@
 package dev.kord.common.ratelimit
 
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -22,7 +21,6 @@ interface RateLimiter {
  *
  * @param action The action that correlates to a single permit.
  */
-@OptIn(ExperimentalContracts::class)
 suspend inline fun <T> RateLimiter.consume(action: () -> T): T {
     contract {
         callsInPlace(action, InvocationKind.EXACTLY_ONCE)
@@ -30,4 +28,3 @@ suspend inline fun <T> RateLimiter.consume(action: () -> T): T {
     consume()
     return action()
 }
-

--- a/common/src/test/kotlin/json/ChannelTest.kt
+++ b/common/src/test/kotlin/json/ChannelTest.kt
@@ -1,5 +1,3 @@
-@file:Suppress("EXPERIMENTAL_API_USAGE")
-
 package json
 
 import dev.kord.common.entity.DiscordChannel

--- a/common/src/test/kotlin/json/EmojiTest.kt
+++ b/common/src/test/kotlin/json/EmojiTest.kt
@@ -1,5 +1,3 @@
-@file:Suppress("EXPERIMENTAL_API_USAGE")
-
 package json
 
 import dev.kord.common.entity.DiscordEmoji
@@ -58,5 +56,3 @@ fun `Emoji serialization`() {
     }
 
 }
-
-

--- a/common/src/test/kotlin/json/EmojiTest.kt
+++ b/common/src/test/kotlin/json/EmojiTest.kt
@@ -1,6 +1,7 @@
 package json
 
 import dev.kord.common.entity.DiscordEmoji
+import dev.kord.common.entity.Snowflake
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Test
 
@@ -13,46 +14,42 @@ private fun file(name: String): String {
 class EmojiTest {
 
     @Test
-    fun `Emoji serialization`() {
+    fun `Custom Emoji serialization`() {
         val emoji = Json.decodeFromString(DiscordEmoji.serializer(), file("customemoji"))
 
         with(emoji) {
             id!!.toString() shouldBe "41771983429993937"
             name shouldBe "LUL"
         }
-
-    }
-}
-
-@Test
-fun `Standard Emoji serialization`() {
-    val emoji = Json.decodeFromString(DiscordEmoji.serializer(), file("standardemoji"))
-
-    with(emoji) {
-        id shouldBe null
-        name shouldBe "🔥"
     }
 
-}
+    @Test
+    fun `Standard Emoji serialization`() {
+        val emoji = Json.decodeFromString(DiscordEmoji.serializer(), file("standardemoji"))
 
-
-@Test
-fun `Emoji serialization`() {
-    val emoji = Json.decodeFromString(DiscordEmoji.serializer(), file("emoji"))
-
-    with(emoji) {
-        id shouldBe "41771983429993937"
-        name shouldBe "LUL"
-        roles shouldBe listOf("41771983429993000", "41771983429993111")
-        with(user.value!!) {
-            username shouldBe "Luigi"
-            discriminator shouldBe "0002"
-            id shouldBe "96008815106887111"
-            avatar shouldBe "5500909a3274e1812beb4e8de6631111"
+        with(emoji) {
+            id shouldBe null
+            name shouldBe "🔥"
         }
-        requireColons shouldBe true
-        managed shouldBe false
-        animated shouldBe false
     }
 
+    @Test
+    fun `Emoji serialization`() {
+        val emoji = Json.decodeFromString(DiscordEmoji.serializer(), file("emoji"))
+
+        with(emoji) {
+            id shouldBe "41771983429993937"
+            name shouldBe "LUL"
+            roles shouldBe listOf("41771983429993000", "41771983429993111").map { Snowflake(it) }
+            with(user.value!!) {
+                username shouldBe "Luigi"
+                discriminator shouldBe "0002"
+                id shouldBe "96008815106887111"
+                avatar shouldBe "5500909a3274e1812beb4e8de6631111"
+            }
+            requireColons shouldBe true
+            managed shouldBe false
+            animated shouldBe false
+        }
+    }
 }

--- a/common/src/test/kotlin/json/GuildTest.kt
+++ b/common/src/test/kotlin/json/GuildTest.kt
@@ -1,5 +1,3 @@
-@file:Suppress("EXPERIMENTAL_API_USAGE")
-
 package json
 
 import dev.kord.common.entity.*
@@ -104,4 +102,3 @@ fun `PartialGuild serialization`() {
     }
 
 }
-

--- a/common/src/test/kotlin/json/GuildTest.kt
+++ b/common/src/test/kotlin/json/GuildTest.kt
@@ -59,46 +59,43 @@ class GuildTest {
             publicUpdatesChannelId shouldBe "281283303326089216"
             nsfwLevel shouldBe NsfwLevel.Default
         }
-
-    }
-}
-
-@Test
-fun `UnavailableGuild serialization`() {
-    val guild = Json.decodeFromString(DiscordUnavailableGuild.serializer(), file("unavailableguild"))
-
-    with(guild) {
-        id shouldBe "41771983423143937"
-        unavailable shouldBe true
     }
 
-}
+    @Test
+    fun `UnavailableGuild serialization`() {
+        val guild = Json.decodeFromString(DiscordUnavailableGuild.serializer(), file("unavailableguild"))
 
+        with(guild) {
+            id shouldBe "41771983423143937"
+            unavailable shouldBe true
+        }
 
-@Test
-fun `GuildMember serialization`() {
-    val member = Json.decodeFromString(DiscordGuildMember.serializer(), file("guildmember"))
-
-    with(member) {
-        nick shouldBe "NOT API SUPPORT"
-        roles shouldBe emptyList()
-        joinedAt shouldBe "2015-04-26T06:26:56.936000+00:00"
-        deaf shouldBe false
-        mute shouldBe false
-    }
-}
-
-
-@Test
-fun `PartialGuild serialization`() {
-    val guild = Json.decodeFromString(DiscordGuild.serializer(), file("partialguild"))
-
-    with(guild) {
-        id shouldBe "80351110224678912"
-        name shouldBe "1337 Krew"
-        icon shouldBe "8342729096ea3675442027381ff50dfe"
-        owner shouldBe true
-        permissions.value shouldBe 36953089
     }
 
+    @Test
+    fun `GuildMember serialization`() {
+        val member = Json.decodeFromString(DiscordGuildMember.serializer(), file("guildmember"))
+
+        with(member) {
+            nick shouldBe "NOT API SUPPORT"
+            roles shouldBe emptyList()
+            joinedAt shouldBe "2015-04-26T06:26:56.936000+00:00"
+            deaf shouldBe false
+            mute shouldBe false
+        }
+    }
+
+    @Test
+    fun `PartialGuild serialization`() {
+        val guild = Json.decodeFromString(DiscordPartialGuild.serializer(), file("partialguild"))
+
+        with(guild) {
+            id shouldBe "80351110224678912"
+            name shouldBe "1337 Krew"
+            icon shouldBe "8342729096ea3675442027381ff50dfe"
+            owner shouldBe true
+            permissions shouldBe Permissions("36953089")
+            features shouldBe listOf(GuildFeature.Community, GuildFeature.News)
+        }
+    }
 }

--- a/common/src/test/kotlin/json/MessageTest.kt
+++ b/common/src/test/kotlin/json/MessageTest.kt
@@ -1,5 +1,3 @@
-@file:Suppress("EXPERIMENTAL_API_USAGE")
-
 package json
 
 import dev.kord.common.entity.*

--- a/common/src/test/kotlin/json/MessageTest.kt
+++ b/common/src/test/kotlin/json/MessageTest.kt
@@ -46,49 +46,47 @@ class MessageTest {
             mentions shouldBe emptyList()
             type.code shouldBe 0
         }
-
     }
-}
 
-@Test
-fun `User serialization`() {
-    val message = Json.decodeFromString(DiscordMessage.serializer(), file("crossposted"))
+    @Test
+    fun `User serialization`() {
+        val message = Json.decodeFromString(DiscordMessage.serializer(), file("crossposted"))
 
-    with(message) {
-        reactions.value!!.size shouldBe 1
-        with(reactions.value!!.first()) {
-            count shouldBe 1
-            me shouldBe false
-            with(emoji) {
-                id shouldBe null
-                name shouldBe "🔥"
+        with(message) {
+            reactions.value!!.size shouldBe 1
+            with(reactions.value!!.first()) {
+                count shouldBe 1
+                me shouldBe false
+                with(emoji) {
+                    id shouldBe null
+                    name shouldBe "🔥"
+                }
+            }
+            attachments shouldBe emptyList()
+            tts shouldBe false
+            embeds shouldBe emptyList()
+            timestamp shouldBe "2017-07-11T17:27:07.299000+00:00"
+            mentionEveryone shouldBe false
+            id.toString() shouldBe "334385199974967042"
+            pinned shouldBe false
+            editedTimestamp shouldBe null
+            with(author) {
+                username shouldBe "Mason"
+                discriminator shouldBe "9999"
+                id.toString() shouldBe "53908099506183680"
+                avatar shouldBe "a_bab14f271d565501444b2ca3be944b25"
+            }
+            mentionRoles shouldBe emptyList()
+            content shouldBe "Big news! In this <#278325129692446722> channel!"
+            channelId.toString() shouldBe "290926798999357250"
+            mentions shouldBe emptyList()
+            type.code shouldBe 0
+            flags shouldBe MessageFlags(MessageFlag.IsCrossPost.code)
+            with(messageReference.value!!) {
+                channelId.value?.toString() shouldBe "278325129692446722"
+                guildId.value!!.toString() shouldBe "278325129692446720"
+                id.value!!.toString() shouldBe "306588351130107906"
             }
         }
-        attachments shouldBe emptyList()
-        tts shouldBe false
-        embeds shouldBe emptyList()
-        timestamp shouldBe "2017-07-11T17:27:07.299000+00:00"
-        mentionEveryone shouldBe false
-        id.toString() shouldBe "334385199974967042"
-        pinned shouldBe false
-        editedTimestamp shouldBe null
-        with(author) {
-            username shouldBe "Mason"
-            discriminator shouldBe "9999"
-            id.toString() shouldBe "53908099506183680"
-            avatar shouldBe "a_bab14f271d565501444b2ca3be944b25"
-        }
-        mentionRoles shouldBe emptyList()
-        content shouldBe "Big news! In this <#278325129692446722> channel!"
-        channelId.toString() shouldBe "290926798999357250"
-        mentions shouldBe emptyList()
-        type.code shouldBe 0
-        flags shouldBe MessageFlags(MessageFlag.IsCrossPost.code)
-        with(messageReference.value!!) {
-            channelId.value?.toString() shouldBe "278325129692446722"
-            guildId.value!!.toString() shouldBe "278325129692446720"
-            id.value!!.toString() shouldBe "306588351130107906"
-        }
     }
-
 }

--- a/common/src/test/kotlin/json/UserTest.kt
+++ b/common/src/test/kotlin/json/UserTest.kt
@@ -1,5 +1,3 @@
-@file:Suppress("EXPERIMENTAL_API_USAGE")
-
 package json
 
 import dev.kord.common.entity.DiscordUser
@@ -31,4 +29,3 @@ class UserTest {
 
     }
 }
-

--- a/common/src/test/kotlin/json/VoiceStateTest.kt
+++ b/common/src/test/kotlin/json/VoiceStateTest.kt
@@ -1,5 +1,3 @@
-@file:Suppress("EXPERIMENTAL_API_USAGE")
-
 package json
 
 import dev.kord.common.entity.DiscordVoiceState

--- a/common/src/test/kotlin/ratelimit/BucketRateLimiterTest.kt
+++ b/common/src/test/kotlin/ratelimit/BucketRateLimiterTest.kt
@@ -2,7 +2,6 @@ package ratelimit
 
 import dev.kord.common.ratelimit.BucketRateLimiter
 import fixed
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.currentTime
 import kotlinx.coroutines.test.runBlockingTest
 import kotlinx.coroutines.test.runTest
@@ -11,10 +10,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.asserter
 import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.ExperimentalTime
 
-@ExperimentalTime
-@ExperimentalCoroutinesApi
 class BucketRateLimiterTest {
 
     val interval = 1_000_000.milliseconds

--- a/common/src/test/resources/json/guild/partialguild.json
+++ b/common/src/test/resources/json/guild/partialguild.json
@@ -3,5 +3,6 @@
   "name": "1337 Krew",
   "icon": "8342729096ea3675442027381ff50dfe",
   "owner": true,
-  "permissions": 36953089
+  "permissions": "36953089",
+  "features": ["COMMUNITY", "NEWS"]
 }

--- a/core/src/main/kotlin/Kord.kt
+++ b/core/src/main/kotlin/Kord.kt
@@ -73,7 +73,6 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import mu.KLogger
 import mu.KotlinLogging
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 import kotlin.coroutines.CoroutineContext
@@ -160,7 +159,6 @@ public class Kord(
     /**
      * Logs in to the configured [Gateways][Gateway]. Suspends until [logout] or [shutdown] is called.
      */
-    @OptIn(ExperimentalContracts::class)
     public suspend inline fun login(builder: LoginBuilder.() -> Unit = {}) {
         contract {
             callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
@@ -206,7 +204,6 @@ public class Kord(
         ReplaceWith("createGuild(\"name\", builder)"),
         DeprecationLevel.WARNING
     )
-    @OptIn(ExperimentalContracts::class)
     public suspend inline fun createGuild(builder: GuildCreateBuilder.() -> Unit): Guild {
         contract {
             callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
@@ -221,7 +218,6 @@ public class Kord(
      * @throws [RequestException] if anything went wrong during the request.
      * @return The newly created Guild.
      */
-    @OptIn(ExperimentalContracts::class)
     public suspend inline fun createGuild(name: String, builder: GuildCreateBuilder.() -> Unit): Guild {
         contract {
             callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
@@ -345,7 +341,6 @@ public class Kord(
     public suspend fun getSelf(strategy: EntitySupplyStrategy<*> = resources.defaultStrategy): User =
         strategy.supply(this).getSelf()
 
-    @OptIn(ExperimentalContracts::class)
     public suspend fun editSelf(builder: CurrentUserModifyBuilder.() -> Unit): User {
         contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
         return User(UserData.from(rest.user.modifyCurrentUser(builder)), this)
@@ -381,7 +376,6 @@ public class Kord(
      *
      * @throws [RequestException] if anything went wrong during the request.
      */
-    @OptIn(ExperimentalContracts::class)
     public suspend inline fun editPresence(builder: PresenceBuilder.() -> Unit) {
         contract {
             callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
@@ -411,7 +405,6 @@ public class Kord(
          * Similarly, [cache][Kord.cache] related functionality has been disabled and
          * replaced with a no-op implementation.
          */
-        @OptIn(ExperimentalContracts::class)
         @KordExperimental
         public inline fun restOnly(token: String, builder: KordRestOnlyBuilder.() -> Unit = {}): Kord {
             contract {
@@ -474,7 +467,6 @@ public class Kord(
     }
 
 
-    @OptIn(ExperimentalContracts::class)
     public suspend inline fun createGlobalChatInputCommand(
         name: String,
         description: String,
@@ -491,7 +483,6 @@ public class Kord(
         return GlobalChatInputCommand(data, rest.interaction)
     }
 
-    @OptIn(ExperimentalContracts::class)
     public suspend inline fun createGlobalMessageCommand(
         name: String,
         builder: MessageCommandCreateBuilder.() -> Unit = {},
@@ -503,7 +494,6 @@ public class Kord(
         return GlobalMessageCommand(data, rest.interaction)
     }
 
-    @OptIn(ExperimentalContracts::class)
     public suspend inline fun createGlobalUserCommand(
         name: String,
         builder: UserCommandCreateBuilder.() -> Unit = {},
@@ -516,7 +506,6 @@ public class Kord(
     }
 
 
-    @OptIn(ExperimentalContracts::class)
     public suspend inline fun createGlobalApplicationCommands(
         builder: MultiApplicationCommandBuilder.() -> Unit,
     ): Flow<GlobalApplicationCommand> {
@@ -531,7 +520,6 @@ public class Kord(
         }
     }
 
-    @OptIn(ExperimentalContracts::class)
     public suspend inline fun createGuildChatInputCommand(
         guildId: Snowflake,
         name: String,
@@ -552,7 +540,6 @@ public class Kord(
     }
 
 
-    @OptIn(ExperimentalContracts::class)
     public suspend inline fun createGuildMessageCommand(
         guildId: Snowflake,
         name: String,
@@ -569,7 +556,6 @@ public class Kord(
         return GuildMessageCommand(data, rest.interaction)
     }
 
-    @OptIn(ExperimentalContracts::class)
     public suspend inline fun createGuildUserCommand(
         guildId: Snowflake,
         name: String,
@@ -588,7 +574,6 @@ public class Kord(
     }
 
 
-    @OptIn(ExperimentalContracts::class)
     public suspend inline fun createGuildApplicationCommands(
         guildId: Snowflake,
         builder: MultiApplicationCommandBuilder.() -> Unit,
@@ -605,7 +590,6 @@ public class Kord(
         }
     }
 
-    @OptIn(ExperimentalContracts::class)
     public suspend inline fun editApplicationCommandPermissions(
         guildId: Snowflake,
         commandId: Snowflake,
@@ -616,7 +600,6 @@ public class Kord(
     }
 
 
-    @OptIn(ExperimentalContracts::class)
     public suspend inline fun bulkEditApplicationCommandPermissions(
         guildId: Snowflake,
         builder: ApplicationCommandPermissionsBulkModifyBuilder.() -> Unit,
@@ -631,7 +614,6 @@ public class Kord(
  *
  * @throws KordInitializationException if something went wrong while getting the bot's gateway information.
  */
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun Kord(token: String, builder: KordBuilder.() -> Unit = {}): Kord {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
     return KordBuilder(token).apply(builder).build()

--- a/core/src/main/kotlin/Unsafe.kt
+++ b/core/src/main/kotlin/Unsafe.kt
@@ -44,7 +44,6 @@ import dev.kord.rest.service.InteractionService
  */
 @KordUnsafe
 @KordExperimental
-@Suppress("EXPERIMENTAL_API_USAGE")
 public class Unsafe(private val kord: Kord) {
 
     public fun message(channelId: Snowflake, messageId: Snowflake): MessageBehavior =

--- a/core/src/main/kotlin/Util.kt
+++ b/core/src/main/kotlin/Util.kt
@@ -23,7 +23,6 @@ import dev.kord.rest.route.Position
 import kotlinx.coroutines.flow.*
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 import kotlin.reflect.KClass
@@ -41,7 +40,6 @@ internal fun ULong?.toSnowflakeOrNull(): Snowflake? = when {
 internal fun Int.toInstant() = Instant.fromEpochMilliseconds(toLong())
 internal fun Long.toInstant() = Instant.fromEpochMilliseconds(this)
 
-@OptIn(ExperimentalContracts::class)
 internal inline fun <T> catchNotFound(block: () -> T): T? {
     contract {
         callsInPlace(block, InvocationKind.EXACTLY_ONCE)
@@ -54,7 +52,6 @@ internal inline fun <T> catchNotFound(block: () -> T): T? {
     }
 }
 
-@OptIn(ExperimentalContracts::class)
 internal inline fun <T> catchDiscordError(vararg codes: JsonErrorCode, block: () -> T): T? {
     contract {
         callsInPlace(block, InvocationKind.EXACTLY_ONCE)

--- a/core/src/main/kotlin/behavior/ChatInputCommandBehavior.kt
+++ b/core/src/main/kotlin/behavior/ChatInputCommandBehavior.kt
@@ -5,7 +5,6 @@ import dev.kord.core.entity.application.ChatInputCommandCommand
 import dev.kord.core.entity.application.GlobalChatInputCommand
 import dev.kord.core.entity.application.GuildChatInputCommand
 import dev.kord.rest.builder.interaction.ChatInputModifyBuilder
-import kotlin.contracts.ExperimentalContracts
 
 
 public interface ChatInputCommandBehavior : ApplicationCommandBehavior {
@@ -17,7 +16,6 @@ public interface ChatInputCommandBehavior : ApplicationCommandBehavior {
 
 public interface GuildChatInputCommandBehavior : ChatInputCommandBehavior, GuildApplicationCommandBehavior {
 
-     @OptIn(ExperimentalContracts::class)
      override suspend fun edit(builder: suspend ChatInputModifyBuilder.() -> Unit): GuildChatInputCommand {
           val request = ChatInputModifyBuilder().apply { builder() }.toRequest()
           val response = service.modifyGuildApplicationCommand(applicationId, guildId, id, request)
@@ -30,7 +28,6 @@ public interface GuildChatInputCommandBehavior : ChatInputCommandBehavior, Guild
 
 public interface GlobalChatInputCommandBehavior : ChatInputCommandBehavior,GlobalApplicationCommandBehavior {
 
-     @OptIn(ExperimentalContracts::class)
      override suspend fun edit(builder: suspend ChatInputModifyBuilder.() -> Unit): GlobalChatInputCommand {
           val request = ChatInputModifyBuilder().apply { builder() }.toRequest()
           val response = service.modifyGlobalApplicationCommand(applicationId,id, request)

--- a/core/src/main/kotlin/behavior/GuildBehavior.kt
+++ b/core/src/main/kotlin/behavior/GuildBehavior.kt
@@ -117,7 +117,6 @@ import kotlinx.coroutines.flow.takeWhile
 import kotlinx.coroutines.flow.transformWhile
 import kotlinx.datetime.Instant
 import java.util.Objects
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -672,7 +671,6 @@ public fun GuildBehavior(
 }
 
 
-@OptIn(ExperimentalContracts::class)
 
 public suspend inline fun GuildBehavior.createChatInputCommand(
     name: String,
@@ -684,7 +682,6 @@ public suspend inline fun GuildBehavior.createChatInputCommand(
 }
 
 
-@OptIn(ExperimentalContracts::class)
 
 public suspend inline fun GuildBehavior.createMessageCommand(
     name: String,
@@ -694,7 +691,6 @@ public suspend inline fun GuildBehavior.createMessageCommand(
     return kord.createGuildMessageCommand(id, name, builder)
 }
 
-@OptIn(ExperimentalContracts::class)
 
 public suspend inline fun GuildBehavior.createUserCommand(
     name: String,
@@ -705,7 +701,6 @@ public suspend inline fun GuildBehavior.createUserCommand(
 }
 
 
-@OptIn(ExperimentalContracts::class)
 
 public suspend inline fun GuildBehavior.createApplicationCommands(
     builder: MultiApplicationCommandBuilder.() -> Unit
@@ -721,7 +716,6 @@ public suspend inline fun GuildBehavior.createApplicationCommands(
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun GuildBehavior.edit(builder: GuildModifyBuilder.() -> Unit): Guild {
     contract {
         callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
@@ -737,7 +731,6 @@ public suspend inline fun GuildBehavior.edit(builder: GuildModifyBuilder.() -> U
     ReplaceWith("createEmoji(\"name\", Image.fromUrl(\"url\"), builder)")
 )
 @DeprecatedSinceKord("0.7.0")
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun GuildBehavior.createEmoji(builder: EmojiCreateBuilder.() -> Unit): GuildEmoji {
     contract {
         callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
@@ -745,7 +738,6 @@ public suspend inline fun GuildBehavior.createEmoji(builder: EmojiCreateBuilder.
     return createEmoji("name", Image.raw(byteArrayOf(), Image.Format.PNG), builder)
 }
 
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun GuildBehavior.createEmoji(
     name: String,
     image: Image,
@@ -771,7 +763,6 @@ public suspend inline fun GuildBehavior.createEmoji(
     DeprecationLevel.WARNING
 )
 @DeprecatedSinceKord("0.7.0")
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun GuildBehavior.createTextChannel(builder: TextChannelCreateBuilder.() -> Unit): TextChannel {
     contract {
         callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
@@ -787,7 +778,6 @@ public suspend inline fun GuildBehavior.createTextChannel(builder: TextChannelCr
  * @throws [RestRequestException] if something went wrong during the request.
  */
 
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun GuildBehavior.createTextChannel(
     name: String,
     builder: TextChannelCreateBuilder.() -> Unit = {}
@@ -814,7 +804,6 @@ public suspend inline fun GuildBehavior.createTextChannel(
     DeprecationLevel.WARNING
 )
 @DeprecatedSinceKord("0.7.0")
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun GuildBehavior.createVoiceChannel(builder: VoiceChannelCreateBuilder.() -> Unit): VoiceChannel {
     contract {
         callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
@@ -829,7 +818,6 @@ public suspend inline fun GuildBehavior.createVoiceChannel(builder: VoiceChannel
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun GuildBehavior.createVoiceChannel(
     name: String,
     builder: VoiceChannelCreateBuilder.() -> Unit = {}
@@ -856,7 +844,6 @@ public suspend inline fun GuildBehavior.createVoiceChannel(
     DeprecationLevel.WARNING
 )
 @DeprecatedSinceKord("0.7.0")
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun GuildBehavior.createNewsChannel(builder: NewsChannelCreateBuilder.() -> Unit): NewsChannel {
     contract {
         callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
@@ -871,7 +858,6 @@ public suspend inline fun GuildBehavior.createNewsChannel(builder: NewsChannelCr
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun GuildBehavior.createNewsChannel(
     name: String,
     builder: NewsChannelCreateBuilder.() -> Unit = {}
@@ -899,7 +885,6 @@ public suspend inline fun GuildBehavior.createNewsChannel(
     DeprecationLevel.WARNING
 )
 @DeprecatedSinceKord("0.7.0")
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun GuildBehavior.createCategory(builder: CategoryCreateBuilder.() -> Unit): Category {
     contract {
         callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
@@ -914,7 +899,6 @@ public suspend inline fun GuildBehavior.createCategory(builder: CategoryCreateBu
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun GuildBehavior.createCategory(
     name: String,
     builder: CategoryCreateBuilder.() -> Unit = {}
@@ -933,7 +917,6 @@ public suspend inline fun GuildBehavior.createCategory(
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun GuildBehavior.swapChannelPositions(builder: GuildChannelPositionModifyBuilder.() -> Unit) {
     contract {
         callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
@@ -950,7 +933,6 @@ public suspend inline fun GuildBehavior.swapChannelPositions(builder: GuildChann
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun GuildBehavior.swapRolePositions(builder: RolePositionsModifyBuilder.() -> Unit): Flow<Role> {
     contract {
         callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
@@ -967,7 +949,6 @@ public suspend inline fun GuildBehavior.swapRolePositions(builder: RolePositions
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
-@OptIn(ExperimentalContracts::class)
 @DeprecatedSinceKord("0.7.0")
 @Deprecated("Use createRole instead.", ReplaceWith("createRole(builder)"), DeprecationLevel.ERROR)
 public suspend inline fun GuildBehavior.addRole(builder: RoleCreateBuilder.() -> Unit = {}): Role = createRole(builder)
@@ -979,7 +960,6 @@ public suspend inline fun GuildBehavior.addRole(builder: RoleCreateBuilder.() ->
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun GuildBehavior.createRole(builder: RoleCreateBuilder.() -> Unit = {}): Role {
     contract {
         callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
@@ -995,7 +975,6 @@ public suspend inline fun GuildBehavior.createRole(builder: RoleCreateBuilder.()
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun GuildBehavior.ban(userId: Snowflake, builder: BanCreateBuilder.() -> Unit) {
     contract {
         callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
@@ -1031,7 +1010,6 @@ public suspend inline fun <reified T : GuildChannel> GuildBehavior.getChannelOfO
     return channel
 }
 
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun GuildBehavior.editWidget(builder: GuildWidgetModifyBuilder.() -> Unit): GuildWidget {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
     return GuildWidget(GuildWidgetData.from(kord.rest.guild.modifyGuildWidget(id, builder)), id, kord)
@@ -1052,7 +1030,6 @@ public suspend inline fun GuildBehavior.editWidget(builder: GuildWidgetModifyBui
  *  println("user changed nickname from $old to $new")
  *  ```
  */
-@OptIn(ExperimentalContracts::class)
 public inline fun GuildBehavior.getAuditLogEntries(builder: AuditLogGetRequestBuilder.() -> Unit = {}): Flow<AuditLogEntry> {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
     return kord.with(rest).getAuditLogEntries(id, builder).map { AuditLogEntry(it, kord) }
@@ -1075,7 +1052,6 @@ public inline fun GuildBehavior.getAuditLogEntries(builder: AuditLogGetRequestBu
  * This function expects [request.nonce][RequestGuildMembers.nonce] to contain a value, but it is not required.
  * If no nonce was provided one will be generated instead.
  */
-@OptIn(ExperimentalContracts::class)
 @PrivilegedIntent
 public inline fun GuildBehavior.requestMembers(builder: RequestGuildMembersBuilder.() -> Unit = { requestAllMembers() }): Flow<MembersChunkEvent> {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
@@ -1083,7 +1059,6 @@ public inline fun GuildBehavior.requestMembers(builder: RequestGuildMembersBuild
     return requestMembers(request)
 }
 
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun GuildBehavior.bulkEditSlashCommandPermissions(noinline builder: ApplicationCommandPermissionsBulkModifyBuilder.() -> Unit) {
 
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
@@ -1094,7 +1069,6 @@ public suspend inline fun GuildBehavior.bulkEditSlashCommandPermissions(noinline
 /**
  * Creates a new [GuildScheduledEvent].
  */
-@OptIn(ExperimentalContracts::class)
 public suspend fun GuildBehavior.createScheduledEvent(
     name: String,
     privacyLevel: StageInstancePrivacyLevel,

--- a/core/src/main/kotlin/behavior/GuildEmojiBehavior.kt
+++ b/core/src/main/kotlin/behavior/GuildEmojiBehavior.kt
@@ -11,7 +11,6 @@ import dev.kord.core.supplier.EntitySupplyStrategy
 import dev.kord.rest.builder.guild.EmojiModifyBuilder
 import dev.kord.rest.request.RestRequestException
 import java.util.*
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -77,7 +76,6 @@ internal fun GuildEmojiBehavior(
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun GuildEmojiBehavior.edit(builder: EmojiModifyBuilder.() -> Unit): GuildEmoji {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
     val response = kord.rest.emoji.modifyEmoji(guildId, id, builder)

--- a/core/src/main/kotlin/behavior/GuildScheduledEventBehavior.kt
+++ b/core/src/main/kotlin/behavior/GuildScheduledEventBehavior.kt
@@ -17,7 +17,6 @@ import dev.kord.rest.builder.scheduled_events.ScheduledEventModifyBuilder
 import dev.kord.rest.service.modifyScheduledEvent
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -100,7 +99,6 @@ internal fun GuildScheduledEventBehavior(
  *
  * @throws RequestException if anything goes wrong during the request
  */
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun GuildScheduledEventBehavior.edit(builder: ScheduledEventModifyBuilder.() -> Unit): DiscordGuildScheduledEvent {
     contract {
         callsInPlace(builder, InvocationKind.EXACTLY_ONCE)

--- a/core/src/main/kotlin/behavior/MemberBehavior.kt
+++ b/core/src/main/kotlin/behavior/MemberBehavior.kt
@@ -17,7 +17,6 @@ import dev.kord.rest.builder.ban.BanCreateBuilder
 import dev.kord.rest.builder.member.MemberModifyBuilder
 import dev.kord.rest.request.RestRequestException
 import java.util.*
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -217,7 +216,6 @@ public fun MemberBehavior(
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun MemberBehavior.ban(builder: BanCreateBuilder.() -> Unit = {}) {
     contract {
         callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
@@ -230,7 +228,6 @@ public suspend inline fun MemberBehavior.ban(builder: BanCreateBuilder.() -> Uni
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun MemberBehavior.edit(builder: MemberModifyBuilder.() -> Unit): Member {
     contract {
         callsInPlace(builder, InvocationKind.EXACTLY_ONCE)

--- a/core/src/main/kotlin/behavior/MessageBehavior.kt
+++ b/core/src/main/kotlin/behavior/MessageBehavior.kt
@@ -22,7 +22,6 @@ import dev.kord.rest.request.RestRequestException
 import dev.kord.rest.service.RestClient
 import kotlinx.coroutines.flow.Flow
 import java.util.*
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -239,7 +238,6 @@ public fun MessageBehavior(
  * @throws [RestRequestException] if something went wrong during the request.
  * @see editWebhookMessage
  */
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun MessageBehavior.edit(builder: UserMessageModifyBuilder.() -> Unit): Message {
     contract {
         callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
@@ -260,7 +258,6 @@ public suspend inline fun MessageBehavior.edit(builder: UserMessageModifyBuilder
  * @throws [RestRequestException] if something went wrong during the request.
  * @see edit
  */
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun MessageBehavior.editWebhookMessage(
     webhookId: Snowflake,
     token: String,
@@ -287,7 +284,6 @@ public suspend inline fun MessageBehavior.editWebhookMessage(
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun MessageBehavior.reply(builder: UserMessageCreateBuilder.() -> Unit): Message {
     contract {
         callsInPlace(builder, InvocationKind.EXACTLY_ONCE)

--- a/core/src/main/kotlin/behavior/RoleBehavior.kt
+++ b/core/src/main/kotlin/behavior/RoleBehavior.kt
@@ -7,7 +7,6 @@ import dev.kord.core.cache.data.RoleData
 import dev.kord.core.entity.KordEntity
 import dev.kord.core.entity.Role
 import dev.kord.core.entity.Strategizable
-import dev.kord.core.entity.User
 import dev.kord.core.exception.EntityNotFoundException
 import dev.kord.core.indexOfFirstOrNull
 import dev.kord.core.sorted
@@ -19,7 +18,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.map
 import java.util.*
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -151,7 +149,6 @@ public fun RoleBehavior(
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun RoleBehavior.edit(builder: RoleModifyBuilder.() -> Unit): Role {
     contract {
         callsInPlace(builder, InvocationKind.EXACTLY_ONCE)

--- a/core/src/main/kotlin/behavior/TemplateBehavior.kt
+++ b/core/src/main/kotlin/behavior/TemplateBehavior.kt
@@ -9,7 +9,6 @@ import dev.kord.core.entity.Template
 import dev.kord.rest.builder.template.GuildFromTemplateCreateBuilder
 import dev.kord.rest.builder.template.GuildTemplateModifyBuilder
 import java.util.*
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -32,7 +31,6 @@ public interface TemplateBehavior : KordObject {
 }
 
 
-@OptIn(ExperimentalContracts::class)
 public suspend fun TemplateBehavior.edit(builder: GuildTemplateModifyBuilder.() -> Unit): Template {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
     val response = kord.rest.template.modifyGuildTemplate(guildId, code, builder)
@@ -40,7 +38,6 @@ public suspend fun TemplateBehavior.edit(builder: GuildTemplateModifyBuilder.() 
     return Template(data, kord)
 }
 
-@OptIn(ExperimentalContracts::class)
 public suspend fun TemplateBehavior.createGuild(name: String, builder: GuildFromTemplateCreateBuilder.() -> Unit): Guild {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
     val response = kord.rest.template.createGuildFromTemplate(code, name, builder)

--- a/core/src/main/kotlin/behavior/WebhookBehavior.kt
+++ b/core/src/main/kotlin/behavior/WebhookBehavior.kt
@@ -14,7 +14,6 @@ import dev.kord.rest.builder.message.create.WebhookMessageCreateBuilder
 import dev.kord.rest.builder.webhook.WebhookModifyBuilder
 import dev.kord.rest.request.RestRequestException
 import java.util.*
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -80,7 +79,6 @@ internal fun WebhookBehavior(
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun WebhookBehavior.edit(builder: WebhookModifyBuilder.() -> Unit): Webhook {
     contract {
         callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
@@ -98,7 +96,6 @@ public suspend inline fun WebhookBehavior.edit(builder: WebhookModifyBuilder.() 
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun WebhookBehavior.edit(token: String, builder: WebhookModifyBuilder.() -> Unit): Webhook {
     contract {
         callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
@@ -114,7 +111,6 @@ public suspend inline fun WebhookBehavior.edit(token: String, builder: WebhookMo
  * if [threadId] is specified the execution will occur in that thread.
  * @throws [RestRequestException] if something went wrong during the request.
  */
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun WebhookBehavior.execute(token: String, threadId: Snowflake? = null, builder: WebhookMessageCreateBuilder.() -> Unit): Message {
     contract {
         callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
@@ -139,7 +135,6 @@ public suspend inline fun WebhookBehavior.execute(token: String, threadId: Snowf
  * Exception if the request wasn't executed.
  * if [threadId] is specified the execution will occur in that thread.
  */
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun WebhookBehavior.executeIgnored(token: String, threadId: Snowflake? = null, builder: WebhookMessageCreateBuilder.() -> Unit) {
     contract {
         callsInPlace(builder, InvocationKind.EXACTLY_ONCE)

--- a/core/src/main/kotlin/behavior/channel/CategoryBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/CategoryBehavior.kt
@@ -23,7 +23,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterIsInstance
 import java.util.*
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -122,7 +121,6 @@ public fun CategoryBehavior(
  * @return The edited [Category].
  * @throws [RestRequestException] if something went wrong during the request.
  */
-@OptIn(ExperimentalContracts::class)
 public suspend fun CategoryBehavior.edit(builder: CategoryModifyBuilder.() -> Unit): Category {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
     val response = kord.rest.channel.patchCategory(id, builder)
@@ -138,8 +136,6 @@ public suspend fun CategoryBehavior.edit(builder: CategoryModifyBuilder.() -> Un
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
-
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun CategoryBehavior.createTextChannel(
     name: String,
     builder: TextChannelCreateBuilder.() -> Unit = {}
@@ -164,7 +160,6 @@ public suspend inline fun CategoryBehavior.createTextChannel(
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun CategoryBehavior.createVoiceChannel(
     name: String,
     builder: VoiceChannelCreateBuilder.() -> Unit = {}
@@ -188,7 +183,6 @@ public suspend inline fun CategoryBehavior.createVoiceChannel(
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun CategoryBehavior.createNewsChannel(
     name: String,
     builder: NewsChannelCreateBuilder.() -> Unit = {}

--- a/core/src/main/kotlin/behavior/channel/MessageChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/MessageChannelBehavior.kt
@@ -25,7 +25,6 @@ import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import java.util.*
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 import kotlin.coroutines.coroutineContext
@@ -274,7 +273,6 @@ public fun MessageChannelBehavior(
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun MessageChannelBehavior.createMessage(builder: UserMessageCreateBuilder.() -> Unit): Message {
     contract {
         callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
@@ -290,7 +288,6 @@ public suspend inline fun MessageChannelBehavior.createMessage(builder: UserMess
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun MessageChannelBehavior.createEmbed(block: EmbedBuilder.() -> Unit): Message {
     contract {
         callsInPlace(block, InvocationKind.EXACTLY_ONCE)
@@ -311,7 +308,6 @@ public suspend inline fun MessageChannelBehavior.createEmbed(block: EmbedBuilder
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun <T : MessageChannelBehavior> T.withTyping(block: T.() -> Unit) {
     contract {
         callsInPlace(block, InvocationKind.EXACTLY_ONCE)

--- a/core/src/main/kotlin/behavior/channel/NewsChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/NewsChannelBehavior.kt
@@ -24,7 +24,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.datetime.Instant
 import java.util.*
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -144,7 +143,6 @@ public fun NewsChannelBehavior(
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun NewsChannelBehavior.edit(builder: NewsChannelModifyBuilder.() -> Unit): NewsChannel {
     contract {
         callsInPlace(builder, InvocationKind.EXACTLY_ONCE)

--- a/core/src/main/kotlin/behavior/channel/StageChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/StageChannelBehavior.kt
@@ -17,7 +17,6 @@ import dev.kord.rest.service.createStageInstance
 import dev.kord.rest.service.modifyCurrentVoiceState
 import dev.kord.rest.service.modifyVoiceState
 import dev.kord.rest.service.patchStageVoiceChannel
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -48,7 +47,6 @@ public interface StageChannelBehavior : BaseVoiceChannelBehavior {
 /**
  * Requests to edit the current user's voice state in this [StageChannel].
  */
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun StageChannelBehavior.editCurrentVoiceState(builder: CurrentVoiceStateModifyBuilder.() -> Unit) {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
     kord.rest.guild.modifyCurrentVoiceState(guildId, id, builder)
@@ -57,7 +55,6 @@ public suspend inline fun StageChannelBehavior.editCurrentVoiceState(builder: Cu
 /**
  * Requests to edit the another user's voice state in this [StageChannel].
  */
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun StageChannelBehavior.editVoiceState(
     userId: Snowflake,
     builder: VoiceStateModifyBuilder.() -> Unit
@@ -73,7 +70,6 @@ public suspend inline fun StageChannelBehavior.editVoiceState(
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
-@OptIn(ExperimentalContracts::class)
 public suspend fun StageChannelBehavior.edit(builder: StageVoiceChannelModifyBuilder.() -> Unit): StageChannel {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
     val response = kord.rest.channel.patchStageVoiceChannel(id, builder)

--- a/core/src/main/kotlin/behavior/channel/StoreChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/StoreChannelBehavior.kt
@@ -13,7 +13,6 @@ import dev.kord.rest.builder.channel.StoreChannelModifyBuilder
 import dev.kord.rest.request.RestRequestException
 import dev.kord.rest.service.patchStoreChannel
 import java.util.*
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -97,7 +96,6 @@ public fun StoreChannelBehavior(
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun StoreChannelBehavior.edit(builder: StoreChannelModifyBuilder.() -> Unit): StoreChannel {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
     val response = kord.rest.channel.patchStoreChannel(id, builder)

--- a/core/src/main/kotlin/behavior/channel/TextChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/TextChannelBehavior.kt
@@ -3,8 +3,6 @@ package dev.kord.core.behavior.channel
 import dev.kord.common.entity.ArchiveDuration
 import dev.kord.common.entity.ChannelType
 import dev.kord.common.entity.Snowflake
-import dev.kord.common.entity.optional.OptionalBoolean
-import dev.kord.common.entity.optional.optional
 import dev.kord.common.exception.RequestException
 import dev.kord.core.Kord
 import dev.kord.core.behavior.channel.threads.PrivateThreadParentChannelBehavior
@@ -25,7 +23,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.datetime.Instant
 import java.util.*
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -152,7 +149,6 @@ public fun TextChannelBehavior(
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun TextChannelBehavior.edit(builder: TextChannelModifyBuilder.() -> Unit): TextChannel {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
     val response = kord.rest.channel.patchTextChannel(id, builder)

--- a/core/src/main/kotlin/behavior/channel/TopGuildChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/TopGuildChannelBehavior.kt
@@ -20,7 +20,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.withIndex
 import java.util.*
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -147,7 +146,6 @@ internal fun TopGuildChannelBehavior(
  *
  *  @throws [RestRequestException] if something went wrong during the request.
  */
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun TopGuildChannelBehavior.editRolePermission(
     roleId: Snowflake,
     builder: ChannelPermissionModifyBuilder.() -> Unit
@@ -163,7 +161,6 @@ public suspend inline fun TopGuildChannelBehavior.editRolePermission(
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun TopGuildChannelBehavior.editMemberPermission(
     memberId: Snowflake,
     builder: ChannelPermissionModifyBuilder.() -> Unit

--- a/core/src/main/kotlin/behavior/channel/TopGuildMessageChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/TopGuildMessageChannelBehavior.kt
@@ -15,7 +15,6 @@ import dev.kord.rest.service.RestClient
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import java.util.*
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -120,7 +119,6 @@ internal fun TopGuildMessageChannelBehavior(
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun TopGuildMessageChannelBehavior.createWebhook(
     name: String,
     builder: WebhookCreateBuilder.() -> Unit = {}

--- a/core/src/main/kotlin/behavior/channel/VoiceChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/VoiceChannelBehavior.kt
@@ -13,7 +13,6 @@ import dev.kord.rest.builder.channel.VoiceChannelModifyBuilder
 import dev.kord.rest.request.RestRequestException
 import dev.kord.rest.service.patchVoiceChannel
 import java.util.*
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -94,7 +93,6 @@ public fun VoiceChannelBehavior(
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun VoiceChannelBehavior.edit(builder: VoiceChannelModifyBuilder.() -> Unit): VoiceChannel {
     contract {
         callsInPlace(builder, InvocationKind.EXACTLY_ONCE)

--- a/core/src/main/kotlin/behavior/channel/threads/ThreadChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/threads/ThreadChannelBehavior.kt
@@ -16,7 +16,6 @@ import dev.kord.core.supplier.getChannelOf
 import dev.kord.core.supplier.getChannelOfOrNull
 import dev.kord.rest.builder.channel.thread.ThreadModifyBuilder
 import kotlinx.coroutines.flow.Flow
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -136,7 +135,6 @@ public interface ThreadChannelBehavior : GuildMessageChannelBehavior {
  * [autoArchiveDuration][ThreadModifyBuilder.autoArchiveDuration] fields
  * requires [Manage Threads][dev.kord.common.entity.Permission.ManageThreads] or that the current user is the thread creator.
  */
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun ThreadChannelBehavior.edit(builder: ThreadModifyBuilder.() -> Unit): ThreadChannel {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
     val appliedBuilder = ThreadModifyBuilder().apply(builder)

--- a/core/src/main/kotlin/behavior/interaction/ActionInteractionBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/ActionInteractionBehavior.kt
@@ -6,7 +6,6 @@ import dev.kord.core.entity.Message
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 import dev.kord.rest.builder.message.create.InteractionResponseCreateBuilder
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -48,8 +47,6 @@ public interface ActionInteractionBehavior : InteractionBehavior {
  * @param builder [InteractionResponseCreateBuilder] used to create a public response.
  * @return [PublicInteractionResponseBehavior] public response to the interaction.
  */
-
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun ActionInteractionBehavior.respondPublic(
     builder: InteractionResponseCreateBuilder.() -> Unit
 ): PublicInteractionResponseBehavior {
@@ -69,8 +66,6 @@ public suspend inline fun ActionInteractionBehavior.respondPublic(
  * @param builder [InteractionResponseCreateBuilder] used to a create an ephemeral response.
  * @return [InteractionResponseBehavior] ephemeral response to the interaction.
  */
-
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun ActionInteractionBehavior.respondEphemeral(
     builder: InteractionResponseCreateBuilder.() -> Unit
 ): EphemeralInteractionResponseBehavior {

--- a/core/src/main/kotlin/behavior/interaction/AutoCompleteInteractionBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/AutoCompleteInteractionBehavior.kt
@@ -5,7 +5,6 @@ import dev.kord.common.entity.DiscordAutoComplete
 import dev.kord.rest.builder.interaction.IntChoiceBuilder
 import dev.kord.rest.builder.interaction.NumberChoiceBuilder
 import dev.kord.rest.builder.interaction.StringChoiceBuilder
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -26,7 +25,6 @@ public interface AutoCompleteInteractionBehavior : InteractionBehavior
  *
  * @see IntChoiceBuilder
  */
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun AutoCompleteInteractionBehavior.suggestInt(builder: IntChoiceBuilder.() -> Unit) {
     contract {
         callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
@@ -41,7 +39,6 @@ public suspend inline fun AutoCompleteInteractionBehavior.suggestInt(builder: In
  * The provided choices are only suggestions and the user can provide any other input as well.
  * @see NumberChoiceBuilder
  */
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun AutoCompleteInteractionBehavior.suggestNumber(builder: NumberChoiceBuilder.() -> Unit) {
     contract {
         callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
@@ -57,7 +54,6 @@ public suspend inline fun AutoCompleteInteractionBehavior.suggestNumber(builder:
  *
  * @see StringChoiceBuilder
  */
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun AutoCompleteInteractionBehavior.suggestString(builder: StringChoiceBuilder.() -> Unit) {
     contract {
         callsInPlace(builder, InvocationKind.EXACTLY_ONCE)

--- a/core/src/main/kotlin/behavior/interaction/ComponentInteractionBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/ComponentInteractionBehavior.kt
@@ -11,7 +11,6 @@ import dev.kord.core.supplier.EntitySupplyStrategy
 import dev.kord.rest.builder.message.create.UpdateMessageInteractionResponseCreateBuilder
 import dev.kord.rest.json.request.InteractionApplicationCommandCallbackData
 import dev.kord.rest.json.request.InteractionResponseCreateRequest
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -29,7 +28,6 @@ public interface ComponentInteractionBehavior : ActionInteractionBehavior {
      * on public and ephemeral messages. The only difference is in the **followUp** calls,
      * which will become public or ephemeral respectively.
      */
-    @OptIn(ExperimentalContracts::class)
     public suspend fun acknowledgePublicDeferredMessageUpdate(): PublicInteractionResponseBehavior {
         val request = InteractionResponseCreateRequest(
             type = InteractionResponseType.DeferredUpdateMessage
@@ -51,7 +49,6 @@ public interface ComponentInteractionBehavior : ActionInteractionBehavior {
      * on public and ephemeral messages. The only difference is in the **followUp** calls,
      * which will become ephemeral or public respectively.
      */
-    @OptIn(ExperimentalContracts::class)
     public suspend fun acknowledgeEphemeralDeferredMessageUpdate(): EphemeralInteractionResponseBehavior {
         val request = InteractionResponseCreateRequest(
             data = Optional.Value(
@@ -114,8 +111,6 @@ public fun ComponentInteractionBehavior(
  * on public and ephemeral messages. The only difference is in the **followUp** calls,
  * which will become public or ephemeral respectively.
  */
-
-@OptIn(ExperimentalContracts::class)
 public suspend fun ComponentInteractionBehavior.acknowledgePublicUpdateMessage(
     builder: UpdateMessageInteractionResponseCreateBuilder.() -> Unit
 ): PublicInteractionResponseBehavior {
@@ -140,8 +135,6 @@ public suspend fun ComponentInteractionBehavior.acknowledgePublicUpdateMessage(
  * on public and ephemeral messages. The only difference is in the **followUp** calls,
  * which will become ephemeral or public respectively.
  */
-
-@OptIn(ExperimentalContracts::class)
 public suspend fun ComponentInteractionBehavior.acknowledgeEphemeralUpdateMessage(
     builder: UpdateMessageInteractionResponseCreateBuilder.() -> Unit
 ): EphemeralInteractionResponseBehavior {

--- a/core/src/main/kotlin/behavior/interaction/FollowupMessageBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/FollowupMessageBehavior.kt
@@ -13,7 +13,6 @@ import dev.kord.core.supplier.getChannelOf
 import dev.kord.core.supplier.getChannelOfOrNull
 import dev.kord.rest.builder.message.modify.FollowupMessageModifyBuilder
 import dev.kord.rest.request.RestRequestException
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -42,8 +41,6 @@ public interface FollowupMessageBehavior : KordEntity, Strategizable {
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
-
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun FollowupMessageBehavior.edit(builder: FollowupMessageModifyBuilder.() -> Unit): EphemeralFollowupMessage {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
     val builder = FollowupMessageModifyBuilder().apply(builder)

--- a/core/src/main/kotlin/behavior/interaction/InteractionResponseBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/InteractionResponseBehavior.kt
@@ -9,7 +9,6 @@ import dev.kord.core.entity.interaction.PublicFollowupMessage
 import dev.kord.rest.builder.message.create.FollowupMessageCreateBuilder
 import dev.kord.rest.builder.message.modify.InteractionResponseModifyBuilder
 import dev.kord.rest.request.RestRequestException
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -26,7 +25,6 @@ public interface InteractionResponseBehavior : KordObject {
 /**
  * Follows up an interaction response without the [Ephemeral flag][dev.kord.common.entity.MessageFlag.Ephemeral]
  */
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun InteractionResponseBehavior.followUp(builder: FollowupMessageCreateBuilder.() -> Unit): PublicFollowupMessage {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
     val builder = FollowupMessageCreateBuilder(false).apply(builder)
@@ -39,7 +37,6 @@ public suspend inline fun InteractionResponseBehavior.followUp(builder: Followup
  * Follows up an interaction response with the [Ephemeral flag][dev.kord.common.entity.MessageFlag.Ephemeral]
  *
  */
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun InteractionResponseBehavior.followUpEphemeral(builder: FollowupMessageCreateBuilder.() -> Unit): EphemeralFollowupMessage {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
     val builder = FollowupMessageCreateBuilder(true).apply(builder)
@@ -55,7 +52,6 @@ public suspend inline fun InteractionResponseBehavior.followUpEphemeral(builder:
  * @throws [RestRequestException] if something went wrong during the request.
  */
 
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun InteractionResponseBehavior.edit(builder: InteractionResponseModifyBuilder.() -> Unit) {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
     val builder = InteractionResponseModifyBuilder().apply(builder)

--- a/core/src/main/kotlin/behavior/interaction/PublicFollowupMessageBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/PublicFollowupMessageBehavior.kt
@@ -9,7 +9,6 @@ import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 import dev.kord.rest.builder.message.modify.FollowupMessageModifyBuilder
 import dev.kord.rest.request.RestRequestException
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -42,8 +41,6 @@ public interface PublicFollowupMessageBehavior : FollowupMessageBehavior {
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
-
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun PublicFollowupMessageBehavior.edit(builder: FollowupMessageModifyBuilder.() -> Unit): PublicFollowupMessage {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
     val builder = FollowupMessageModifyBuilder().apply(builder)

--- a/core/src/main/kotlin/builder/kord/KordBuilder.kt
+++ b/core/src/main/kotlin/builder/kord/KordBuilder.kt
@@ -37,7 +37,6 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import mu.KotlinLogging
 import kotlin.concurrent.thread
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 import kotlin.time.Duration.Companion.seconds
@@ -170,7 +169,6 @@ public class KordBuilder(public val token: String) {
      * }
      * ```
      */
-    @OptIn(ExperimentalContracts::class)
     public fun cache(builder: KordCacheBuilder.(resources: ClientResources) -> Unit) {
         contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
         val old = cacheBuilder

--- a/core/src/main/kotlin/builder/kord/KordBuilder.kt
+++ b/core/src/main/kotlin/builder/kord/KordBuilder.kt
@@ -1,4 +1,3 @@
-@file:Suppress("EXPERIMENTAL_API_USAGE")
 
 package dev.kord.core.builder.kord
 

--- a/core/src/main/kotlin/cache/CachingGateway.kt
+++ b/core/src/main/kotlin/cache/CachingGateway.kt
@@ -12,7 +12,6 @@ import kotlin.coroutines.CoroutineContext
 /**
  * A bridge between [DataCache] and [Gateway] that automatically empties cache on disconnect.
  */
-@FlowPreview
 public class CachingGateway(
     private val cache: DataCache,
     private val gateway: Gateway,

--- a/core/src/main/kotlin/entity/GuildEmoji.kt
+++ b/core/src/main/kotlin/entity/GuildEmoji.kt
@@ -15,7 +15,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filter
 import java.util.*
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -123,7 +122,6 @@ public class GuildEmoji(
      *
      *  @throws [RequestException] if anything went wrong during the request.
      */
-    @OptIn(ExperimentalContracts::class)
     public suspend inline fun edit(builder: EmojiModifyBuilder.() -> Unit) {
         contract {
             callsInPlace(builder, InvocationKind.EXACTLY_ONCE)

--- a/core/src/main/kotlin/entity/GuildWidget.kt
+++ b/core/src/main/kotlin/entity/GuildWidget.kt
@@ -12,7 +12,6 @@ import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 import dev.kord.core.supplier.getChannelOfOrNull
 import dev.kord.rest.builder.guild.GuildWidgetModifyBuilder
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -40,7 +39,6 @@ public class GuildWidget(
     public suspend inline fun <reified T : Channel> getChannelOfOrNull(): T? =
         data.channelId?.let { supplier.getChannelOfOrNull(it) }
 
-    @OptIn(ExperimentalContracts::class)
     public suspend inline fun edit(builder: GuildWidgetModifyBuilder.() -> Unit): GuildWidget {
         contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
         return GuildWidget(GuildWidgetData.from(kord.rest.guild.modifyGuildWidget(guildId, builder)), guildId, kord)

--- a/core/src/main/kotlin/entity/Integration.kt
+++ b/core/src/main/kotlin/entity/Integration.kt
@@ -16,7 +16,6 @@ import dev.kord.rest.request.RestRequestException
 import kotlinx.datetime.Instant
 import kotlinx.datetime.toInstant
 import java.util.*
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 import kotlin.time.Duration
@@ -187,7 +186,6 @@ public class Integration(
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun Integration.edit(builder: IntegrationModifyBuilder.() -> Unit) {
     contract {
         callsInPlace(builder, InvocationKind.EXACTLY_ONCE)

--- a/core/src/main/kotlin/entity/channel/CategorizableChannel.kt
+++ b/core/src/main/kotlin/entity/channel/CategorizableChannel.kt
@@ -7,7 +7,6 @@ import dev.kord.core.cache.data.InviteData
 import dev.kord.core.entity.Invite
 import dev.kord.rest.builder.channel.InviteCreateBuilder
 import dev.kord.rest.request.RestRequestException
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -40,7 +39,6 @@ public interface CategorizableChannel : TopGuildChannel {
  * @return the created [Invite].
  * @throws RestRequestException if something went wrong during the request.
  */
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun CategorizableChannel.createInvite(builder: InviteCreateBuilder.() -> Unit = {}): Invite {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
     val response = kord.rest.channel.createInvite(id, builder)

--- a/core/src/main/kotlin/entity/channel/InviteChannel.kt
+++ b/core/src/main/kotlin/entity/channel/InviteChannel.kt
@@ -4,7 +4,6 @@ import dev.kord.core.cache.data.InviteData
 import dev.kord.core.entity.Invite
 import dev.kord.rest.builder.channel.InviteCreateBuilder
 import dev.kord.rest.request.RestRequestException
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -16,7 +15,6 @@ public interface InviteChannel : TopGuildChannel
  * @return the created [Invite].
  * @throws RestRequestException if something went wrong during the request.
  */
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun InviteChannel.createInvite(builder: InviteCreateBuilder.() -> Unit = {}): Invite {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
     val response = kord.rest.channel.createInvite(id, builder)

--- a/core/src/main/kotlin/gateway/MasterGateway.kt
+++ b/core/src/main/kotlin/gateway/MasterGateway.kt
@@ -1,7 +1,6 @@
 package dev.kord.core.gateway
 
 import dev.kord.gateway.*
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
@@ -21,7 +20,6 @@ public interface MasterGateway {
     public val averagePing: Duration?
 
 
-    @OptIn(FlowPreview::class)
     public val events: Flow<ShardEvent>
 
     public suspend fun startWithConfig(configuration: GatewayConfiguration): Unit = coroutineScope {

--- a/core/src/main/kotlin/gateway/handler/ChannelEventHandler.kt
+++ b/core/src/main/kotlin/gateway/handler/ChannelEventHandler.kt
@@ -17,7 +17,6 @@ import dev.kord.gateway.*
 import kotlinx.coroutines.CoroutineScope
 import dev.kord.core.event.Event as CoreEvent
 
-@Suppress("EXPERIMENTAL_API_USAGE")
 internal class ChannelEventHandler(
     cache: DataCache
 ) : BaseGatewayEventHandler(cache) {

--- a/core/src/main/kotlin/gateway/handler/DefaultGatewayEventInterceptor.kt
+++ b/core/src/main/kotlin/gateway/handler/DefaultGatewayEventInterceptor.kt
@@ -6,15 +6,11 @@ import dev.kord.core.event.kordCoroutineScope
 import dev.kord.core.gateway.ShardEvent
 import io.ktor.util.*
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.job
 import mu.KotlinLogging
-import kotlin.coroutines.CoroutineContext
 import dev.kord.core.event.Event as CoreEvent
 
 private val logger = KotlinLogging.logger { }
 
-@Suppress("EXPERIMENTAL_API_USAGE")
 public class DefaultGatewayEventInterceptor(
     cache: DataCache,
     private val eventScope: ((ShardEvent, Kord) -> CoroutineScope) = { _, kord -> kordCoroutineScope(kord) }

--- a/core/src/main/kotlin/gateway/handler/GuildEventHandler.kt
+++ b/core/src/main/kotlin/gateway/handler/GuildEventHandler.kt
@@ -56,7 +56,6 @@ import kotlinx.coroutines.flow.toSet
 import dev.kord.common.entity.DiscordGuild as GatewayGuild
 import dev.kord.core.event.Event as CoreEvent
 
-@Suppress("EXPERIMENTAL_API_USAGE")
 internal class GuildEventHandler(
     cache: DataCache
 ) : BaseGatewayEventHandler(cache) {

--- a/core/src/main/kotlin/gateway/handler/LifeCycleEventHandler.kt
+++ b/core/src/main/kotlin/gateway/handler/LifeCycleEventHandler.kt
@@ -13,7 +13,6 @@ import dev.kord.gateway.*
 import kotlinx.coroutines.CoroutineScope
 import dev.kord.core.event.Event as CoreEvent
 
-@Suppress("EXPERIMENTAL_API_USAGE")
 internal class LifeCycleEventHandler(
     cache: DataCache
 ) : BaseGatewayEventHandler(cache) {

--- a/core/src/main/kotlin/gateway/handler/MessageEventHandler.kt
+++ b/core/src/main/kotlin/gateway/handler/MessageEventHandler.kt
@@ -13,12 +13,10 @@ import dev.kord.core.entity.ReactionEmoji
 import dev.kord.core.event.message.*
 import dev.kord.gateway.*
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.singleOrNull
 import kotlinx.coroutines.flow.toSet
 
-@Suppress("EXPERIMENTAL_API_USAGE")
 internal class MessageEventHandler(
     cache: DataCache
 ) : BaseGatewayEventHandler(cache) {

--- a/core/src/main/kotlin/gateway/handler/UserEventHandler.kt
+++ b/core/src/main/kotlin/gateway/handler/UserEventHandler.kt
@@ -15,7 +15,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.singleOrNull
 import dev.kord.core.event.Event as CoreEvent
 
-@Suppress("EXPERIMENTAL_API_USAGE")
 internal class UserEventHandler(
     cache: DataCache
 ) : BaseGatewayEventHandler(cache) {

--- a/core/src/main/kotlin/gateway/handler/VoiceEventHandler.kt
+++ b/core/src/main/kotlin/gateway/handler/VoiceEventHandler.kt
@@ -15,10 +15,8 @@ import dev.kord.gateway.VoiceStateUpdate
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.singleOrNull
-import kotlin.coroutines.CoroutineContext
 import dev.kord.core.event.Event as CoreEvent
 
-@Suppress("EXPERIMENTAL_API_USAGE")
 internal class VoiceEventHandler(
     cache: DataCache
 ) : BaseGatewayEventHandler(cache) {

--- a/core/src/main/kotlin/gateway/handler/WebhookEventHandler.kt
+++ b/core/src/main/kotlin/gateway/handler/WebhookEventHandler.kt
@@ -6,10 +6,8 @@ import dev.kord.core.event.guild.WebhookUpdateEvent
 import dev.kord.gateway.Event
 import dev.kord.gateway.WebhooksUpdate
 import kotlinx.coroutines.CoroutineScope
-import kotlin.coroutines.CoroutineContext
 import dev.kord.core.event.Event as CoreEvent
 
-@Suppress("EXPERIMENTAL_API_USAGE")
 internal class WebhookEventHandler(
     cache: DataCache
 ) : BaseGatewayEventHandler(cache) {

--- a/core/src/main/kotlin/live/LiveKordEntity.kt
+++ b/core/src/main/kotlin/live/LiveKordEntity.kt
@@ -10,7 +10,6 @@ import dev.kord.core.kordLogger
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.*
-import kotlin.coroutines.CoroutineContext
 
 /**
  * A Discord entity that only emits events *related* to this entity.
@@ -27,11 +26,10 @@ public interface LiveKordEntity : KordEntity, CoroutineScope {
 
 @KordPreview
 public abstract class AbstractLiveKordEntity(
-    override val kord: Kord,
+    final override val kord: Kord,
     coroutineScope: CoroutineScope = kord + SupervisorJob(kord.coroutineContext.job)
 ) : LiveKordEntity, CoroutineScope by coroutineScope {
 
-    @Suppress("EXPERIMENTAL_API_USAGE")
     final override val events: SharedFlow<Event> =
         kord.events.filter { filter(it) }.onEach { update(it) }.shareIn(this, SharingStarted.Eagerly)
 

--- a/core/src/main/kotlin/supplier/CacheEntitySupplier.kt
+++ b/core/src/main/kotlin/supplier/CacheEntitySupplier.kt
@@ -49,7 +49,6 @@ import dev.kord.core.entity.channel.thread.ThreadChannel
 import dev.kord.core.entity.channel.thread.ThreadMember
 import dev.kord.core.exception.EntityNotFoundException
 import dev.kord.gateway.Gateway
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.emitAll
@@ -127,7 +126,6 @@ public class CacheEntitySupplier(private val kord: Kord) : EntitySupplier {
     /**
      *  fetches all cached [Member]s
      */
-    @OptIn(FlowPreview::class)
     public val members: Flow<Member>
         get() = cache.query<MemberData>().asFlow().mapNotNull {
             val userData =
@@ -311,7 +309,7 @@ public class CacheEntitySupplier(private val kord: Kord) : EntitySupplier {
     }
 
     override fun getTemplates(guildId: Snowflake): Flow<Template> {
-        return cache.query<TemplateData>() {
+        return cache.query<TemplateData> {
             idEq(TemplateData::sourceGuildId, guildId)
         }.asFlow().map { Template(it, kord) }
     }

--- a/core/src/main/kotlin/supplier/RestEntitySupplier.kt
+++ b/core/src/main/kotlin/supplier/RestEntitySupplier.kt
@@ -25,7 +25,6 @@ import dev.kord.rest.route.Position
 import dev.kord.rest.service.*
 import kotlinx.coroutines.flow.*
 import kotlinx.datetime.Instant
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 import kotlin.math.min
@@ -310,7 +309,6 @@ public class RestEntitySupplier(public val kord: Kord) : EntitySupplier {
     }
 
 
-    @OptIn(ExperimentalContracts::class)
     public inline fun getAuditLogEntries(
         guildId: Snowflake,
         builder: AuditLogGetRequestBuilder.() -> Unit

--- a/core/src/test/kotlin/UtilKtTest.kt
+++ b/core/src/test/kotlin/UtilKtTest.kt
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test
 internal class UtilKtTest {
 
     @Test
-    @ExperimentalStdlibApi
     fun `paginate forwards selects the right id`() = runBlockingTest {
 
         val flow = paginateForwards(start = Snowflake(0u), batchSize = 100, idSelector = { it }) {
@@ -28,7 +27,6 @@ internal class UtilKtTest {
     }
 
     @Test
-    @ExperimentalStdlibApi
     fun `paginate backwards selects the right id`() = runBlockingTest {
 
         val flow = paginateBackwards(start = Snowflake(1000u), batchSize = 100, idSelector = { it }) {

--- a/core/src/test/kotlin/live/AbstractLiveEntityTest.kt
+++ b/core/src/test/kotlin/live/AbstractLiveEntityTest.kt
@@ -41,7 +41,6 @@ abstract class AbstractLiveEntityTest<LIVE : AbstractLiveKordEntity> {
     class GatewayMock : Gateway {
         override val coroutineContext: CoroutineContext = EmptyCoroutineContext + SupervisorJob()
 
-        @OptIn(FlowPreview::class)
         override val events: MutableSharedFlow<Event> = MutableSharedFlow()
 
         override val ping: StateFlow<Duration?> = MutableStateFlow(null)

--- a/core/src/test/kotlin/performance/KordEventDropTest.kt
+++ b/core/src/test/kotlin/performance/KordEventDropTest.kt
@@ -33,7 +33,6 @@ class KordEventDropTest {
 
         override val coroutineContext: CoroutineContext = SupervisorJob() + EmptyCoroutineContext
 
-        @OptIn(FlowPreview::class)
         override val events: MutableSharedFlow<Event> = MutableSharedFlow()
 
         override val ping: StateFlow<Duration?> = MutableStateFlow(null)

--- a/gateway/src/main/kotlin/DefaultGateway.kt
+++ b/gateway/src/main/kotlin/DefaultGateway.kt
@@ -63,14 +63,13 @@ data class DefaultGatewayData(
  */
 class DefaultGateway(private val data: DefaultGatewayData) : Gateway {
 
-    override val coroutineContext: CoroutineContext = SupervisorJob() +data.dispatcher
+    override val coroutineContext: CoroutineContext = SupervisorJob() + data.dispatcher
 
     private val compression: Boolean = URLBuilder(data.url).parameters.contains("compress", "zlib-stream")
 
     private val _ping = MutableStateFlow<Duration?>(null)
     override val ping: StateFlow<Duration?> get() = _ping
 
-    @OptIn(FlowPreview::class)
     override val events: SharedFlow<Event> = data.eventFlow
 
     private lateinit var socket: DefaultClientWebSocketSession
@@ -271,7 +270,6 @@ class DefaultGateway(private val data: DefaultGatewayData) : Gateway {
         sendUnsafe(command)
     }
 
-    @Suppress("EXPERIMENTAL_API_USAGE")
     private suspend fun sendUnsafe(command: Command) {
         data.sendRateLimiter.consume()
         val json = Json.encodeToString(Command.Companion, command)

--- a/gateway/src/main/kotlin/DefaultGateway.kt
+++ b/gateway/src/main/kotlin/DefaultGateway.kt
@@ -26,7 +26,6 @@ import mu.KotlinLogging
 import java.io.ByteArrayOutputStream
 import java.util.zip.Inflater
 import java.util.zip.InflaterOutputStream
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 import kotlin.coroutines.CoroutineContext
@@ -291,7 +290,6 @@ class DefaultGateway(private val data: DefaultGatewayData) : Gateway {
     }
 }
 
-@OptIn(ExperimentalContracts::class)
 inline fun DefaultGateway(builder: DefaultGatewayBuilder.() -> Unit = {}): DefaultGateway {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
     return DefaultGatewayBuilder().apply(builder).build()

--- a/gateway/src/main/kotlin/Gateway.kt
+++ b/gateway/src/main/kotlin/Gateway.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.*
 import mu.KotlinLogging
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 import kotlin.coroutines.CoroutineContext
@@ -102,7 +101,6 @@ interface Gateway : CoroutineScope {
     }
 }
 
-@OptIn(ExperimentalContracts::class)
 suspend inline fun Gateway.editPresence(builder: PresenceBuilder.() -> Unit) {
     contract {
         callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
@@ -133,7 +131,6 @@ suspend inline fun Gateway.editPresence(builder: PresenceBuilder.() -> Unit) {
  * @param token The Discord token of the bot.
  * @param config additional configuration for the gateway.
  */
-@OptIn(ExperimentalContracts::class)
 suspend inline fun Gateway.start(token: String, config: GatewayConfigurationBuilder.() -> Unit = {}) {
     contract {
         callsInPlace(config, InvocationKind.EXACTLY_ONCE)
@@ -186,7 +183,7 @@ inline fun <reified T : Event> Gateway.on(
  * This function expects [request.nonce][RequestGuildMembers.nonce] to contain a value, but it is not required.
  * If no nonce was provided one will be generated instead.
  */
-@OptIn(PrivilegedIntent::class, ExperimentalContracts::class)
+@OptIn(PrivilegedIntent::class)
 fun Gateway.requestGuildMembers(
     guildId: Snowflake,
     builder: RequestGuildMembersBuilder.() -> Unit = { requestAllMembers() }

--- a/gateway/src/main/kotlin/GatewayConfiguration.kt
+++ b/gateway/src/main/kotlin/GatewayConfiguration.kt
@@ -5,7 +5,6 @@ import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.coerceToMissing
 import dev.kord.common.entity.optional.optional
 import dev.kord.gateway.builder.PresenceBuilder
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -47,7 +46,6 @@ data class GatewayConfigurationBuilder(
     /**
      * Calls the [builder] on a new [PresenceBuilder] and assigns the result to [presence].
      */
-    @OptIn(ExperimentalContracts::class)
     inline fun presence(builder: PresenceBuilder.() -> Unit) {
         contract {
             callsInPlace(builder, InvocationKind.EXACTLY_ONCE)

--- a/gateway/src/main/kotlin/Intent.kt
+++ b/gateway/src/main/kotlin/Intent.kt
@@ -10,7 +10,6 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlin.RequiresOptIn.Level
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -185,7 +184,6 @@ sealed class Intent(val code: DiscordBitSet) {
     }
 }
 
-@OptIn(ExperimentalContracts::class)
 inline fun Intents(builder: Intents.IntentsBuilder.() -> Unit = {}): Intents {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
     return Intents.IntentsBuilder().apply(builder).flags()
@@ -250,7 +248,6 @@ data class Intents internal constructor(val code: DiscordBitSet) {
     /**
      * copy this [Intents] and apply the [block] to it.
      */
-    @OptIn(ExperimentalContracts::class)
     inline fun copy(block: IntentsBuilder.() -> Unit): Intents {
         contract {
             callsInPlace(block, InvocationKind.EXACTLY_ONCE)
@@ -313,5 +310,3 @@ object IntentsSerializer : KSerializer<Intents> {
 
     }
 }
-
-

--- a/gateway/src/main/kotlin/builder/LoginBuilder.kt
+++ b/gateway/src/main/kotlin/builder/LoginBuilder.kt
@@ -3,7 +3,6 @@ package dev.kord.gateway.builder
 import dev.kord.common.entity.PresenceStatus
 import dev.kord.gateway.DiscordPresence
 import dev.kord.gateway.Intents
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -14,7 +13,6 @@ class LoginBuilder {
     var intents: Intents = Intents.nonPrivileged
     var name: String = "Kord"
 
-    @OptIn(ExperimentalContracts::class)
     fun presence(builder: PresenceBuilder.() -> Unit) {
         contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
         this.presence = PresenceBuilder().apply(builder).toPresence()

--- a/gateway/src/samples/kotlin/EventListener.kt
+++ b/gateway/src/samples/kotlin/EventListener.kt
@@ -18,9 +18,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.serialization.json.Json
 import kotlin.time.Duration.Companion.seconds
-import kotlin.time.ExperimentalTime
 
-@ExperimentalTime
 suspend fun main(args: Array<String>) {
     val token = args.firstOrNull() ?: error("expected a token")
 

--- a/gateway/src/test/kotlin/gateway/DefaultGatewayTest.kt
+++ b/gateway/src/test/kotlin/gateway/DefaultGatewayTest.kt
@@ -11,7 +11,6 @@ import io.ktor.client.engine.cio.*
 import io.ktor.client.features.json.*
 import io.ktor.client.features.json.serializer.*
 import io.ktor.client.features.websocket.*
-import io.ktor.util.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.flowOn
@@ -21,17 +20,11 @@ import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import kotlin.time.Duration.Companion.seconds
-import kotlin.time.ExperimentalTime
 
-@FlowPreview
-@KtorExperimentalAPI
-@ObsoleteCoroutinesApi
-@ExperimentalCoroutinesApi
 class DefaultGatewayTest {
     @OptIn(DelicateCoroutinesApi::class)
     @Test
     @Disabled
-    @ExperimentalTime
     fun `default gateway functions correctly`() {
         val token = System.getenv("KORD_TEST_TOKEN")
 

--- a/gateway/src/test/kotlin/json/CommandTest.kt
+++ b/gateway/src/test/kotlin/json/CommandTest.kt
@@ -1,5 +1,3 @@
-@file:Suppress("EXPERIMENTAL_API_USAGE")
-
 package json
 
 import dev.kord.common.entity.DiscordBotActivity

--- a/gateway/src/test/kotlin/json/SerializationTest.kt
+++ b/gateway/src/test/kotlin/json/SerializationTest.kt
@@ -1,8 +1,5 @@
-@file:Suppress("EXPERIMENTAL_API_USAGE")
-
 package json
 
-import dev.kord.common.entity.Overwrite
 import dev.kord.common.entity.UserFlags
 import dev.kord.common.entity.UserPremium
 import dev.kord.common.entity.optional.value

--- a/rest/src/main/kotlin/Image.kt
+++ b/rest/src/main/kotlin/Image.kt
@@ -27,7 +27,6 @@ class Image private constructor(val data: ByteArray, val format: Format) {
             val contentType = call.headers["Content-Type"]
                 ?: error("expected 'Content-Type' header in image request")
 
-            @Suppress("EXPERIMENTAL_API_USAGE")
             val bytes = call.content.toByteArray()
 
             Image(bytes, Format.fromContentType(contentType))

--- a/rest/src/main/kotlin/builder/channel/GuildChannelPositionModifyBuilder.kt
+++ b/rest/src/main/kotlin/builder/channel/GuildChannelPositionModifyBuilder.kt
@@ -8,7 +8,6 @@ import dev.kord.common.entity.optional.OptionalInt
 import dev.kord.common.entity.optional.delegate.delegate
 import dev.kord.rest.json.request.ChannelPositionSwapRequest
 import dev.kord.rest.json.request.GuildChannelPositionModifyRequest
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -25,7 +24,6 @@ class GuildChannelPositionModifyBuilder : AuditRequestBuilder<GuildChannelPositi
         pairs.forEach { move(it) }
     }
 
-    @OptIn(ExperimentalContracts::class)
     inline fun move(channel: Snowflake, builder: GuildChannelSwapBuilder.() -> Unit) {
         contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
         swaps.firstOrNull { it.channelId == channel }?.builder() ?: run {

--- a/rest/src/main/kotlin/builder/channel/PermissionOverwritesBuilder.kt
+++ b/rest/src/main/kotlin/builder/channel/PermissionOverwritesBuilder.kt
@@ -3,7 +3,6 @@ package dev.kord.rest.builder.channel
 import dev.kord.common.entity.Overwrite
 import dev.kord.common.entity.OverwriteType
 import dev.kord.common.entity.Snowflake
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -45,7 +44,6 @@ interface PermissionOverwritesModifyBuilder : PermissionOverwritesBuilder {
 /**
  * Adds an [Overwrite] for the [memberId].
  */
-@OptIn(ExperimentalContracts::class)
 inline fun PermissionOverwritesBuilder.addMemberOverwrite(
     memberId: Snowflake,
     builder: PermissionOverwriteBuilder.() -> Unit
@@ -61,7 +59,6 @@ inline fun PermissionOverwritesBuilder.addMemberOverwrite(
 /**
  * Adds an [Overwrite] for the [roleId].
  */
-@OptIn(ExperimentalContracts::class)
 inline fun PermissionOverwritesBuilder.addRoleOverwrite(
     roleId: Snowflake,
     builder: PermissionOverwriteBuilder.() -> Unit

--- a/rest/src/main/kotlin/builder/component/ActionRowBuilder.kt
+++ b/rest/src/main/kotlin/builder/component/ActionRowBuilder.kt
@@ -1,12 +1,10 @@
 package dev.kord.rest.builder.component
 
 import dev.kord.common.annotation.KordDsl
-import dev.kord.common.annotation.KordPreview
 import dev.kord.common.entity.ButtonStyle
 import dev.kord.common.entity.ComponentType
 import dev.kord.common.entity.DiscordComponent
 import dev.kord.common.entity.optional.Optional
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -14,7 +12,6 @@ import kotlin.contracts.contract
 class ActionRowBuilder : MessageComponentBuilder {
     val components = mutableListOf<ActionRowComponentBuilder>()
 
-    @OptIn(ExperimentalContracts::class)
     inline fun interactionButton(
         style: ButtonStyle,
         customId: String,
@@ -29,7 +26,6 @@ class ActionRowBuilder : MessageComponentBuilder {
         )
     }
 
-    @OptIn(ExperimentalContracts::class)
     inline fun linkButton(
         url: String,
         builder: ButtonBuilder.LinkButtonBuilder.() -> Unit
@@ -47,7 +43,6 @@ class ActionRowBuilder : MessageComponentBuilder {
      * Creates and adds a select menu with the [customId] and configured by the [builder].
      * An ActionRow with a select menu cannot have any other select menus or buttons.
      */
-    @OptIn(ExperimentalContracts::class)
     inline fun selectMenu(customId: String, builder: SelectMenuBuilder.() -> Unit){
         contract {
             callsInPlace(builder, InvocationKind.EXACTLY_ONCE)

--- a/rest/src/main/kotlin/builder/component/SelectMenuBuilder.kt
+++ b/rest/src/main/kotlin/builder/component/SelectMenuBuilder.kt
@@ -1,14 +1,12 @@
 package dev.kord.rest.builder.component
 
 import dev.kord.common.annotation.KordDsl
-import dev.kord.common.annotation.KordPreview
 import dev.kord.common.entity.ComponentType
 import dev.kord.common.entity.DiscordComponent
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
 import dev.kord.common.entity.optional.OptionalInt
 import dev.kord.common.entity.optional.delegate.delegate
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -58,7 +56,6 @@ class SelectMenuBuilder(
      * @param label The user-facing name of the option, max 25 characters.
      * @param value The dev-define value of the option, max 100 characters.
      */
-    @OptIn(ExperimentalContracts::class)
     inline fun option(label: String, value: String, builder: SelectOptionBuilder.() -> Unit = {}) {
         contract {
             callsInPlace(builder, InvocationKind.EXACTLY_ONCE)

--- a/rest/src/main/kotlin/builder/guild/GuildCreateBuilder.kt
+++ b/rest/src/main/kotlin/builder/guild/GuildCreateBuilder.kt
@@ -17,7 +17,6 @@ import dev.kord.rest.builder.role.RoleCreateBuilder
 import dev.kord.rest.json.request.GuildChannelCreateRequest
 import dev.kord.rest.json.request.GuildCreateRequest
 import dev.kord.rest.json.request.GuildRoleCreateRequest
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 import kotlin.random.Random
@@ -85,7 +84,6 @@ class GuildCreateBuilder(var name: String) : RequestBuilder<GuildCreateRequest> 
      */
     var systemChannelId: Snowflake? by ::_systemChannelId.delegate()
 
-    @OptIn(ExperimentalContracts::class)
     inline fun textChannel(
         name: String,
         id: Snowflake = newUniqueSnowflake(),
@@ -98,7 +96,6 @@ class GuildCreateBuilder(var name: String) : RequestBuilder<GuildCreateRequest> 
         return id
     }
 
-    @OptIn(ExperimentalContracts::class)
     inline fun newsChannel(
         name: String,
         id: Snowflake = newUniqueSnowflake(),
@@ -111,7 +108,6 @@ class GuildCreateBuilder(var name: String) : RequestBuilder<GuildCreateRequest> 
         return id
     }
 
-    @OptIn(ExperimentalContracts::class)
     inline fun category(
         name: String,
         id: Snowflake = newUniqueSnowflake(),
@@ -124,7 +120,6 @@ class GuildCreateBuilder(var name: String) : RequestBuilder<GuildCreateRequest> 
         return id
     }
 
-    @OptIn(ExperimentalContracts::class)
     inline fun role(id: Snowflake = newUniqueSnowflake(), builder: RoleCreateBuilder.() -> Unit): Snowflake {
         contract {
             callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
@@ -133,7 +128,6 @@ class GuildCreateBuilder(var name: String) : RequestBuilder<GuildCreateRequest> 
         return id
     }
 
-    @OptIn(ExperimentalContracts::class)
     inline fun everyoneRole(builder: RoleCreateBuilder.() -> Unit) {
         contract {
             callsInPlace(builder, InvocationKind.EXACTLY_ONCE)

--- a/rest/src/main/kotlin/builder/guild/WelcomeScreenModifyBuilder.kt
+++ b/rest/src/main/kotlin/builder/guild/WelcomeScreenModifyBuilder.kt
@@ -5,14 +5,10 @@ import dev.kord.common.entity.Snowflake
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
 import dev.kord.common.entity.optional.delegate.delegate
-import dev.kord.common.entity.optional.map
 import dev.kord.common.entity.optional.mapList
 import dev.kord.rest.builder.AuditRequestBuilder
 import dev.kord.rest.builder.RequestBuilder
 import dev.kord.rest.json.request.GuildWelcomeScreenModifyRequest
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -30,7 +26,6 @@ class WelcomeScreenModifyBuilder : AuditRequestBuilder<GuildWelcomeScreenModifyR
 
     var welcomeScreenChannels: MutableList<WelcomeScreenChannelBuilder>? by ::_welcomeScreenChannels.delegate()
 
-    @OptIn(ExperimentalContracts::class)
     inline fun welcomeChannel(id: Snowflake, description: String, builder: WelcomeScreenChannelBuilder.() -> Unit) {
         contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
         if (welcomeScreenChannels == null) welcomeScreenChannels = mutableListOf()

--- a/rest/src/main/kotlin/builder/interaction/ApplicationCommandBuilders.kt
+++ b/rest/src/main/kotlin/builder/interaction/ApplicationCommandBuilders.kt
@@ -1,20 +1,14 @@
 package dev.kord.rest.builder.interaction
 
 import dev.kord.common.annotation.KordDsl
-import dev.kord.common.annotation.KordPreview
 import dev.kord.common.entity.ApplicationCommandType
 import dev.kord.common.entity.DiscordGuildApplicationCommandPermission
 import dev.kord.common.entity.PartialDiscordGuildApplicationCommandPermissions
 import dev.kord.common.entity.Snowflake
-import dev.kord.common.entity.optional.Optional
-import dev.kord.common.entity.optional.OptionalBoolean
-import dev.kord.common.entity.optional.delegate.delegate
-import dev.kord.common.entity.optional.mapList
 import dev.kord.rest.builder.RequestBuilder
 import dev.kord.rest.json.request.ApplicationCommandCreateRequest
 import dev.kord.rest.json.request.ApplicationCommandModifyRequest
 import dev.kord.rest.json.request.ApplicationCommandPermissionsEditRequest
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -40,7 +34,6 @@ class ApplicationCommandPermissionsBulkModifyBuilder :
     @PublishedApi
     internal val permissions = mutableMapOf<Snowflake, ApplicationCommandPermissionsModifyBuilder>()
 
-    @OptIn(ExperimentalContracts::class)
     inline fun command(
         commandId: Snowflake,
         builder: ApplicationCommandPermissionsModifyBuilder.() -> Unit,

--- a/rest/src/main/kotlin/builder/interaction/InputChatBuilders.kt
+++ b/rest/src/main/kotlin/builder/interaction/InputChatBuilders.kt
@@ -1,17 +1,12 @@
 package dev.kord.rest.builder.interaction
 
 import dev.kord.common.annotation.KordDsl
-import dev.kord.common.annotation.KordPreview
 import dev.kord.common.entity.ApplicationCommandType
 import dev.kord.common.entity.optional.Optional
-import dev.kord.common.entity.optional.OptionalBoolean
 import dev.kord.common.entity.optional.delegate.delegate
 import dev.kord.common.entity.optional.mapList
-import dev.kord.rest.builder.RequestBuilder
-import dev.kord.rest.builder.interaction.*
 import dev.kord.rest.json.request.ApplicationCommandCreateRequest
 import dev.kord.rest.json.request.ApplicationCommandModifyRequest
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -22,7 +17,6 @@ sealed interface BaseInputChatBuilder {
 
 }
 
-@OptIn(ExperimentalContracts::class)
 inline fun BaseInputChatBuilder.mentionable(name: String, description: String, builder: MentionableBuilder.() -> Unit = {}) {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
     if (options == null) options = mutableListOf()
@@ -30,35 +24,30 @@ inline fun BaseInputChatBuilder.mentionable(name: String, description: String, b
 
 }
 
-@OptIn(ExperimentalContracts::class)
 inline fun BaseInputChatBuilder.channel(name: String, description: String, builder: ChannelBuilder.() -> Unit = {}) {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
     if (options == null) options = mutableListOf()
     options!!.add(ChannelBuilder(name, description).apply(builder))
 }
 
-@OptIn(ExperimentalContracts::class)
 inline fun BaseInputChatBuilder.user(name: String, description: String, builder: UserBuilder.() -> Unit = {}) {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
     if (options == null) options = mutableListOf()
     options!!.add(UserBuilder(name, description).apply(builder))
 }
 
-@OptIn(ExperimentalContracts::class)
 inline fun BaseInputChatBuilder.role(name: String, description: String, builder: RoleBuilder.() -> Unit = {}) {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
     if (options == null) options = mutableListOf()
     options!!.add(RoleBuilder(name, description).apply(builder))
 }
 
-@OptIn(ExperimentalContracts::class)
 inline fun BaseInputChatBuilder.number(name: String, description: String, builder: NumberChoiceBuilder.() -> Unit = {}) {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
     if (options == null) options = mutableListOf()
     options!!.add(NumberChoiceBuilder(name, description).apply(builder))
 }
 
-@OptIn(ExperimentalContracts::class)
 inline fun BaseInputChatBuilder.string(
     name: String,
     description: String,
@@ -69,14 +58,12 @@ inline fun BaseInputChatBuilder.string(
     options!!.add(StringChoiceBuilder(name, description).apply(builder))
 }
 
-@OptIn(ExperimentalContracts::class)
 inline fun BaseInputChatBuilder.int(name: String, description: String, builder: IntChoiceBuilder.() -> Unit = {}) {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
     if (options == null) options = mutableListOf()
     options!!.add(IntChoiceBuilder(name, description).apply(builder))
 }
 
-@OptIn(ExperimentalContracts::class)
 inline fun BaseInputChatBuilder.boolean(name: String, description: String, builder: BooleanBuilder.() -> Unit = {}) {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
     if (options == null) options = mutableListOf()
@@ -86,14 +73,12 @@ inline fun BaseInputChatBuilder.boolean(name: String, description: String, build
 @KordDsl
 interface RootInputChatBuilder : BaseInputChatBuilder
 
-@OptIn(ExperimentalContracts::class)
 inline fun RootInputChatBuilder.subCommand(name: String, description: String, builder: SubCommandBuilder.() -> Unit = {}) {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
     if (options == null) options = mutableListOf()
     options!!.add(SubCommandBuilder(name, description).apply(builder))
 }
 
-@OptIn(ExperimentalContracts::class)
 inline fun RootInputChatBuilder.group(name: String, description: String, builder: GroupCommandBuilder.() -> Unit = {}) {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
     if (options == null) options = mutableListOf()

--- a/rest/src/main/kotlin/builder/interaction/MultiApplicationCommandBuilder.kt
+++ b/rest/src/main/kotlin/builder/interaction/MultiApplicationCommandBuilder.kt
@@ -1,29 +1,24 @@
 package dev.kord.rest.builder.interaction
 
 import dev.kord.common.annotation.KordDsl
-import dev.kord.common.entity.ApplicationCommandType
-import dev.kord.common.entity.DiscordApplicationCommand
-import dev.kord.rest.builder.RequestBuilder
 import dev.kord.rest.json.request.ApplicationCommandCreateRequest
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
+
 @KordDsl
 class MultiApplicationCommandBuilder {
     val commands = mutableListOf<ApplicationCommandCreateBuilder>()
 
-    @OptIn(ExperimentalContracts::class)
     inline fun message(name: String, builder: MessageCommandCreateBuilder.() -> Unit = {}) {
         contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
         commands += MessageCommandCreateBuilder(name).apply(builder)
     }
 
-    @OptIn(ExperimentalContracts::class)
     inline fun user(name: String, builder: UserCommandCreateBuilder.() -> Unit = {}) {
         contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
         commands += UserCommandCreateBuilder(name).apply(builder)
     }
-    @OptIn(ExperimentalContracts::class)
+
     inline fun input(
         name: String,
         description: String,

--- a/rest/src/main/kotlin/builder/interaction/OptionsBuilder.kt
+++ b/rest/src/main/kotlin/builder/interaction/OptionsBuilder.kt
@@ -8,10 +8,8 @@ import dev.kord.common.entity.Choice
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
 import dev.kord.common.entity.optional.delegate.delegate
-import dev.kord.common.entity.optional.delegate.delegateList
 import dev.kord.common.entity.optional.mapList
 import dev.kord.rest.builder.RequestBuilder
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -165,7 +163,7 @@ class SubCommandBuilder(name: String, description: String) :
 @KordDsl
 class GroupCommandBuilder(name: String, description: String) :
     BaseCommandOptionBuilder(name, description, ApplicationCommandOptionType.SubCommandGroup) {
-    @OptIn(ExperimentalContracts::class)
+
     inline fun subCommand(
         name: String,
         description: String,

--- a/rest/src/main/kotlin/builder/message/create/MessageCreateBuilder.kt
+++ b/rest/src/main/kotlin/builder/message/create/MessageCreateBuilder.kt
@@ -1,6 +1,5 @@
 package dev.kord.rest.builder.message.create
 
-import dev.kord.common.annotation.KordPreview
 import dev.kord.rest.NamedFile
 import dev.kord.rest.builder.component.ActionRowBuilder
 import dev.kord.rest.builder.component.MessageComponentBuilder
@@ -11,7 +10,6 @@ import kotlinx.coroutines.withContext
 import java.io.InputStream
 import java.nio.file.Files
 import java.nio.file.Path
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -74,7 +72,6 @@ sealed interface MessageCreateBuilder {
 /**
  * Adds an embed to the message, configured by the [block]. A message can have up to 10 embeds.
  */
-@OptIn(ExperimentalContracts::class)
 inline fun MessageCreateBuilder.embed(block: EmbedBuilder.() -> Unit) {
     contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
     embeds.add(EmbedBuilder().apply(block))
@@ -85,7 +82,6 @@ inline fun MessageCreateBuilder.embed(block: EmbedBuilder.() -> Unit) {
  * (ping everything), calling this function but not configuring it before the request is build will result in all
  * pings being ignored.
  */
-@OptIn(ExperimentalContracts::class)
 inline fun MessageCreateBuilder.allowedMentions(block: AllowedMentionsBuilder.() -> Unit = {}) {
     contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
     allowedMentions = (allowedMentions ?: AllowedMentionsBuilder()).apply(block)
@@ -94,8 +90,6 @@ inline fun MessageCreateBuilder.allowedMentions(block: AllowedMentionsBuilder.()
 /**
  * Adds an Action Row to the message, configured by the [builder]. A message can have up to 5 action rows.
  */
-@OptIn(ExperimentalContracts::class)
-
 inline fun MessageCreateBuilder.actionRow(builder: ActionRowBuilder.() -> Unit) {
     contract {
         callsInPlace(builder, InvocationKind.EXACTLY_ONCE)

--- a/rest/src/main/kotlin/builder/message/modify/MessageModifyBuilder.kt
+++ b/rest/src/main/kotlin/builder/message/modify/MessageModifyBuilder.kt
@@ -2,8 +2,6 @@ package dev.kord.rest.builder.message.modify
 
 import dev.kord.common.annotation.KordPreview
 import dev.kord.common.entity.DiscordAttachment
-import dev.kord.common.entity.MessageFlags
-import dev.kord.common.entity.optional.Optional
 import dev.kord.rest.NamedFile
 import dev.kord.rest.builder.component.ActionRowBuilder
 import dev.kord.rest.builder.component.MessageComponentBuilder
@@ -14,7 +12,6 @@ import kotlinx.coroutines.withContext
 import java.io.InputStream
 import java.nio.file.Files
 import java.nio.file.Path
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -53,7 +50,6 @@ sealed interface MessageModifyBuilder {
 
 }
 
-@OptIn(ExperimentalContracts::class)
 inline fun MessageModifyBuilder.embed(block: EmbedBuilder.() -> Unit) {
     contract {
         callsInPlace(block, InvocationKind.EXACTLY_ONCE)
@@ -68,7 +64,6 @@ inline fun MessageModifyBuilder.embed(block: EmbedBuilder.() -> Unit) {
  * (ping everything), calling this function but not configuring it before the request is build will result in all
  * pings being ignored.
  */
-@OptIn(ExperimentalContracts::class)
 inline fun MessageModifyBuilder.allowedMentions(block: AllowedMentionsBuilder.() -> Unit = {}) {
     contract {
         callsInPlace(block, InvocationKind.EXACTLY_ONCE)
@@ -77,7 +72,6 @@ inline fun MessageModifyBuilder.allowedMentions(block: AllowedMentionsBuilder.()
 }
 
 
-@OptIn(ExperimentalContracts::class)
 inline fun MessageModifyBuilder.actionRow(builder: ActionRowBuilder.() -> Unit) {
     contract {
         callsInPlace(builder, InvocationKind.EXACTLY_ONCE)

--- a/rest/src/main/kotlin/ratelimit/RequestRateLimiter.kt
+++ b/rest/src/main/kotlin/ratelimit/RequestRateLimiter.kt
@@ -2,7 +2,6 @@ package dev.kord.rest.ratelimit
 
 import dev.kord.rest.request.Request
 import kotlinx.datetime.Instant
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -24,7 +23,6 @@ interface RequestRateLimiter {
  * [Awaits][RequestRateLimiter.await] the rate limits for the [request] and then runs [consumer].
  * Throws an [IllegalStateException] if the supplied [RequestToken] was not completed.
  */
-@OptIn(ExperimentalContracts::class)
 suspend inline fun <T> RequestRateLimiter.consume(
     request: Request<*, *>,
     consumer: (token: RequestToken) -> T

--- a/rest/src/main/kotlin/request/KtorRequestHandler.kt
+++ b/rest/src/main/kotlin/request/KtorRequestHandler.kt
@@ -31,7 +31,6 @@ internal val jsonDefault = Json {
  * @param clock A [Clock] to calculate bucket reset times, exposed for testing.
  * @param parser Serializer used to parse payloads.
  */
-@Suppress("EXPERIMENTAL_API_USAGE")
 class KtorRequestHandler(
     private val client: HttpClient,
     private val requestRateLimiter: RequestRateLimiter = ExclusionRequestRateLimiter(),
@@ -86,7 +85,7 @@ class KtorRequestHandler(
                 val requestBody = request.body ?: return@run
                 val json = parser.encodeToString(requestBody.strategy, requestBody.body)
                 logger.debug { request.logString(json) }
-                this.body = TextContent(json, io.ktor.http.ContentType.Application.Json)
+                this.body = TextContent(json, ContentType.Application.Json)
             }
             is MultipartRequest -> {
                 val content = request.data

--- a/rest/src/main/kotlin/service/ChannelService.kt
+++ b/rest/src/main/kotlin/service/ChannelService.kt
@@ -1,6 +1,5 @@
 package dev.kord.rest.service
 
-import dev.kord.common.annotation.KordPreview
 import dev.kord.common.entity.*
 import dev.kord.common.entity.optional.orEmpty
 import dev.kord.rest.builder.channel.*
@@ -15,7 +14,6 @@ import dev.kord.rest.request.RequestHandler
 import dev.kord.rest.request.auditLogReason
 import dev.kord.rest.route.Position
 import dev.kord.rest.route.Route
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -30,7 +28,6 @@ class ChannelService(requestHandler: RequestHandler) : RestService(requestHandle
         }
     }
 
-    @OptIn(ExperimentalContracts::class)
     suspend inline fun createMessage(channelId: Snowflake, builder: UserMessageCreateBuilder.() -> Unit): DiscordMessage {
         contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
         val multipartRequest = UserMessageCreateBuilder().apply(builder).toRequest()
@@ -179,7 +176,6 @@ class ChannelService(requestHandler: RequestHandler) : RestService(requestHandle
             body(UserAddDMRequest.serializer(), addUser)
         }
 
-    @OptIn(ExperimentalContracts::class)
     suspend inline fun createInvite(channelId: Snowflake, builder: InviteCreateBuilder.() -> Unit = {}): DiscordInvite {
         contract {
             callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
@@ -192,7 +188,6 @@ class ChannelService(requestHandler: RequestHandler) : RestService(requestHandle
         }
     }
 
-    @OptIn(ExperimentalContracts::class)
     suspend inline fun editMessage(
         channelId: Snowflake,
         messageId: Snowflake,
@@ -291,7 +286,6 @@ class ChannelService(requestHandler: RequestHandler) : RestService(requestHandle
         }
     }
 
-    @OptIn(ExperimentalContracts::class)
     suspend fun startThreadWithMessage(
         channelId: Snowflake,
         messageId: Snowflake,
@@ -316,7 +310,6 @@ class ChannelService(requestHandler: RequestHandler) : RestService(requestHandle
         }
     }
 
-    @OptIn(ExperimentalContracts::class)
     suspend fun startThread(
         channelId: Snowflake,
         name: String,
@@ -397,7 +390,6 @@ class ChannelService(requestHandler: RequestHandler) : RestService(requestHandle
 
 }
 
-@OptIn(ExperimentalContracts::class)
 suspend inline fun ChannelService.patchTextChannel(
     channelId: Snowflake,
     builder: TextChannelModifyBuilder.() -> Unit
@@ -409,7 +401,6 @@ suspend inline fun ChannelService.patchTextChannel(
     return patchChannel(channelId, modifyBuilder.toRequest(), modifyBuilder.reason)
 }
 
-@OptIn(ExperimentalContracts::class)
 suspend inline fun ChannelService.patchVoiceChannel(
     channelId: Snowflake,
     builder: VoiceChannelModifyBuilder.() -> Unit
@@ -422,7 +413,6 @@ suspend inline fun ChannelService.patchVoiceChannel(
 }
 
 
-@OptIn(ExperimentalContracts::class)
 suspend inline fun ChannelService.patchStageVoiceChannel(
     channelId: Snowflake,
     builder: StageVoiceChannelModifyBuilder.() -> Unit
@@ -433,7 +423,6 @@ suspend inline fun ChannelService.patchStageVoiceChannel(
     return patchChannel(channelId, StageVoiceChannelModifyBuilder().apply(builder).toRequest())
 }
 
-@OptIn(ExperimentalContracts::class)
 suspend inline fun ChannelService.patchStoreChannel(
     channelId: Snowflake,
     builder: StoreChannelModifyBuilder.() -> Unit
@@ -445,7 +434,6 @@ suspend inline fun ChannelService.patchStoreChannel(
     return patchChannel(channelId, modifyBuilder.toRequest(), modifyBuilder.reason)
 }
 
-@OptIn(ExperimentalContracts::class)
 suspend inline fun ChannelService.patchNewsChannel(
     channelId: Snowflake,
     builder: NewsChannelModifyBuilder.() -> Unit
@@ -457,7 +445,6 @@ suspend inline fun ChannelService.patchNewsChannel(
     return patchChannel(channelId, modifyBuilder.toRequest(), modifyBuilder.reason)
 }
 
-@OptIn(ExperimentalContracts::class)
 suspend inline fun ChannelService.patchCategory(
     channelId: Snowflake,
     builder: CategoryModifyBuilder.() -> Unit
@@ -469,7 +456,6 @@ suspend inline fun ChannelService.patchCategory(
     return patchChannel(channelId, modifyBuilder.toRequest(), modifyBuilder.reason)
 }
 
-@OptIn(ExperimentalContracts::class)
 suspend inline fun ChannelService.editMemberPermissions(
     channelId: Snowflake,
     memberId: Snowflake,
@@ -482,7 +468,6 @@ suspend inline fun ChannelService.editMemberPermissions(
     editChannelPermissions(channelId, memberId, modifyBuilder.toRequest(), modifyBuilder.reason)
 }
 
-@OptIn(ExperimentalContracts::class)
 suspend inline fun ChannelService.editRolePermission(
     channelId: Snowflake,
     roleId: Snowflake,

--- a/rest/src/main/kotlin/service/EmojiService.kt
+++ b/rest/src/main/kotlin/service/EmojiService.kt
@@ -10,13 +10,11 @@ import dev.kord.rest.json.request.EmojiModifyRequest
 import dev.kord.rest.request.RequestHandler
 import dev.kord.rest.request.auditLogReason
 import dev.kord.rest.route.Route
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
 class EmojiService(requestHandler: RequestHandler) : RestService(requestHandler) {
 
-    @OptIn(ExperimentalContracts::class)
     suspend inline fun createEmoji(
         guildId: Snowflake,
         name: String,
@@ -49,7 +47,6 @@ class EmojiService(requestHandler: RequestHandler) : RestService(requestHandler)
             auditLogReason(reason)
         }
 
-    @OptIn(ExperimentalContracts::class)
     suspend inline fun modifyEmoji(
         guildId: Snowflake,
         emojiId: Snowflake,

--- a/rest/src/main/kotlin/service/GuildService.kt
+++ b/rest/src/main/kotlin/service/GuildService.kt
@@ -57,13 +57,11 @@ import dev.kord.rest.request.auditLogReason
 import dev.kord.rest.route.Position
 import dev.kord.rest.route.Route
 import kotlinx.datetime.Instant
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
 class GuildService(requestHandler: RequestHandler) : RestService(requestHandler) {
 
-    @OptIn(ExperimentalContracts::class)
     suspend inline fun createGuild(name: String, builder: GuildCreateBuilder.() -> Unit): DiscordGuild {
         contract {
             callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
@@ -89,7 +87,6 @@ class GuildService(requestHandler: RequestHandler) : RestService(requestHandler)
         keys[Route.GuildId] = guildId
     }
 
-    @OptIn(ExperimentalContracts::class)
     suspend inline fun modifyGuild(guildId: Snowflake, builder: GuildModifyBuilder.() -> Unit): DiscordGuild {
         contract {
             callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
@@ -118,7 +115,6 @@ class GuildService(requestHandler: RequestHandler) : RestService(requestHandler)
             auditLogReason(reason)
         }
 
-    @OptIn(ExperimentalContracts::class)
     suspend inline fun modifyGuildChannelPosition(
         guildId: Snowflake,
         builder: GuildChannelPositionModifyBuilder.() -> Unit
@@ -161,7 +157,6 @@ class GuildService(requestHandler: RequestHandler) : RestService(requestHandler)
         parameter("limit", "$limit")
     }
 
-    @OptIn(ExperimentalContracts::class)
     suspend fun addGuildMember(
         guildId: Snowflake,
         userId: Snowflake,
@@ -176,7 +171,6 @@ class GuildService(requestHandler: RequestHandler) : RestService(requestHandler)
         }
     }
 
-    @OptIn(ExperimentalContracts::class)
     suspend inline fun modifyGuildMember(
         guildId: Snowflake,
         userId: Snowflake,
@@ -231,7 +225,6 @@ class GuildService(requestHandler: RequestHandler) : RestService(requestHandler)
         keys[Route.UserId] = userId
     }
 
-    @OptIn(ExperimentalContracts::class)
     suspend inline fun addGuildBan(guildId: Snowflake, userId: Snowflake, builder: BanCreateBuilder.() -> Unit) {
         contract {
             callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
@@ -257,7 +250,6 @@ class GuildService(requestHandler: RequestHandler) : RestService(requestHandler)
         keys[Route.GuildId] = guildId
     }
 
-    @OptIn(ExperimentalContracts::class)
     suspend inline fun createGuildRole(guildId: Snowflake, builder: RoleCreateBuilder.() -> Unit = {}): DiscordRole {
         contract {
             callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
@@ -271,7 +263,6 @@ class GuildService(requestHandler: RequestHandler) : RestService(requestHandler)
         }
     }
 
-    @OptIn(ExperimentalContracts::class)
     suspend inline fun modifyGuildRolePosition(
         guildId: Snowflake,
         builder: RolePositionsModifyBuilder.() -> Unit
@@ -286,7 +277,6 @@ class GuildService(requestHandler: RequestHandler) : RestService(requestHandler)
         }
     }
 
-    @OptIn(ExperimentalContracts::class)
     suspend inline fun modifyGuildRole(
         guildId: Snowflake,
         roleId: Snowflake,
@@ -344,7 +334,6 @@ class GuildService(requestHandler: RequestHandler) : RestService(requestHandler)
             body(GuildIntegrationCreateRequest.serializer(), integration)
         }
 
-    @OptIn(ExperimentalContracts::class)
     suspend inline fun modifyGuildIntegration(
         guildId: Snowflake,
         integrationId: Snowflake,
@@ -403,7 +392,6 @@ class GuildService(requestHandler: RequestHandler) : RestService(requestHandler)
             auditLogReason(reason)
         }
 
-    @OptIn(ExperimentalContracts::class)
     suspend inline fun modifyGuildWidget(
         guildId: Snowflake,
         builder: GuildWidgetModifyBuilder.() -> Unit
@@ -533,7 +521,6 @@ class GuildService(requestHandler: RequestHandler) : RestService(requestHandler)
     }
 }
 
-@OptIn(ExperimentalContracts::class)
 suspend inline fun GuildService.modifyGuildWelcomeScreen(
     guildId: Snowflake,
     builder: WelcomeScreenModifyBuilder.() -> Unit
@@ -543,7 +530,6 @@ suspend inline fun GuildService.modifyGuildWelcomeScreen(
     return modifyGuildWelcomeScreen(guildId, builder.toRequest(), builder.reason)
 }
 
-@OptIn(ExperimentalContracts::class)
 suspend inline fun GuildService.createTextChannel(
     guildId: Snowflake,
     name: String,
@@ -554,7 +540,6 @@ suspend inline fun GuildService.createTextChannel(
     return createGuildChannel(guildId, createBuilder.toRequest(), createBuilder.reason)
 }
 
-@OptIn(ExperimentalContracts::class)
 suspend inline fun GuildService.createNewsChannel(
     guildId: Snowflake,
     name: String,
@@ -565,7 +550,6 @@ suspend inline fun GuildService.createNewsChannel(
     return createGuildChannel(guildId, createBuilder.toRequest(), createBuilder.reason)
 }
 
-@OptIn(ExperimentalContracts::class)
 suspend inline fun GuildService.createVoiceChannel(
     guildId: Snowflake,
     name: String,
@@ -576,7 +560,6 @@ suspend inline fun GuildService.createVoiceChannel(
     return createGuildChannel(guildId, createBuilder.toRequest(), createBuilder.reason)
 }
 
-@OptIn(ExperimentalContracts::class)
 suspend inline fun GuildService.createCategory(
     guildId: Snowflake,
     name: String,
@@ -588,7 +571,6 @@ suspend inline fun GuildService.createCategory(
 }
 
 
-@OptIn(ExperimentalContracts::class)
 suspend inline fun GuildService.modifyCurrentVoiceState(
     guildId: Snowflake,
     channelId: Snowflake,
@@ -600,7 +582,6 @@ suspend inline fun GuildService.modifyCurrentVoiceState(
 }
 
 
-@OptIn(ExperimentalContracts::class)
 suspend inline fun GuildService.modifyVoiceState(
     guildId: Snowflake,
     channelId: Snowflake,
@@ -612,7 +593,6 @@ suspend inline fun GuildService.modifyVoiceState(
     modifyVoiceState(guildId, userId, modifyBuilder.toRequest())
 }
 
-@OptIn(ExperimentalContracts::class)
 suspend inline fun GuildService.createScheduledEvent(
     guildId: Snowflake,
     name: String,
@@ -635,7 +615,6 @@ suspend inline fun GuildService.createScheduledEvent(
     return createScheduledEvent(guildId, appliedBuilder.toRequest())
 }
 
-@OptIn(ExperimentalContracts::class)
 suspend inline fun GuildService.modifyScheduledEvent(
     guildId: Snowflake,
     eventId: Snowflake,

--- a/rest/src/main/kotlin/service/InteractionService.kt
+++ b/rest/src/main/kotlin/service/InteractionService.kt
@@ -47,7 +47,6 @@ import dev.kord.rest.route.Route
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.serializer
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -189,7 +188,6 @@ class InteractionService(requestHandler: RequestHandler) : RestService(requestHa
         return createAutoCompleteInteractionResponse(interactionId, interactionToken, DiscordAutoComplete(choices))
     }
 
-    @OptIn(ExperimentalContracts::class)
     suspend inline fun createIntAutoCompleteInteractionResponse(
         interactionId: Snowflake,
         interactionToken: String,
@@ -207,7 +205,6 @@ class InteractionService(requestHandler: RequestHandler) : RestService(requestHa
         )
     }
 
-    @OptIn(ExperimentalContracts::class)
     suspend inline fun createNumberAutoCompleteInteractionResponse(
         interactionId: Snowflake,
         interactionToken: String,
@@ -225,7 +222,6 @@ class InteractionService(requestHandler: RequestHandler) : RestService(requestHa
         )
     }
 
-    @OptIn(ExperimentalContracts::class)
     suspend inline fun createStringAutoCompleteInteractionResponse(
         interactionId: Snowflake,
         interactionToken: String,
@@ -381,7 +377,6 @@ class InteractionService(requestHandler: RequestHandler) : RestService(requestHa
     }
 
 
-    @OptIn(ExperimentalContracts::class)
     suspend inline fun createGlobalChatInputApplicationCommand(
         applicationId: Snowflake,
         name: String,
@@ -396,7 +391,6 @@ class InteractionService(requestHandler: RequestHandler) : RestService(requestHa
     }
 
 
-    @OptIn(ExperimentalContracts::class)
     suspend inline fun createGlobalMessageCommandApplicationCommand(
         applicationId: Snowflake,
         name: String,
@@ -411,7 +405,6 @@ class InteractionService(requestHandler: RequestHandler) : RestService(requestHa
         )
     }
 
-    @OptIn(ExperimentalContracts::class)
     suspend inline fun createGlobalUserCommandApplicationCommand(
         applicationId: Snowflake,
         name: String,
@@ -426,7 +419,6 @@ class InteractionService(requestHandler: RequestHandler) : RestService(requestHa
         )
     }
 
-    @OptIn(ExperimentalContracts::class)
     suspend inline fun createGlobalApplicationCommands(
         applicationId: Snowflake,
         builder: MultiApplicationCommandBuilder.() -> Unit
@@ -440,7 +432,6 @@ class InteractionService(requestHandler: RequestHandler) : RestService(requestHa
         )
     }
 
-    @OptIn(ExperimentalContracts::class)
     suspend inline fun modifyGlobalChatInputApplicationCommand(
         applicationId: Snowflake,
         commandId: Snowflake,
@@ -456,7 +447,6 @@ class InteractionService(requestHandler: RequestHandler) : RestService(requestHa
     }
 
 
-    @OptIn(ExperimentalContracts::class)
     suspend inline fun modifyGlobalMessageApplicationCommand(
         applicationId: Snowflake,
         commandId: Snowflake,
@@ -471,7 +461,6 @@ class InteractionService(requestHandler: RequestHandler) : RestService(requestHa
         )
     }
 
-    @OptIn(ExperimentalContracts::class)
     suspend inline fun modifyGlobalUserApplicationCommand(
         applicationId: Snowflake,
         commandId: Snowflake,
@@ -486,7 +475,6 @@ class InteractionService(requestHandler: RequestHandler) : RestService(requestHa
     }
 
 
-    @OptIn(ExperimentalContracts::class)
     suspend inline fun createGuildChatInputApplicationCommand(
         applicationId: Snowflake,
         guildId: Snowflake,
@@ -503,7 +491,6 @@ class InteractionService(requestHandler: RequestHandler) : RestService(requestHa
     }
 
 
-    @OptIn(ExperimentalContracts::class)
     suspend inline fun createGuildMessageCommandApplicationCommand(
         applicationId: Snowflake,
         guildId: Snowflake,
@@ -520,7 +507,6 @@ class InteractionService(requestHandler: RequestHandler) : RestService(requestHa
         )
     }
 
-    @OptIn(ExperimentalContracts::class)
     suspend inline fun createGuildUserCommandApplicationCommand(
         applicationId: Snowflake,
         guildId: Snowflake,
@@ -537,7 +523,6 @@ class InteractionService(requestHandler: RequestHandler) : RestService(requestHa
         )
     }
 
-    @OptIn(ExperimentalContracts::class)
     suspend inline fun createGuildApplicationCommands(
         applicationId: Snowflake,
         guildId: Snowflake,
@@ -553,7 +538,6 @@ class InteractionService(requestHandler: RequestHandler) : RestService(requestHa
         )
     }
 
-    @OptIn(ExperimentalContracts::class)
     suspend inline fun modifyGuildChatInputApplicationCommand(
         applicationId: Snowflake,
         guildId: Snowflake,
@@ -571,7 +555,6 @@ class InteractionService(requestHandler: RequestHandler) : RestService(requestHa
     }
 
 
-    @OptIn(ExperimentalContracts::class)
     suspend inline fun modifyGuildMessageApplicationCommand(
         applicationId: Snowflake,
         guildId: Snowflake,
@@ -588,7 +571,6 @@ class InteractionService(requestHandler: RequestHandler) : RestService(requestHa
         )
     }
 
-    @OptIn(ExperimentalContracts::class)
     suspend inline fun modifyGuildUserApplicationCommand(
         applicationId: Snowflake,
         guildId: Snowflake,
@@ -619,7 +601,6 @@ class InteractionService(requestHandler: RequestHandler) : RestService(requestHa
     }
 
 
-    @OptIn(ExperimentalContracts::class)
     suspend inline fun modifyInteractionResponse(
         applicationId: Snowflake,
         interactionToken: String,
@@ -634,7 +615,6 @@ class InteractionService(requestHandler: RequestHandler) : RestService(requestHa
         )
     }
 
-    @OptIn(ExperimentalContracts::class)
     suspend inline fun createFollowupMessage(
         applicationId: Snowflake,
         interactionToken: String,
@@ -649,7 +629,6 @@ class InteractionService(requestHandler: RequestHandler) : RestService(requestHa
         )
     }
 
-    @OptIn(ExperimentalContracts::class)
     suspend inline fun modifyFollowupMessage(
         applicationId: Snowflake,
         interactionToken: String,
@@ -666,7 +645,6 @@ class InteractionService(requestHandler: RequestHandler) : RestService(requestHa
     }
 
 
-    @OptIn(ExperimentalContracts::class)
     suspend inline fun bulkEditApplicationCommandPermissions(
         applicationId: Snowflake,
         guildId: Snowflake,
@@ -680,7 +658,6 @@ class InteractionService(requestHandler: RequestHandler) : RestService(requestHa
         )
     }
 
-    @OptIn(ExperimentalContracts::class)
     suspend inline fun editApplicationCommandPermissions(
         applicationId: Snowflake,
         guildId: Snowflake,

--- a/rest/src/main/kotlin/service/RestClient.kt
+++ b/rest/src/main/kotlin/service/RestClient.kt
@@ -6,7 +6,6 @@ import dev.kord.rest.request.KtorRequestHandler
 import dev.kord.rest.request.RequestBuilder
 import dev.kord.rest.request.RequestHandler
 import dev.kord.rest.route.Route
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -33,7 +32,6 @@ class RestClient(requestHandler: RequestHandler) : RestService(requestHandler) {
      * @param route The route to which to send a request.
      * @param block The configuration for this request.
      */
-    @OptIn(ExperimentalContracts::class)
     @KordUnsafe
     @KordExperimental
     suspend inline fun <T> unsafe(route: Route<T>, block: RequestBuilder<T>.() -> Unit): T {

--- a/rest/src/main/kotlin/service/RestService.kt
+++ b/rest/src/main/kotlin/service/RestService.kt
@@ -3,13 +3,11 @@ package dev.kord.rest.service
 import dev.kord.rest.request.RequestHandler
 import dev.kord.rest.request.RequestBuilder
 import dev.kord.rest.route.Route
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
 abstract class RestService(@PublishedApi internal val requestHandler: RequestHandler) {
 
-    @OptIn(ExperimentalContracts::class)
     @PublishedApi
     internal suspend inline fun <T> call(route: Route<T>, builder: RequestBuilder<T>.() -> Unit = {}): T {
         contract {
@@ -20,4 +18,3 @@ abstract class RestService(@PublishedApi internal val requestHandler: RequestHan
     }
 
 }
-

--- a/rest/src/main/kotlin/service/TemplateService.kt
+++ b/rest/src/main/kotlin/service/TemplateService.kt
@@ -11,7 +11,6 @@ import dev.kord.rest.json.request.GuildTemplateCreateRequest
 import dev.kord.rest.json.request.GuildTemplateModifyRequest
 import dev.kord.rest.request.RequestHandler
 import dev.kord.rest.route.Route
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -88,7 +87,6 @@ class TemplateService(requestHandler: RequestHandler) : RestService(requestHandl
     /**
      * Create a new guild with a [name] based on a template with the given [code] and configured by the [builder], returns the created guild.
      */
-    @OptIn(ExperimentalContracts::class)
     suspend inline fun createGuildFromTemplate(
         code: String,
         name: String,
@@ -104,7 +102,6 @@ class TemplateService(requestHandler: RequestHandler) : RestService(requestHandl
      *
      * Returns the modified [DiscordTemplate].
      */
-    @OptIn(ExperimentalContracts::class)
     suspend inline fun modifyGuildTemplate(
         guildId: Snowflake,
         code: String,
@@ -120,7 +117,6 @@ class TemplateService(requestHandler: RequestHandler) : RestService(requestHandl
      *
      * Returns the new [DiscordTemplate].
      */
-    @OptIn(ExperimentalContracts::class)
     suspend inline fun createGuildTemplate(
         guildId: Snowflake,
         name: String,

--- a/rest/src/main/kotlin/service/UserService.kt
+++ b/rest/src/main/kotlin/service/UserService.kt
@@ -11,7 +11,6 @@ import dev.kord.rest.json.request.GroupDMCreateRequest
 import dev.kord.rest.request.RequestHandler
 import dev.kord.rest.route.Position
 import dev.kord.rest.route.Route
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -41,7 +40,6 @@ class UserService(requestHandler: RequestHandler) : RestService(requestHandler) 
         body(DMCreateRequest.serializer(), dm)
     }
 
-    @OptIn(ExperimentalContracts::class)
     suspend inline fun createGroupDM(builder: GroupDMCreateBuilder.() -> Unit): DiscordChannel {
         contract {
             callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
@@ -52,7 +50,6 @@ class UserService(requestHandler: RequestHandler) : RestService(requestHandler) 
         }
     }
 
-    @OptIn(ExperimentalContracts::class)
     suspend inline fun modifyCurrentUser(builder: CurrentUserModifyBuilder.() -> Unit): DiscordUser {
         contract {
             callsInPlace(builder, InvocationKind.EXACTLY_ONCE)

--- a/rest/src/main/kotlin/service/WebhookService.kt
+++ b/rest/src/main/kotlin/service/WebhookService.kt
@@ -17,13 +17,11 @@ import dev.kord.rest.request.RequestHandler
 import dev.kord.rest.request.auditLogReason
 import dev.kord.rest.route.Route
 import kotlinx.serialization.json.JsonObject
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
 class WebhookService(requestHandler: RequestHandler) : RestService(requestHandler) {
 
-    @OptIn(ExperimentalContracts::class)
     suspend inline fun createWebhook(
         channelId: Snowflake,
         name: String,
@@ -58,7 +56,6 @@ class WebhookService(requestHandler: RequestHandler) : RestService(requestHandle
         keys[Route.WebhookToken] = token
     }
 
-    @OptIn(ExperimentalContracts::class)
     suspend inline fun modifyWebhook(webhookId: Snowflake, builder: WebhookModifyBuilder.() -> Unit): DiscordWebhook {
         contract {
             callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
@@ -72,7 +69,6 @@ class WebhookService(requestHandler: RequestHandler) : RestService(requestHandle
         }
     }
 
-    @OptIn(ExperimentalContracts::class)
     suspend inline fun modifyWebhookWithToken(
         webhookId: Snowflake,
         token: String,
@@ -103,7 +99,6 @@ class WebhookService(requestHandler: RequestHandler) : RestService(requestHandle
             auditLogReason(reason)
         }
 
-    @OptIn(ExperimentalContracts::class)
     suspend inline fun executeWebhook(
         webhookId: Snowflake,
         token: String,
@@ -144,7 +139,6 @@ class WebhookService(requestHandler: RequestHandler) : RestService(requestHandle
             body(JsonObject.serializer(), body)
         }
 
-    @OptIn(ExperimentalContracts::class)
     suspend inline fun editWebhookMessage(
         webhookId: Snowflake,
         token: String,

--- a/rest/src/test/kotlin/ratelimit/AbstractRequestRateLimiterTest.kt
+++ b/rest/src/test/kotlin/ratelimit/AbstractRequestRateLimiterTest.kt
@@ -4,7 +4,6 @@ import dev.kord.common.entity.DiscordGuild
 import dev.kord.rest.request.JsonRequest
 import dev.kord.rest.route.Route
 import io.ktor.util.*
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.currentTime
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
@@ -14,10 +13,7 @@ import kotlinx.datetime.Instant
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.seconds
-import kotlin.time.ExperimentalTime
 
-@ExperimentalTime
-@ExperimentalCoroutinesApi
 abstract class AbstractRequestRateLimiterTest {
 
     abstract fun newRequestRateLimiter(clock: Clock): RequestRateLimiter

--- a/rest/src/test/kotlin/ratelimit/ExclusionRequestRateLimiterTest.kt
+++ b/rest/src/test/kotlin/ratelimit/ExclusionRequestRateLimiterTest.kt
@@ -1,11 +1,7 @@
 package dev.kord.rest.ratelimit
 
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.datetime.Clock
-import kotlin.time.ExperimentalTime
 
-@ExperimentalTime
-@ExperimentalCoroutinesApi
 class ExclusionRequestRateLimiterTest : AbstractRequestRateLimiterTest() {
 
     override fun newRequestRateLimiter(clock: Clock): RequestRateLimiter {

--- a/rest/src/test/kotlin/ratelimit/ParallelRequestRateLimiterTest.kt
+++ b/rest/src/test/kotlin/ratelimit/ParallelRequestRateLimiterTest.kt
@@ -1,14 +1,11 @@
 package dev.kord.rest.ratelimit
 
-import kotlinx.coroutines.ExperimentalCoroutinesApi
+import dev.kord.common.annotation.KordUnsafe
 import kotlinx.datetime.Clock
-import kotlin.time.ExperimentalTime
 
-@ExperimentalTime
-@ExperimentalCoroutinesApi
-@Suppress("EXPERIMENTAL_API_USAGE")
 class ParallelRequestRateLimiterTest : AbstractRequestRateLimiterTest() {
 
+    @OptIn(KordUnsafe::class)
     override fun newRequestRateLimiter(clock: Clock): RequestRateLimiter {
         return ParallelRequestRateLimiter(clock)
     }

--- a/voice/src/main/kotlin/SpeakingFlag.kt
+++ b/voice/src/main/kotlin/SpeakingFlag.kt
@@ -8,7 +8,6 @@ import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -84,7 +83,6 @@ public class SpeakingFlags internal constructor(public val code: Int) {
 }
 
 @KordVoice
-@OptIn(ExperimentalContracts::class)
 public inline fun SpeakingFlags(builder: SpeakingFlags.Builder.() -> Unit): SpeakingFlags {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
     return SpeakingFlags.Builder().apply(builder).flags()

--- a/voice/src/main/kotlin/VoiceConnection.kt
+++ b/voice/src/main/kotlin/VoiceConnection.kt
@@ -14,7 +14,6 @@ import dev.kord.voice.streams.Streams
 import dev.kord.voice.udp.AudioFrameSender
 import dev.kord.voice.udp.VoiceUdpSocket
 import kotlinx.coroutines.*
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -126,7 +125,6 @@ public class VoiceConnection(
  * @throws dev.kord.voice.exception.VoiceConnectionInitializationException when there was a problem retrieving voice information from Discord.
  */
 @KordVoice
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun VoiceConnection(
     gateway: Gateway,
     selfId: Snowflake,

--- a/voice/src/main/kotlin/VoiceConnectionBuilder.kt
+++ b/voice/src/main/kotlin/VoiceConnectionBuilder.kt
@@ -1,5 +1,3 @@
-@file:Suppress("EXPERIMENTAL_API_USAGE")
-
 package dev.kord.voice
 
 import dev.kord.common.annotation.KordVoice

--- a/voice/src/main/kotlin/gateway/DefaultVoiceGateway.kt
+++ b/voice/src/main/kotlin/gateway/DefaultVoiceGateway.kt
@@ -182,7 +182,6 @@ public class DefaultVoiceGateway(
         sendUnsafe(command)
     }
 
-    @Suppress("EXPERIMENTAL_API_USAGE")
     private suspend fun sendUnsafe(command: Command) {
         val json = Json.encodeToString(Command, command)
         if (command is Identify) {


### PR DESCRIPTION
- remove no longer necessary opt-in / experimental annotations
- some tests were top-level functions that wouldn't get executed by gradle test task -> moved to classes + minor changes to make them pass
- `@OptIn(ExperimentalContracts::class)` was used a lot -> compiler argument opt-in for all modules