### PR TITLE
Add missing default value for strategy for getWebhookWithTokenOrNull

### DIFF
--- a/core/src/main/kotlin/Kord.kt
+++ b/core/src/main/kotlin/Kord.kt
@@ -322,7 +322,7 @@ public class Kord(
     public suspend fun getWebhookWithTokenOrNull(
         id: Snowflake,
         token: String,
-        strategy: EntitySupplyStrategy<*>
+        strategy: EntitySupplyStrategy<*> = resources.defaultStrategy
     ): Webhook? =
         strategy.supply(this).getWebhookWithTokenOrNull(id, token)
 


### PR DESCRIPTION
For some reason, this is the only webhook related method that didn't have a default value for the strategy argument. I'm guessing it was just overlooked.