### PR TITLE
Fix issues with autocomplete serialization

### DIFF
--- a/common/src/main/kotlin/entity/Interactions.kt
+++ b/common/src/main/kotlin/entity/Interactions.kt
@@ -576,7 +576,11 @@ sealed class CommandArgument<out T> : Option() {
                     )
                     is IntegerArgument -> encodeLongElement(descriptor, 1, value.value)
                     is NumberArgument -> encodeDoubleElement(descriptor, 1, value.value)
-                    is StringArgument -> encodeStringElement(descriptor, 1, value.value)
+                    is AutoCompleteArgument, is StringArgument -> encodeStringElement(
+                        descriptor,
+                        1,
+                        value.value as String
+                    )
                 }
             }
         }

--- a/core/src/main/kotlin/entity/interaction/ActionInteraction.kt
+++ b/core/src/main/kotlin/entity/interaction/ActionInteraction.kt
@@ -18,11 +18,7 @@ import dev.kord.core.behavior.interaction.ActionInteractionBehavior
 import dev.kord.core.cache.data.ApplicationInteractionData
 import dev.kord.core.cache.data.InteractionData
 import dev.kord.core.cache.data.ResolvedObjectsData
-import dev.kord.core.entity.Entity
-import dev.kord.core.entity.Member
-import dev.kord.core.entity.Message
-import dev.kord.core.entity.Role
-import dev.kord.core.entity.User
+import dev.kord.core.entity.*
 import dev.kord.core.entity.application.GlobalApplicationCommand
 import dev.kord.core.entity.channel.ResolvedChannel
 import dev.kord.core.supplier.EntitySupplier
@@ -279,7 +275,10 @@ public fun OptionValue(value: CommandArgument<*>, resolvedObjects: ResolvedObjec
         is CommandArgument.NumberArgument -> OptionValue.NumberOptionValue(value.value, focused)
         is CommandArgument.BooleanArgument -> OptionValue.BooleanOptionValue(value.value, focused)
         is CommandArgument.IntegerArgument -> OptionValue.IntOptionValue(value.value, focused)
-        is CommandArgument.StringArgument -> OptionValue.StringOptionValue(value.value, focused)
+        is CommandArgument.StringArgument, is CommandArgument.AutoCompleteArgument -> OptionValue.StringOptionValue(
+            value.value as String,
+            focused
+        )
         is CommandArgument.ChannelArgument -> {
             val channel = resolvedObjects?.channels.orEmpty()[value.value]
             requireNotNull(channel) { "channel expected for $value but was missing" }

--- a/core/src/main/kotlin/entity/interaction/ContextInteraction.kt
+++ b/core/src/main/kotlin/entity/interaction/ContextInteraction.kt
@@ -1,6 +1,7 @@
 package dev.kord.core.entity.interaction
 
 import dev.kord.common.entity.ApplicationCommandType
+import dev.kord.common.entity.CommandArgument
 import dev.kord.common.entity.Snowflake
 import dev.kord.common.entity.optional.OptionalSnowflake
 import dev.kord.common.entity.optional.unwrap
@@ -15,7 +16,7 @@ import dev.kord.core.entity.Message
 import dev.kord.core.entity.User
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
-import java.util.Objects
+import java.util.*
 
 /**
  * Interaction which contains a contains command data.
@@ -224,6 +225,8 @@ public class UnknownApplicationCommandInteraction(
  * ActionInteraction indicating an auto-complete request from Discord.
  *
  * **Follow-ups and normals responses don't work on this type**
+ *
+ * **No matter what argument type is used all arguments will be [CommandArgument.AutoCompleteArgument]s
  *
  * Check [AutoCompleteInteractionBehavior] for response options
  */

--- a/core/src/main/kotlin/entity/interaction/ContextInteraction.kt
+++ b/core/src/main/kotlin/entity/interaction/ContextInteraction.kt
@@ -226,7 +226,7 @@ public class UnknownApplicationCommandInteraction(
  *
  * **Follow-ups and normals responses don't work on this type**
  *
- * **No matter what argument type is used all arguments will be [CommandArgument.AutoCompleteArgument]s
+ * **No matter what argument type is used all [focused][CommandArgument.focused] arguments will be [CommandArgument.AutoCompleteArgument]s**
  *
  * Check [AutoCompleteInteractionBehavior] for response options
  */


### PR DESCRIPTION
Users can enter strings into numeric types in auto complete

![](https://cdn.discordapp.com/attachments/631147109311053844/933722956507516968/idea64_2022-01-20_14-01-30.png)