### PR TITLE
Nullable limit and before parameters in pagination, more precise Position type, multiple fixes

### DIFF
--- a/core/src/main/kotlin/Util.kt
+++ b/core/src/main/kotlin/Util.kt
@@ -242,7 +242,7 @@ internal fun <T : KordEntity> paginateBackwards(
 )
 
 /**
- * Paginates the [Collection] returned by [request] with [start] as a initial reference in time.
+ * Paginates the [Collection] returned by [request] with [start] as an initial reference in time.
  * [instantSelector] is used to select the new reference to fetch from.
  *
  * Termination scenarios:
@@ -251,14 +251,14 @@ internal fun <T : KordEntity> paginateBackwards(
  */
 internal fun <C : Collection<T>, T> paginateByDate(
     batchSize: Int,
-    start: Instant = Clock.System.now(),
+    start: Instant?,
     instantSelector: (C) -> Instant?,
     request: suspend (Instant) -> C,
 ): Flow<T> = flow {
 
     var currentTimestamp = start
     while (true) {
-        val response = request(currentTimestamp)
+        val response = request(currentTimestamp ?: Clock.System.now()) // get default current time as late as possible
 
         for (item in response) emit(item)
 
@@ -274,7 +274,7 @@ internal fun <C : Collection<T>, T> paginateByDate(
  */
 internal fun paginateThreads(
     batchSize: Int,
-    start: Instant = Clock.System.now(),
+    start: Instant?,
     request: suspend (Instant) -> Collection<ThreadChannel>,
 ) = paginateByDate(
     batchSize,

--- a/core/src/main/kotlin/Util.kt
+++ b/core/src/main/kotlin/Util.kt
@@ -120,7 +120,7 @@ internal suspend fun <T> Flow<T>.indexOfFirstOrNull(predicate: suspend (T) -> Bo
         .singleOrNull()?.first
 }
 
-internal fun <Batch : Collection<Item>, Item, Direction : Position.BeforeOrAfter> paginate(
+internal fun <Batch : Collection<Item>, Item : Any, Direction : Position.BeforeOrAfter> paginate(
     start: Snowflake,
     batchSize: Int,
     itemSelector: (Batch) -> Item?,
@@ -179,7 +179,7 @@ internal fun <T> oldestItem(idSelector: (T) -> Snowflake): (Collection<T>) -> T?
 /**
  *  Selects the [Position.After] the youngest item in the batch.
  */
-internal fun <T> paginateForwards(
+internal fun <T : Any> paginateForwards(
     batchSize: Int,
     start: Snowflake = Snowflake.min,
     idSelector: (T) -> Snowflake,
@@ -212,7 +212,7 @@ internal fun <T : KordEntity> paginateForwards(
 /**
  *  Selects the [Position.Before] the oldest item in the batch.
  */
-internal fun <T> paginateBackwards(
+internal fun <T : Any> paginateBackwards(
     batchSize: Int,
     start: Snowflake = Snowflake.max,
     idSelector: (T) -> Snowflake,
@@ -250,7 +250,7 @@ internal fun <T : KordEntity> paginateBackwards(
  * * [Collection]'s size fall behind [batchSize].
  * * [instantSelector] returns null.
  */
-internal fun <Batch : Collection<Item>, Item> paginateByDate(
+internal fun <Batch : Collection<Item>, Item : Any> paginateByDate(
     batchSize: Int,
     start: Instant?,
     instantSelector: (Batch) -> Instant?,

--- a/core/src/main/kotlin/Util.kt
+++ b/core/src/main/kotlin/Util.kt
@@ -179,43 +179,67 @@ internal fun <T> oldestItem(idSelector: (T) -> Snowflake): (Collection<T>) -> T?
  *  Selects the [Position.After] the youngest item in the batch.
  */
 internal fun <T> paginateForwards(
-    start: Snowflake = Snowflake.min,
     batchSize: Int,
+    start: Snowflake = Snowflake.min,
     idSelector: (T) -> Snowflake,
     request: suspend (after: Position.After) -> Collection<T>,
-): Flow<T> =
-    paginate(start, batchSize, idSelector, youngestItem(idSelector), Position::After, request)
+): Flow<T> = paginate(
+    start,
+    batchSize,
+    idSelector,
+    itemSelector = youngestItem(idSelector),
+    directionSelector = Position::After,
+    request,
+)
 
 /**
  *  Selects the [Position.After] the youngest item in the batch.
  */
 internal fun <T : KordEntity> paginateForwards(
-    start: Snowflake = Snowflake.min,
     batchSize: Int,
+    start: Snowflake = Snowflake.min,
     request: suspend (after: Position.After) -> Collection<T>,
-): Flow<T> =
-    paginate(start, batchSize, { it.id }, youngestItem { it.id }, Position::After, request)
+): Flow<T> = paginate(
+    start,
+    batchSize,
+    idSelector = { it.id },
+    itemSelector = youngestItem { it.id },
+    directionSelector = Position::After,
+    request,
+)
 
 /**
  *  Selects the [Position.Before] the oldest item in the batch.
  */
 internal fun <T> paginateBackwards(
-    start: Snowflake = Snowflake.max,
     batchSize: Int,
+    start: Snowflake = Snowflake.max,
     idSelector: (T) -> Snowflake,
     request: suspend (before: Position.Before) -> Collection<T>,
-): Flow<T> =
-    paginate(start, batchSize, idSelector, oldestItem(idSelector), Position::Before, request)
+): Flow<T> = paginate(
+    start,
+    batchSize,
+    idSelector,
+    itemSelector = oldestItem(idSelector),
+    directionSelector = Position::Before,
+    request,
+)
 
 /**
  *  Selects the [Position.Before] the oldest item in the batch.
  */
 internal fun <T : KordEntity> paginateBackwards(
-    start: Snowflake = Snowflake.max,
     batchSize: Int,
+    start: Snowflake = Snowflake.max,
     request: suspend (before: Position.Before) -> Collection<T>,
-): Flow<T> =
-    paginate(start, batchSize, { it.id }, oldestItem { it.id }, Position::Before, request)
+): Flow<T> = paginate(
+    start,
+    batchSize,
+    idSelector = { it.id },
+    itemSelector = oldestItem { it.id },
+    directionSelector = Position::Before,
+    request,
+)
 
 /**
  * Paginates the [Collection] returned by [request] with [start] as a initial reference in time.
@@ -226,8 +250,8 @@ internal fun <T : KordEntity> paginateBackwards(
  * * [instantSelector] returns null.
  */
 internal fun <C : Collection<T>, T> paginateByDate(
-    start: Instant = Clock.System.now(),
     batchSize: Int,
+    start: Instant = Clock.System.now(),
     instantSelector: (C) -> Instant?,
     request: suspend (Instant) -> C,
 ): Flow<T> = flow {
@@ -251,14 +275,13 @@ internal fun <C : Collection<T>, T> paginateByDate(
 internal fun paginateThreads(
     batchSize: Int,
     start: Instant = Clock.System.now(),
-    request: suspend (Instant) -> Collection<ThreadChannel>
-) =
-    paginateByDate(
-        start,
-        batchSize,
-        { threads -> threads.minOfOrNull { it.archiveTimestamp } },
-        request
-    )
+    request: suspend (Instant) -> Collection<ThreadChannel>,
+) = paginateByDate(
+    batchSize,
+    start,
+    instantSelector = { threads -> threads.minOfOrNull { it.archiveTimestamp } },
+    request,
+)
 
 public inline fun <reified T : Event> Intents.IntentsBuilder.enableEvent(): Unit = enableEvent(T::class)
 

--- a/core/src/main/kotlin/Util.kt
+++ b/core/src/main/kotlin/Util.kt
@@ -129,7 +129,6 @@ internal fun <C : Collection<T>, T, P : Position> paginate(
     request: suspend (position: P) -> C,
 ): Flow<T> = flow {
     var position = directionSelector(start)
-    var size = batchSize
 
     while (true) {
         val response = request(position)
@@ -138,8 +137,7 @@ internal fun <C : Collection<T>, T, P : Position> paginate(
         val id = itemSelector(response)?.let(idSelector) ?: break
         position = directionSelector(id)
 
-        if (response.size < size) break
-        size = response.size
+        if (response.size < batchSize) break
     }
 }
 

--- a/core/src/main/kotlin/behavior/GuildBehavior.kt
+++ b/core/src/main/kotlin/behavior/GuildBehavior.kt
@@ -161,9 +161,9 @@ public interface GuildBehavior : KordEntity, Strategizable {
     /**
      * Requests to get all present members in this guild.
      *
-     * Unrestricted consumption of the returned [Flow] is a potentially performance intensive operation, it is thus recommended
-     * to limit the amount of messages requested by using [Flow.take], [Flow.takeWhile] or other functions that limit the amount
-     * of messages requested.
+     * Unrestricted consumption of the returned [Flow] is a potentially performance-intensive operation, it is thus
+     * recommended limiting the amount of messages requested by using [Flow.take], [Flow.takeWhile] or other functions
+     * that limit the amount of messages requested.
      *
      * ```kotlin
      *  guild.members.first { it.displayName == targetName }
@@ -288,7 +288,7 @@ public interface GuildBehavior : KordEntity, Strategizable {
         supplier.getGuildApplicationCommandOrNull(kord.resources.applicationId, id, commandId)
 
     /**
-     * Requests to get the this behavior as a [Guild].
+     * Requests to get this behavior as a [Guild].
      *
      * @throws [RequestException] if anything went wrong during the request.
      * @throws [EntityNotFoundException] if the guild wasn't present.
@@ -350,11 +350,9 @@ public interface GuildBehavior : KordEntity, Strategizable {
      *
      * The returned flow is lazily executed, any [RequestException] will be thrown on
      * [terminal operators](https://kotlinlang.org/docs/reference/coroutines/flow.html#terminal-flow-operators) instead.
-     *
-     * This function is not part of the officially documented Discord API and may be removed/altered/stop working in the future.
      */
     @KordExperimental
-    public suspend fun getMembers(query: String, limit: Int = 1000): Flow<Member> = flow {
+    public fun getMembers(query: String, limit: Int = 1000): Flow<Member> = flow {
         kord.rest.guild.getGuildMembers(id, query, limit).forEach {
             emit(
                 Member(

--- a/core/src/main/kotlin/behavior/channel/MessageChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/MessageChannelBehavior.kt
@@ -37,7 +37,7 @@ import kotlin.time.TimeMark
 public interface MessageChannelBehavior : ChannelBehavior, Strategizable {
 
     /**
-     * Requests to get the this behavior as a [MessageChannel].
+     * Requests to get this behavior as a [MessageChannel].
      *
      * @throws [RequestException] if something went wrong during the request.
      * @throws [EntityNotFoundException] if the channel wasn't present.
@@ -74,9 +74,9 @@ public interface MessageChannelBehavior : ChannelBehavior, Strategizable {
      * Requests to get all messages in this channel.
      *
      * Messages retrieved by this function will be emitted in chronological order (oldest -> newest).
-     * Unrestricted consumption of the returned [Flow] is a potentially performance intensive operation, it is thus recommended
-     * to limit the amount of messages requested by using [Flow.take], [Flow.takeWhile] or other functions that limit the amount
-     * of messages requested.
+     * Unrestricted consumption of the returned [Flow] is a potentially performance-intensive operation, it is thus
+     * recommended limiting the amount of messages requested by using [Flow.take], [Flow.takeWhile] or other functions
+     * that limit the amount of messages requested.
      *
      * ```kotlin
      *  channel.getMessagesBefore(newer.id).takeWhile { it.id > older.id }
@@ -127,11 +127,11 @@ public interface MessageChannelBehavior : ChannelBehavior, Strategizable {
      * Messages retrieved by this function will be emitted in reverse-chronological older (newest -> oldest).
      *
      * The flow may use paginated requests to supply messages, [limit] will limit the maximum number of messages
-     * supplied and may optimize the batch size accordingly. A value of [Int.MAX_VALUE] means no limit.
+     * supplied and may optimize the batch size accordingly. `null` means no limit.
      *
-     * Unrestricted consumption of the returned [Flow] is a potentially performance intensive operation, it is thus recommended
-     * to limit the amount of messages requested by using [Flow.take], [Flow.takeWhile] or other functions that limit the amount
-     * of messages requested.
+     * Unrestricted consumption of the returned [Flow] is a potentially performance-intensive operation, it is thus
+     * recommended limiting the amount of messages requested by using [Flow.take], [Flow.takeWhile] or other functions
+     * that limit the amount of messages requested.
      *
      * ```kotlin
      *  channel.getMessagesBefore(newer.id).takeWhile { it.id > older.id }
@@ -142,7 +142,7 @@ public interface MessageChannelBehavior : ChannelBehavior, Strategizable {
      *
      * @throws IllegalArgumentException if a [limit] < 1 was supplied.
      */
-    public fun getMessagesBefore(messageId: Snowflake, limit: Int = Int.MAX_VALUE): Flow<Message> =
+    public fun getMessagesBefore(messageId: Snowflake, limit: Int? = null): Flow<Message> =
         supplier.getMessagesBefore(channelId = id, messageId = messageId, limit = limit)
 
     /**
@@ -151,11 +151,11 @@ public interface MessageChannelBehavior : ChannelBehavior, Strategizable {
      * Messages retrieved by this function will be emitted in chronological older (oldest -> newest).
      *
      * The flow may use paginated requests to supply messages, [limit] will limit the maximum number of messages
-     * supplied and may optimize the batch size accordingly. A value of [Int.MAX_VALUE] means no limit.
+     * supplied and may optimize the batch size accordingly. `null` means no limit.
      *
-     * Unrestricted consumption of the returned [Flow] is a potentially performance intensive operation, it is thus recommended
-     * to limit the amount of messages requested by using [Flow.take], [Flow.takeWhile] or other functions that limit the amount
-     * of messages requested.
+     * Unrestricted consumption of the returned [Flow] is a potentially performance-intensive operation, it is thus
+     * recommended limiting the amount of messages requested by using [Flow.take], [Flow.takeWhile] or other functions
+     * that limit the amount of messages requested.
      *
      * ```kotlin
      *  channel.getMessagesAfter(older.id).takeWhile { it.id < newer.id }
@@ -165,19 +165,22 @@ public interface MessageChannelBehavior : ChannelBehavior, Strategizable {
      *
      * @throws IllegalArgumentException if a [limit] < 1 was supplied.
      */
-    public fun getMessagesAfter(messageId: Snowflake, limit: Int = Int.MAX_VALUE): Flow<Message> =
+    public fun getMessagesAfter(messageId: Snowflake, limit: Int? = null): Flow<Message> =
         supplier.getMessagesAfter(channelId = id, messageId = messageId, limit = limit)
 
     /**
-     * Requests to get messages around (both older and newer) the [messageId].
+     * Requests to get [Message]s around (both older and newer) the [messageId].
      *
      * Messages retrieved by this function will be emitted in chronological older (oldest -> newest).
      *
      * Unlike [getMessagesAfter] and [getMessagesBefore], this flow can return **a maximum of 100 messages**.
      * As such, the accepted range of [limit] is reduced to 1..100.
      *
-     * Supplied messages will be equally distributed  before and after the [messageId].
-     * The remaining message for an odd [limit] is undefined and may appear on either side.
+     * Supplied messages will be equally distributed before and after the [messageId].
+     * The remaining message for an odd [limit] is undefined and may appear on either side or no side at all.
+     *
+     * If a message with the given [messageId] exists, the flow might also contain it, so it **could have one more
+     * element than the given [limit]**.
      *
      * The returned flow is lazily executed, any [RequestException] will be thrown on
      * [terminal operators](https://kotlinlang.org/docs/reference/coroutines/flow.html#terminal-flow-operators) instead.
@@ -185,7 +188,7 @@ public interface MessageChannelBehavior : ChannelBehavior, Strategizable {
      * @throws IllegalArgumentException if the [limit] is outside the range of 1..100.
      */
     public fun getMessagesAround(messageId: Snowflake, limit: Int = 100): Flow<Message> =
-        supplier.getMessagesAround(channelId = id, messageId = messageId, limit = 100)
+        supplier.getMessagesAround(channelId = id, messageId = messageId, limit = limit)
 
     /**
      * Requests to get a message with the given [messageId].

--- a/core/src/main/kotlin/behavior/channel/NewsChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/NewsChannelBehavior.kt
@@ -100,7 +100,7 @@ public interface NewsChannelBehavior : ThreadParentChannelBehavior {
     }
 
 
-    override fun getPublicArchivedThreads(before: Instant, limit: Int): Flow<NewsChannelThread> {
+    override fun getPublicArchivedThreads(before: Instant?, limit: Int?): Flow<NewsChannelThread> {
         return super.getPublicArchivedThreads(before, limit).filterIsInstance()
     }
 

--- a/core/src/main/kotlin/behavior/channel/TextChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/TextChannelBehavior.kt
@@ -32,7 +32,7 @@ public interface TextChannelBehavior : PrivateThreadParentChannelBehavior {
         get() = super.activeThreads.filterIsInstance()
 
     /**
-     * Requests to get the this behavior as a [TextChannel].
+     * Requests to get this behavior as a [TextChannel].
      *
      * @throws [RequestException] if anything went wrong during the request.
      * @throws [EntityNotFoundException] if the channel wasn't present.
@@ -96,15 +96,15 @@ public interface TextChannelBehavior : PrivateThreadParentChannelBehavior {
         return unsafeStartPublicThreadWithMessage(messageId, name, archiveDuration, reason) as TextChannelThread
     }
 
-    override fun getPublicArchivedThreads(before: Instant, limit: Int): Flow<TextChannelThread> {
+    override fun getPublicArchivedThreads(before: Instant?, limit: Int?): Flow<TextChannelThread> {
         return super.getPublicArchivedThreads(before, limit).filterIsInstance()
     }
 
-    override fun getPrivateArchivedThreads(before: Instant, limit: Int): Flow<TextChannelThread> {
+    override fun getPrivateArchivedThreads(before: Instant?, limit: Int?): Flow<TextChannelThread> {
         return super.getPrivateArchivedThreads(before, limit).filterIsInstance()
     }
 
-    override fun getJoinedPrivateArchivedThreads(before: Snowflake, limit: Int): Flow<TextChannelThread> {
+    override fun getJoinedPrivateArchivedThreads(before: Snowflake?, limit: Int?): Flow<TextChannelThread> {
         return super.getJoinedPrivateArchivedThreads(before, limit).filterIsInstance()
     }
 

--- a/core/src/main/kotlin/behavior/channel/threads/ThreadParentChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/threads/ThreadParentChannelBehavior.kt
@@ -3,9 +3,6 @@ package dev.kord.core.behavior.channel.threads
 import dev.kord.common.entity.ArchiveDuration
 import dev.kord.common.entity.ChannelType
 import dev.kord.common.entity.Snowflake
-import dev.kord.common.entity.optional.Optional
-import dev.kord.common.entity.optional.OptionalBoolean
-import dev.kord.common.entity.optional.optional
 import dev.kord.common.exception.RequestException
 import dev.kord.core.Kord
 import dev.kord.core.behavior.channel.ChannelBehavior
@@ -22,7 +19,6 @@ import dev.kord.rest.builder.channel.thread.StartThreadBuilder
 import dev.kord.rest.json.request.StartThreadRequest
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filter
-import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import java.util.*
 
@@ -49,8 +45,8 @@ public interface ThreadParentChannelBehavior : TopGuildMessageChannelBehavior {
      * [terminal operators](https://kotlinlang.org/docs/reference/coroutines/flow.html#terminal-flow-operators) instead.
      */
     public fun getPublicArchivedThreads(
-        before: Instant = Clock.System.now(),
-        limit: Int = Int.MAX_VALUE
+        before: Instant? = null,
+        limit: Int? = null,
     ): Flow<ThreadChannel> {
         return supplier.getPublicArchivedThreads(id, before, limit)
     }
@@ -103,8 +99,8 @@ public interface PrivateThreadParentChannelBehavior : ThreadParentChannelBehavio
      * [terminal operators](https://kotlinlang.org/docs/reference/coroutines/flow.html#terminal-flow-operators) instead.
      */
     public fun getPrivateArchivedThreads(
-        before: Instant = Clock.System.now(),
-        limit: Int = Int.MAX_VALUE
+        before: Instant? = null,
+        limit: Int? = null,
     ): Flow<ThreadChannel> {
         return supplier.getPrivateArchivedThreads(id, before, limit)
     }
@@ -118,8 +114,8 @@ public interface PrivateThreadParentChannelBehavior : ThreadParentChannelBehavio
      * [terminal operators](https://kotlinlang.org/docs/reference/coroutines/flow.html#terminal-flow-operators) instead.
      */
     public fun getJoinedPrivateArchivedThreads(
-        before: Snowflake = Snowflake.max,
-        limit: Int = Int.MAX_VALUE
+        before: Snowflake? = null,
+        limit: Int? = null,
     ): Flow<ThreadChannel> {
         return supplier.getJoinedPrivateArchivedThreads(id, before, limit)
     }

--- a/core/src/main/kotlin/cache/Query.kt
+++ b/core/src/main/kotlin/cache/Query.kt
@@ -29,6 +29,10 @@ public fun <T : Any> QueryBuilder<T>.idGt(property: KProperty1<T, Snowflake>, va
     property.gt(value)
 }
 
+public fun <T : Any> QueryBuilder<T>.idLt(property: KProperty1<T, Snowflake>, value: Snowflake) {
+    property.lt(value)
+}
+
 @JvmName("stringEq")
 public fun <T : Any> QueryBuilder<T>.idEq(property: KProperty1<T, String?>, value: String?) {
     property.eq(value)

--- a/core/src/main/kotlin/supplier/CacheEntitySupplier.kt
+++ b/core/src/main/kotlin/supplier/CacheEntitySupplier.kt
@@ -10,6 +10,8 @@ import dev.kord.core.Kord
 import dev.kord.core.any
 import dev.kord.core.cache.data.*
 import dev.kord.core.cache.idEq
+import dev.kord.core.cache.idGt
+import dev.kord.core.cache.idLt
 import dev.kord.core.entity.*
 import dev.kord.core.entity.application.ApplicationCommandPermissions
 import dev.kord.core.entity.application.GlobalApplicationCommand
@@ -151,7 +153,7 @@ public class CacheEntitySupplier(private val kord: Kord) : EntitySupplier {
         checkLimit(limit)
         return cache.query<MessageData> {
             idEq(MessageData::channelId, channelId)
-            MessageData::id gt messageId
+            idGt(MessageData::id, messageId)
         }.asFlow().map { Message(it, kord) }.limit(limit)
     }
 
@@ -159,7 +161,7 @@ public class CacheEntitySupplier(private val kord: Kord) : EntitySupplier {
         checkLimit(limit)
         return cache.query<MessageData> {
             idEq(MessageData::channelId, channelId)
-            MessageData::id lt messageId
+            idLt(MessageData::id, messageId)
         }.asFlow().map { Message(it, kord) }.limit(limit)
     }
 

--- a/core/src/main/kotlin/supplier/EntitySupplier.kt
+++ b/core/src/main/kotlin/supplier/EntitySupplier.kt
@@ -14,6 +14,7 @@ import dev.kord.core.entity.channel.thread.ThreadChannel
 import dev.kord.core.entity.channel.thread.ThreadMember
 import dev.kord.core.exception.EntityNotFoundException
 import kotlinx.coroutines.flow.Flow
+import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 
 /**
@@ -61,7 +62,7 @@ public interface EntitySupplier {
         getGuildPreviewOrNull(guildId) ?: EntityNotFoundException.entityNotFound("Guild Preview", guildId)
 
     /**
-     * Requests to get the widget of this guild through the [strategy],
+     * Requests to get the widget of a [Guild] with the given [id][guildId],
      * returns null if the [GuildWidget] isn't present.
      *
      * @throws [RequestException] if anything went wrong during the request.
@@ -70,7 +71,7 @@ public interface EntitySupplier {
 
 
     /**
-     * Requests to get the widget of this [guildId].
+     * Requests to get the widget of a [Guild] with the given [id][guildId].
      *
      * @throws [RequestException] if anything went wrong during the request.
      * @throws [EntityNotFoundException] if the [GuildWidget] wasn't present.
@@ -314,9 +315,9 @@ public interface EntitySupplier {
     public fun getEmojis(guildId: Snowflake): Flow<GuildEmoji>
 
     /**
-     * Requests the [guild emojis][GuildEmoji] of the [Guild] with the given [guildId].
+     * Requests [guilds][Guild] this bot is known to be part of.
      *
-     *  The flow may use paginated requests to supply guilds, [limit] will limit the maximum number of guilds
+     * The flow may use paginated requests to supply guilds, [limit] will limit the maximum number of guilds
      * supplied and may optimize the batch size accordingly. A value of [Int.MAX_VALUE] means no limit.
      *
      * The returned flow is lazily executed, any [RequestException] will be thrown on
@@ -377,12 +378,10 @@ public interface EntitySupplier {
 
     /**
      * Requests the [Template] with the given [code].
-     * returns null when the webhook isn't present.
+     * returns null when the template isn't present.
      *
      * @throws RequestException if something went wrong while retrieving the template.
      */
-
-
     public suspend fun getTemplateOrNull(code: String): Template?
 
     /**
@@ -406,11 +405,23 @@ public interface EntitySupplier {
 
     public fun getActiveThreads(guildId: Snowflake): Flow<ThreadChannel>
 
-    public fun getPublicArchivedThreads(channelId: Snowflake, before: Instant, limit: Int): Flow<ThreadChannel>
+    public fun getPublicArchivedThreads(
+        channelId: Snowflake,
+        before: Instant = Clock.System.now(),
+        limit: Int = Int.MAX_VALUE,
+    ): Flow<ThreadChannel>
 
-    public fun getPrivateArchivedThreads(channelId: Snowflake, before: Instant, limit: Int): Flow<ThreadChannel>
+    public fun getPrivateArchivedThreads(
+        channelId: Snowflake,
+        before: Instant = Clock.System.now(),
+        limit: Int = Int.MAX_VALUE,
+    ): Flow<ThreadChannel>
 
-    public fun getJoinedPrivateArchivedThreads(channelId: Snowflake, before: Snowflake, limit: Int): Flow<ThreadChannel>
+    public fun getJoinedPrivateArchivedThreads(
+        channelId: Snowflake,
+        before: Snowflake = Snowflake.max,
+        limit: Int = Int.MAX_VALUE,
+    ): Flow<ThreadChannel>
 
     public fun getGuildApplicationCommands(applicationId: Snowflake, guildId: Snowflake): Flow<GuildApplicationCommand>
 

--- a/core/src/main/kotlin/supplier/EntitySupplier.kt
+++ b/core/src/main/kotlin/supplier/EntitySupplier.kt
@@ -14,7 +14,6 @@ import dev.kord.core.entity.channel.thread.ThreadChannel
 import dev.kord.core.entity.channel.thread.ThreadMember
 import dev.kord.core.exception.EntityNotFoundException
 import kotlinx.coroutines.flow.Flow
-import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 
 /**
@@ -151,28 +150,28 @@ public interface EntitySupplier {
      * in the [channel][MessageChannel] with the [channelId].
      *
      * The flow may use paginated requests to supply messages, [limit] will limit the maximum number of messages
-     * supplied and may optimize the batch size accordingly. A value of [Int.MAX_VALUE] means no limit.
+     * supplied and may optimize the batch size accordingly. `null` means no limit.
      *
      * The returned flow is lazily executed, any [RequestException] will be thrown on
      * [terminal operators](https://kotlinlang.org/docs/reference/coroutines/flow.html#terminal-flow-operators) instead.
      *
      * @throws IllegalArgumentException if a [limit] < 1 was supplied.
      */
-    public fun getMessagesAfter(messageId: Snowflake, channelId: Snowflake, limit: Int = Int.MAX_VALUE): Flow<Message>
+    public fun getMessagesAfter(messageId: Snowflake, channelId: Snowflake, limit: Int? = null): Flow<Message>
 
     /**
      * Requests a flow of messages created before the [Message] with the [messageId]
      * in the [channel][MessageChannel] with the [channelId].
      *
      * The flow may use paginated requests to supply messages, [limit] will limit the maximum number of messages
-     * supplied and may optimize the batch size accordingly. A value of [Int.MAX_VALUE] means no limit.
+     * supplied and may optimize the batch size accordingly. `null` means no limit.
      *
      * The returned flow is lazily executed, any [RequestException] will be thrown on
      * [terminal operators](https://kotlinlang.org/docs/reference/coroutines/flow.html#terminal-flow-operators) instead.
      *
      * @throws IllegalArgumentException if a [limit] < 1 was supplied.
      */
-    public fun getMessagesBefore(messageId: Snowflake, channelId: Snowflake, limit: Int = Int.MAX_VALUE): Flow<Message>
+    public fun getMessagesBefore(messageId: Snowflake, channelId: Snowflake, limit: Int? = null): Flow<Message>
 
     /**
      * Requests a flow of messages created around the [Message] with the [messageId]
@@ -183,7 +182,10 @@ public interface EntitySupplier {
      *
      * Supplied messages will be equally distributed
      * before and after the [messageId]. The remaining message for an odd [limit] is undefined and may appear on either
-     * side.
+     * side or no side at all.
+     *
+     * If a [Message] with the given [messageId] exists, the flow might also contain it, so it **could have one more
+     * element than the given [limit]**.
      *
      * The returned flow is lazily executed, any [RequestException] will be thrown on
      * [terminal operators](https://kotlinlang.org/docs/reference/coroutines/flow.html#terminal-flow-operators) instead.
@@ -279,7 +281,7 @@ public interface EntitySupplier {
      * The returned flow is lazily executed, any [RequestException] will be thrown on
      * [terminal operators](https://kotlinlang.org/docs/reference/coroutines/flow.html#terminal-flow-operators) instead.
      */
-    public fun getGuildMembers(guildId: Snowflake, limit: Int = Int.MAX_VALUE): Flow<Member>
+    public fun getGuildMembers(guildId: Snowflake, limit: Int? = null): Flow<Member>
 
     /**
      * Requests the [regions][Region] of the [Guild] with the given [guildId].
@@ -318,14 +320,14 @@ public interface EntitySupplier {
      * Requests [guilds][Guild] this bot is known to be part of.
      *
      * The flow may use paginated requests to supply guilds, [limit] will limit the maximum number of guilds
-     * supplied and may optimize the batch size accordingly. A value of [Int.MAX_VALUE] means no limit.
+     * supplied and may optimize the batch size accordingly. `null` means no limit.
      *
      * The returned flow is lazily executed, any [RequestException] will be thrown on
      * [terminal operators](https://kotlinlang.org/docs/reference/coroutines/flow.html#terminal-flow-operators) instead.
      *
      * @throws IllegalArgumentException if a [limit] < 1 was supplied.
      */
-    public fun getCurrentUserGuilds(limit: Int = Int.MAX_VALUE): Flow<Guild>
+    public fun getCurrentUserGuilds(limit: Int? = null): Flow<Guild>
 
     /**
      * Requests the [webhooks][Webhook] of the [MessageChannel] with the given [channelId].
@@ -407,20 +409,20 @@ public interface EntitySupplier {
 
     public fun getPublicArchivedThreads(
         channelId: Snowflake,
-        before: Instant = Clock.System.now(),
-        limit: Int = Int.MAX_VALUE,
+        before: Instant? = null,
+        limit: Int? = null,
     ): Flow<ThreadChannel>
 
     public fun getPrivateArchivedThreads(
         channelId: Snowflake,
-        before: Instant = Clock.System.now(),
-        limit: Int = Int.MAX_VALUE,
+        before: Instant? = null,
+        limit: Int? = null,
     ): Flow<ThreadChannel>
 
     public fun getJoinedPrivateArchivedThreads(
         channelId: Snowflake,
-        before: Snowflake = Snowflake.max,
-        limit: Int = Int.MAX_VALUE,
+        before: Snowflake? = null,
+        limit: Int? = null,
     ): Flow<ThreadChannel>
 
     public fun getGuildApplicationCommands(applicationId: Snowflake, guildId: Snowflake): Flow<GuildApplicationCommand>

--- a/core/src/main/kotlin/supplier/EntitySupplyStrategy.kt
+++ b/core/src/main/kotlin/supplier/EntitySupplyStrategy.kt
@@ -41,12 +41,12 @@ public interface EntitySupplyStrategy<T : EntitySupplier> {
 
         /**
          * A supplier providing a strategy which exclusively uses REST calls to fetch entities.
-         * fetched entities are stored in [Kord's cache][kord.cache].
+         * fetched entities are stored in [Kord's cache][Kord.cache].
          * See [StoreEntitySupplier] for more details.
          */
         public val cachingRest: EntitySupplyStrategy<EntitySupplier> = object : EntitySupplyStrategy<EntitySupplier> {
             override fun supply(kord: Kord): EntitySupplier {
-                return StoreEntitySupplier(rest.supply(kord), kord.cache, kord)
+                return StoreEntitySupplier(rest.supply(kord), kord.cache)
             }
 
             override fun toString(): String = "EntitySupplyStrategy.cacheAwareRest"

--- a/core/src/main/kotlin/supplier/FallbackEntitySupplier.kt
+++ b/core/src/main/kotlin/supplier/FallbackEntitySupplier.kt
@@ -50,11 +50,11 @@ private class FallbackEntitySupplier(val first: EntitySupplier, val second: Enti
     override suspend fun getMember(guildId: Snowflake, userId: Snowflake): Member =
         getMemberOrNull(guildId, userId)!!
 
-    override fun getMessagesAfter(messageId: Snowflake, channelId: Snowflake, limit: Int): Flow<Message> =
+    override fun getMessagesAfter(messageId: Snowflake, channelId: Snowflake, limit: Int?): Flow<Message> =
         first.getMessagesAfter(messageId, channelId, limit)
             .switchIfEmpty(second.getMessagesAfter(messageId, channelId, limit))
 
-    override fun getMessagesBefore(messageId: Snowflake, channelId: Snowflake, limit: Int): Flow<Message> =
+    override fun getMessagesBefore(messageId: Snowflake, channelId: Snowflake, limit: Int?): Flow<Message> =
         first.getMessagesBefore(messageId, channelId, limit)
             .switchIfEmpty(second.getMessagesBefore(messageId, channelId, limit))
 
@@ -81,7 +81,7 @@ private class FallbackEntitySupplier(val first: EntitySupplier, val second: Enti
     override fun getGuildBans(guildId: Snowflake): Flow<Ban> =
         first.getGuildBans(guildId).switchIfEmpty(second.getGuildBans(guildId))
 
-    override fun getGuildMembers(guildId: Snowflake, limit: Int): Flow<Member> =
+    override fun getGuildMembers(guildId: Snowflake, limit: Int?): Flow<Member> =
         first.getGuildMembers(guildId, limit).switchIfEmpty(second.getGuildMembers(guildId, limit))
 
     override fun getGuildVoiceRegions(guildId: Snowflake): Flow<Region> =
@@ -93,7 +93,7 @@ private class FallbackEntitySupplier(val first: EntitySupplier, val second: Enti
     override fun getEmojis(guildId: Snowflake): Flow<GuildEmoji> =
         first.getEmojis(guildId).switchIfEmpty(second.getEmojis(guildId))
 
-    override fun getCurrentUserGuilds(limit: Int): Flow<Guild> =
+    override fun getCurrentUserGuilds(limit: Int?): Flow<Guild> =
         first.getCurrentUserGuilds(limit).switchIfEmpty(second.getCurrentUserGuilds(limit))
 
     override fun getChannelWebhooks(channelId: Snowflake): Flow<Webhook> =
@@ -132,20 +132,20 @@ private class FallbackEntitySupplier(val first: EntitySupplier, val second: Enti
         return first.getActiveThreads(guildId).switchIfEmpty(second.getActiveThreads(guildId))
     }
 
-    override fun getPublicArchivedThreads(channelId: Snowflake, before: Instant, limit: Int): Flow<ThreadChannel> {
+    override fun getPublicArchivedThreads(channelId: Snowflake, before: Instant?, limit: Int?): Flow<ThreadChannel> {
         return first.getPublicArchivedThreads(channelId, before, limit)
             .switchIfEmpty(second.getPublicArchivedThreads(channelId, before, limit))
     }
 
-    override fun getPrivateArchivedThreads(channelId: Snowflake, before: Instant, limit: Int): Flow<ThreadChannel> {
+    override fun getPrivateArchivedThreads(channelId: Snowflake, before: Instant?, limit: Int?): Flow<ThreadChannel> {
         return first.getPrivateArchivedThreads(channelId, before, limit)
             .switchIfEmpty(second.getPrivateArchivedThreads(channelId, before, limit))
     }
 
     override fun getJoinedPrivateArchivedThreads(
         channelId: Snowflake,
-        before: Snowflake,
-        limit: Int
+        before: Snowflake?,
+        limit: Int?,
     ): Flow<ThreadChannel> {
         return first.getJoinedPrivateArchivedThreads(channelId, before, limit)
             .switchIfEmpty(second.getJoinedPrivateArchivedThreads(channelId, before, limit))
@@ -225,4 +225,3 @@ private class FallbackEntitySupplier(val first: EntitySupplier, val second: Enti
         return "FallbackEntitySupplier(first=$first, second=$second)"
     }
 }
-

--- a/core/src/main/kotlin/supplier/RestEntitySupplier.kt
+++ b/core/src/main/kotlin/supplier/RestEntitySupplier.kt
@@ -150,7 +150,7 @@ public class RestEntitySupplier(public val kord: Kord) : EntitySupplier {
     }
 
     override fun getMessagesAround(messageId: Snowflake, channelId: Snowflake, limit: Int): Flow<Message> = flow {
-        val responses = channel.getMessages(channelId, Position.Around(messageId))
+        val responses = channel.getMessages(channelId, Position.Around(messageId), limit)
 
         for (response in responses) {
             val data = MessageData.from(response)

--- a/core/src/main/kotlin/supplier/RestEntitySupplier.kt
+++ b/core/src/main/kotlin/supplier/RestEntitySupplier.kt
@@ -121,7 +121,7 @@ public class RestEntitySupplier(public val kord: Kord) : EntitySupplier {
     // maxBatchSize: see https://discord.com/developers/docs/resources/channel#get-channel-messages
     override fun getMessagesAfter(messageId: Snowflake, channelId: Snowflake, limit: Int): Flow<Message> =
         limitedPagination(limit, maxBatchSize = 100) { batchSize ->
-            paginateForwards(start = messageId, batchSize, idSelector = { it.id }) { after ->
+            paginateForwards(batchSize, start = messageId, idSelector = { it.id }) { after ->
                 channel.getMessages(channelId, position = after, limit = batchSize)
             }
         }.map {
@@ -132,7 +132,7 @@ public class RestEntitySupplier(public val kord: Kord) : EntitySupplier {
     // maxBatchSize: see https://discord.com/developers/docs/resources/channel#get-channel-messages
     override fun getMessagesBefore(messageId: Snowflake, channelId: Snowflake, limit: Int): Flow<Message> =
         limitedPagination(limit, maxBatchSize = 100) { batchSize ->
-            paginateBackwards(start = messageId, batchSize, idSelector = { it.id }) { before ->
+            paginateBackwards(batchSize, start = messageId, idSelector = { it.id }) { before ->
                 channel.getMessages(channelId, position = before, limit = batchSize)
             }
         }.map {
@@ -181,7 +181,7 @@ public class RestEntitySupplier(public val kord: Kord) : EntitySupplier {
     // maxBatchSize: see https://discord.com/developers/docs/resources/guild#list-guild-members
     override fun getGuildMembers(guildId: Snowflake, limit: Int): Flow<Member> =
         limitedPagination(limit, maxBatchSize = 1000) { batchSize ->
-            paginateForwards(idSelector = { it.user.value!!.id }, batchSize = batchSize) { after ->
+            paginateForwards(batchSize, idSelector = { it.user.value!!.id }) { after ->
                 guild.getGuildMembers(guildId, after, limit = batchSize)
             }
         }.map {
@@ -222,7 +222,7 @@ public class RestEntitySupplier(public val kord: Kord) : EntitySupplier {
     // maxBatchSize: see https://discord.com/developers/docs/resources/user#get-current-user-guilds
     override fun getCurrentUserGuilds(limit: Int): Flow<Guild> =
         limitedPagination(limit, maxBatchSize = 200) { batchSize ->
-            paginateForwards(batchSize = batchSize, idSelector = { it.id }) { after ->
+            paginateForwards(batchSize, idSelector = { it.id }) { after ->
                 user.getCurrentUserGuilds(position = after, limit = batchSize)
             }
         }.map {
@@ -313,7 +313,7 @@ public class RestEntitySupplier(public val kord: Kord) : EntitySupplier {
         guildId: Snowflake,
         request: AuditLogGetRequest = AuditLogGetRequest(),
     ): Flow<DiscordAuditLogEntry> = limitedPagination(request.limit, maxBatchSize = 100) { batchSize ->
-        paginateBackwards(batchSize = batchSize, idSelector = { it.id }) { beforePosition ->
+        paginateBackwards(batchSize, idSelector = { it.id }) { beforePosition ->
             val r = request.copy(before = beforePosition.value, limit = batchSize)
             auditLog.getAuditLogs(guildId, request = r).auditLogEntries
         }
@@ -371,7 +371,7 @@ public class RestEntitySupplier(public val kord: Kord) : EntitySupplier {
         before: Snowflake,
         limit: Int,
     ): Flow<ThreadChannel> = limitedPagination(limit, maxBatchSize = 100) { batchSize ->
-        paginateBackwards(start = before, batchSize, idSelector = { it.id }) { beforePosition ->
+        paginateBackwards(batchSize, start = before, idSelector = { it.id }) { beforePosition ->
             val request = ListThreadsBySnowflakeRequest(before = beforePosition.value, limit = batchSize)
             channel.listJoinedPrivateArchivedThreads(channelId, request).threads
         }.mapNotNull {

--- a/core/src/main/kotlin/supplier/RestEntitySupplier.kt
+++ b/core/src/main/kotlin/supplier/RestEntitySupplier.kt
@@ -343,7 +343,7 @@ public class RestEntitySupplier(public val kord: Kord) : EntitySupplier {
         }
     }
 
-    // no maxBatchSize documented: see https://discord.com/developers/docs/resources/channel#list-public-archived-threads
+    // no maxBatchSize documented (but api errors say it's 100): see https://discord.com/developers/docs/resources/channel#list-public-archived-threads
     override fun getPublicArchivedThreads(channelId: Snowflake, before: Instant?, limit: Int?): Flow<ThreadChannel> =
         limitedPagination(limit, maxBatchSize = 100) { batchSize ->
             paginateThreads(batchSize, start = before) { beforeTimestamp ->
@@ -355,7 +355,7 @@ public class RestEntitySupplier(public val kord: Kord) : EntitySupplier {
             }
         }
 
-    // no maxBatchSize documented: see https://discord.com/developers/docs/resources/channel#list-private-archived-threads
+    // no maxBatchSize documented (but api errors say it's 100): see https://discord.com/developers/docs/resources/channel#list-private-archived-threads
     override fun getPrivateArchivedThreads(channelId: Snowflake, before: Instant?, limit: Int?): Flow<ThreadChannel> =
         limitedPagination(limit, maxBatchSize = 100) { batchSize ->
             paginateThreads(batchSize, start = before) { beforeTimestamp ->
@@ -367,7 +367,7 @@ public class RestEntitySupplier(public val kord: Kord) : EntitySupplier {
             }
         }
 
-    // no maxBatchSize documented: see https://discord.com/developers/docs/resources/channel#list-joined-private-archived-threads
+    // no maxBatchSize documented (but api errors say it's 100): see https://discord.com/developers/docs/resources/channel#list-joined-private-archived-threads
     override fun getJoinedPrivateArchivedThreads(
         channelId: Snowflake,
         before: Snowflake?,

--- a/core/src/main/kotlin/supplier/RestEntitySupplier.kt
+++ b/core/src/main/kotlin/supplier/RestEntitySupplier.kt
@@ -1,7 +1,6 @@
 package dev.kord.core.supplier
 
 import dev.kord.common.entity.DiscordAuditLogEntry
-import dev.kord.common.entity.DiscordPartialGuild
 import dev.kord.common.entity.Snowflake
 import dev.kord.common.entity.optional.OptionalSnowflake
 import dev.kord.common.entity.optional.optionalSnowflake
@@ -55,10 +54,8 @@ public class RestEntitySupplier(public val kord: Kord) : EntitySupplier {
     private val sticker: StickerService get() = kord.rest.sticker
 
     override val guilds: Flow<Guild>
-        get() = paginateForwards(
-            idSelector = DiscordPartialGuild::id,
-            batchSize = 200 // max batchSize/limit: see https://discord.com/developers/docs/resources/user#get-current-user-guilds
-        ) { after ->
+        // max batchSize/limit: see https://discord.com/developers/docs/resources/user#get-current-user-guilds
+        get() = paginateForwards(batchSize = 200, idSelector = { it.id }) { after ->
             user.getCurrentUserGuilds(position = after, limit = 200)
         }.map {
             val data = guild.getGuild(it.id).toData()

--- a/core/src/main/kotlin/supplier/RestEntitySupplier.kt
+++ b/core/src/main/kotlin/supplier/RestEntitySupplier.kt
@@ -376,10 +376,10 @@ public class RestEntitySupplier(public val kord: Kord) : EntitySupplier {
         paginateBackwards(batchSize, start = before ?: Snowflake.max, idSelector = { it.id }) { beforePosition ->
             val request = ListThreadsBySnowflakeRequest(before = beforePosition.value, limit = batchSize)
             channel.listJoinedPrivateArchivedThreads(channelId, request).threads
-        }.mapNotNull {
-            val data = ChannelData.from(it)
-            Channel.from(data, kord) as? ThreadChannel
         }
+    }.mapNotNull {
+        val data = ChannelData.from(it)
+        Channel.from(data, kord) as? ThreadChannel
     }
 
     override fun getGuildApplicationCommands(

--- a/core/src/main/kotlin/supplier/RestEntitySupplier.kt
+++ b/core/src/main/kotlin/supplier/RestEntitySupplier.kt
@@ -53,8 +53,8 @@ public class RestEntitySupplier(public val kord: Kord) : EntitySupplier {
     private val stageInstance: StageInstanceService get() = kord.rest.stageInstance
     private val sticker: StickerService get() = kord.rest.sticker
 
+    // max batchSize/limit: see https://discord.com/developers/docs/resources/user#get-current-user-guilds
     override val guilds: Flow<Guild>
-        // max batchSize/limit: see https://discord.com/developers/docs/resources/user#get-current-user-guilds
         get() = paginateForwards(batchSize = 200, idSelector = { it.id }) { after ->
             user.getCurrentUserGuilds(position = after, limit = 200)
         }.map {

--- a/core/src/main/kotlin/supplier/RestEntitySupplier.kt
+++ b/core/src/main/kotlin/supplier/RestEntitySupplier.kt
@@ -57,8 +57,8 @@ public class RestEntitySupplier(public val kord: Kord) : EntitySupplier {
     override val guilds: Flow<Guild>
         get() = paginateForwards(
             idSelector = DiscordPartialGuild::id,
-            batchSize = 100
-        ) { position -> user.getCurrentUserGuilds(position, 100) }
+            batchSize = 200 // max batchSize/limit: see https://discord.com/developers/docs/resources/user#get-current-user-guilds
+        ) { position -> user.getCurrentUserGuilds(position, limit = 200) }
             .map {
                 val guild = guild.getGuild(it.id)
                 val data = GuildData.from(guild)

--- a/core/src/main/kotlin/supplier/RestEntitySupplier.kt
+++ b/core/src/main/kotlin/supplier/RestEntitySupplier.kt
@@ -132,7 +132,7 @@ public class RestEntitySupplier(public val kord: Kord) : EntitySupplier {
             Message(data, kord)
         }
 
-        return if (limit != Int.MAX_VALUE) flow.take(limit) else flow
+        return flow.limitPagination(limit)
     }
 
     override fun getMessagesBefore(messageId: Snowflake, channelId: Snowflake, limit: Int): Flow<Message> {
@@ -146,7 +146,7 @@ public class RestEntitySupplier(public val kord: Kord) : EntitySupplier {
             Message(data, kord)
         }
 
-        return if (limit != Int.MAX_VALUE) flow.take(limit) else flow
+        return flow.limitPagination(limit)
     }
 
     override fun getMessagesAround(messageId: Snowflake, channelId: Snowflake, limit: Int): Flow<Message> = flow {
@@ -199,9 +199,7 @@ public class RestEntitySupplier(public val kord: Kord) : EntitySupplier {
             Member(memberData, userData, kord)
         }
 
-
-        return if (limit != Int.MAX_VALUE) flow.take(limit)
-        else flow
+        return flow.limitPagination(limit)
     }
 
 
@@ -246,8 +244,7 @@ public class RestEntitySupplier(public val kord: Kord) : EntitySupplier {
             user.getCurrentUserGuilds(position, batchSize).map { Guild(guild.getGuild(it.id).toData(), kord) }
         }
 
-        return if (limit != Int.MAX_VALUE) flow.take(limit)
-        else flow
+        return flow.limitPagination(limit)
     }
 
     override fun getChannelWebhooks(channelId: Snowflake): Flow<Webhook> = flow {
@@ -370,7 +367,8 @@ public class RestEntitySupplier(public val kord: Kord) : EntitySupplier {
                 Channel.from(data, kord) as? ThreadChannel
             }
         }
-        return if (limit != Int.MAX_VALUE) flow.take(limit) else flow
+
+        return flow.limitPagination(limit)
     }
 
     override fun getPrivateArchivedThreads(channelId: Snowflake, before: Instant, limit: Int): Flow<ThreadChannel> {
@@ -386,7 +384,8 @@ public class RestEntitySupplier(public val kord: Kord) : EntitySupplier {
                 Channel.from(data, kord) as? ThreadChannel
             }
         }
-        return if (limit != Int.MAX_VALUE) flow.take(limit) else flow
+
+        return flow.limitPagination(limit)
     }
 
     override fun getJoinedPrivateArchivedThreads(
@@ -406,7 +405,8 @@ public class RestEntitySupplier(public val kord: Kord) : EntitySupplier {
                 Channel.from(data, kord) as? ThreadChannel
             }
         }
-        return if (limit != Int.MAX_VALUE) flow.take(limit) else flow
+
+        return flow.limitPagination(limit)
     }
 
     override fun getGuildApplicationCommands(
@@ -536,3 +536,5 @@ private fun checkLimitAndGetBatchSize(limit: Int, max: Int): Int {
     require(limit > 0) { "At least 1 item should be requested, but got $limit." }
     return min(limit, max)
 }
+
+private fun <T> Flow<T>.limitPagination(limit: Int): Flow<T> = if (limit == Int.MAX_VALUE) this else take(limit)

--- a/core/src/main/kotlin/supplier/StoreEntitySupplier.kt
+++ b/core/src/main/kotlin/supplier/StoreEntitySupplier.kt
@@ -24,9 +24,15 @@ import kotlinx.datetime.Instant
 public class StoreEntitySupplier(
     private val supplier: EntitySupplier,
     private val cache: DataCache,
-    private val kord: Kord
 ) : EntitySupplier {
 
+    @Deprecated(
+        "'kord' parameter is unused, use other constructor instead.",
+        ReplaceWith("StoreEntitySupplier(supplier, cache)"),
+        DeprecationLevel.ERROR,
+    )
+    @Suppress("UNUSED_PARAMETER")
+    public constructor(supplier: EntitySupplier, cache: DataCache, kord: Kord) : this(supplier, cache)
 
     override val guilds: Flow<Guild>
         get() = storeOnEach(supplier.guilds) { it.data }
@@ -69,11 +75,11 @@ public class StoreEntitySupplier(
         return storeAndReturn(supplier.getMessageOrNull(channelId, messageId)) { it.data }
     }
 
-    override fun getMessagesAfter(messageId: Snowflake, channelId: Snowflake, limit: Int): Flow<Message> {
+    override fun getMessagesAfter(messageId: Snowflake, channelId: Snowflake, limit: Int?): Flow<Message> {
         return storeOnEach(supplier.getMessagesAfter(messageId, channelId, limit)) { it.data }
     }
 
-    override fun getMessagesBefore(messageId: Snowflake, channelId: Snowflake, limit: Int): Flow<Message> {
+    override fun getMessagesBefore(messageId: Snowflake, channelId: Snowflake, limit: Int?): Flow<Message> {
         return storeOnEach(supplier.getMessagesBefore(messageId, channelId, limit)) { it.data }
     }
 
@@ -105,7 +111,7 @@ public class StoreEntitySupplier(
         return storeOnEach(supplier.getGuildBans(guildId)) { it.data }
     }
 
-    override fun getGuildMembers(guildId: Snowflake, limit: Int): Flow<Member> {
+    override fun getGuildMembers(guildId: Snowflake, limit: Int?): Flow<Member> {
         return storeOnEach(supplier.getGuildMembers(guildId, limit)) { it.data }
     }
 
@@ -122,7 +128,7 @@ public class StoreEntitySupplier(
 
     }
 
-    override fun getCurrentUserGuilds(limit: Int): Flow<Guild> {
+    override fun getCurrentUserGuilds(limit: Int?): Flow<Guild> {
         return storeOnEach(supplier.getCurrentUserGuilds(limit)) { it.data }
 
     }
@@ -163,18 +169,18 @@ public class StoreEntitySupplier(
         return storeOnEach(supplier.getActiveThreads(guildId)) { it.data }
     }
 
-    override fun getPublicArchivedThreads(channelId: Snowflake, before: Instant, limit: Int): Flow<ThreadChannel> {
+    override fun getPublicArchivedThreads(channelId: Snowflake, before: Instant?, limit: Int?): Flow<ThreadChannel> {
         return storeOnEach(supplier.getPublicArchivedThreads(channelId, before, limit)) { it.data }
     }
 
-    override fun getPrivateArchivedThreads(channelId: Snowflake, before: Instant, limit: Int): Flow<ThreadChannel> {
+    override fun getPrivateArchivedThreads(channelId: Snowflake, before: Instant?, limit: Int?): Flow<ThreadChannel> {
         return storeOnEach(supplier.getPrivateArchivedThreads(channelId, before, limit)) { it.data }
     }
 
     override fun getJoinedPrivateArchivedThreads(
         channelId: Snowflake,
-        before: Snowflake,
-        limit: Int
+        before: Snowflake?,
+        limit: Int?,
     ): Flow<ThreadChannel> {
         return storeOnEach(supplier.getJoinedPrivateArchivedThreads(channelId, before, limit)) { it.data }
     }

--- a/core/src/main/kotlin/supplier/StoreEntitySupplier.kt
+++ b/core/src/main/kotlin/supplier/StoreEntitySupplier.kt
@@ -27,7 +27,7 @@ public class StoreEntitySupplier(
 ) : EntitySupplier {
 
     @Deprecated(
-        "'kord' parameter is unused, use other constructor instead.",
+        "Parameter 'kord' is unused, use other constructor instead.",
         ReplaceWith("StoreEntitySupplier(supplier, cache)"),
         DeprecationLevel.ERROR,
     )

--- a/rest/src/main/kotlin/builder/auditlog/AuditLogGetRequestBuilder.kt
+++ b/rest/src/main/kotlin/builder/auditlog/AuditLogGetRequestBuilder.kt
@@ -23,12 +23,9 @@ class AuditLogGetRequestBuilder : RequestBuilder<AuditLogGetRequest> {
     var before: Snowflake? = null
 
     /**
-     * How many entries are returned (default 50, minimum 1, maximum 100)
-     * ([see Discord's docs](https://discord.com/developers/docs/resources/audit-log#get-guild-audit-log)).
-     *
-     * Set to `100` by default.
+     * How many entries are returned (default 50, minimum 1, maximum 100).
      */
-    var limit: Int = 100
+    var limit: Int = 50
 
     override fun toRequest(): AuditLogGetRequest = AuditLogGetRequest(userId, action, before, limit)
 }

--- a/rest/src/main/kotlin/builder/auditlog/AuditLogGetRequestBuilder.kt
+++ b/rest/src/main/kotlin/builder/auditlog/AuditLogGetRequestBuilder.kt
@@ -8,12 +8,12 @@ import dev.kord.rest.json.request.AuditLogGetRequest
 class AuditLogGetRequestBuilder : RequestBuilder<AuditLogGetRequest> {
 
     /**
-     * The id of the user whose actions should be filtered for. `null` be default.
+     * The id of the user whose actions should be filtered for. `null` by default.
      */
     var userId: Snowflake? = null
 
     /**
-     * The type of [AuditLogEvent] which should be filtered for. `null` be default.
+     * The type of [AuditLogEvent] which should be filtered for. `null` by default.
      */
     var action: AuditLogEvent? = null
 
@@ -23,7 +23,10 @@ class AuditLogGetRequestBuilder : RequestBuilder<AuditLogGetRequest> {
     var before: Snowflake? = null
 
     /**
-     * How many entries are returned (default 50, minimum 1, maximum 100).
+     * How many entries are returned (default 50, minimum 1, maximum 100)
+     * ([see Discord's docs](https://discord.com/developers/docs/resources/audit-log#get-guild-audit-log)).
+     *
+     * Set to `100` by default.
      */
     var limit: Int = 100
 

--- a/rest/src/main/kotlin/builder/auditlog/AuditLogGetRequestBuilder.kt
+++ b/rest/src/main/kotlin/builder/auditlog/AuditLogGetRequestBuilder.kt
@@ -4,6 +4,7 @@ import dev.kord.common.entity.AuditLogEvent
 import dev.kord.common.entity.Snowflake
 import dev.kord.rest.builder.RequestBuilder
 import dev.kord.rest.json.request.AuditLogGetRequest
+import dev.kord.rest.service.AuditLogService
 
 class AuditLogGetRequestBuilder : RequestBuilder<AuditLogGetRequest> {
 
@@ -23,9 +24,13 @@ class AuditLogGetRequestBuilder : RequestBuilder<AuditLogGetRequest> {
     var before: Snowflake? = null
 
     /**
-     * How many entries are returned (default 50, minimum 1, maximum 100).
+     * How many entries are returned.
+     *
+     * When used in a [direct rest request][AuditLogService.getAuditLogs]: default 50, minimum 1, maximum 100.
+     *
+     * When used through pagination in core module: `null` means no limit, must be positive otherwise.
      */
-    var limit: Int = 50
+    var limit: Int? = null
 
     override fun toRequest(): AuditLogGetRequest = AuditLogGetRequest(userId, action, before, limit)
 }

--- a/rest/src/main/kotlin/json/request/AuditLogRequests.kt
+++ b/rest/src/main/kotlin/json/request/AuditLogRequests.kt
@@ -7,5 +7,5 @@ data class AuditLogGetRequest(
     val userId: Snowflake? = null,
     val action: AuditLogEvent? = null,
     val before: Snowflake? = null,
-    val limit: Int = 50,
+    val limit: Int? = null,
 )

--- a/rest/src/main/kotlin/route/Position.kt
+++ b/rest/src/main/kotlin/route/Position.kt
@@ -2,8 +2,24 @@ package dev.kord.rest.route
 
 import dev.kord.common.entity.Snowflake
 
-sealed class Position(val key: String, val value: Snowflake) {
-    class Before(id: Snowflake) : Position("before", id)
-    class After(id: Snowflake) : Position("after", id)
-    class Around(id: Snowflake) : Position("around", id)
+sealed interface Position {
+    val key: String
+    val value: Snowflake
+
+    sealed interface BeforeOrAfter : Position
+
+    class Before(id: Snowflake) : BeforeOrAfter {
+        override val key get() = "before"
+        override val value = id
+    }
+
+    class After(id: Snowflake) : BeforeOrAfter {
+        override val key get() = "after"
+        override val value = id
+    }
+
+    class Around(id: Snowflake) : Position {
+        override val key get() = "around"
+        override val value = id
+    }
 }

--- a/rest/src/main/kotlin/service/AuditLogService.kt
+++ b/rest/src/main/kotlin/service/AuditLogService.kt
@@ -26,6 +26,6 @@ class AuditLogService(requestHandler: RequestHandler) : RestService(requestHandl
         request.userId?.let { parameter("user_id", it) }
         request.action?.let { parameter("action_type", "${it.value}") }
         request.before?.let { parameter("before", it) }
-        parameter("limit", "${request.limit}")
+        request.limit?.let { parameter("limit", it) }
     }
 }

--- a/rest/src/main/kotlin/service/ChannelService.kt
+++ b/rest/src/main/kotlin/service/ChannelService.kt
@@ -34,14 +34,11 @@ class ChannelService(requestHandler: RequestHandler) : RestService(requestHandle
         return createMessage(channelId, multipartRequest)
     }
 
-    suspend fun getMessages(channelId: Snowflake, position: Position? = null, limit: Int = 50) =
+    suspend fun getMessages(channelId: Snowflake, position: Position? = null, limit: Int? = null) =
         call(Route.MessagesGet) {
             keys[Route.ChannelId] = channelId
-            if (position != null) {
-                parameter(position.key, position.value)
-            }
-            parameter("limit", "$limit")
-
+            position?.let { parameter(it.key, it.value) }
+            limit?.let { parameter("limit", it) }
         }
 
     suspend fun getMessage(channelId: Snowflake, messageId: Snowflake) = call(Route.MessageGet) {
@@ -148,16 +145,14 @@ class ChannelService(requestHandler: RequestHandler) : RestService(requestHandle
         messageId: Snowflake,
         emoji: String,
         after: Position.After? = null,
-        limit: Int = 25
+        limit: Int? = null,
     ) = call(Route.ReactionsGet) {
         keys[Route.ChannelId] = channelId
         keys[Route.MessageId] = messageId
         keys[Route.Emoji] = emoji
 
-        if (after != null) {
-            parameter(after.key, after.value)
-        }
-        parameter("limit", "$limit")
+        after?.let { parameter(it.key, it.value) }
+        limit?.let { parameter("limit", it) }
     }
 
     suspend fun triggerTypingIndicator(channelId: Snowflake) = call(Route.TypingIndicatorPost) {

--- a/rest/src/main/kotlin/service/ChannelService.kt
+++ b/rest/src/main/kotlin/service/ChannelService.kt
@@ -147,15 +147,15 @@ class ChannelService(requestHandler: RequestHandler) : RestService(requestHandle
         channelId: Snowflake,
         messageId: Snowflake,
         emoji: String,
-        position: Position? = null,
+        after: Position.After? = null,
         limit: Int = 25
     ) = call(Route.ReactionsGet) {
         keys[Route.ChannelId] = channelId
         keys[Route.MessageId] = messageId
         keys[Route.Emoji] = emoji
 
-        if (position != null) {
-            parameter(position.key, position.value)
+        if (after != null) {
+            parameter(after.key, after.value)
         }
         parameter("limit", "$limit")
     }

--- a/rest/src/main/kotlin/service/GuildService.kt
+++ b/rest/src/main/kotlin/service/GuildService.kt
@@ -136,11 +136,11 @@ class GuildService(requestHandler: RequestHandler) : RestService(requestHandler)
         keys[Route.UserId] = userId
     }
 
-    suspend fun getGuildMembers(guildId: Snowflake, position: Position? = null, limit: Int = 1) =
+    suspend fun getGuildMembers(guildId: Snowflake, after: Position.After? = null, limit: Int = 1) =
         call(Route.GuildMembersGet) {
             keys[Route.GuildId] = guildId
-            if (position != null) {
-                parameter(position.key, position.value)
+            if (after != null) {
+                parameter(after.key, after.value)
             }
             parameter("limit", "$limit")
         }

--- a/rest/src/main/kotlin/service/GuildService.kt
+++ b/rest/src/main/kotlin/service/GuildService.kt
@@ -136,25 +136,23 @@ class GuildService(requestHandler: RequestHandler) : RestService(requestHandler)
         keys[Route.UserId] = userId
     }
 
-    suspend fun getGuildMembers(guildId: Snowflake, after: Position.After? = null, limit: Int = 1) =
+    suspend fun getGuildMembers(guildId: Snowflake, after: Position.After? = null, limit: Int? = null) =
         call(Route.GuildMembersGet) {
             keys[Route.GuildId] = guildId
-            if (after != null) {
-                parameter(after.key, after.value)
-            }
-            parameter("limit", "$limit")
+            after?.let { parameter(it.key, it.value) }
+            limit?.let { parameter("limit", it) }
         }
 
     /**
-     * Requests members with a username or nickname matching [query].
+     * Requests members with a username or nickname starting with [query].
      *
      * @param limit limits the maximum amount of members returned. Max `1000`, defaults to `1`.
      */
     @KordExperimental
-    suspend fun getGuildMembers(guildId: Snowflake, query: String, limit: Int = 1) = call(Route.GuildMembersSearchGet) {
+    suspend fun getGuildMembers(guildId: Snowflake, query: String, limit: Int? = null) = call(Route.GuildMembersSearchGet) {
         keys[Route.GuildId] = guildId
         parameter("query", query)
-        parameter("limit", "$limit")
+        limit?.let { parameter("limit", it) }
     }
 
     suspend fun addGuildMember(

--- a/rest/src/main/kotlin/service/UserService.kt
+++ b/rest/src/main/kotlin/service/UserService.kt
@@ -22,7 +22,7 @@ class UserService(requestHandler: RequestHandler) : RestService(requestHandler) 
         keys[Route.UserId] = userId
     }
 
-    suspend fun getCurrentUserGuilds(position: Position? = null, limit: Int = 200) = call(Route.CurrentUsersGuildsGet) {
+    suspend fun getCurrentUserGuilds(position: Position.BeforeOrAfter? = null, limit: Int = 200) = call(Route.CurrentUsersGuildsGet) {
         if (position != null) {
             parameter(position.key, position.value)
         }

--- a/rest/src/main/kotlin/service/UserService.kt
+++ b/rest/src/main/kotlin/service/UserService.kt
@@ -22,13 +22,11 @@ class UserService(requestHandler: RequestHandler) : RestService(requestHandler) 
         keys[Route.UserId] = userId
     }
 
-    suspend fun getCurrentUserGuilds(position: Position.BeforeOrAfter? = null, limit: Int = 200) = call(Route.CurrentUsersGuildsGet) {
-        if (position != null) {
-            parameter(position.key, position.value)
+    suspend fun getCurrentUserGuilds(position: Position.BeforeOrAfter? = null, limit: Int? = null) =
+        call(Route.CurrentUsersGuildsGet) {
+            position?.let { parameter(it.key, it.value) }
+            limit?.let { parameter("limit", it) }
         }
-
-        parameter("limit", "$limit")
-    }
 
     suspend fun leaveGuild(guildId: Snowflake) = call(Route.GuildLeave) {
         keys[Route.GuildId] = guildId

--- a/rest/src/main/kotlin/service/UserService.kt
+++ b/rest/src/main/kotlin/service/UserService.kt
@@ -22,7 +22,7 @@ class UserService(requestHandler: RequestHandler) : RestService(requestHandler) 
         keys[Route.UserId] = userId
     }
 
-    suspend fun getCurrentUserGuilds(position: Position? = null, limit: Int = 100) = call(Route.CurrentUsersGuildsGet) {
+    suspend fun getCurrentUserGuilds(position: Position? = null, limit: Int = 200) = call(Route.CurrentUsersGuildsGet) {
         if (position != null) {
             parameter(position.key, position.value)
         }


### PR DESCRIPTION
# Changes

## `Position`
- change to `sealed interface`
- introduce additional `Position.BeforeOrAfter` type to restrict position parameters in services
- type change `Position?` -> `Position.After?` in `ChannelService.getReactions()` and `GuildService.getGuildMembers()`
- type change `Position?` -> `Position.BeforeOrAfter?` in `UserService.getCurrentUserGuilds()`

## `paginate()` and `paginateByDate()`
- more specific types (e. g. `Position` -> `Direction : Position.BeforeOrAfter`)
- `size` will now always stay `batchSize` -> hypothetical page that is longer than `batchSize` will not lead to unwanted behavior in size comparison with next page
- changed order: `break` on smaller batch size before selecting next direction/timestamp

## nullable `limit` parameter for
- `AuditLogGetRequestBuilder`, `AuditLogGetRequest`
- `AuditLogService.getAuditLogs()`
- `getMessages[Before|After]()` in `MessageChannelBehavior`, `EntitySupplier`
- `getPublicArchivedThreads()` in `ThreadParentChannelBehavior`, `EntitySupplier`
- `get[Joined]PrivateArchivedThreads()` in `PrivateThreadParentChannelBehavior`, `EntitySupplier`
- `getGuildMembers()` in `EntitySupplier`, `GuildService`
- `getCurrentUserGuilds()` in `EntitySupplier`, `UserService`
- `getMessages()`, `getReactions()` in `ChannelService`

## nullable `before` parameter for
- `getPublicArchivedThreads()` in `ThreadParentChannelBehavior`, `EntitySupplier`
- `get[Joined]PrivateArchivedThreads()` in `PrivateThreadParentChannelBehavior`, `EntitySupplier`

## `CacheEntitySupplier`
- fix `getMessagesBefore()` behaving the same as `getMessagesAfter()` -> replace `idGt` with `lt`
- also emit message with `messageId` in `getMessagesAround()`
- fix flow from `getGuildMemebers()` not being limited
- check `limit` parameter in `get[...]ArchivedThreads()`

## `RestEntitySupplier`
- increase max pagination `batchSize` for `guilds` and `getCurrentUserGuilds()` to 200, see https://discord.com/developers/docs/resources/user#get-current-user-guilds and https://github.com/discord/discord-api-docs/commit/daa13f60634396296092da02bb8acd8f3360e03b
- higher-order `limitedPagination()` function that checks `limit`, calculates `batchSize`, creates the pagination flow and limits it
- check `limit` parameter in `getMessagesAround()`
- fix not using `limit` parameter in `getMessagesAround()`
- lazy `map` on flow instead of pagination batch directly to potentially safe requests made on `guild.getGuild()` in `getCurrentUserGuilds()`
- fix `getAuditLogEntries()` not using optimized `batchSize` and not adjusting `request.limit`
- fix not using `Snowflake`/`Instant` from pagination in  `get[...]ArchivedThreads()`

## `MessageChannelBehavior.getMessagesAround()`
- fix not using `limit` parameter

## `GuildBehavior`
- removed unnecessary `suspend` modifier on `getMembers()`

## `StoreEntitySupplier`
- deprecate constructor with `kord` parameter, parameter was unused

## Documentation
- remove no longer applicable warning in `GuildBehavior.getMembers()` doc
- add note about flow additionally containing message itself for `getMessagesAround()` in `MessageChannelBehavior`, `EntitySupplier`
- document different usages of `AuditLogGetRequestBuilder.limit`
- ...
