### PR TITLE
ComponentBuilders refactorings

### DIFF
--- a/rest/src/main/kotlin/builder/component/ButtonBuilder.kt
+++ b/rest/src/main/kotlin/builder/component/ButtonBuilder.kt
@@ -1,34 +1,35 @@
+@file:Suppress("PropertyName")
+
 package dev.kord.rest.builder.component
 
 import dev.kord.common.annotation.KordDsl
-import dev.kord.common.annotation.KordPreview
 import dev.kord.common.entity.ButtonStyle
 import dev.kord.common.entity.ComponentType
 import dev.kord.common.entity.DiscordComponent
 import dev.kord.common.entity.DiscordPartialEmoji
 import dev.kord.common.entity.optional.Optional
-import dev.kord.common.entity.optional.OptionalBoolean
 import dev.kord.common.entity.optional.delegate.delegate
 
 @KordDsl
-sealed class ButtonBuilder : ActionRowComponentBuilder {
+sealed class ButtonBuilder : ActionRowComponentBuilder() {
+
+    protected var _label: Optional<String> = Optional.Missing()
+        private set
 
     /**
      * The text that appears on the button, either this and/or [emoji] need to be set
      * for the button to be valid.
      */
-    abstract var label: String?
+    var label: String? by ::_label.delegate()
+
+    protected var _emoji: Optional<DiscordPartialEmoji> = Optional.Missing()
+        private set
 
     /**
      * The emoji that appears on the button, either this and/or [label] need to be set
      * for the button to be valid.
      */
-    abstract var emoji: DiscordPartialEmoji?
-
-    /**
-     * Whether the button is clickable.
-     */
-    var disabled: Boolean = false
+    var emoji: DiscordPartialEmoji? by ::_emoji.delegate()
 
     /**
      * A builder for a button that can create Interactions when clicked.
@@ -40,13 +41,6 @@ sealed class ButtonBuilder : ActionRowComponentBuilder {
         var style: ButtonStyle,
         var customId: String
     ) : ButtonBuilder() {
-
-        private var _emoji: Optional<DiscordPartialEmoji> = Optional.Missing()
-        override var emoji: DiscordPartialEmoji? by ::_emoji.delegate()
-
-        private var _label: Optional<String> = Optional.Missing()
-        override var label: String? by ::_label.delegate()
-
         override fun build(): DiscordComponent = DiscordComponent(
             ComponentType.Button,
             Optional(style),
@@ -54,9 +48,8 @@ sealed class ButtonBuilder : ActionRowComponentBuilder {
             _emoji,
             Optional(customId),
             Optional.Missing(),
-            OptionalBoolean.Value(disabled),
+            _disabled,
         )
-
     }
 
     /**
@@ -67,13 +60,6 @@ sealed class ButtonBuilder : ActionRowComponentBuilder {
     class LinkButtonBuilder(
         var url: String
     ) : ButtonBuilder() {
-
-        private var _emoji: Optional<DiscordPartialEmoji> = Optional.Missing()
-        override var emoji: DiscordPartialEmoji? by ::_emoji.delegate()
-
-        private var _label: Optional<String> = Optional.Missing()
-        override var label: String? by ::_label.delegate()
-
         override fun build(): DiscordComponent = DiscordComponent(
             ComponentType.Button,
             Optional(ButtonStyle.Link),
@@ -81,9 +67,7 @@ sealed class ButtonBuilder : ActionRowComponentBuilder {
             _emoji,
             Optional.Missing(),
             Optional.Value(url),
-            OptionalBoolean.Value(disabled),
+            _disabled,
         )
-
     }
-
 }

--- a/rest/src/main/kotlin/builder/component/ComponentBuilders.kt
+++ b/rest/src/main/kotlin/builder/component/ComponentBuilders.kt
@@ -1,7 +1,10 @@
+@file:Suppress("PropertyName")
+
 package dev.kord.rest.builder.component
 
-import dev.kord.common.annotation.KordPreview
 import dev.kord.common.entity.DiscordComponent
+import dev.kord.common.entity.optional.OptionalBoolean
+import dev.kord.common.entity.optional.delegate.delegate
 
 
 sealed interface ComponentBuilder {
@@ -9,7 +12,14 @@ sealed interface ComponentBuilder {
 }
 
 
-sealed interface ActionRowComponentBuilder : ComponentBuilder
+sealed class ActionRowComponentBuilder : ComponentBuilder {
+
+    protected var _disabled: OptionalBoolean = OptionalBoolean.Missing
+        private set
+
+    /** Whether the component is disabled. Defaults to `false`. */
+    var disabled: Boolean? by ::_disabled.delegate()
+}
 
 
 sealed interface MessageComponentBuilder : ComponentBuilder

--- a/rest/src/main/kotlin/builder/component/SelectMenuBuilder.kt
+++ b/rest/src/main/kotlin/builder/component/SelectMenuBuilder.kt
@@ -4,7 +4,6 @@ import dev.kord.common.annotation.KordDsl
 import dev.kord.common.entity.ComponentType
 import dev.kord.common.entity.DiscordComponent
 import dev.kord.common.entity.optional.Optional
-import dev.kord.common.entity.optional.OptionalBoolean
 import dev.kord.common.entity.optional.OptionalInt
 import dev.kord.common.entity.optional.delegate.delegate
 import kotlin.contracts.InvocationKind
@@ -19,14 +18,7 @@ import kotlin.contracts.contract
 @KordDsl
 class SelectMenuBuilder(
     var customId: String
-) : ActionRowComponentBuilder {
-
-    private var _disabled: OptionalBoolean = OptionalBoolean.Missing
-
-    /**
-     * if this select menu is disabled.
-     */
-    var disabled: Boolean? by ::_disabled.delegate()
+) : ActionRowComponentBuilder() {
 
     /**
      * The choices in the select, max 25.


### PR DESCRIPTION
- `disabled` can be set for all `ActionRowComponentBuilder`s:
  - move up in hierarchy
  - `ActionRowComponentBuilder` is `sealed class now`
  - `disabled` is now nullable for `ButtonBuilder`
- `_label` and `_emoji` delegates are the same in `InteractionButtonBuilder` and `LinkButtonBuilder`: move up in hierarchy
