### PR TITLE
Optional timestamp style

### DIFF
--- a/common/src/main/kotlin/DiscordTimestamp.kt
+++ b/common/src/main/kotlin/DiscordTimestamp.kt
@@ -2,8 +2,8 @@ package dev.kord.common
 
 import kotlinx.datetime.Instant
 
-public fun Instant.toMessageFormat(style: DiscordTimestampStyle = DiscordTimestampStyle.ShortDateTime): String =
-    "<t:$epochSeconds:${style.style}>"
+public fun Instant.toMessageFormat(style: DiscordTimestampStyle? = null): String =
+    if (style == null) "<t:$epochSeconds>" else "<t:$epochSeconds:${style.style}>"
 
 /**
  * The class representing the [style of a timestamp](https://discord.com/developers/docs/reference#message-formatting-timestamp-styles)


### PR DESCRIPTION
Discord allows to send [formatted timestamps](https://discord.com/developers/docs/reference#message-formatting-formats) and specifying a [timestamp style](https://discord.com/developers/docs/reference#message-formatting-timestamp-styles). However, the style is optional.
This PR makes the `style` parameter of the `toMessageFormat()` extension on `Instant` nullable and will fall back to Discord's default style if not provided.