### PR TITLE
Fix both ci triggers skipping

### DIFF
--- a/.github/workflows/deployment-ci.yml
+++ b/.github/workflows/deployment-ci.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     if: |
       !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.pull_request.title, '[ci skip]')
-      && !(github.event_name == 'pull_request' && github.event.pull_request.repo == 'kordlib/kord')
+      && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'kordlib/kord')
 
     name: Build Kord
     runs-on: ubuntu-latest

--- a/.github/workflows/deployment-ci.yml
+++ b/.github/workflows/deployment-ci.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     if: |
       !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.pull_request.title, '[ci skip]')
-      && !(github.event_name != 'pull_request' && github.event.pull_request.repo != 'kordlib/kord')
+      && !(github.event_name == 'pull_request' && github.event.pull_request.repo == 'kordlib/kord')
 
     name: Build Kord
     runs-on: ubuntu-latest

--- a/.github/workflows/deployment-ci.yml
+++ b/.github/workflows/deployment-ci.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     if: |
       !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.pull_request.title, '[ci skip]')
-      && !(github.repository == 'kordlib/kord' && github.event_name == 'pull_request')
+      && (github.repository != 'kordlib/kord' || github.event_name != 'pull_request')
 
     name: Build Kord
     runs-on: ubuntu-latest
@@ -41,8 +41,7 @@ jobs:
     name: Publish artifacts
     runs-on: ubuntu-latest
     if: |
-      !contains(github.event.head_commit.message, '[publish skip]') && !contains(github.event.pull_request.title, '[publish skip]')
-      && github.event_name != 'pull_request' &&  github.ref != 'refs/heads/master'
+      !contains(github.event.head_commit.message, '[publish skip]') && github.event_name != 'pull_request' &&  github.ref != 'refs/heads/master'
 
     needs: build
     env:

--- a/.github/workflows/deployment-ci.yml
+++ b/.github/workflows/deployment-ci.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     if: |
       !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.pull_request.title, '[ci skip]')
-      && (github.repository != 'kordlib/kord' || github.event_name != 'pull_request')
+      && !(github.event_name != 'pull_request' && github.event.pull_request.repo != 'kordlib/kord')
 
     name: Build Kord
     runs-on: ubuntu-latest


### PR DESCRIPTION
Currently, both CIs get skipped, I changed it so on external repos the PR trigger gets used and on the Kord repo the push trigger gets used