### PR TITLE
Add support for attachment options in chat input interactions

### DIFF
--- a/common/src/main/kotlin/entity/Interactions.kt
+++ b/common/src/main/kotlin/entity/Interactions.kt
@@ -119,6 +119,7 @@ public sealed class ApplicationCommandOptionType(public val type: Int) {
                 8 -> Role
                 9 -> Mentionable
                 10 -> Number
+                11 -> Attachment
                 else -> Unknown(type)
             }
         }
@@ -371,6 +372,7 @@ public sealed class Option {
                 ApplicationCommandOptionType.Mentionable,
                 ApplicationCommandOptionType.Role,
                 ApplicationCommandOptionType.String,
+                ApplicationCommandOptionType.Attachment,
                 ApplicationCommandOptionType.User -> CommandArgument.Serializer.deserialize(
                     json, jsonValue!!, name, type!!, focused
                 )

--- a/common/src/main/kotlin/entity/Interactions.kt
+++ b/common/src/main/kotlin/entity/Interactions.kt
@@ -99,6 +99,7 @@ public sealed class ApplicationCommandOptionType(public val type: Int) {
     public object Role : ApplicationCommandOptionType(8)
     public object Mentionable : ApplicationCommandOptionType(9)
     public object Number : ApplicationCommandOptionType(10)
+    public object Attachment : ApplicationCommandOptionType(11)
     public class Unknown(type: Int) : ApplicationCommandOptionType(type)
 
     internal object Serializer : KSerializer<ApplicationCommandOptionType> {
@@ -186,7 +187,8 @@ public data class ResolvedObjects(
     val users: Optional<Map<Snowflake, DiscordUser>> = Optional.Missing(),
     val roles: Optional<Map<Snowflake, DiscordRole>> = Optional.Missing(),
     val channels: Optional<Map<Snowflake, DiscordChannel>> = Optional.Missing(),
-    val messages: Optional<Map<Snowflake, DiscordMessage>> = Optional.Missing()
+    val messages: Optional<Map<Snowflake, DiscordMessage>> = Optional.Missing(),
+    val attachments: Optional<Map<Snowflake, DiscordAttachment>> = Optional.Missing()
 )
 
 @Serializable
@@ -496,6 +498,15 @@ public sealed class CommandArgument<out T> : Option() {
             get() = ApplicationCommandOptionType.Mentionable
     }
 
+    public data class AttachmentArgument(
+        override val name: String,
+        override val value: Snowflake,
+        override val focused: OptionalBoolean = OptionalBoolean.Missing
+    ) : CommandArgument<Snowflake>() {
+        override val type: ApplicationCommandOptionType
+            get() = ApplicationCommandOptionType.Attachment
+    }
+
     /**
      * Representation of a partial user input of an auto completed argument.
      *
@@ -551,6 +562,12 @@ public sealed class CommandArgument<out T> : Option() {
                     )
                     is IntegerArgument -> encodeLongElement(descriptor, 1, value.value)
                     is NumberArgument -> encodeDoubleElement(descriptor, 1, value.value)
+                    is AttachmentArgument -> encodeSerializableElement(
+                        descriptor,
+                        1,
+                        Snowflake.serializer(),
+                        value.value
+                    )
                     is AutoCompleteArgument, is StringArgument -> encodeStringElement(
                         descriptor,
                         1,
@@ -598,6 +615,9 @@ public sealed class CommandArgument<out T> : Option() {
                     name, json.decodeFromJsonElement(Snowflake.serializer(), element), focused
                 )
                 ApplicationCommandOptionType.User -> UserArgument(
+                    name, json.decodeFromJsonElement(Snowflake.serializer(), element), focused
+                )
+                ApplicationCommandOptionType.Attachment -> UserArgument(
                     name, json.decodeFromJsonElement(Snowflake.serializer(), element), focused
                 )
                 ApplicationCommandOptionType.SubCommand,

--- a/common/src/main/kotlin/entity/Interactions.kt
+++ b/common/src/main/kotlin/entity/Interactions.kt
@@ -619,7 +619,7 @@ public sealed class CommandArgument<out T> : Option() {
                 ApplicationCommandOptionType.User -> UserArgument(
                     name, json.decodeFromJsonElement(Snowflake.serializer(), element), focused
                 )
-                ApplicationCommandOptionType.Attachment -> UserArgument(
+                ApplicationCommandOptionType.Attachment -> AttachmentArgument(
                     name, json.decodeFromJsonElement(Snowflake.serializer(), element), focused
                 )
                 ApplicationCommandOptionType.SubCommand,

--- a/core/src/main/kotlin/cache/data/InteractionData.kt
+++ b/core/src/main/kotlin/cache/data/InteractionData.kt
@@ -61,7 +61,8 @@ public data class ResolvedObjectsData(
     val users: Optional<Map<Snowflake, UserData>> = Optional.Missing(),
     val roles: Optional<Map<Snowflake, RoleData>> = Optional.Missing(),
     val channels: Optional<Map<Snowflake, ChannelData>> = Optional.Missing(),
-    val messages: Optional<Map<Snowflake, MessageData>> = Optional.Missing()
+    val messages: Optional<Map<Snowflake, MessageData>> = Optional.Missing(),
+    val attachments: Optional<Map<Snowflake, AttachmentData>> = Optional.Missing()
 ) {
     public companion object {
         public fun from(data: ResolvedObjects, guildId: Snowflake?): ResolvedObjectsData {
@@ -70,7 +71,8 @@ public data class ResolvedObjectsData(
                 channels = data.channels.mapValues { ChannelData.from(it.value) },
                 roles = data.roles.mapValues { RoleData.from(guildId!!, it.value) },
                 users = data.users.mapValues { it.value.toData() },
-                messages = data.messages.mapValues { it.value.toData() }
+                messages = data.messages.mapValues { it.value.toData() },
+                attachments = data.attachments.mapValues { AttachmentData.from(it.value) }
             )
         }
     }

--- a/core/src/main/kotlin/entity/interaction/ActionInteraction.kt
+++ b/core/src/main/kotlin/entity/interaction/ActionInteraction.kt
@@ -223,6 +223,8 @@ public class ResolvedObjects(
     public val messages: Map<Snowflake, Message>?
         get() = data.messages.mapValues { Message(it.value, kord) }.value
 
+    public val attachments: Map<Snowflake, Attachment>?
+        get() = data.attachments.mapValues { Attachment(it.value, kord) }.value
 }
 
 
@@ -243,6 +245,10 @@ public sealed class OptionValue<out T>(public val value: T, public val focused: 
     public class ChannelOptionValue(value: ResolvedChannel, focused: Boolean) :
         OptionValue<ResolvedChannel>(value, focused) {
         override fun toString(): String = "ChannelOptionValue(value=$value)"
+    }
+
+    public class AttachmentOptionValue(value: Attachment, focused: Boolean) : OptionValue<Attachment>(value, focused) {
+        override fun toString(): String = "AttachmentOptionValue(value=$value)"
     }
 
     public class IntOptionValue(value: Long, focused: Boolean) : OptionValue<Long>(value, focused) {
@@ -314,6 +320,13 @@ public fun OptionValue(value: CommandArgument<*>, resolvedObjects: ResolvedObjec
             requireNotNull(user) { "user expected for $value but was missing" }
 
             OptionValue.UserOptionValue(user, focused)
+        }
+
+        is CommandArgument.AttachmentArgument -> {
+            val attachment = resolvedObjects?.attachments.orEmpty()[value.value]
+            requireNotNull(attachment) { "attachment expected for $value but was missing" }
+
+            OptionValue.AttachmentOptionValue(attachment, focused)
         }
     }
 }

--- a/rest/src/main/kotlin/builder/interaction/InputChatBuilders.kt
+++ b/rest/src/main/kotlin/builder/interaction/InputChatBuilders.kt
@@ -42,6 +42,12 @@ public inline fun BaseInputChatBuilder.role(name: String, description: String, b
     options!!.add(RoleBuilder(name, description).apply(builder))
 }
 
+public inline fun BaseInputChatBuilder.attachment(name: String, description: String, builder: AttachmentBuilder.() -> Unit = {}) {
+    contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
+    if (options == null) options = mutableListOf()
+    options!!.add(AttachmentBuilder(name, description).apply(builder))
+}
+
 public inline fun BaseInputChatBuilder.number(name: String, description: String, builder: NumberChoiceBuilder.() -> Unit = {}) {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
     if (options == null) options = mutableListOf()

--- a/rest/src/main/kotlin/builder/interaction/OptionsBuilder.kt
+++ b/rest/src/main/kotlin/builder/interaction/OptionsBuilder.kt
@@ -135,6 +135,10 @@ public class MentionableBuilder(name: String, description: String) :
     OptionsBuilder(name, description, ApplicationCommandOptionType.Mentionable)
 
 @KordDsl
+public class AttachmentBuilder(name: String, description: String) :
+    OptionsBuilder(name, description, ApplicationCommandOptionType.Attachment)
+
+@KordDsl
 public sealed class BaseCommandOptionBuilder(
     name: String,
     description: String,


### PR DESCRIPTION
Just as the title says. Currently attachments in chat input interactions support is locked and is only available to some users.

![image](https://user-images.githubusercontent.com/9496359/152690819-857f5ef6-e5d9-42c3-8ab8-e8e72d8d81fd.png)
![image](https://user-images.githubusercontent.com/9496359/152690847-e93eb8d9-8293-4942-b27f-0e865b50b7e7.png)
![DiscordCanary_K1TrakyPCR](https://user-images.githubusercontent.com/9496359/153109070-0cbd2499-2856-43ca-8496-4a360dbe7e4c.gif)

~~**This PR is a draft because the feature isn't released yet, but it already works**, so it can be merged when the feature is officially released :)~~ The feature is officially released!
