### PR TITLE
Deprecate Stage Discovery, stickers in GuildPreview, createTimestamp for Threads

### DIFF
--- a/common/src/main/kotlin/entity/DiscordChannel.kt
+++ b/common/src/main/kotlin/entity/DiscordChannel.kt
@@ -4,6 +4,7 @@ import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
 import dev.kord.common.entity.optional.OptionalInt
 import dev.kord.common.entity.optional.OptionalSnowflake
+import kotlinx.datetime.Instant
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -178,14 +179,16 @@ sealed class OverwriteType(val value: Int) {
 }
 
 @Serializable
-class DiscordThreadMetadata(
+data class DiscordThreadMetadata(
     val archived: Boolean,
     @SerialName("archive_timestamp")
     val archiveTimestamp: String,
     @SerialName("auto_archive_duration")
     val autoArchiveDuration: ArchiveDuration,
     val locked: OptionalBoolean = OptionalBoolean.Missing,
-    val invitable: OptionalBoolean = OptionalBoolean.Missing
+    val invitable: OptionalBoolean = OptionalBoolean.Missing,
+    @SerialName("create_timestamp")
+    val createTimestamp: Optional<Instant> = Optional.Missing(),
 )
 
 @Serializable(with = ArchiveDuration.Serializer::class)

--- a/common/src/main/kotlin/entity/DiscordGuildPreview.kt
+++ b/common/src/main/kotlin/entity/DiscordGuildPreview.kt
@@ -17,5 +17,6 @@ data class DiscordGuildPreview(
     val approximateMemberCount: Int,
     @SerialName("approximate_presence_count")
     val approximatePresenceCount: Int,
-    val description: String?
+    val description: String?,
+    val stickers: List<DiscordMessageSticker>,
 )

--- a/common/src/main/kotlin/entity/DiscordStageInstance.kt
+++ b/common/src/main/kotlin/entity/DiscordStageInstance.kt
@@ -30,6 +30,7 @@ data class DiscordStageInstance(
     val topic: String,
     @SerialName("privacy_level")
     val privacyLevel: StageInstancePrivacyLevel,
+    @Deprecated("Stages are no longer discoverable")
     @SerialName("discoverable_disabled")
     val discoverableDisabled: Boolean
 )
@@ -39,9 +40,11 @@ data class DiscordStageInstance(
  */
 @Serializable(with = StageInstancePrivacyLevel.Serializer::class)
 sealed class StageInstancePrivacyLevel(val value: Int) {
+
     /**
      * The Stage instance is visible publicly, such as on Stage Discovery.
      */
+    @Deprecated("Stages are no longer discoverable")
     object Public : StageInstancePrivacyLevel(1)
 
     /**
@@ -58,6 +61,7 @@ sealed class StageInstancePrivacyLevel(val value: Int) {
         override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("StageInstancePrivacyLevel", PrimitiveKind.INT)
 
         override fun deserialize(decoder: Decoder): StageInstancePrivacyLevel {
+            @Suppress("DEPRECATION")
             return when (val value = decoder.decodeInt()) {
                 1 -> Public
                 2 -> GuildOnly

--- a/core/src/main/kotlin/cache/data/ChannelData.kt
+++ b/core/src/main/kotlin/cache/data/ChannelData.kt
@@ -4,6 +4,7 @@ import dev.kord.cache.api.data.DataDescription
 import dev.kord.cache.api.data.description
 import dev.kord.common.entity.*
 import dev.kord.common.entity.optional.*
+import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -78,12 +79,13 @@ public data class ThreadMetadataData(
     val archiveTimestamp: String,
     val autoArchiveDuration: ArchiveDuration,
     val locked: OptionalBoolean = OptionalBoolean.Missing,
-    val invitable: OptionalBoolean = OptionalBoolean.Missing
+    val invitable: OptionalBoolean = OptionalBoolean.Missing,
+    val createTimestamp: Optional<Instant> = Optional.Missing(),
 ) {
-    
-  public companion object {
+
+    public companion object {
         public fun from(threadMetadata: DiscordThreadMetadata): ThreadMetadataData = with(threadMetadata) {
-            ThreadMetadataData(archived, archiveTimestamp, autoArchiveDuration, locked, invitable)
+            ThreadMetadataData(archived, archiveTimestamp, autoArchiveDuration, locked, invitable, createTimestamp)
 
         }
     }

--- a/core/src/main/kotlin/cache/data/GuildPreviewData.kt
+++ b/core/src/main/kotlin/cache/data/GuildPreviewData.kt
@@ -16,7 +16,8 @@ public class GuildPreviewData(
     public val features: List<GuildFeature>,
     public val approximateMemberCount: Int,
     public val approximatePresenceCount: Int,
-    public val description: String? = null
+    public val description: String? = null,
+    public val stickers: List<StickerData>,
 ) {
     public companion object {
         public fun from(entity: DiscordGuildPreview): GuildPreviewData = with(entity) {
@@ -30,9 +31,9 @@ public class GuildPreviewData(
                 features,
                 approximateMemberCount,
                 approximatePresenceCount,
-                description
+                description,
+                stickers.map { StickerData.from(it) },
             )
         }
     }
-
 }

--- a/core/src/main/kotlin/entity/GuildPreview.kt
+++ b/core/src/main/kotlin/entity/GuildPreview.kt
@@ -14,7 +14,7 @@ public class GuildPreview(
         get() = data.id
 
     /**
-     * The name of the guild
+     * The name of the guild.
      */
     public val name: String get() = data.name
 
@@ -34,7 +34,7 @@ public class GuildPreview(
     public val discoverySplash: String? get() = data.discoverySplash
 
     /**
-     * Ids of custom guild emojis.
+     * Custom guild emojis.
      */
     public val emojis: Set<GuildEmoji> get() = data.emojis.map { GuildEmoji(it, kord) }.toSet()
 
@@ -58,8 +58,12 @@ public class GuildPreview(
      */
     public val description: String? get() = data.description
 
+    /**
+     * Custom guild stickers.
+     */
+    public val stickers: Set<Sticker> get() = data.stickers.map { GuildSticker(it, kord) }.toSet()
+
     override fun toString(): String {
         return "GuildPreview(data=$data, kord=$kord)"
     }
-
 }

--- a/core/src/main/kotlin/entity/channel/thread/TextChannelThread.kt
+++ b/core/src/main/kotlin/entity/channel/thread/TextChannelThread.kt
@@ -18,10 +18,18 @@ public class TextChannelThread(
     override val kord: Kord,
     override val supplier: EntitySupplier = kord.defaultSupplier
 ) : ThreadChannel {
+
     /**
-     * Whether this thread is private
+     * Whether this thread is private.
      */
     public val isPrivate: Boolean get() = data.type == ChannelType.PrivateThread
+
+    /**
+     * Whether non-moderators can add other non-moderators to a thread.
+     *
+     * This is only applicable to [private][isPrivate] threads and will always be `false` for public threads.
+     */
+    public val isInvitable: Boolean get() = data.threadMetadata.value!!.invitable.discordBoolean
 
     override suspend fun getParent(): TextChannel {
         return supplier.getChannelOf(parentId)

--- a/core/src/main/kotlin/entity/channel/thread/ThreadChannel.kt
+++ b/core/src/main/kotlin/entity/channel/thread/ThreadChannel.kt
@@ -63,7 +63,7 @@ public interface ThreadChannel : GuildMessageChannel, ThreadChannelBehavior {
         get() = archiveTimestamp
 
     /**
-     * timestamp when the thread's archive status was last changed.
+     * The timestamp when the thread's archive status was last changed.
      */
     public val archiveTimestamp: Instant get() = threadData.archiveTimestamp.toInstant()
 
@@ -71,6 +71,13 @@ public interface ThreadChannel : GuildMessageChannel, ThreadChannelBehavior {
      * The time in which the thread will be auto archived after inactivity.
      */
     public val autoArchiveDuration: ArchiveDuration get() = threadData.autoArchiveDuration
+
+    /**
+     * The timestamp when the thread was created.
+     *
+     * This is only available for threads created after 2022-01-09.
+     */
+    public val createTimestamp: Instant? get() = threadData.createTimestamp.value
 
     /**
      * amount of seconds a user has to wait before sending another message


### PR DESCRIPTION
- deprecate Stage Discovery, see https://github.com/discord/discord-api-docs/issues/3152, https://github.com/discord/discord-api-docs/pull/4191 and https://github.com/discord/discord-api-docs/pull/4296
- add new `stickers` field to `DiscordGuildPreview`, `GuildPreviewData` and `GuildPreview`, see https://github.com/discord/discord-api-docs/commit/5b023e04b3bcc055b5be83ad0562862431620e4c
- add new `createTimestamp` field/property to `DiscordThreadMetadata`, `ThreadMetadataData` and `ThreadData`, see https://github.com/discord/discord-api-docs/commit/53ee0109b874bde5ec2316379bf266bb332630a0
- add missing `isInvitable` property to `TextChannelThread` (`NewsChannelThread`s are always public so it would be useless there), see https://discord.com/developers/docs/resources/channel#thread-metadata-object
- `data class` for `DiscordThreadMetadata`