### PR TITLE
Fix wrong serializer in autocomplete

### DIFF
--- a/core/src/main/kotlin/behavior/interaction/AutoCompleteInteractionBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/AutoCompleteInteractionBehavior.kt
@@ -11,10 +11,10 @@ import kotlin.contracts.contract
 /**
  * Behavior of an AutoComplete interaction.
  *
- * @see respondNumber
- * @see respondString
- * @see respondInt
- * @see respond
+ * @see suggestString
+ * @see suggestInt
+ * @see suggestNumber
+ * @see suggest
  */
 public interface AutoCompleteInteractionBehavior : InteractionBehavior
 
@@ -37,6 +37,7 @@ public suspend inline fun AutoCompleteInteractionBehavior.suggestInt(builder: In
  * Responds with the number choices specified by [builder].
  *
  * The provided choices are only suggestions and the user can provide any other input as well.
+ *
  * @see NumberChoiceBuilder
  */
 public suspend inline fun AutoCompleteInteractionBehavior.suggestNumber(builder: NumberChoiceBuilder.() -> Unit) {

--- a/rest/src/main/kotlin/builder/interaction/OptionsBuilder.kt
+++ b/rest/src/main/kotlin/builder/interaction/OptionsBuilder.kt
@@ -18,8 +18,7 @@ public sealed class OptionsBuilder(
     public var name: String,
     public var description: String,
     public val type: ApplicationCommandOptionType,
-) :
-    RequestBuilder<ApplicationCommandOption> {
+) : RequestBuilder<ApplicationCommandOption> {
     internal var _default: OptionalBoolean = OptionalBoolean.Missing
     public var default: Boolean? by ::_default.delegate()
 
@@ -53,6 +52,9 @@ public sealed class BaseChoiceBuilder<T>(
     description: String,
     type: ApplicationCommandOptionType
 ) : OptionsBuilder(name, description, type) {
+    // TODO We can change these types to Optional<MutableList<Choice<T>>> and MutableList<Choice<T>> once
+    //  https://youtrack.jetbrains.com/issue/KT-51045 is fixed.
+    //  The bug from that issue prevents you from setting BaseChoiceBuilder<*>.choices to `null`.
     private var _choices: Optional<MutableList<Choice<*>>> = Optional.Missing()
     public var choices: MutableList<Choice<*>>? by ::_choices.delegate()
 

--- a/rest/src/main/kotlin/service/InteractionService.kt
+++ b/rest/src/main/kotlin/service/InteractionService.kt
@@ -142,7 +142,11 @@ public class InteractionService(requestHandler: RequestHandler) : RestService(re
         builder: Builder,
         builderFunction: Builder.() -> Unit
     ) {
-        val choices = builder.apply(builderFunction).choices ?: emptyList()
+        // TODO We can remove this cast when we change the type of BaseChoiceBuilder.choices to MutableList<Choice<T>>.
+        //  This can be done once https://youtrack.jetbrains.com/issue/KT-51045 is fixed.
+        //  Until then this cast is necessary to get the right serializer through reified generics.
+        @Suppress("UNCHECKED_CAST")
+        val choices = (builder.apply(builderFunction).choices ?: emptyList()) as List<Choice<T>>
 
         return createAutoCompleteInteractionResponse(interactionId, interactionToken, DiscordAutoComplete(choices))
     }


### PR DESCRIPTION
When reverting the type change of `BaseChoiceBuilder.choices` in https://github.com/kordlib/kord/pull/512 I did not put the cast to `List<Choice<T>>` in `InteractionService.createBuilderAutoCompleteInteractionResponse()` back in place.
Because that function calls `InteractionService.createAutoCompleteInteractionResponse()`, which takes a serializer that by default is supplied by the reified generic function `serializer<T>()`, it was implicitly trying to get the serializer for `Any`, which does not exist.
By putting the cast back this should be fixed.