### PR TITLE
Add support for InteractionCreateEvent in LiveMessage

### DIFF
--- a/core/src/main/kotlin/live/LiveMessage.kt
+++ b/core/src/main/kotlin/live/LiveMessage.kt
@@ -11,6 +11,7 @@ import dev.kord.core.entity.ReactionEmoji
 import dev.kord.core.event.Event
 import dev.kord.core.event.channel.ChannelDeleteEvent
 import dev.kord.core.event.guild.GuildDeleteEvent
+import dev.kord.core.event.interaction.InteractionCreateEvent
 import dev.kord.core.event.message.*
 import dev.kord.core.live.exception.LiveCancellationException
 import dev.kord.core.supplier.EntitySupplyStrategy
@@ -162,6 +163,8 @@ public class LiveMessage(
         is ChannelDeleteEvent -> event.channel.id == message.channelId
 
         is GuildDeleteEvent -> event.guildId == guildId
+
+        is InteractionCreateEvent -> event.interaction.data.message.value?.id == message.id
         else -> false
     }
 
@@ -181,6 +184,8 @@ public class LiveMessage(
         is ChannelDeleteEvent -> shutDown(LiveCancellationException(event, "The channel is deleted"))
 
         is GuildDeleteEvent -> shutDown(LiveCancellationException(event, "The guild is deleted"))
+
+        is InteractionCreateEvent -> Unit
         else -> Unit
     }
 

--- a/core/src/main/kotlin/live/LiveMessage.kt
+++ b/core/src/main/kotlin/live/LiveMessage.kt
@@ -12,6 +12,7 @@ import dev.kord.core.event.Event
 import dev.kord.core.event.channel.ChannelDeleteEvent
 import dev.kord.core.event.guild.GuildDeleteEvent
 import dev.kord.core.event.interaction.InteractionCreateEvent
+import dev.kord.core.event.interaction.MessageCommandInteractionCreateEvent
 import dev.kord.core.event.message.*
 import dev.kord.core.live.exception.LiveCancellationException
 import dev.kord.core.supplier.EntitySupplyStrategy
@@ -164,6 +165,7 @@ public class LiveMessage(
 
         is GuildDeleteEvent -> event.guildId == guildId
 
+        is MessageCommandInteractionCreateEvent -> event.interaction.messages.keys.contains(message.id)
         is InteractionCreateEvent -> event.interaction.data.message.value?.id == message.id
         else -> false
     }
@@ -185,6 +187,7 @@ public class LiveMessage(
 
         is GuildDeleteEvent -> shutDown(LiveCancellationException(event, "The guild is deleted"))
 
+        is MessageCommandInteractionCreateEvent -> Unit
         is InteractionCreateEvent -> Unit
         else -> Unit
     }


### PR DESCRIPTION
First PR on Github and started Kotlin not long ago

Thought it was weird that InteractionCreateEvent was not supported in LiveMessage.

Condition in update() is doing nothing but wanted to keep consistency.
Still need to cast the interaction to ComponentInteraction in the event consumer..