### PR TITLE
fix bug when choices never get set

### DIFF
--- a/rest/src/main/kotlin/builder/interaction/OptionsBuilder.kt
+++ b/rest/src/main/kotlin/builder/interaction/OptionsBuilder.kt
@@ -53,8 +53,8 @@ sealed class BaseChoiceBuilder<T>(
     description: String,
     type: ApplicationCommandOptionType
 ) : OptionsBuilder(name, description, type) {
-    private var _choices: Optional<MutableList<Choice<*>>> = Optional.Missing()
-    var choices: MutableList<Choice<*>>? by ::_choices.delegate()
+    private var _choices: Optional<MutableList<Choice<T>>> = Optional.Missing()
+    var choices: MutableList<Choice<T>>? by ::_choices.delegate()
 
     abstract fun choice(name: String, value: T)
 

--- a/rest/src/main/kotlin/service/InteractionService.kt
+++ b/rest/src/main/kotlin/service/InteractionService.kt
@@ -182,8 +182,7 @@ class InteractionService(requestHandler: RequestHandler) : RestService(requestHa
         builder: Builder,
         builderFunction: Builder.() -> Unit
     ) {
-        @Suppress("UNCHECKED_CAST")
-        val choices = builder.apply(builderFunction).choices as List<Choice<T>>? ?: emptyList()
+        val choices = builder.apply(builderFunction).choices ?: emptyList()
 
         return createAutoCompleteInteractionResponse(interactionId, interactionToken, DiscordAutoComplete(choices))
     }

--- a/rest/src/main/kotlin/service/InteractionService.kt
+++ b/rest/src/main/kotlin/service/InteractionService.kt
@@ -183,7 +183,7 @@ class InteractionService(requestHandler: RequestHandler) : RestService(requestHa
         builderFunction: Builder.() -> Unit
     ) {
         @Suppress("UNCHECKED_CAST")
-        val choices = builder.apply(builderFunction).choices as List<Choice<T>>
+        val choices = builder.apply(builderFunction).choices as List<Choice<T>>? ?: emptyList()
 
         return createAutoCompleteInteractionResponse(interactionId, interactionToken, DiscordAutoComplete(choices))
     }


### PR DESCRIPTION
The `.choices` call returns a `MutableList<Choice<*>>?`, which causes the line in question to throw an error if it's null (the default given that it's a delegate call with the default being `Optional.Missing`) due to the cast requiring the result to be non-null.