### PR TITLE
Miscellaneous little fixes and changes

### DIFF
--- a/common/src/main/kotlin/entity/DiscordChannel.kt
+++ b/common/src/main/kotlin/entity/DiscordChannel.kt
@@ -178,7 +178,7 @@ sealed class OverwriteType(val value: Int) {
 }
 
 @Serializable
-class DiscordThreadMetadata(
+data class DiscordThreadMetadata(
     val archived: Boolean,
     @SerialName("archive_timestamp")
     val archiveTimestamp: String,

--- a/common/src/main/kotlin/entity/DiscordSelectOption.kt
+++ b/common/src/main/kotlin/entity/DiscordSelectOption.kt
@@ -14,7 +14,7 @@ import kotlinx.serialization.Serializable
  * @param default whether to render this option as selected by default
  */
 @Serializable
-class DiscordSelectOption(
+data class DiscordSelectOption(
     val label: String,
     val value: String,
     val description: Optional<String> = Optional.Missing(),

--- a/common/src/main/kotlin/entity/Interactions.kt
+++ b/common/src/main/kotlin/entity/Interactions.kt
@@ -60,7 +60,7 @@ sealed class ApplicationCommandType(val value: Int) {
 }
 
 @Serializable
-class ApplicationCommandOption(
+data class ApplicationCommandOption(
     val type: ApplicationCommandOptionType,
     val name: String,
     val description: String,
@@ -141,9 +141,9 @@ sealed class Choice<out T> {
     abstract val name: String
     abstract val value: T
 
-    class IntChoice(override val name: String, override val value: Long) : Choice<Long>()
-    class NumberChoice(override val name: String, override val value: Double) : Choice<Double>()
-    class StringChoice(override val name: String, override val value: String) : Choice<String>()
+    data class IntChoice(override val name: String, override val value: Long) : Choice<Long>()
+    data class NumberChoice(override val name: String, override val value: Double) : Choice<Double>()
+    data class StringChoice(override val name: String, override val value: String) : Choice<String>()
     internal class ChoiceSerializer<T>(serializer: KSerializer<T>) : KSerializer<Choice<*>> {
         override val descriptor: SerialDescriptor = buildClassSerialDescriptor("Choice") {
             element<String>("name")
@@ -195,7 +195,7 @@ data class ResolvedObjects(
 )
 
 @Serializable
-class DiscordInteraction(
+data class DiscordInteraction(
     val id: Snowflake,
     @SerialName("application_id")
     val applicationId: Snowflake,
@@ -431,92 +431,76 @@ sealed class CommandArgument<out T> : Option() {
     abstract val value: T
     abstract val focused: OptionalBoolean
 
-    class StringArgument(
+    data class StringArgument(
         override val name: String,
         override val value: String,
         override val focused: OptionalBoolean = OptionalBoolean.Missing
     ) : CommandArgument<String>() {
         override val type: ApplicationCommandOptionType
             get() = ApplicationCommandOptionType.String
-
-        override fun toString(): String = "StringArgument(name=$name, value=$value)"
     }
 
-    class IntegerArgument(
+    data class IntegerArgument(
         override val name: String,
         override val value: Long,
         override val focused: OptionalBoolean = OptionalBoolean.Missing
     ) : CommandArgument<Long>() {
         override val type: ApplicationCommandOptionType
             get() = ApplicationCommandOptionType.Integer
-
-        override fun toString(): String = "IntegerArgument(name=$name, value=$value)"
     }
 
-    class NumberArgument(
+    data class NumberArgument(
         override val name: String,
         override val value: Double,
         override val focused: OptionalBoolean = OptionalBoolean.Missing
     ) : CommandArgument<Double>() {
         override val type: ApplicationCommandOptionType
             get() = ApplicationCommandOptionType.Number
-
-        override fun toString(): String = "NumberArgument(name=$name, value=$value)"
     }
 
-    class BooleanArgument(
+    data class BooleanArgument(
         override val name: String,
         override val value: Boolean,
         override val focused: OptionalBoolean = OptionalBoolean.Missing
     ) : CommandArgument<Boolean>() {
         override val type: ApplicationCommandOptionType
             get() = ApplicationCommandOptionType.Boolean
-
-        override fun toString(): String = "BooleanArgument(name=$name, value=$value)"
     }
 
-    class UserArgument(
+    data class UserArgument(
         override val name: String,
         override val value: Snowflake,
         override val focused: OptionalBoolean = OptionalBoolean.Missing
     ) : CommandArgument<Snowflake>() {
         override val type: ApplicationCommandOptionType
             get() = ApplicationCommandOptionType.User
-
-        override fun toString(): String = "UserArgument(name=$name, value=$value)"
     }
 
-    class ChannelArgument(
+    data class ChannelArgument(
         override val name: String,
         override val value: Snowflake,
         override val focused: OptionalBoolean = OptionalBoolean.Missing
     ) : CommandArgument<Snowflake>() {
         override val type: ApplicationCommandOptionType
             get() = ApplicationCommandOptionType.Channel
-
-        override fun toString(): String = "ChannelArgument(name=$name, value=$value)"
     }
 
-    class RoleArgument(
+    data class RoleArgument(
         override val name: String,
         override val value: Snowflake,
         override val focused: OptionalBoolean = OptionalBoolean.Missing
     ) : CommandArgument<Snowflake>() {
         override val type: ApplicationCommandOptionType
             get() = ApplicationCommandOptionType.Role
-
-        override fun toString(): String = "RoleArgument(name=$name, value=$value)"
     }
 
-    class MentionableArgument(
+    data class MentionableArgument(
         override val name: String,
         override val value: Snowflake,
         override val focused: OptionalBoolean = OptionalBoolean.Missing
     ) : CommandArgument<Snowflake>() {
         override val type: ApplicationCommandOptionType
             get() = ApplicationCommandOptionType.Mentionable
-
-        override fun toString(): String = "MentionableArgument(name=$name, value=$value)"
     }
 
     internal object Serializer : KSerializer<CommandArgument<*>> {

--- a/core/src/main/kotlin/supplier/CacheEntitySupplier.kt
+++ b/core/src/main/kotlin/supplier/CacheEntitySupplier.kt
@@ -40,12 +40,11 @@ import kotlinx.datetime.toInstant
  * if none are presented like other `getX` functions. Instead, the flow will be empty.
  */
 public class CacheEntitySupplier(private val kord: Kord) : EntitySupplier {
+
     /**
-     *
      * The Cache this [CacheEntitySupplier] operates on.
      *
      * Shorthand for [kord.cache][Kord.cache].
-     *
      */
     private val cache: DataCache get() = kord.cache
 
@@ -476,9 +475,8 @@ public class CacheEntitySupplier(private val kord: Kord) : EntitySupplier {
             idEq(GuildScheduledEventData::guildId, guildId)
         }.asFlow().map { GuildScheduledEvent(it, kord) }
 
-    override fun toString(): String {
-        return "CacheEntitySupplier(cache=$cache)"
-    }
+
+    override fun toString(): String = "CacheEntitySupplier(cache=$cache)"
 }
 
 

--- a/core/src/main/kotlin/supplier/EntitySupplier.kt
+++ b/core/src/main/kotlin/supplier/EntitySupplier.kt
@@ -13,6 +13,7 @@ import dev.kord.core.entity.channel.TopGuildChannel
 import dev.kord.core.entity.channel.thread.ThreadChannel
 import dev.kord.core.entity.channel.thread.ThreadMember
 import dev.kord.core.exception.EntityNotFoundException
+import dev.kord.rest.request.RestRequestException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.datetime.Instant
 
@@ -55,8 +56,22 @@ public interface EntitySupplier {
      */
     public suspend fun getGuild(id: Snowflake): Guild = getGuildOrNull(id) ?: EntityNotFoundException.guildNotFound(id)
 
+    /**
+     * Returns the preview of the guild matching the [guildId].
+     * If the bot is not in the guild, then the guild must be lurkable.
+     * Returns `null` if the preview was not found.
+     *
+     * @throws RestRequestException if something went wrong during the request.
+     */
     public suspend fun getGuildPreviewOrNull(guildId: Snowflake): GuildPreview?
 
+    /**
+     * Returns the preview of the guild matching the [guildId].
+     * If the bot is not in the guild, then the guild must be lurkable.
+     *
+     * @throws RestRequestException if something went wrong during the request.
+     * @throws EntityNotFoundException if the preview was not found.
+     */
     public suspend fun getGuildPreview(guildId: Snowflake): GuildPreview =
         getGuildPreviewOrNull(guildId) ?: EntityNotFoundException.entityNotFound("Guild Preview", guildId)
 

--- a/core/src/main/kotlin/supplier/EntitySupplier.kt
+++ b/core/src/main/kotlin/supplier/EntitySupplier.kt
@@ -13,7 +13,6 @@ import dev.kord.core.entity.channel.TopGuildChannel
 import dev.kord.core.entity.channel.thread.ThreadChannel
 import dev.kord.core.entity.channel.thread.ThreadMember
 import dev.kord.core.exception.EntityNotFoundException
-import dev.kord.rest.request.RestRequestException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.datetime.Instant
 
@@ -57,19 +56,19 @@ public interface EntitySupplier {
     public suspend fun getGuild(id: Snowflake): Guild = getGuildOrNull(id) ?: EntityNotFoundException.guildNotFound(id)
 
     /**
-     * Returns the preview of the guild matching the [guildId].
+     * Requests the preview of the guild matching the [guildId].
      * If the bot is not in the guild, then the guild must be lurkable.
      * Returns `null` if the preview was not found.
      *
-     * @throws RestRequestException if something went wrong during the request.
+     * @throws RequestException if something went wrong during the request.
      */
     public suspend fun getGuildPreviewOrNull(guildId: Snowflake): GuildPreview?
 
     /**
-     * Returns the preview of the guild matching the [guildId].
+     * Requests the preview of the guild matching the [guildId].
      * If the bot is not in the guild, then the guild must be lurkable.
      *
-     * @throws RestRequestException if something went wrong during the request.
+     * @throws RequestException if something went wrong during the request.
      * @throws EntityNotFoundException if the preview was not found.
      */
     public suspend fun getGuildPreview(guildId: Snowflake): GuildPreview =

--- a/core/src/main/kotlin/supplier/FallbackEntitySupplier.kt
+++ b/core/src/main/kotlin/supplier/FallbackEntitySupplier.kt
@@ -47,9 +47,6 @@ private class FallbackEntitySupplier(val first: EntitySupplier, val second: Enti
     override suspend fun getMessageOrNull(channelId: Snowflake, messageId: Snowflake): Message? =
         first.getMessageOrNull(channelId, messageId) ?: second.getMessageOrNull(channelId, messageId)
 
-    override suspend fun getMember(guildId: Snowflake, userId: Snowflake): Member =
-        getMemberOrNull(guildId, userId)!!
-
     override fun getMessagesAfter(messageId: Snowflake, channelId: Snowflake, limit: Int?): Flow<Message> =
         first.getMessagesAfter(messageId, channelId, limit)
             .switchIfEmpty(second.getMessagesAfter(messageId, channelId, limit))
@@ -220,8 +217,5 @@ private class FallbackEntitySupplier(val first: EntitySupplier, val second: Enti
         first.getGuildStickers(guildId).switchIfEmpty(second.getGuildStickers(guildId))
 
 
-
-    override fun toString(): String {
-        return "FallbackEntitySupplier(first=$first, second=$second)"
-    }
+    override fun toString(): String = "FallbackEntitySupplier(first=$first, second=$second)"
 }

--- a/core/src/main/kotlin/supplier/RestEntitySupplier.kt
+++ b/core/src/main/kotlin/supplier/RestEntitySupplier.kt
@@ -86,22 +86,6 @@ public class RestEntitySupplier(public val kord: Kord) : EntitySupplier {
     override suspend fun getGuildOrNull(id: Snowflake): Guild? =
         catchNotFound { Guild(guild.getGuild(id).toData(), kord) }
 
-    /**
-     * Returns the preview of the guild matching the [guildId]. The bot does not need to present in this guild
-     * for this to complete successfully.
-     *
-     * @throws [RestRequestException] if something went wrong during the request.
-     * @throws [EntityNotFoundException] if the preview was not found.
-     */
-    override suspend fun getGuildPreview(guildId: Snowflake): GuildPreview =
-        getGuildPreviewOrNull(guildId) ?: EntityNotFoundException.entityNotFound("Guild preview", guildId)
-
-    /**
-     * Returns the preview of the guild matching the [guildId]. The bot does not need to present in this guild
-     * for this to complete successfully. Returns null if the preview was not found.
-     *
-     * @throws [RestRequestException] if something went wrong during the request.
-     */
     override suspend fun getGuildPreviewOrNull(guildId: Snowflake): GuildPreview? = catchNotFound {
         val discordPreview = guild.getGuildPreview(guildId)
         GuildPreview(GuildPreviewData.from(discordPreview), kord)
@@ -499,9 +483,8 @@ public class RestEntitySupplier(public val kord: Kord) : EntitySupplier {
         GuildApplicationCommand(data, interaction)
     }
 
-    override fun toString(): String {
-        return "RestEntitySupplier(rest=${kord.rest})"
-    }
+
+    override fun toString(): String = "RestEntitySupplier(rest=${kord.rest})"
 }
 
 

--- a/core/src/main/kotlin/supplier/StoreEntitySupplier.kt
+++ b/core/src/main/kotlin/supplier/StoreEntitySupplier.kt
@@ -266,4 +266,7 @@ public class StoreEntitySupplier(
         cache.put(transform(value))
         return value
     }
+
+
+    override fun toString(): String = "StoreEntitySupplier(supplier=$supplier, cache=$cache)"
 }

--- a/gateway/src/main/kotlin/Event.kt
+++ b/gateway/src/main/kotlin/Event.kt
@@ -478,7 +478,7 @@ sealed class Close : Event() {
      *
      * @param recoverable true if the gateway will automatically try to reconnect.
      */
-    class DiscordClose(val closeCode: GatewayCloseCode, val recoverable: Boolean) : Close()
+    data class DiscordClose(val closeCode: GatewayCloseCode, val recoverable: Boolean) : Close()
 
     /**
      * The gateway closed and will attempt to resume the session.

--- a/gateway/src/main/kotlin/GatewayConfiguration.kt
+++ b/gateway/src/main/kotlin/GatewayConfiguration.kt
@@ -17,7 +17,7 @@ data class GatewayConfiguration(
     val intents: Intents
 )
 
-data class GatewayConfigurationBuilder(
+class GatewayConfigurationBuilder(
     /**
      * The token of the bot.
      */

--- a/rest/src/main/kotlin/json/JsonErrorCode.kt
+++ b/rest/src/main/kotlin/json/JsonErrorCode.kt
@@ -392,6 +392,9 @@ enum class JsonErrorCode(val code: Int) {
     /** `before` value is earlier than the thread creation date. */
     BeforeValueBeforeThreadCreate(50085),
 
+    /** Community server channels must be text channels */
+    CommunityServerChannelMustBeTextChannel(50086),
+
     /** This server is not available in your location. */
     ServerNotAvailableInLocation(50095),
 

--- a/rest/src/main/kotlin/json/JsonErrorCode.kt
+++ b/rest/src/main/kotlin/json/JsonErrorCode.kt
@@ -392,7 +392,7 @@ enum class JsonErrorCode(val code: Int) {
     /** `before` value is earlier than the thread creation date. */
     BeforeValueBeforeThreadCreate(50085),
 
-    /** Community server channels must be text channels */
+    /** Community server channels must be text channels. */
     CommunityServerChannelMustBeTextChannel(50086),
 
     /** This server is not available in your location. */

--- a/rest/src/main/kotlin/json/response/DiscordErrorResponse.kt
+++ b/rest/src/main/kotlin/json/response/DiscordErrorResponse.kt
@@ -14,7 +14,7 @@ import kotlinx.serialization.json.*
  * Represents a [Discord error response](https://discord.com/developers/docs/topics/opcodes-and-status-codes#json).
  */
 @Serializable
-class DiscordErrorResponse(
+data class DiscordErrorResponse(
     val code: JsonErrorCode = JsonErrorCode.Unknown,
     val errors: JsonElement? = null,
     val message: String? = null,

--- a/rest/src/main/kotlin/route/CdnUrl.kt
+++ b/rest/src/main/kotlin/route/CdnUrl.kt
@@ -23,5 +23,8 @@ class CdnUrl(private val rawAssetUri: String) {
         return "CdnUrl(rawAssetUri=$rawAssetUri)"
     }
 
-    data class UrlFormatBuilder(var format: Image.Format = Image.Format.WEBP, var size: Image.Size? = null)
+    class UrlFormatBuilder {
+        var format: Image.Format = Image.Format.WEBP
+        var size: Image.Size? = null
+    }
 }

--- a/rest/src/main/kotlin/service/InteractionService.kt
+++ b/rest/src/main/kotlin/service/InteractionService.kt
@@ -604,7 +604,6 @@ class InteractionService(requestHandler: RequestHandler) : RestService(requestHa
     suspend inline fun modifyInteractionResponse(
         applicationId: Snowflake,
         interactionToken: String,
-        ephemeral: Boolean = false,
         builder: InteractionResponseModifyBuilder.() -> Unit
     ): DiscordMessage {
         contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }

--- a/voice/src/main/kotlin/gateway/VoiceEvent.kt
+++ b/voice/src/main/kotlin/gateway/VoiceEvent.kt
@@ -127,7 +127,7 @@ public sealed class Close : VoiceEvent() {
      *
      * @param recoverable true if the gateway will automatically try to reconnect.
      */
-    public class DiscordClose(public val closeCode: VoiceGatewayCloseCode, public val recoverable: Boolean) : Close()
+    public data class DiscordClose(val closeCode: VoiceGatewayCloseCode, val recoverable: Boolean) : Close()
 
     /**
      * The gateway closed and will attempt to resume the session.


### PR DESCRIPTION
- remove `ephemeral` parameter for `InteractionService.modifyInteractionResponse()`, it was unused and does not exist for the endpoint
- `data class` for `DiscordThreadMetadata`, `DiscordSelectOption`, `ApplicationCommandOption`, `[Int|Number|String]Choice`, `DiscordInteraction`, `[String|Integer|Number|Boolean|User|Channel|Role|Mentionable]Argument` (remove `toString()`, it's generated), `DiscordClose`, `DiscordErrorResponse`
- no `data class` for `GatewayConfigurationBuilder` and `UrlFormatBuilder`
- remove override for `getMember()` in `FallbackEntitySupplier` (use default from `EntitySupplier` instead)
- remove override for `getGuildPreview()` in `RestEntitySupplier` (use default from `EntitySupplier` instead)
- move doc for `getGuildPreview[OrNull]()` to `EntitySupplier`
- `toString()` for `StoreEntitySupplier`
- add `JsonErrorCode` 50086, see https://github.com/discord/discord-api-docs/commit/a833b5c8eb6915c849596c0805e5662440be2160