### PR TITLE
Generic interaction create events

### DIFF
--- a/core/src/main/kotlin/event/interaction/ApplicationCreate.kt
+++ b/core/src/main/kotlin/event/interaction/ApplicationCreate.kt
@@ -1,12 +1,7 @@
 package dev.kord.core.event.interaction
 
 import dev.kord.core.Kord
-import dev.kord.core.behavior.interaction.AutoCompleteInteractionBehavior
-import dev.kord.core.behavior.interaction.EphemeralInteractionResponseBehavior
-import dev.kord.core.behavior.interaction.PublicInteractionResponseBehavior
-import dev.kord.core.behavior.interaction.followUp
-import dev.kord.core.behavior.interaction.respondEphemeral
-import dev.kord.core.behavior.interaction.respondPublic
+import dev.kord.core.behavior.interaction.*
 import dev.kord.core.entity.application.ApplicationCommand
 import dev.kord.core.entity.interaction.*
 import dev.kord.core.event.kordCoroutineScope
@@ -38,20 +33,24 @@ import kotlinx.coroutines.CoroutineScope
  * In the current iteration, ephemeral messages (regardless of the type) don't support files and/or embeds.
  */
 
-public sealed interface ApplicationInteractionCreateEvent : ActionInteractionCreateEvent {
-    override val interaction: ApplicationCommandInvocationInteraction
+public sealed interface ApplicationInteractionCreateEvent<out I : ApplicationCommandInvocationInteraction> :
+    ActionInteractionCreateEvent<I> {
+    override val interaction: I
 }
 
-public sealed interface GlobalApplicationInteractionCreateEvent : ApplicationInteractionCreateEvent {
-    override val interaction: GlobalApplicationCommandInteraction
+public sealed interface GlobalApplicationInteractionCreateEvent<out I : GlobalApplicationCommandInteraction> :
+    ApplicationInteractionCreateEvent<I> {
+    override val interaction: I
 }
 
-public sealed interface GuildApplicationInteractionCreateEvent : ApplicationInteractionCreateEvent {
-    override val interaction: GuildApplicationCommandInteraction
+public sealed interface GuildApplicationInteractionCreateEvent<out I : GuildApplicationCommandInteraction> :
+    ApplicationInteractionCreateEvent<I> {
+    override val interaction: I
 }
 
-public sealed interface UserCommandInteractionCreateEvent : ApplicationInteractionCreateEvent {
-    override val interaction: UserCommandInteraction
+public sealed interface UserCommandInteractionCreateEvent<out I : UserCommandInteraction> :
+    ApplicationInteractionCreateEvent<I> {
+    override val interaction: I
 }
 
 public class GuildUserCommandInteractionCreateEvent(
@@ -59,18 +58,23 @@ public class GuildUserCommandInteractionCreateEvent(
     override val kord: Kord,
     override val shard: Int,
     public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : GuildApplicationInteractionCreateEvent, UserCommandInteractionCreateEvent, CoroutineScope by coroutineScope
+) : GuildApplicationInteractionCreateEvent<GuildUserCommandInteraction>,
+    UserCommandInteractionCreateEvent<GuildUserCommandInteraction>,
+    CoroutineScope by coroutineScope
 
 public class GlobalUserCommandInteractionCreateEvent(
     override val interaction: GlobalUserCommandInteraction,
     override val kord: Kord,
     override val shard: Int,
     public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : GlobalApplicationInteractionCreateEvent, UserCommandInteractionCreateEvent, CoroutineScope by coroutineScope
+) : GlobalApplicationInteractionCreateEvent<GlobalUserCommandInteraction>,
+    UserCommandInteractionCreateEvent<GlobalUserCommandInteraction>,
+    CoroutineScope by coroutineScope
 
 
-public sealed interface MessageCommandInteractionCreateEvent : ApplicationInteractionCreateEvent {
-    override val interaction: MessageCommandInteraction
+public sealed interface MessageCommandInteractionCreateEvent<out I : MessageCommandInteraction> :
+    ApplicationInteractionCreateEvent<I> {
+    override val interaction: I
 }
 
 public class GuildMessageCommandInteractionCreateEvent(
@@ -78,18 +82,23 @@ public class GuildMessageCommandInteractionCreateEvent(
     override val kord: Kord,
     override val shard: Int,
     public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : GuildApplicationInteractionCreateEvent, MessageCommandInteractionCreateEvent, CoroutineScope by coroutineScope
+) : GuildApplicationInteractionCreateEvent<GuildMessageCommandInteraction>,
+    MessageCommandInteractionCreateEvent<GuildMessageCommandInteraction>,
+    CoroutineScope by coroutineScope
 
 public class GlobalMessageCommandInteractionCreateEvent(
     override val interaction: GlobalMessageCommandInteraction,
     override val kord: Kord,
     override val shard: Int,
     public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : GlobalApplicationInteractionCreateEvent, MessageCommandInteractionCreateEvent, CoroutineScope by coroutineScope
+) : GlobalApplicationInteractionCreateEvent<GlobalMessageCommandInteraction>,
+    MessageCommandInteractionCreateEvent<GlobalMessageCommandInteraction>,
+    CoroutineScope by coroutineScope
 
 
-public sealed interface ChatInputCommandInteractionCreateEvent : ApplicationInteractionCreateEvent {
-    override val interaction: ChatInputCommandInvocationInteraction
+public sealed interface ChatInputCommandInteractionCreateEvent<out I : ChatInputCommandInvocationInteraction> :
+    ApplicationInteractionCreateEvent<I> {
+    override val interaction: I
 }
 
 public class GuildChatInputCommandInteractionCreateEvent(
@@ -97,14 +106,18 @@ public class GuildChatInputCommandInteractionCreateEvent(
     override val kord: Kord,
     override val shard: Int,
     public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : GuildApplicationInteractionCreateEvent, ChatInputCommandInteractionCreateEvent, CoroutineScope by coroutineScope
+) : GuildApplicationInteractionCreateEvent<GuildChatInputCommandInteraction>,
+    ChatInputCommandInteractionCreateEvent<GuildChatInputCommandInteraction>,
+    CoroutineScope by coroutineScope
 
 public class GlobalChatInputCommandInteractionCreateEvent(
     override val interaction: GlobalChatInputCommandInteraction,
     override val kord: Kord,
     override val shard: Int,
     public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : GlobalApplicationInteractionCreateEvent, ChatInputCommandInteractionCreateEvent, CoroutineScope by coroutineScope
+) : GlobalApplicationInteractionCreateEvent<GlobalChatInputCommandInteraction>,
+    ChatInputCommandInteractionCreateEvent<GlobalChatInputCommandInteraction>,
+    CoroutineScope by coroutineScope
 
 /**
  * ActionInteraction received when a users types into an auto-completed option.
@@ -113,22 +126,9 @@ public class GlobalChatInputCommandInteractionCreateEvent(
  *
  * @see AutoCompleteInteraction
  */
-public sealed interface AutoCompleteInteractionCreateEvent : DataInteractionCreateEvent {
-    override val interaction: AutoCompleteInteraction
-}
-
-internal fun AutoCompleteInteractionCreateEvent(
-    interaction: AutoCompleteInteraction,
-    kord: Kord,
-    shard: Int,
-    coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-): AutoCompleteInteractionCreateEvent = when (interaction) {
-    is GuildAutoCompleteInteraction -> GuildAutoCompleteInteractionCreateEvent(
-        kord, shard, interaction, coroutineScope
-    )
-    else -> GlobalAutoCompleteInteractionCreateEvent(
-        kord, shard, interaction as GlobalAutoCompleteInteraction, coroutineScope
-    )
+public sealed interface AutoCompleteInteractionCreateEvent<out I : AutoCompleteInteraction> :
+    DataInteractionCreateEvent<I> {
+    override val interaction: I
 }
 
 /**
@@ -143,7 +143,7 @@ public class GlobalAutoCompleteInteractionCreateEvent(
     override val shard: Int,
     override val interaction: GlobalAutoCompleteInteraction,
     public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : AutoCompleteInteractionCreateEvent, CoroutineScope by coroutineScope
+) : AutoCompleteInteractionCreateEvent<GlobalAutoCompleteInteraction>, CoroutineScope by coroutineScope
 
 /**
  * ActionInteraction received when a users types into an auto-completed option.
@@ -157,4 +157,4 @@ public class GuildAutoCompleteInteractionCreateEvent(
     override val shard: Int,
     override val interaction: GuildAutoCompleteInteraction,
     public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : AutoCompleteInteractionCreateEvent, CoroutineScope by coroutineScope
+) : AutoCompleteInteractionCreateEvent<GuildAutoCompleteInteraction>, CoroutineScope by coroutineScope

--- a/core/src/main/kotlin/event/interaction/ComponentCreate.kt
+++ b/core/src/main/kotlin/event/interaction/ComponentCreate.kt
@@ -4,30 +4,32 @@ import dev.kord.core.Kord
 import dev.kord.core.entity.interaction.*
 import dev.kord.core.event.kordCoroutineScope
 import kotlinx.coroutines.CoroutineScope
-import kotlin.coroutines.CoroutineContext
 
 
-public sealed interface ComponentInteractionCreateEvent : InteractionCreateEvent {
-    override val interaction: ComponentInteraction
+public sealed interface ComponentInteractionCreateEvent<out I : ComponentInteraction> : InteractionCreateEvent<I> {
+    override val interaction: I
 }
 
-public sealed interface GlobalComponentInteractionCreateEvent : InteractionCreateEvent {
-    override val interaction: GlobalComponentInteraction
-}
-
-
-public sealed interface GuildComponentInteractionCreateEvent : InteractionCreateEvent {
-    override val interaction: GuildComponentInteraction
+public sealed interface GlobalComponentInteractionCreateEvent<out I : GlobalComponentInteraction> :
+    InteractionCreateEvent<I> {
+    override val interaction: I
 }
 
 
-public sealed interface ButtonInteractionCreateEvent : ComponentInteractionCreateEvent {
-    override val interaction: ButtonInteraction
+public sealed interface GuildComponentInteractionCreateEvent<out I : GuildComponentInteraction> :
+    InteractionCreateEvent<I> {
+    override val interaction: I
 }
 
 
-public sealed interface SelectMenuInteractionCreateEvent : ComponentInteractionCreateEvent {
-    override val interaction: SelectMenuInteraction
+public sealed interface ButtonInteractionCreateEvent<out I : ButtonInteraction> : ComponentInteractionCreateEvent<I> {
+    override val interaction: I
+}
+
+
+public sealed interface SelectMenuInteractionCreateEvent<out I : SelectMenuInteraction> :
+    ComponentInteractionCreateEvent<I> {
+    override val interaction: I
 }
 
 
@@ -36,7 +38,9 @@ public class GuildButtonInteractionCreateEvent(
     override val kord: Kord,
     override val shard: Int,
     public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : ButtonInteractionCreateEvent, GuildComponentInteractionCreateEvent, CoroutineScope by coroutineScope
+) : ButtonInteractionCreateEvent<GuildButtonInteraction>,
+    GuildComponentInteractionCreateEvent<GuildButtonInteraction>,
+    CoroutineScope by coroutineScope
 
 
 public class GlobalButtonInteractionCreateEvent(
@@ -44,7 +48,9 @@ public class GlobalButtonInteractionCreateEvent(
     override val kord: Kord,
     override val shard: Int,
     public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : ButtonInteractionCreateEvent, GlobalComponentInteractionCreateEvent, CoroutineScope by coroutineScope
+) : ButtonInteractionCreateEvent<GlobalButtonInteraction>,
+    GlobalComponentInteractionCreateEvent<GlobalButtonInteraction>,
+    CoroutineScope by coroutineScope
 
 
 public class GuildSelectMenuInteractionCreateEvent(
@@ -52,7 +58,9 @@ public class GuildSelectMenuInteractionCreateEvent(
     override val kord: Kord,
     override val shard: Int,
     public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : SelectMenuInteractionCreateEvent, GuildComponentInteractionCreateEvent, CoroutineScope by coroutineScope
+) : SelectMenuInteractionCreateEvent<GuildSelectMenuInteraction>,
+    GuildComponentInteractionCreateEvent<GuildSelectMenuInteraction>,
+    CoroutineScope by coroutineScope
 
 
 public class GlobalSelectMenuInteractionCreateEvent(
@@ -60,4 +68,6 @@ public class GlobalSelectMenuInteractionCreateEvent(
     override val kord: Kord,
     override val shard: Int,
     public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : SelectMenuInteractionCreateEvent, GlobalComponentInteractionCreateEvent, CoroutineScope by coroutineScope
+) : SelectMenuInteractionCreateEvent<GlobalSelectMenuInteraction>,
+    GlobalComponentInteractionCreateEvent<GlobalSelectMenuInteraction>,
+    CoroutineScope by coroutineScope

--- a/core/src/main/kotlin/event/interaction/ComponentCreate.kt
+++ b/core/src/main/kotlin/event/interaction/ComponentCreate.kt
@@ -11,13 +11,13 @@ public sealed interface ComponentInteractionCreateEvent<out I : ComponentInterac
 }
 
 public sealed interface GlobalComponentInteractionCreateEvent<out I : GlobalComponentInteraction> :
-    InteractionCreateEvent<I> {
+    ComponentInteractionCreateEvent<I> {
     override val interaction: I
 }
 
 
 public sealed interface GuildComponentInteractionCreateEvent<out I : GuildComponentInteraction> :
-    InteractionCreateEvent<I> {
+    ComponentInteractionCreateEvent<I> {
     override val interaction: I
 }
 

--- a/core/src/main/kotlin/event/interaction/InteractionCreate.kt
+++ b/core/src/main/kotlin/event/interaction/InteractionCreate.kt
@@ -5,14 +5,14 @@ import dev.kord.core.entity.interaction.DataInteraction
 import dev.kord.core.entity.interaction.Interaction
 import dev.kord.core.event.Event
 
-public sealed interface InteractionCreateEvent : Event {
-    public val interaction: Interaction
+public sealed interface InteractionCreateEvent<out I : Interaction> : Event {
+    public val interaction: I
 }
 
-public sealed interface ActionInteractionCreateEvent : InteractionCreateEvent {
-    override val interaction: ActionInteraction
+public sealed interface ActionInteractionCreateEvent<out I : ActionInteraction> : InteractionCreateEvent<I> {
+    override val interaction: I
 }
 
-public sealed interface DataInteractionCreateEvent : InteractionCreateEvent {
-    override val interaction: DataInteraction
+public sealed interface DataInteractionCreateEvent<out I : DataInteraction> : InteractionCreateEvent<I> {
+    override val interaction: I
 }

--- a/core/src/main/kotlin/gateway/handler/InteractionEventHandler.kt
+++ b/core/src/main/kotlin/gateway/handler/InteractionEventHandler.kt
@@ -7,48 +7,9 @@ import dev.kord.core.Kord
 import dev.kord.core.cache.data.ApplicationCommandData
 import dev.kord.core.cache.data.InteractionData
 import dev.kord.core.cache.idEq
-import dev.kord.core.entity.application.GuildApplicationCommand
-import dev.kord.core.entity.application.GuildChatInputCommand
-import dev.kord.core.entity.application.GuildMessageCommand
-import dev.kord.core.entity.application.GuildUserCommand
-import dev.kord.core.entity.application.UnknownGuildApplicationCommand
-import dev.kord.core.entity.interaction.AutoCompleteInteraction
-import dev.kord.core.entity.interaction.GlobalButtonInteraction
-import dev.kord.core.entity.interaction.GlobalChatInputCommandInteraction
-import dev.kord.core.entity.interaction.GlobalMessageCommandInteraction
-import dev.kord.core.entity.interaction.GlobalSelectMenuInteraction
-import dev.kord.core.entity.interaction.GlobalUserCommandInteraction
-import dev.kord.core.entity.interaction.GuildButtonInteraction
-import dev.kord.core.entity.interaction.GuildChatInputCommandInteraction
-import dev.kord.core.entity.interaction.GuildMessageCommandInteraction
-import dev.kord.core.entity.interaction.GuildSelectMenuInteraction
-import dev.kord.core.entity.interaction.GuildUserCommandInteraction
-import dev.kord.core.entity.interaction.Interaction
-import dev.kord.core.entity.interaction.UnknownApplicationCommandInteraction
-import dev.kord.core.entity.interaction.UnknownComponentInteraction
-import dev.kord.core.event.interaction.AutoCompleteInteractionCreateEvent
-import dev.kord.core.event.interaction.ChatInputCommandCreateEvent
-import dev.kord.core.event.interaction.ChatInputCommandDeleteEvent
-import dev.kord.core.event.interaction.ChatInputCommandUpdateEvent
-import dev.kord.core.event.interaction.GlobalButtonInteractionCreateEvent
-import dev.kord.core.event.interaction.GlobalChatInputCommandInteractionCreateEvent
-import dev.kord.core.event.interaction.GlobalMessageCommandInteractionCreateEvent
-import dev.kord.core.event.interaction.GlobalSelectMenuInteractionCreateEvent
-import dev.kord.core.event.interaction.GlobalUserCommandInteractionCreateEvent
-import dev.kord.core.event.interaction.GuildButtonInteractionCreateEvent
-import dev.kord.core.event.interaction.GuildChatInputCommandInteractionCreateEvent
-import dev.kord.core.event.interaction.GuildMessageCommandInteractionCreateEvent
-import dev.kord.core.event.interaction.GuildSelectMenuInteractionCreateEvent
-import dev.kord.core.event.interaction.GuildUserCommandInteractionCreateEvent
-import dev.kord.core.event.interaction.MessageCommandCreateEvent
-import dev.kord.core.event.interaction.MessageCommandDeleteEvent
-import dev.kord.core.event.interaction.MessageCommandUpdateEvent
-import dev.kord.core.event.interaction.UnknownApplicationCommandCreateEvent
-import dev.kord.core.event.interaction.UnknownApplicationCommandDeleteEvent
-import dev.kord.core.event.interaction.UnknownApplicationCommandUpdateEvent
-import dev.kord.core.event.interaction.UserCommandCreateEvent
-import dev.kord.core.event.interaction.UserCommandDeleteEvent
-import dev.kord.core.event.interaction.UserCommandUpdateEvent
+import dev.kord.core.entity.application.*
+import dev.kord.core.entity.interaction.*
+import dev.kord.core.event.interaction.*
 import dev.kord.gateway.*
 import kotlinx.coroutines.CoroutineScope
 import dev.kord.core.event.Event as CoreEvent
@@ -69,8 +30,9 @@ public class InteractionEventHandler(
 
     private fun handle(event: InteractionCreate, shard: Int, kord: Kord, coroutineScope: CoroutineScope): CoreEvent {
         val data = InteractionData.from(event.interaction)
-        val coreEvent = when(val interaction = Interaction.from(data, kord)) {
-            is AutoCompleteInteraction -> AutoCompleteInteractionCreateEvent(interaction, kord, shard, coroutineScope)
+        val coreEvent = when (val interaction = Interaction.from(data, kord)) {
+            is GlobalAutoCompleteInteraction -> GlobalAutoCompleteInteractionCreateEvent(kord, shard, interaction, coroutineScope)
+            is GuildAutoCompleteInteraction -> GuildAutoCompleteInteractionCreateEvent(kord, shard, interaction, coroutineScope)
             is GlobalChatInputCommandInteraction -> GlobalChatInputCommandInteractionCreateEvent(interaction, kord, shard, coroutineScope)
             is GlobalUserCommandInteraction -> GlobalUserCommandInteractionCreateEvent(interaction, kord, shard, coroutineScope)
             is GlobalMessageCommandInteraction -> GlobalMessageCommandInteractionCreateEvent(interaction, kord, shard, coroutineScope)

--- a/core/src/main/kotlin/live/LiveMessage.kt
+++ b/core/src/main/kotlin/live/LiveMessage.kt
@@ -165,8 +165,8 @@ public class LiveMessage(
 
         is GuildDeleteEvent -> event.guildId == guildId
 
-        is MessageCommandInteractionCreateEvent -> event.interaction.messages.keys.contains(message.id)
-        is InteractionCreateEvent -> event.interaction.data.message.value?.id == message.id
+        is MessageCommandInteractionCreateEvent<*> -> event.interaction.messages.keys.contains(message.id)
+        is InteractionCreateEvent<*> -> event.interaction.data.message.value?.id == message.id
         else -> false
     }
 
@@ -187,8 +187,8 @@ public class LiveMessage(
 
         is GuildDeleteEvent -> shutDown(LiveCancellationException(event, "The guild is deleted"))
 
-        is MessageCommandInteractionCreateEvent -> Unit
-        is InteractionCreateEvent -> Unit
+        is MessageCommandInteractionCreateEvent<*> -> Unit
+        is InteractionCreateEvent<*> -> Unit
         else -> Unit
     }
 


### PR DESCRIPTION
## Changes

* make `InteractionCreateEvent` generic over its `interaction` property
* change superinterface of `GuildComponentInteractionCreateEvent` and `GlobalComponentInteractionCreateEvent`

#### before
```
Event <- InteractionCreateEvent <- [Guild|Global]ComponentInteractionCreateEvent
```
#### after
```
Event <- InteractionCreateEvent <- ComponentInteractionCreateEvent <- [Guild|Global]ComponentInteractionCreateEvent
```

## Example where you can benefit from a generic `interaction` property

#### Without generic interaction
```kotlin
suspend inline fun <E : InteractionCreateEvent> E.foo(ack: E.() -> InteractionResponseBehavior) {
    val response = this.ack()
    response.edit { /* ... */ }
}

suspend fun ButtonInteractionCreateEvent.bar() {
    // you have to obtain `interaction` here to access all its methods
    foo { interaction.acknowledgePublicDeferredMessageUpdate() }
}

suspend fun ChatInputCommandInteractionCreateEvent.baz() {
    foo { interaction.acknowledgePublic() }
}
```

#### With generic interaction
```kotlin
suspend inline fun <I : Interaction, E : InteractionCreateEvent<I>> E.foo(ack: I.() -> InteractionResponseBehavior) {
    val response = interaction.ack()
    response.edit { /* ... */ }
}

suspend fun ButtonInteractionCreateEvent<*>.bar() {
    // access methods of interaction directly, its type is know through generics
    foo { acknowledgePublicDeferredMessageUpdate() }
}

suspend fun ChatInputCommandInteractionCreateEvent<*>.baz() {
    foo { acknowledgePublic() }
}
```