### PR TITLE
Fix oversights in forms support

### DIFF
--- a/common/src/main/kotlin/entity/Interactions.kt
+++ b/common/src/main/kotlin/entity/Interactions.kt
@@ -521,7 +521,7 @@ public sealed class CommandArgument<out T> : Option() {
      * @property value whatever the user already typed into the argument field
      * @property focused always true, since this is an auto complete argument
      */
-    public class AutoCompleteArgument(
+    public data class AutoCompleteArgument(
         override val name: String,
         override val type: ApplicationCommandOptionType,
         override val value: String,

--- a/core/src/main/kotlin/entity/interaction/AutoCompleteInteraction.kt
+++ b/core/src/main/kotlin/entity/interaction/AutoCompleteInteraction.kt
@@ -1,7 +1,6 @@
 package dev.kord.core.entity.interaction
 
 import dev.kord.common.entity.CommandArgument
-import dev.kord.common.entity.Snowflake
 import dev.kord.common.entity.optional.OptionalSnowflake
 import dev.kord.core.Kord
 import dev.kord.core.behavior.interaction.AutoCompleteInteractionBehavior
@@ -20,11 +19,22 @@ import dev.kord.core.supplier.EntitySupplyStrategy
  */
 public sealed interface AutoCompleteInteraction : DataInteraction, AutoCompleteInteractionBehavior {
 
-    /** The id of the command. */
-    public val commandId: Snowflake get() = data.data.id.value!!
+    /**
+     * An [InteractionCommand] that contains the values the user filled so far.
+     *
+     * This might not contain all [options][InteractionCommand.options] and
+     * [resolvedObjects][InteractionCommand.resolvedObjects], they will be available in a [ChatInputCommandInteraction].
+     */
+    public val command: InteractionCommand get() = InteractionCommand(data.data, kord)
 
-    /** The name of the command. */
-    public val commandName: String get() = data.data.name.value!!
+    /**
+     * The single [focused][OptionValue.focused] option the user is currently typing.
+     *
+     * This is always a [StringOptionValue], the [value][OptionValue.value] is not validated yet, so it could be
+     * anything.
+     */
+    public val focusedOption: StringOptionValue
+        get() = command.options.values.single { it.focused } as StringOptionValue
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): AutoCompleteInteraction
 }

--- a/rest/src/main/kotlin/builder/component/ActionRowBuilder.kt
+++ b/rest/src/main/kotlin/builder/component/ActionRowBuilder.kt
@@ -2,9 +2,8 @@ package dev.kord.rest.builder.component
 
 import dev.kord.common.annotation.KordDsl
 import dev.kord.common.entity.ButtonStyle
-import dev.kord.common.entity.DiscordChatComponent
 import dev.kord.common.entity.ComponentType
-import dev.kord.common.entity.DiscordComponent
+import dev.kord.common.entity.DiscordChatComponent
 import dev.kord.common.entity.TextInputStyle
 import dev.kord.common.entity.optional.Optional
 import kotlin.contracts.InvocationKind
@@ -61,7 +60,7 @@ public class ActionRowBuilder : MessageComponentBuilder {
         style: TextInputStyle,
         customId: String,
         label: String,
-        builder: TextInputBuilder.() -> Unit
+        builder: TextInputBuilder.() -> Unit = {},
     ) {
         contract {
             callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
@@ -70,7 +69,7 @@ public class ActionRowBuilder : MessageComponentBuilder {
         components.add(TextInputBuilder(style, customId, label).apply(builder))
     }
 
-    override fun build(): DiscordComponent =
+    override fun build(): DiscordChatComponent =
         DiscordChatComponent(
             ComponentType.ActionRow,
             components = Optional.missingOnEmpty(components.map(ActionRowComponentBuilder::build))

--- a/rest/src/main/kotlin/builder/component/ButtonBuilder.kt
+++ b/rest/src/main/kotlin/builder/component/ButtonBuilder.kt
@@ -4,9 +4,8 @@ package dev.kord.rest.builder.component
 
 import dev.kord.common.annotation.KordDsl
 import dev.kord.common.entity.ButtonStyle
-import dev.kord.common.entity.DiscordChatComponent
 import dev.kord.common.entity.ComponentType
-import dev.kord.common.entity.DiscordComponent
+import dev.kord.common.entity.DiscordChatComponent
 import dev.kord.common.entity.DiscordPartialEmoji
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.delegate.delegate
@@ -32,6 +31,8 @@ public sealed class ButtonBuilder : ActionRowComponentBuilder() {
      */
     public var emoji: DiscordPartialEmoji? by ::_emoji.delegate()
 
+    abstract override fun build(): DiscordChatComponent
+
     /**
      * A builder for a button that can create Interactions when clicked.
      *
@@ -42,7 +43,7 @@ public sealed class ButtonBuilder : ActionRowComponentBuilder() {
         public var style: ButtonStyle,
         public var customId: String,
     ) : ButtonBuilder() {
-        override fun build(): DiscordComponent = DiscordChatComponent(
+        override fun build(): DiscordChatComponent = DiscordChatComponent(
             ComponentType.Button,
             Optional(style),
             _label,
@@ -61,7 +62,7 @@ public sealed class ButtonBuilder : ActionRowComponentBuilder() {
     public class LinkButtonBuilder(
         public var url: String,
     ) : ButtonBuilder() {
-        override fun build(): DiscordComponent = DiscordChatComponent(
+        override fun build(): DiscordChatComponent = DiscordChatComponent(
             ComponentType.Button,
             Optional(ButtonStyle.Link),
             _label,

--- a/rest/src/main/kotlin/builder/component/SelectMenuBuilder.kt
+++ b/rest/src/main/kotlin/builder/component/SelectMenuBuilder.kt
@@ -1,9 +1,8 @@
 package dev.kord.rest.builder.component
 
 import dev.kord.common.annotation.KordDsl
-import dev.kord.common.entity.DiscordChatComponent
 import dev.kord.common.entity.ComponentType
-import dev.kord.common.entity.DiscordComponent
+import dev.kord.common.entity.DiscordChatComponent
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalInt
 import dev.kord.common.entity.optional.delegate.delegate
@@ -57,7 +56,7 @@ public class SelectMenuBuilder(
         options.add(SelectOptionBuilder(label = label, value = value).apply(builder))
     }
 
-    override fun build(): DiscordComponent {
+    override fun build(): DiscordChatComponent {
         return DiscordChatComponent(
             ComponentType.SelectMenu,
             customId = Optional(customId),

--- a/rest/src/main/kotlin/builder/component/TextInputBuilder.kt
+++ b/rest/src/main/kotlin/builder/component/TextInputBuilder.kt
@@ -2,7 +2,6 @@ package dev.kord.rest.builder.component
 
 import dev.kord.common.annotation.KordDsl
 import dev.kord.common.entity.ComponentType
-import dev.kord.common.entity.DiscordComponent
 import dev.kord.common.entity.DiscordTextInputComponent
 import dev.kord.common.entity.TextInputStyle
 import dev.kord.common.entity.optional.Optional
@@ -47,7 +46,7 @@ public class TextInputBuilder(
      */
     public var required: Boolean? by ::_required.delegate()
 
-    override fun build(): DiscordComponent {
+    override fun build(): DiscordTextInputComponent {
         return DiscordTextInputComponent(
             type = ComponentType.TextInput,
             style = Optional(style),


### PR DESCRIPTION
* default `builder` in `ActionRowBuilder.textInput()`
* `ComponentBuilder.build()` returns different types
* add `command` and `focusedOption` to `AutoCompleteInteraction`