### PR TITLE
Fix `Team.ownerUserId` returning the wrong id

### DIFF
--- a/core/src/main/kotlin/entity/Team.kt
+++ b/core/src/main/kotlin/entity/Team.kt
@@ -39,7 +39,7 @@ public class Team(
      * The ID of the user that owns the team.
      */
     public val ownerUserId: Snowflake
-        get() = data.id
+        get() = data.ownerUserId
 
 
     /**


### PR DESCRIPTION
Did return the id of the team instead of the id of the owner.