### PR TITLE
Revert change to `choices` type in `BaseChoiceBuilder` from #505

### DIFF
--- a/rest/src/main/kotlin/builder/interaction/OptionsBuilder.kt
+++ b/rest/src/main/kotlin/builder/interaction/OptionsBuilder.kt
@@ -53,8 +53,8 @@ public sealed class BaseChoiceBuilder<T>(
     description: String,
     type: ApplicationCommandOptionType
 ) : OptionsBuilder(name, description, type) {
-    private var _choices: Optional<MutableList<Choice<T>>> = Optional.Missing()
-    public var choices: MutableList<Choice<T>>? by ::_choices.delegate()
+    private var _choices: Optional<MutableList<Choice<*>>> = Optional.Missing()
+    public var choices: MutableList<Choice<*>>? by ::_choices.delegate()
 
     public abstract fun choice(name: String, value: T)
 


### PR DESCRIPTION
There is currently an issue where you can't set a nullable star projected property to `null`.
I opened [an issue in the Kotlin YouTrack](https://youtrack.jetbrains.com/issue/KT-51045) for this.
To temporarily fix this I reverted the type change made in #505.