### PR TITLE
Don't encode Authorization header

### DIFF
--- a/core/src/main/kotlin/builder/kord/KordBuilder.kt
+++ b/core/src/main/kotlin/builder/kord/KordBuilder.kt
@@ -185,14 +185,16 @@ public class KordBuilder(public val token: String) {
      */
     private suspend fun HttpClient.getGatewayInfo(): BotGatewayResponse {
         val response = get<HttpResponse>("${Route.baseUrl}${Route.GatewayBotGet.path}") {
-            header(Authorization, token)
+            header(Authorization, "Bot $token")
         }
         val responseBody = response.readText()
         if (response.isError) {
             val message = buildString {
-                append("Something went wrong while initializing Kord.")
+                append("Something went wrong while initializing Kord")
                 if (response.status == HttpStatusCode.Unauthorized) {
                     append(", make sure the bot token you entered is valid.")
+                } else {
+                    append('.')
                 }
 
                 appendLine(responseBody)

--- a/rest/src/main/kotlin/request/HttpUtils.kt
+++ b/rest/src/main/kotlin/request/HttpUtils.kt
@@ -20,7 +20,7 @@ private const val auditLogReason = "X-Audit-Log-Reason"
 /**
  * Sets the reason that will show up in the [Discord Audit Log]() to [reason] for this request.
  */
-fun <T> RequestBuilder<T>.auditLogReason(reason: String?) = reason?.let { header(auditLogReason, reason) }
+fun <T> RequestBuilder<T>.auditLogReason(reason: String?) = reason?.let { urlEncodedHeader(auditLogReason, reason) }
 
 val HttpResponse.channelResetPoint: Instant
     get() {

--- a/rest/src/main/kotlin/request/RequestBuilder.kt
+++ b/rest/src/main/kotlin/request/RequestBuilder.kt
@@ -28,7 +28,22 @@ class RequestBuilder<T>(private val route: Route<T>, keySize: Int = 2) {
 
     fun parameter(key: String, value: Any) = parameters.append(key, value.toString())
 
-    fun header(key: String, value: String) = headers.append(key, value.encodeURLQueryComponent())
+    @Deprecated(
+        "'header' was renamed to 'urlEncodedHeader'",
+        ReplaceWith("urlEncodedHeader(key, value)"),
+        DeprecationLevel.ERROR,
+    )
+    fun header(key: String, value: String) = urlEncodedHeader(key, value)
+
+    /** Adds a header and encodes its [value] as an [URL query component][encodeURLQueryComponent]. */
+    fun urlEncodedHeader(key: String, value: String) {
+        headers.append(key, value.encodeURLQueryComponent())
+    }
+
+    /** Adds a header without encoding its [value]. */
+    fun unencodedHeader(key: String, value: String) {
+        headers.append(key, value)
+    }
 
     fun file(name: String, input: java.io.InputStream) {
         files.add(NamedFile(name, input))

--- a/rest/src/main/kotlin/service/ChannelService.kt
+++ b/rest/src/main/kotlin/service/ChannelService.kt
@@ -117,6 +117,7 @@ class ChannelService(requestHandler: RequestHandler) : RestService(requestHandle
     suspend fun bulkDelete(channelId: Snowflake, messages: BulkDeleteRequest, reason: String?) = call(Route.BulkMessageDeletePost) {
         keys[Route.ChannelId] = channelId
         body(BulkDeleteRequest.serializer(), messages)
+        auditLogReason(reason)
     }
 
     suspend fun deleteChannel(channelId: Snowflake, reason: String? = null) = call(Route.ChannelDelete) {
@@ -243,7 +244,7 @@ class ChannelService(requestHandler: RequestHandler) : RestService(requestHandle
         call(Route.ChannelPut) {
             keys[Route.ChannelId] = channelId
             body(ChannelModifyPutRequest.serializer(), channel)
-            reason?.let { header("X-Audit-Log-Reason", reason) }
+            auditLogReason(reason)
         }
 
     suspend fun patchChannel(channelId: Snowflake, channel: ChannelModifyPatchRequest, reason: String? = null) =
@@ -256,7 +257,7 @@ class ChannelService(requestHandler: RequestHandler) : RestService(requestHandle
         call(Route.ChannelPatch) {
             keys[Route.ChannelId] = threadId
             body(ChannelModifyPatchRequest.serializer(), thread)
-            reason?.let { header("X-Audit-Log-Reason", reason) }
+            auditLogReason(reason)
         }
 
 
@@ -282,7 +283,7 @@ class ChannelService(requestHandler: RequestHandler) : RestService(requestHandle
             keys[Route.ChannelId] = channelId
             keys[Route.MessageId] = messageId
             body(StartThreadRequest.serializer(), request)
-            reason?.let { header("X-Audit-Log-Reason", reason) }
+            auditLogReason(reason)
         }
     }
 
@@ -306,7 +307,7 @@ class ChannelService(requestHandler: RequestHandler) : RestService(requestHandle
         return call(Route.StartThreadPost) {
             keys[Route.ChannelId] = channelId
             body(StartThreadRequest.serializer(), request)
-            reason?.let { header("X-Audit-Log-Reason", reason) }
+            auditLogReason(reason)
         }
     }
 

--- a/rest/src/main/kotlin/service/RestService.kt
+++ b/rest/src/main/kotlin/service/RestService.kt
@@ -3,7 +3,7 @@ package dev.kord.rest.service
 import dev.kord.rest.request.RequestBuilder
 import dev.kord.rest.request.RequestHandler
 import dev.kord.rest.route.Route
-import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpHeaders.Authorization
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -18,11 +18,10 @@ abstract class RestService(@PublishedApi internal val requestHandler: RequestHan
             .apply(builder)
             .apply {
                 if (route.requiresAuthorization) {
-                    header(HttpHeaders.Authorization, "Bot ${requestHandler.token}")
+                    unencodedHeader(Authorization, "Bot ${requestHandler.token}")
                 }
             }
             .build()
         return requestHandler.handle(request)
     }
-
 }


### PR DESCRIPTION
### Fix bugs introduced by https://github.com/kordlib/kord/pull/450

- Authorization header was encoded as an URL query component which replaced the space between `"Bot"` and `token` with `"%20"` which Discord does not accept.  To clarify that `RequestBuilder.header()` encodes its value, I deprecated it and named the replacement `urlEncodedHeader()`.

- `KordBuilder.getGatewayInfo()` was also missing the Authorization header after https://github.com/kordlib/kord/pull/450.