### PR TITLE
Fixes for #513 (Guild Scheduled Events)

### DIFF
--- a/common/src/main/kotlin/entity/DiscordGuildScheduledEvent.kt
+++ b/common/src/main/kotlin/entity/DiscordGuildScheduledEvent.kt
@@ -113,11 +113,9 @@ public sealed class GuildScheduledEventStatus(public val value: Int) {
 /**
  * Entity metadata for [DiscordGuildScheduledEvent].
  *
- * @property speakerIds the speakers of the stage channel
  * @property location location of the event
  */
 @Serializable
 public data class GuildScheduledEventEntityMetadata(
-    val speakerIds: Optional<List<Snowflake>> = Optional.Missing(),
     val location: Optional<String> = Optional.Missing()
 )

--- a/common/src/main/kotlin/entity/DiscordGuildScheduledEvent.kt
+++ b/common/src/main/kotlin/entity/DiscordGuildScheduledEvent.kt
@@ -23,7 +23,7 @@ import kotlinx.serialization.encoding.Encoder
  * @property description the description of the event
  * @property scheduledStartTime the [Instant] in which the event will start
  * @property scheduledEndTime the [Instant] in which the event wil stop, if any
- * @property privacyLevel the [event privacy level][StageInstancePrivacyLevel]
+ * @property privacyLevel the [event privacy level][GuildScheduledEventPrivacyLevel]
  * @property status the [event status][GuildScheduledEventStatus]
  * @property entityType the [ScheduledEntityType] of the event
  * @property entityId entity id
@@ -47,7 +47,7 @@ public data class DiscordGuildScheduledEvent(
     @SerialName("scheduled_end_time")
     val scheduledEndTime: Instant?,
     @SerialName("privacy_level")
-    val privacyLevel: StageInstancePrivacyLevel,
+    val privacyLevel: GuildScheduledEventPrivacyLevel,
     val status: GuildScheduledEventStatus,
     @SerialName("entity_type")
     val entityType: ScheduledEntityType,
@@ -59,6 +59,33 @@ public data class DiscordGuildScheduledEvent(
     @SerialName("user_count")
     val userCount: OptionalInt = OptionalInt.Missing,
 )
+
+/** Privacy level of a [DiscordGuildScheduledEvent]. */
+@Serializable(with = GuildScheduledEventPrivacyLevel.Serializer::class)
+public sealed class GuildScheduledEventPrivacyLevel(public val value: Int) {
+
+    /** The scheduled event is only accessible to guild members. */
+    public object GuildOnly : GuildScheduledEventPrivacyLevel(2)
+
+    /** An unknown privacy level. */
+    public class Unknown(value: Int) : GuildScheduledEventPrivacyLevel(value)
+
+    internal object Serializer : KSerializer<GuildScheduledEventPrivacyLevel> {
+        override val descriptor: SerialDescriptor =
+            PrimitiveSerialDescriptor("GuildScheduledEventPrivacyLevel", PrimitiveKind.INT)
+
+        override fun deserialize(decoder: Decoder): GuildScheduledEventPrivacyLevel {
+            return when (val value = decoder.decodeInt()) {
+                2 -> GuildOnly
+                else -> Unknown(value)
+            }
+        }
+
+        override fun serialize(encoder: Encoder, value: GuildScheduledEventPrivacyLevel) {
+            encoder.encodeInt(value.value)
+        }
+    }
+}
 
 @Serializable(with = ScheduledEntityType.Serializer::class)
 public sealed class ScheduledEntityType(public val value: Int) {

--- a/common/src/main/kotlin/entity/DiscordGuildScheduledEvent.kt
+++ b/common/src/main/kotlin/entity/DiscordGuildScheduledEvent.kt
@@ -1,7 +1,7 @@
 package dev.kord.common.entity
 
 import dev.kord.common.entity.optional.Optional
-import dev.kord.common.entity.optional.OptionalSnowflake
+import dev.kord.common.entity.optional.OptionalInt
 import kotlinx.datetime.Instant
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
@@ -36,9 +36,10 @@ public data class DiscordGuildScheduledEvent(
     val id: Snowflake,
     @SerialName("guild_id")
     val guildId: Snowflake,
+    @SerialName("channel_id")
     val channelId: Snowflake?,
     @SerialName("creator_id")
-    val creatorId: OptionalSnowflake,
+    val creatorId: Snowflake?,
     val name: String,
     val description: Optional<String> = Optional.Missing(),
     @SerialName("scheduled_start_time")
@@ -53,10 +54,10 @@ public data class DiscordGuildScheduledEvent(
     @SerialName("entity_id")
     val entityId: Snowflake?,
     @SerialName("entity_metadata")
-    val entityMetadata: GuildScheduledEventEntityMetadata,
+    val entityMetadata: GuildScheduledEventEntityMetadata?,
     val creator: Optional<DiscordUser>,
     @SerialName("user_count")
-    val userCount: Int
+    val userCount: OptionalInt = OptionalInt.Missing,
 )
 
 @Serializable(with = ScheduledEntityType.Serializer::class)

--- a/common/src/main/kotlin/entity/DiscordGuildScheduledEvent.kt
+++ b/common/src/main/kotlin/entity/DiscordGuildScheduledEvent.kt
@@ -55,7 +55,7 @@ public data class DiscordGuildScheduledEvent(
     val entityId: Snowflake?,
     @SerialName("entity_metadata")
     val entityMetadata: GuildScheduledEventEntityMetadata?,
-    val creator: Optional<DiscordUser>,
+    val creator: Optional<DiscordUser> = Optional.Missing(),
     @SerialName("user_count")
     val userCount: OptionalInt = OptionalInt.Missing,
 )

--- a/common/src/main/kotlin/entity/DiscordGuildScheduledEvent.kt
+++ b/common/src/main/kotlin/entity/DiscordGuildScheduledEvent.kt
@@ -62,7 +62,6 @@ public data class DiscordGuildScheduledEvent(
 
 @Serializable(with = ScheduledEntityType.Serializer::class)
 public sealed class ScheduledEntityType(public val value: Int) {
-    public object None : ScheduledEntityType(0)
     public object StageInstance : ScheduledEntityType(1)
     public object Voice : ScheduledEntityType(2)
     public object External : ScheduledEntityType(3)
@@ -73,7 +72,6 @@ public sealed class ScheduledEntityType(public val value: Int) {
 
         override fun deserialize(decoder: Decoder): ScheduledEntityType {
             return when (val value = decoder.decodeInt()) {
-                0 -> None
                 1 -> StageInstance
                 2 -> Voice
                 3 -> External

--- a/core/src/main/kotlin/behavior/GuildBehavior.kt
+++ b/core/src/main/kotlin/behavior/GuildBehavior.kt
@@ -4,9 +4,9 @@ import dev.kord.cache.api.query
 import dev.kord.common.annotation.DeprecatedSinceKord
 import dev.kord.common.annotation.KordExperimental
 import dev.kord.common.entity.DiscordUser
+import dev.kord.common.entity.GuildScheduledEventPrivacyLevel
 import dev.kord.common.entity.ScheduledEntityType
 import dev.kord.common.entity.Snowflake
-import dev.kord.common.entity.StageInstancePrivacyLevel
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.unwrap
 import dev.kord.common.exception.RequestException
@@ -19,13 +19,7 @@ import dev.kord.core.entity.application.GuildApplicationCommand
 import dev.kord.core.entity.application.GuildChatInputCommand
 import dev.kord.core.entity.application.GuildMessageCommand
 import dev.kord.core.entity.application.GuildUserCommand
-import dev.kord.core.entity.channel.Category
-import dev.kord.core.entity.channel.Channel
-import dev.kord.core.entity.channel.GuildChannel
-import dev.kord.core.entity.channel.NewsChannel
-import dev.kord.core.entity.channel.TextChannel
-import dev.kord.core.entity.channel.TopGuildChannel
-import dev.kord.core.entity.channel.VoiceChannel
+import dev.kord.core.entity.channel.*
 import dev.kord.core.entity.channel.thread.ThreadChannel
 import dev.kord.core.event.guild.MembersChunkEvent
 import dev.kord.core.exception.EntityNotFoundException
@@ -41,21 +35,9 @@ import dev.kord.rest.Image
 import dev.kord.rest.NamedFile
 import dev.kord.rest.builder.auditlog.AuditLogGetRequestBuilder
 import dev.kord.rest.builder.ban.BanCreateBuilder
-import dev.kord.rest.builder.channel.CategoryCreateBuilder
-import dev.kord.rest.builder.channel.GuildChannelPositionModifyBuilder
-import dev.kord.rest.builder.channel.NewsChannelCreateBuilder
-import dev.kord.rest.builder.channel.TextChannelCreateBuilder
-import dev.kord.rest.builder.channel.VoiceChannelCreateBuilder
-import dev.kord.rest.builder.guild.EmojiCreateBuilder
-import dev.kord.rest.builder.guild.GuildModifyBuilder
-import dev.kord.rest.builder.guild.GuildWidgetModifyBuilder
-import dev.kord.rest.builder.guild.ScheduledEventCreateBuilder
-import dev.kord.rest.builder.guild.WelcomeScreenModifyBuilder
-import dev.kord.rest.builder.interaction.ApplicationCommandPermissionsBulkModifyBuilder
-import dev.kord.rest.builder.interaction.ChatInputCreateBuilder
-import dev.kord.rest.builder.interaction.MessageCommandCreateBuilder
-import dev.kord.rest.builder.interaction.MultiApplicationCommandBuilder
-import dev.kord.rest.builder.interaction.UserCommandCreateBuilder
+import dev.kord.rest.builder.channel.*
+import dev.kord.rest.builder.guild.*
+import dev.kord.rest.builder.interaction.*
 import dev.kord.rest.builder.role.RoleCreateBuilder
 import dev.kord.rest.builder.role.RolePositionsModifyBuilder
 import dev.kord.rest.json.JsonErrorCode
@@ -63,24 +45,8 @@ import dev.kord.rest.json.request.CurrentUserNicknameModifyRequest
 import dev.kord.rest.json.request.GuildStickerCreateRequest
 import dev.kord.rest.json.request.MultipartGuildStickerCreateRequest
 import dev.kord.rest.request.RestRequestException
-import dev.kord.rest.service.RestClient
-import dev.kord.rest.service.createCategory
-import dev.kord.rest.service.createNewsChannel
-import dev.kord.rest.service.createScheduledEvent
-import dev.kord.rest.service.createTextChannel
-import dev.kord.rest.service.createVoiceChannel
-import dev.kord.rest.service.modifyGuildWelcomeScreen
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.asFlow
-import kotlinx.coroutines.flow.emptyFlow
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.filterIsInstance
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onSubscription
-import kotlinx.coroutines.flow.take
-import kotlinx.coroutines.flow.takeWhile
-import kotlinx.coroutines.flow.transformWhile
+import dev.kord.rest.service.*
+import kotlinx.coroutines.flow.*
 import kotlinx.datetime.Instant
 import java.util.Objects
 import kotlin.contracts.InvocationKind
@@ -1049,7 +1015,7 @@ public suspend inline fun GuildBehavior.bulkEditSlashCommandPermissions(noinline
  */
 public suspend fun GuildBehavior.createScheduledEvent(
     name: String,
-    privacyLevel: StageInstancePrivacyLevel,
+    privacyLevel: GuildScheduledEventPrivacyLevel,
     scheduledStartTime: Instant,
     entityType: ScheduledEntityType,
     builder: ScheduledEventCreateBuilder.() -> Unit

--- a/core/src/main/kotlin/cache/data/GuildScheduledEventData.kt
+++ b/core/src/main/kotlin/cache/data/GuildScheduledEventData.kt
@@ -1,13 +1,8 @@
 package dev.kord.core.cache.data
 
-import dev.kord.common.entity.DiscordGuildScheduledEvent
-import dev.kord.common.entity.GuildScheduledEventEntityMetadata
-import dev.kord.common.entity.GuildScheduledEventStatus
-import dev.kord.common.entity.ScheduledEntityType
-import dev.kord.common.entity.Snowflake
-import dev.kord.common.entity.StageInstancePrivacyLevel
+import dev.kord.common.entity.*
 import dev.kord.common.entity.optional.Optional
-import dev.kord.common.entity.optional.OptionalSnowflake
+import dev.kord.common.entity.optional.OptionalInt
 import dev.kord.common.entity.optional.map
 import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
@@ -17,7 +12,7 @@ public data class GuildScheduledEventData(
     val id: Snowflake,
     val guildId: Snowflake,
     val channelId: Snowflake?,
-    val creatorId: OptionalSnowflake = OptionalSnowflake.Missing,
+    val creatorId: Snowflake?,
     val name: String,
     val description: Optional<String> = Optional.Missing(),
     val scheduledStartTime: Instant,
@@ -26,9 +21,9 @@ public data class GuildScheduledEventData(
     val status: GuildScheduledEventStatus,
     val entityId: Snowflake?,
     val entityType: ScheduledEntityType,
-    val entityMetadata: GuildScheduledEventEntityMetadata,
+    val entityMetadata: GuildScheduledEventEntityMetadata?,
     val creator: Optional<UserData> = Optional.Missing(),
-    val userCount: Int
+    val userCount: OptionalInt = OptionalInt.Missing,
 ) {
     public companion object {
         public fun from(event: DiscordGuildScheduledEvent): GuildScheduledEventData = GuildScheduledEventData(
@@ -50,4 +45,3 @@ public data class GuildScheduledEventData(
         )
     }
 }
-

--- a/core/src/main/kotlin/cache/data/GuildScheduledEventData.kt
+++ b/core/src/main/kotlin/cache/data/GuildScheduledEventData.kt
@@ -17,7 +17,7 @@ public data class GuildScheduledEventData(
     val description: Optional<String> = Optional.Missing(),
     val scheduledStartTime: Instant,
     val scheduledEndTime: Instant?,
-    val privacyLevel: StageInstancePrivacyLevel,
+    val privacyLevel: GuildScheduledEventPrivacyLevel,
     val status: GuildScheduledEventStatus,
     val entityId: Snowflake?,
     val entityType: ScheduledEntityType,

--- a/core/src/main/kotlin/entity/GuildScheduledEvent.kt
+++ b/core/src/main/kotlin/entity/GuildScheduledEvent.kt
@@ -74,9 +74,9 @@ public class GuildScheduledEvent(
         get() = data.scheduledEndTime
 
     /**
-     * The [privacy level][StageInstancePrivacyLevel] of this event.
+     * The [privacy level][GuildScheduledEventPrivacyLevel] of this event.
      */
-    public val privacyLevel: StageInstancePrivacyLevel
+    public val privacyLevel: GuildScheduledEventPrivacyLevel
         get() = data.privacyLevel
 
     /**

--- a/core/src/main/kotlin/entity/GuildScheduledEvent.kt
+++ b/core/src/main/kotlin/entity/GuildScheduledEvent.kt
@@ -1,11 +1,8 @@
 package dev.kord.core.entity
 
-import dev.kord.common.entity.GuildScheduledEventEntityMetadata
-import dev.kord.common.entity.GuildScheduledEventStatus
-import dev.kord.common.entity.ScheduledEntityType
-import dev.kord.common.entity.Snowflake
-import dev.kord.common.entity.StageInstancePrivacyLevel
+import dev.kord.common.entity.*
 import dev.kord.common.entity.optional.unwrap
+import dev.kord.common.entity.optional.value
 import dev.kord.common.exception.RequestException
 import dev.kord.core.Kord
 import dev.kord.core.behavior.GuildScheduledEventBehavior
@@ -45,10 +42,12 @@ public class GuildScheduledEvent(
         get() = data.channelId
 
     /**
-     * The id of the user that created the scheduled event
+     * The id of the user that created the scheduled event.
+     *
+     * This is only available for events created after 2021-10-25.
      */
     public val creatorId: Snowflake?
-        get() = data.creatorId.value
+        get() = data.creatorId
 
     /**
      * The name of this event.
@@ -98,17 +97,17 @@ public class GuildScheduledEvent(
     /**
      * The [entity metadata][GuildScheduledEventEntityMetadata] for the scheduled event
      */
-    public val entityMetadata: GuildScheduledEventEntityMetadata
+    public val entityMetadata: GuildScheduledEventEntityMetadata?
         get() = data.entityMetadata
 
     public val creator: User?
         get() = data.creator.unwrap { User(it, kord, supplier) }
 
     /**
-     * The amount of users subscribed to this event.
+     * The number of users subscribed to this event.
      */
-    public val userCount: Int
-        get() = data.userCount
+    public val userCount: Int?
+        get() = data.userCount.value
 
     /**
      * Requests the [Guild] this event is on.

--- a/rest/src/main/kotlin/builder/guild/ScheduledEventCreateBuilder.kt
+++ b/rest/src/main/kotlin/builder/guild/ScheduledEventCreateBuilder.kt
@@ -1,9 +1,9 @@
 package dev.kord.rest.builder.guild
 
 import dev.kord.common.entity.GuildScheduledEventEntityMetadata
+import dev.kord.common.entity.GuildScheduledEventPrivacyLevel
 import dev.kord.common.entity.ScheduledEntityType
 import dev.kord.common.entity.Snowflake
-import dev.kord.common.entity.StageInstancePrivacyLevel
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalSnowflake
 import dev.kord.common.entity.optional.delegate.delegate
@@ -13,7 +13,7 @@ import kotlinx.datetime.Instant
 
 public class ScheduledEventCreateBuilder(
     public var name: String,
-    public var privacyLevel: StageInstancePrivacyLevel,
+    public var privacyLevel: GuildScheduledEventPrivacyLevel,
     public var scheduledStartTime: Instant,
     public var entityType: ScheduledEntityType,
 ) : AuditRequestBuilder<GuildScheduledEventCreateRequest> {

--- a/rest/src/main/kotlin/builder/guild/ScheduledEventCreateBuilder.kt
+++ b/rest/src/main/kotlin/builder/guild/ScheduledEventCreateBuilder.kt
@@ -12,10 +12,10 @@ import dev.kord.rest.json.request.GuildScheduledEventCreateRequest
 import kotlinx.datetime.Instant
 
 public class ScheduledEventCreateBuilder(
-    public val name: String,
-    public val privacyLevel: StageInstancePrivacyLevel,
-    public val scheduledStartTime: Instant,
-    public val entityType: ScheduledEntityType,
+    public var name: String,
+    public var privacyLevel: StageInstancePrivacyLevel,
+    public var scheduledStartTime: Instant,
+    public var entityType: ScheduledEntityType,
 ) : AuditRequestBuilder<GuildScheduledEventCreateRequest> {
     override var reason: String? = null
 

--- a/rest/src/main/kotlin/builder/guild/ScheduledEventCreateBuilder.kt
+++ b/rest/src/main/kotlin/builder/guild/ScheduledEventCreateBuilder.kt
@@ -7,7 +7,7 @@ import dev.kord.common.entity.StageInstancePrivacyLevel
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalSnowflake
 import dev.kord.common.entity.optional.delegate.delegate
-import dev.kord.rest.builder.RequestBuilder
+import dev.kord.rest.builder.AuditRequestBuilder
 import dev.kord.rest.json.request.GuildScheduledEventCreateRequest
 import kotlinx.datetime.Instant
 
@@ -16,7 +16,9 @@ public class ScheduledEventCreateBuilder(
     public val privacyLevel: StageInstancePrivacyLevel,
     public val scheduledStartTime: Instant,
     public val entityType: ScheduledEntityType,
-) : RequestBuilder<GuildScheduledEventCreateRequest> {
+) : AuditRequestBuilder<GuildScheduledEventCreateRequest> {
+    override var reason: String? = null
+
     private var _channelId: OptionalSnowflake = OptionalSnowflake.Missing
     public var channelId: Snowflake? by ::_channelId.delegate()
 

--- a/rest/src/main/kotlin/builder/scheduled_events/ScheduledEventModifyBuilder.kt
+++ b/rest/src/main/kotlin/builder/scheduled_events/ScheduledEventModifyBuilder.kt
@@ -4,11 +4,13 @@ import dev.kord.common.entity.*
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalSnowflake
 import dev.kord.common.entity.optional.delegate.delegate
-import dev.kord.rest.builder.RequestBuilder
+import dev.kord.rest.builder.AuditRequestBuilder
 import dev.kord.rest.json.request.ScheduledEventModifyRequest
 import kotlinx.datetime.Instant
 
-public class ScheduledEventModifyBuilder : RequestBuilder<ScheduledEventModifyRequest> {
+public class ScheduledEventModifyBuilder : AuditRequestBuilder<ScheduledEventModifyRequest> {
+    override var reason: String? = null
+
     private var _channelId: OptionalSnowflake? = OptionalSnowflake.Missing
     public var channelId: Snowflake? by ::_channelId.delegate()
 

--- a/rest/src/main/kotlin/builder/scheduled_events/ScheduledEventModifyBuilder.kt
+++ b/rest/src/main/kotlin/builder/scheduled_events/ScheduledEventModifyBuilder.kt
@@ -9,7 +9,7 @@ import dev.kord.rest.json.request.ScheduledEventModifyRequest
 import kotlinx.datetime.Instant
 
 public class ScheduledEventModifyBuilder : RequestBuilder<ScheduledEventModifyRequest> {
-    private var _channelId: OptionalSnowflake = OptionalSnowflake.Missing
+    private var _channelId: OptionalSnowflake? = OptionalSnowflake.Missing
     public var channelId: Snowflake? by ::_channelId.delegate()
 
     private var _name: Optional<String> = Optional.Missing()

--- a/rest/src/main/kotlin/builder/scheduled_events/ScheduledEventModifyBuilder.kt
+++ b/rest/src/main/kotlin/builder/scheduled_events/ScheduledEventModifyBuilder.kt
@@ -17,8 +17,8 @@ public class ScheduledEventModifyBuilder : AuditRequestBuilder<ScheduledEventMod
     private var _name: Optional<String> = Optional.Missing()
     public var name: String? by ::_name.delegate()
 
-    private var _privacyLevel: Optional<StageInstancePrivacyLevel> = Optional.Missing()
-    public var privacyLevel: StageInstancePrivacyLevel? by ::_privacyLevel.delegate()
+    private var _privacyLevel: Optional<GuildScheduledEventPrivacyLevel> = Optional.Missing()
+    public var privacyLevel: GuildScheduledEventPrivacyLevel? by ::_privacyLevel.delegate()
 
     private var _scheduledStartTime: Optional<Instant> = Optional.Missing()
     public var scheduledStartTime: Instant? by ::_scheduledStartTime.delegate()

--- a/rest/src/main/kotlin/json/request/GuildRequests.kt
+++ b/rest/src/main/kotlin/json/request/GuildRequests.kt
@@ -244,21 +244,6 @@ public data class GuildWelcomeScreenModifyRequest(
     val description: Optional<String> = Optional.Missing()
 )
 
-@Serializable
-public data class GuildScheduledEventCreateRequest(
-    val channelId: OptionalSnowflake = OptionalSnowflake.Missing,
-    val entityMetadata: Optional<GuildScheduledEventEntityMetadata> = Optional.Missing(),
-    val name: String,
-    @SerialName("privacy_level")
-    val privacyLevel: StageInstancePrivacyLevel,
-    @SerialName("scheduled_start_time")
-    val scheduledStartTime: Instant,
-    @SerialName("scheduled_end_time")
-    val scheduledEndTime: Optional<Instant>,
-    val description: Optional<String> = Optional.Missing(),
-    @SerialName("entity_type")
-    val entityType: ScheduledEntityType
-)
 
 @Serializable
 public data class GuildScheduledEventUsersResponse(val users: List<DiscordOptionallyMemberUser>)

--- a/rest/src/main/kotlin/json/request/ScheduledEventRequests.kt
+++ b/rest/src/main/kotlin/json/request/ScheduledEventRequests.kt
@@ -22,7 +22,7 @@ public data class GuildScheduledEventCreateRequest(
     @SerialName("scheduled_start_time")
     val scheduledStartTime: Instant,
     @SerialName("scheduled_end_time")
-    val scheduledEndTime: Optional<Instant>,
+    val scheduledEndTime: Optional<Instant> = Optional.Missing(),
     val description: Optional<String> = Optional.Missing(),
     @SerialName("entity_type")
     val entityType: ScheduledEntityType,
@@ -43,6 +43,6 @@ public data class ScheduledEventModifyRequest(
     val scheduledEndTime: Optional<Instant> = Optional.Missing(),
     val description: Optional<String> = Optional.Missing(),
     @SerialName("entity_type")
-    val entityType: Optional<ScheduledEntityType>,
+    val entityType: Optional<ScheduledEntityType> = Optional.Missing(),
     val status: Optional<GuildScheduledEventStatus> = Optional.Missing()
 )

--- a/rest/src/main/kotlin/json/request/ScheduledEventRequests.kt
+++ b/rest/src/main/kotlin/json/request/ScheduledEventRequests.kt
@@ -1,9 +1,9 @@
 package dev.kord.rest.json.request
 
 import dev.kord.common.entity.GuildScheduledEventEntityMetadata
+import dev.kord.common.entity.GuildScheduledEventPrivacyLevel
 import dev.kord.common.entity.GuildScheduledEventStatus
 import dev.kord.common.entity.ScheduledEntityType
-import dev.kord.common.entity.StageInstancePrivacyLevel
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalSnowflake
 import kotlinx.datetime.Instant
@@ -18,7 +18,7 @@ public data class GuildScheduledEventCreateRequest(
     val entityMetadata: Optional<GuildScheduledEventEntityMetadata> = Optional.Missing(),
     val name: String,
     @SerialName("privacy_level")
-    val privacyLevel: StageInstancePrivacyLevel,
+    val privacyLevel: GuildScheduledEventPrivacyLevel,
     @SerialName("scheduled_start_time")
     val scheduledStartTime: Instant,
     @SerialName("scheduled_end_time")
@@ -36,7 +36,7 @@ public data class ScheduledEventModifyRequest(
     val entityMetadata: Optional<GuildScheduledEventEntityMetadata> = Optional.Missing(),
     val name: Optional<String> = Optional.Missing(),
     @SerialName("privacy_level")
-    val privacyLevel: Optional<StageInstancePrivacyLevel> = Optional.Missing(),
+    val privacyLevel: Optional<GuildScheduledEventPrivacyLevel> = Optional.Missing(),
     @SerialName("scheduled_start_time")
     val scheduledStartTime: Optional<Instant> = Optional.Missing(),
     @SerialName("scheduled_end_time")

--- a/rest/src/main/kotlin/json/request/ScheduledEventRequests.kt
+++ b/rest/src/main/kotlin/json/request/ScheduledEventRequests.kt
@@ -11,9 +11,28 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-public data class ScheduledEventModifyRequest(
+public data class GuildScheduledEventCreateRequest(
     @SerialName("channel_id")
     val channelId: OptionalSnowflake = OptionalSnowflake.Missing,
+    @SerialName("entity_metadata")
+    val entityMetadata: Optional<GuildScheduledEventEntityMetadata> = Optional.Missing(),
+    val name: String,
+    @SerialName("privacy_level")
+    val privacyLevel: StageInstancePrivacyLevel,
+    @SerialName("scheduled_start_time")
+    val scheduledStartTime: Instant,
+    @SerialName("scheduled_end_time")
+    val scheduledEndTime: Optional<Instant>,
+    val description: Optional<String> = Optional.Missing(),
+    @SerialName("entity_type")
+    val entityType: ScheduledEntityType,
+)
+
+@Serializable
+public data class ScheduledEventModifyRequest(
+    @SerialName("channel_id")
+    val channelId: OptionalSnowflake? = OptionalSnowflake.Missing,
+    @SerialName("entity_metadata")
     val entityMetadata: Optional<GuildScheduledEventEntityMetadata> = Optional.Missing(),
     val name: Optional<String> = Optional.Missing(),
     @SerialName("privacy_level")

--- a/rest/src/main/kotlin/service/GuildService.kt
+++ b/rest/src/main/kotlin/service/GuildService.kt
@@ -568,7 +568,7 @@ public suspend inline fun GuildService.modifyVoiceState(
 public suspend inline fun GuildService.createScheduledEvent(
     guildId: Snowflake,
     name: String,
-    privacyLevel: StageInstancePrivacyLevel,
+    privacyLevel: GuildScheduledEventPrivacyLevel,
     scheduledStartTime: Instant,
     entityType: ScheduledEntityType,
     builder: ScheduledEventCreateBuilder.() -> Unit = {}

--- a/rest/src/main/kotlin/service/GuildService.kt
+++ b/rest/src/main/kotlin/service/GuildService.kt
@@ -451,9 +451,10 @@ public class GuildService(requestHandler: RequestHandler) : RestService(requestH
     public suspend fun createScheduledEvent(
         guildId: Snowflake,
         request: GuildScheduledEventCreateRequest,
+        reason: String? = null,
     ): DiscordGuildScheduledEvent = call(Route.GuildScheduledEventsPost) {
         keys[Route.GuildId] = guildId
-
+        auditLogReason(reason)
         body(GuildScheduledEventCreateRequest.serializer(), request)
     }
 
@@ -461,10 +462,11 @@ public class GuildService(requestHandler: RequestHandler) : RestService(requestH
         guildId: Snowflake,
         eventId: Snowflake,
         request: ScheduledEventModifyRequest,
+        reason: String? = null,
     ): DiscordGuildScheduledEvent = call(Route.GuildScheduledEventPatch) {
         keys[Route.GuildId] = guildId
         keys[Route.ScheduledEventId] = eventId
-
+        auditLogReason(reason)
         body(ScheduledEventModifyRequest.serializer(), request)
     }
 
@@ -582,7 +584,7 @@ public suspend inline fun GuildService.createScheduledEvent(
         entityType
     ).apply(builder)
 
-    return createScheduledEvent(guildId, appliedBuilder.toRequest())
+    return createScheduledEvent(guildId, appliedBuilder.toRequest(), appliedBuilder.reason)
 }
 
 public suspend inline fun GuildService.modifyScheduledEvent(
@@ -596,5 +598,5 @@ public suspend inline fun GuildService.modifyScheduledEvent(
 
     val appliedBuilder = ScheduledEventModifyBuilder().apply(builder)
 
-    return modifyScheduledEvent(guildId, eventId, appliedBuilder.toRequest())
+    return modifyScheduledEvent(guildId, eventId, appliedBuilder.toRequest(), appliedBuilder.reason)
 }


### PR DESCRIPTION
### Fixes, see https://discord.com/developers/docs/resources/guild-scheduled-event
- add missing `@SerialName("snake_case_name")` annotations
- make `creatorId` nullable instead of optional
- make `entityMetadata` nullable
- change type of `userCount` from `Int` to `OptionalInt`

### create and modify endpoints
- support audit log reason
- modify: `channelId` is nullable and optional now, was only optional before

### Remove no longer documented things
- `ScheduledEntityType.None`, see https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-entity-types
- `GuildScheduledEventEntityMetadata.speakerIds`, see https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-entity-metadata

### New type for `privacyLevel`: `GuildScheduledEventPrivacyLevel`
This was `StageInstancePrivacyLevel` before but they are documented as two independent types in the docs, see https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-privacy-level and https://discord.com/developers/docs/resources/stage-instance#stage-instance-object-privacy-level.

### Other
- move `GuildScheduledEventCreateRequest` from `GuildRequests.kt` to `ScheduledEventRequests.kt`