### PR TITLE
Fix / add entdpoints without authorization, remove shards field from GatwayResponse

### DIFF
--- a/core/src/main/kotlin/behavior/channel/TopGuildChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/TopGuildChannelBehavior.kt
@@ -89,7 +89,7 @@ public interface TopGuildChannelBehavior : GuildChannelBehavior {
      * @param reason the reason showing up in the audit log
      * @throws [RestRequestException] if something went wrong during the request.
      */
-    public suspend fun addOverwrite(overwrite: PermissionOverwrite, reason: String?) {
+    public suspend fun addOverwrite(overwrite: PermissionOverwrite, reason: String? = null) {
         kord.rest.channel.editChannelPermissions(
             channelId = id,
             overwriteId = overwrite.target,

--- a/core/src/main/kotlin/supplier/CacheEntitySupplier.kt
+++ b/core/src/main/kotlin/supplier/CacheEntitySupplier.kt
@@ -47,7 +47,7 @@ public class CacheEntitySupplier(private val kord: Kord) : EntitySupplier {
      * Shorthand for [kord.cache][Kord.cache].
      *
      */
-    private val cache: DataCache get() = kord.cache
+    private inline val cache: DataCache get() = kord.cache
 
     /**
      *  Returns a [Flow] of [Channel]s fetched from cache.

--- a/core/src/main/kotlin/supplier/RestEntitySupplier.kt
+++ b/core/src/main/kotlin/supplier/RestEntitySupplier.kt
@@ -39,19 +39,19 @@ import kotlin.math.min
  */
 public class RestEntitySupplier(public val kord: Kord) : EntitySupplier {
 
-    private val auditLog: AuditLogService get() = kord.rest.auditLog
-    private val channel: ChannelService get() = kord.rest.channel
-    private val emoji: EmojiService get() = kord.rest.emoji
-    private val guild: GuildService get() = kord.rest.guild
-    private val invite: InviteService get() = kord.rest.invite
-    private val user: UserService get() = kord.rest.user
-    private val voice: VoiceService get() = kord.rest.voice
-    private val webhook: WebhookService get() = kord.rest.webhook
-    private val application: ApplicationService get() = kord.rest.application
-    private val template: TemplateService get() = kord.rest.template
-    private val interaction: InteractionService get() = kord.rest.interaction
-    private val stageInstance: StageInstanceService get() = kord.rest.stageInstance
-    private val sticker: StickerService get() = kord.rest.sticker
+    private inline val auditLog: AuditLogService get() = kord.rest.auditLog
+    private inline val channel: ChannelService get() = kord.rest.channel
+    private inline val emoji: EmojiService get() = kord.rest.emoji
+    private inline val guild: GuildService get() = kord.rest.guild
+    private inline val invite: InviteService get() = kord.rest.invite
+    private inline val user: UserService get() = kord.rest.user
+    private inline val voice: VoiceService get() = kord.rest.voice
+    private inline val webhook: WebhookService get() = kord.rest.webhook
+    private inline val application: ApplicationService get() = kord.rest.application
+    private inline val template: TemplateService get() = kord.rest.template
+    private inline val interaction: InteractionService get() = kord.rest.interaction
+    private inline val stageInstance: StageInstanceService get() = kord.rest.stageInstance
+    private inline val sticker: StickerService get() = kord.rest.sticker
 
     // max batchSize/limit: see https://discord.com/developers/docs/resources/user#get-current-user-guilds
     override val guilds: Flow<Guild>

--- a/rest/src/main/kotlin/json/response/Gateway.kt
+++ b/rest/src/main/kotlin/json/response/Gateway.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class GatewayResponse(val url: String, val shards: Int)
+data class GatewayResponse(val url: String)
 
 @Serializable
 data class BotGatewayResponse(

--- a/rest/src/main/kotlin/route/Route.kt
+++ b/rest/src/main/kotlin/route/Route.kt
@@ -3,8 +3,6 @@ package dev.kord.rest.route
 import dev.kord.common.annotation.DeprecatedSinceKord
 import dev.kord.common.annotation.KordExperimental
 import dev.kord.common.entity.*
-import dev.kord.common.entity.DiscordInvite
-import dev.kord.common.entity.DiscordPartialInvite
 import dev.kord.rest.json.request.GuildScheduledEventUsersResponse
 import dev.kord.rest.json.response.*
 import io.ktor.http.*
@@ -48,21 +46,26 @@ sealed class Route<T>(
     val method: HttpMethod,
     val path: String,
     val mapper: ResponseMapper<T>,
-    val requiresAuthorization: Boolean = true
+    val requiresAuthorizationHeader: Boolean = true,
 ) {
     constructor(
         method: HttpMethod,
         path: String,
         strategy: DeserializationStrategy<T>,
-        requiresAuthorization: Boolean = true,
-    ) : this(method, path, ValueJsonMapper(strategy), requiresAuthorization)
+        requiresAuthorizationHeader: Boolean = true,
+    ) : this(method, path, ValueJsonMapper(strategy), requiresAuthorizationHeader)
 
     @OptIn(ExperimentalSerializationApi::class)
     override fun toString(): String =
         "Route(method:${method.value},path:$path,mapper:$mapper)"
 
-    object GatewayGet
-        : Route<GatewayResponse>(HttpMethod.Get, "/gateway", GatewayResponse.serializer(), false)
+    object GatewayGet :
+        Route<GatewayResponse>(
+            HttpMethod.Get,
+            "/gateway",
+            GatewayResponse.serializer(),
+            requiresAuthorizationHeader = false,
+        )
 
     object GatewayBotGet
         : Route<BotGatewayResponse>(HttpMethod.Get, "/gateway/bot", BotGatewayResponse.serializer())
@@ -427,47 +430,69 @@ sealed class Route<T>(
     object WebhookPost
         : Route<DiscordWebhook>(HttpMethod.Post, "/channels/$ChannelId/webhooks", DiscordWebhook.serializer())
 
-    object WebhookByTokenGet
-        :
-        Route<DiscordWebhook>(HttpMethod.Get, "/webhooks/$WebhookId/$WebhookToken", DiscordWebhook.serializer(), false)
+    object WebhookByTokenGet :
+        Route<DiscordWebhook>(
+            HttpMethod.Get,
+            "/webhooks/$WebhookId/$WebhookToken",
+            DiscordWebhook.serializer(),
+            requiresAuthorizationHeader = false,
+        )
 
-    object WebhookPatch
-        : Route<DiscordWebhook>(HttpMethod.Patch, "/webhooks/$WebhookId", DiscordWebhook.serializer(), false)
+    object WebhookPatch :
+        Route<DiscordWebhook>(HttpMethod.Patch, "/webhooks/$WebhookId", DiscordWebhook.serializer())
 
-    object WebhookByTokenPatch
-        : Route<DiscordWebhook>(
-        HttpMethod.Patch,
-        "/webhooks/$WebhookId/$WebhookToken",
-        DiscordWebhook.serializer(),
-        false
-    )
+    object WebhookByTokenPatch :
+        Route<DiscordWebhook>(
+            HttpMethod.Patch,
+            "/webhooks/$WebhookId/$WebhookToken",
+            DiscordWebhook.serializer(),
+            requiresAuthorizationHeader = false,
+        )
 
     object WebhookDelete
         : Route<Unit>(HttpMethod.Delete, "/webhooks/$WebhookId", NoStrategy)
 
-    object WebhookByTokenDelete
-        : Route<Unit>(HttpMethod.Delete, "/webhooks/$WebhookId/$WebhookToken", NoStrategy, false)
+    object WebhookByTokenDelete :
+        Route<Unit>(
+            HttpMethod.Delete,
+            "/webhooks/$WebhookId/$WebhookToken",
+            NoStrategy,
+            requiresAuthorizationHeader = false,
+        )
 
     //TODO Make sure of the return of these routes below
 
-    object ExecuteWebhookPost
-        : Route<DiscordMessage?>(
-        HttpMethod.Post,
-        "/webhooks/$WebhookId/$WebhookToken",
-        DiscordMessage.serializer().optional
-    )
+    object ExecuteWebhookPost :
+        Route<DiscordMessage?>(
+            HttpMethod.Post,
+            "/webhooks/$WebhookId/$WebhookToken",
+            DiscordMessage.serializer().optional,
+            requiresAuthorizationHeader = false,
+        )
 
-    object ExecuteSlackWebhookPost
-        : Route<Unit>(HttpMethod.Post, "/webhooks/$WebhookId/$WebhookToken/slack", NoStrategy)
+    object ExecuteSlackWebhookPost :
+        Route<Unit>(
+            HttpMethod.Post,
+            "/webhooks/$WebhookId/$WebhookToken/slack",
+            NoStrategy,
+            requiresAuthorizationHeader = false,
+        )
 
-    object ExecuteGithubWebhookPost
-        : Route<Unit>(HttpMethod.Post, "/webhooks/$WebhookId/$WebhookToken/github", NoStrategy)
+    object ExecuteGithubWebhookPost :
+        Route<Unit>(
+            HttpMethod.Post,
+            "/webhooks/$WebhookId/$WebhookToken/github",
+            NoStrategy,
+            requiresAuthorizationHeader = false,
+        )
 
-    object EditWebhookMessage : Route<DiscordMessage>(
-        HttpMethod.Patch,
-        "/webhooks/$WebhookId/$WebhookToken/messages/$MessageId",
-        DiscordMessage.serializer()
-    )
+    object EditWebhookMessage :
+        Route<DiscordMessage>(
+            HttpMethod.Patch,
+            "/webhooks/$WebhookId/$WebhookToken/messages/$MessageId",
+            DiscordMessage.serializer(),
+            requiresAuthorizationHeader = false,
+        )
 
     object VoiceRegionsGet
         : Route<List<DiscordVoiceRegion>>(
@@ -640,36 +665,36 @@ sealed class Route<T>(
         DiscordGuildScheduledEvent.serializer()
     )
 
-    object InteractionResponseCreate : Route<Unit>(
-        HttpMethod.Post,
-        "/interactions/${InteractionId}/${InteractionToken}/callback",
-        NoStrategy,
-        false
-    )
+    object InteractionResponseCreate :
+        Route<Unit>(
+            HttpMethod.Post,
+            "/interactions/${InteractionId}/${InteractionToken}/callback",
+            NoStrategy,
+            requiresAuthorizationHeader = false,
+        )
 
     object OriginalInteractionResponseGet :
-            Route<DiscordMessage>(
-                HttpMethod.Get,
-                "/webhooks/${ApplicationId}/${InteractionToken}/messages/@original",
-                DiscordMessage.serializer(),
-                false
-            )
+        Route<DiscordMessage>(
+            HttpMethod.Get,
+            "/webhooks/${ApplicationId}/${InteractionToken}/messages/@original",
+            DiscordMessage.serializer(),
+            requiresAuthorizationHeader = false,
+        )
 
     object OriginalInteractionResponseModify :
         Route<DiscordMessage>(
             HttpMethod.Patch,
             "/webhooks/${ApplicationId}/${InteractionToken}/messages/@original",
             DiscordMessage.serializer(),
-            false
+            requiresAuthorizationHeader = false,
         )
 
-    object OriginalInteractionResponseDelete
-        :
+    object OriginalInteractionResponseDelete :
         Route<Unit>(
             HttpMethod.Delete,
             "/webhooks/${ApplicationId}/${InteractionToken}/messages/@original",
             NoStrategy,
-            false
+            requiresAuthorizationHeader = false,
         )
 
 
@@ -704,23 +729,28 @@ sealed class Route<T>(
         serializer()
     )
 
-    object FollowupMessageCreate : Route<DiscordMessage>(
-        HttpMethod.Post,
-        "/webhooks/${ApplicationId}/${InteractionToken}",
-        DiscordMessage.serializer()
-    )
+    object FollowupMessageCreate :
+        Route<DiscordMessage>(
+            HttpMethod.Post,
+            "/webhooks/${ApplicationId}/${InteractionToken}",
+            DiscordMessage.serializer(),
+            requiresAuthorizationHeader = false,
+        )
 
-    object FollowupMessageModify : Route<DiscordMessage>(
-        HttpMethod.Patch,
-        "/webhooks/${ApplicationId}/${InteractionToken}/messages/${MessageId}",
-        DiscordMessage.serializer()
-    )
+    object FollowupMessageModify :
+        Route<DiscordMessage>(
+            HttpMethod.Patch,
+            "/webhooks/${ApplicationId}/${InteractionToken}/messages/${MessageId}",
+            DiscordMessage.serializer(),
+            requiresAuthorizationHeader = false,
+        )
 
     object FollowupMessageDelete :
         Route<Unit>(
             HttpMethod.Delete,
             "/webhooks/${ApplicationId}/${InteractionToken}/messages/${MessageId}",
-            NoStrategy
+            NoStrategy,
+            requiresAuthorizationHeader = false,
         )
 
     object SelfVoiceStatePatch :

--- a/rest/src/main/kotlin/service/ChannelService.kt
+++ b/rest/src/main/kotlin/service/ChannelService.kt
@@ -54,7 +54,7 @@ class ChannelService(requestHandler: RequestHandler) : RestService(requestHandle
         keys[Route.ChannelId] = channelId
     }
 
-    suspend fun addPinnedMessage(channelId: Snowflake, messageId: Snowflake, reason: String?) = call(Route.PinPut) {
+    suspend fun addPinnedMessage(channelId: Snowflake, messageId: Snowflake, reason: String? = null) = call(Route.PinPut) {
         keys[Route.MessageId] = messageId
         keys[Route.ChannelId] = channelId
         auditLogReason(reason)
@@ -111,7 +111,7 @@ class ChannelService(requestHandler: RequestHandler) : RestService(requestHandle
             auditLogReason(reason)
         }
 
-    suspend fun bulkDelete(channelId: Snowflake, messages: BulkDeleteRequest, reason: String?) = call(Route.BulkMessageDeletePost) {
+    suspend fun bulkDelete(channelId: Snowflake, messages: BulkDeleteRequest, reason: String? = null) = call(Route.BulkMessageDeletePost) {
         keys[Route.ChannelId] = channelId
         body(BulkDeleteRequest.serializer(), messages)
         auditLogReason(reason)

--- a/rest/src/main/kotlin/service/RestService.kt
+++ b/rest/src/main/kotlin/service/RestService.kt
@@ -17,7 +17,7 @@ abstract class RestService(@PublishedApi internal val requestHandler: RequestHan
         val request = RequestBuilder(route)
             .apply(builder)
             .apply {
-                if (route.requiresAuthorization) {
+                if (route.requiresAuthorizationHeader) {
                     unencodedHeader(Authorization, "Bot ${requestHandler.token}")
                 }
             }


### PR DESCRIPTION
- require authorization for `WebhookPatch`
- don't require authorization for `ExecuteWebhookPost`, `ExecuteSlackWebhookPost`, `ExecuteGithubWebhookPost`, `EditWebhookMessage`, `FollowupMessageCreate`, `FollowupMessageModify` and `FollowupMessageDelete` (see https://github.com/discord/discord-api-docs/pull/4349 regarding followups)
- remove `shards` field from `GatwayResponse`, see https://discord.com/developers/docs/topics/gateway#get-gateway or https://discord.com/api/v9/gateway
- make private shorthand getters in `EntitySupplier`s `inline`
- `null` as default for all `reason: String?` parameters