### PR TITLE
Prevent double CI on PR from branch in kord

### DIFF
--- a/.github/workflows/deployment-ci.yml
+++ b/.github/workflows/deployment-ci.yml
@@ -15,6 +15,7 @@ jobs:
   build:
     if: |
       !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.pull_request.title, '[ci skip]')
+      && !(github.repository == 'kordlib/kord' && github.event_name == 'pull_request')
 
     name: Build Kord
     runs-on: ubuntu-latest


### PR DESCRIPTION
The CI ran twice on PRs from a branch in kordlib/kord.

This PR should prevent that by only running CI for the push event and not the PR event (haven't tried it out though).