### PR TITLE
Preserve binary compatibility for ButtonBuilder

### DIFF
--- a/rest/src/main/kotlin/builder/component/ButtonBuilder.kt
+++ b/rest/src/main/kotlin/builder/component/ButtonBuilder.kt
@@ -13,6 +13,21 @@ import dev.kord.common.entity.optional.delegate.delegate
 @KordDsl
 sealed class ButtonBuilder : ActionRowComponentBuilder() {
 
+    @Suppress("unused", "SpellCheckingInspection")
+    @Deprecated(
+        "Only kept for binary compatibility, was primitive (not nullable) before.",
+        ReplaceWith("disabled"),
+        DeprecationLevel.HIDDEN, // not accessible from source code, just by already compiled classes
+    )
+    @get:JvmName("getDisabled") // preserve: `fun getDisabled ()Z`, new: `fun getDisabled ()Ljava/lang/Boolean;`
+    @set:JvmName("setDisabled") // preserve: `fun setDisabled (Z)V`, new: `fun setDisabled (Ljava/lang/Boolean;)V`
+    var primitiveDisabledForBinaryCompatibility: Boolean
+        get() = disabled ?: false
+        set(value) {
+            disabled = value
+        }
+
+
     protected var _label: Optional<String> = Optional.Missing()
         private set
 


### PR DESCRIPTION
https://github.com/kordlib/kord/pull/494 changed the type of `ButtonBuilder.disabled` from `kotlin.Boolean` to `kotlin.Boolean?`.
On Jvm this means that it will no longer be of the primitve type `boolean` but its wrapper `java.lang.Boolean` instead, which is a binary incompatible change, here's how it got fixed:

This PR adds `ButtonBuilder.primitiveDisabledForBinaryCompatibility`, a property of type `kotlin.Boolean`, and renames its getter and setter to give them the same signatures as the previous `ButtonBuilder.disabled`. The implementation just delegates to `ButtonBuilder.disabled`.
It is given a deprecation level of `HIDDEN` to only allow it to be accessed from already compiled classes but not newly written/compiled source code.
