### PR TITLE
Safe deferred responding

### DIFF
--- a/core/src/main/kotlin/behavior/interaction/ActionInteractionBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/ActionInteractionBehavior.kt
@@ -68,9 +68,8 @@ public interface ActionInteractionBehavior : InteractionBehavior {
     }
 
     /**
-     * Acknowledges the interaction with the intent of responding with an [ephemeral][MessageFlag.Ephemeral]
-     * message later by calling [respond][DeferredEphemeralMessageInteractionResponseBehavior.respond] on the returned
-     * object.
+     * Acknowledges the interaction with the intent of responding with an [ephemeral][MessageFlag.Ephemeral] message
+     * later by calling [respond][DeferredEphemeralMessageInteractionResponseBehavior.respond] on the returned object.
      *
      * There will be a 'loading' animation that is only visible to the [user][Interaction.user] who invoked the
      * interaction.

--- a/core/src/main/kotlin/behavior/interaction/ActionInteractionBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/ActionInteractionBehavior.kt
@@ -50,7 +50,7 @@ public interface ActionInteractionBehavior : InteractionBehavior {
      * ```kotlin
      * val deferred = interaction.deferEphemeralResponse()
      * val response = deferred.respond { ... }
-     * response.followUpPublic { ... }
+     * response.createPublicFollowup { ... }
      * ```
      */
     @Deprecated(
@@ -112,7 +112,7 @@ public interface ActionInteractionBehavior : InteractionBehavior {
      * ```kotlin
      * val deferred = interaction.deferPublicResponse()
      * val response = deferred.respond { ... }
-     * response.followUpEphemeral { ... }
+     * response.createEphemeralFollowup { ... }
      * ```
      */
     @Deprecated(

--- a/core/src/main/kotlin/behavior/interaction/ActionInteractionBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/ActionInteractionBehavior.kt
@@ -81,8 +81,9 @@ public interface ActionInteractionBehavior : InteractionBehavior {
 /**
  * Responds to the interaction with a public message.
  *
- * @param builder [InteractionResponseCreateBuilder] used to create a public response.
+ * @param builder [InteractionResponseCreateBuilder] used to create the public response.
  * @return [PublicMessageInteractionResponseBehavior] public response to the interaction.
+ * @throws RestRequestException if something went wrong during the request.
  */
 public suspend inline fun ActionInteractionBehavior.respondPublic(
     builder: InteractionResponseCreateBuilder.() -> Unit
@@ -96,8 +97,9 @@ public suspend inline fun ActionInteractionBehavior.respondPublic(
 /**
  * Responds to the interaction with an [ephemeral][MessageFlag.Ephemeral] message.
  *
- * @param builder [InteractionResponseCreateBuilder] used to create an ephemeral response.
+ * @param builder [InteractionResponseCreateBuilder] used to create the ephemeral response.
  * @return [EphemeralMessageInteractionResponseBehavior] ephemeral response to the interaction.
+ * @throws RestRequestException if something went wrong during the request.
  */
 public suspend inline fun ActionInteractionBehavior.respondEphemeral(
     builder: InteractionResponseCreateBuilder.() -> Unit

--- a/core/src/main/kotlin/behavior/interaction/ActionInteractionBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/ActionInteractionBehavior.kt
@@ -3,11 +3,10 @@ package dev.kord.core.behavior.interaction
 import dev.kord.common.entity.MessageFlag
 import dev.kord.common.entity.Snowflake
 import dev.kord.core.Kord
-import dev.kord.core.behavior.interaction.response.EphemeralMessageInteractionResponseBehavior
-import dev.kord.core.behavior.interaction.response.PublicMessageInteractionResponseBehavior
-import dev.kord.core.behavior.interaction.response.edit
+import dev.kord.core.behavior.interaction.response.*
 import dev.kord.core.entity.Message
 import dev.kord.core.entity.interaction.ActionInteraction
+import dev.kord.core.entity.interaction.Interaction
 import dev.kord.core.exception.EntityNotFoundException
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
@@ -25,6 +24,7 @@ public interface ActionInteractionBehavior : InteractionBehavior {
      *
      * Call [edit][EphemeralMessageInteractionResponseBehavior.edit] on the returned object to edit the response later.
      */
+    @Suppress("DEPRECATION")
     @Deprecated("Renamed to 'deferEphemeralMessage'.", ReplaceWith("this.deferEphemeralMessage()"))
     public suspend fun acknowledgeEphemeral(): EphemeralMessageInteractionResponseBehavior = deferEphemeralMessage()
 
@@ -32,10 +32,54 @@ public interface ActionInteractionBehavior : InteractionBehavior {
      * Acknowledges the interaction ephemerally with the intent of responding with an [ephemeral][MessageFlag.Ephemeral]
      * message later by calling [edit][EphemeralMessageInteractionResponseBehavior.edit] on the returned object. The
      * user will see a 'loading' animation.
+     *
+     * ## This method is deprecated
+     * Replace code like
+     * ```kotlin
+     * val response = interaction.deferEphemeralMessage()
+     * response.followUpEphemeral { ... }
+     * response.followUp { ... }
+     * ```
+     * or
+     * ```kotlin
+     * val response = interaction.deferEphemeralMessage()
+     * response.edit { ... }
+     * response.followUp { ... }
+     * ```
+     * with
+     * ```kotlin
+     * val deferred = interaction.deferEphemeralResponse()
+     * val response = deferred.respond { ... }
+     * response.followUpPublic { ... }
+     * ```
      */
+    @Deprecated(
+        """
+        Deferring a response now always enforces actually responding before using followups to avoid some strange
+        behavior when using followups before sending an original response.
+        
+        See the documentation of this method for how it should be replaced.
+        """,
+        ReplaceWith("this.deferEphemeralResponse()"),
+    )
     public suspend fun deferEphemeralMessage(): EphemeralMessageInteractionResponseBehavior {
         kord.rest.interaction.deferMessage(id, token, ephemeral = true)
         return EphemeralMessageInteractionResponseBehavior(applicationId, token, kord)
+    }
+
+    /**
+     * Acknowledges the interaction with the intent of responding with an [ephemeral][MessageFlag.Ephemeral]
+     * message later by calling [respond][DeferredEphemeralMessageInteractionResponseBehavior.respond] on the returned
+     * object.
+     *
+     * There will be a 'loading' animation that is only visible to the [user][Interaction.user] who invoked the
+     * interaction.
+     *
+     * @throws RestRequestException if something went wrong during the request.
+     */
+    public suspend fun deferEphemeralResponse(): DeferredEphemeralMessageInteractionResponseBehavior {
+        kord.rest.interaction.deferMessage(id, token, ephemeral = true)
+        return DeferredEphemeralMessageInteractionResponseBehavior(applicationId, token, kord)
     }
 
     /**
@@ -43,6 +87,7 @@ public interface ActionInteractionBehavior : InteractionBehavior {
      *
      * Call [edit][PublicMessageInteractionResponseBehavior.edit] on the returned object to edit the response later.
      */
+    @Suppress("DEPRECATION")
     @Deprecated("Renamed to 'deferPublicMessage'.", ReplaceWith("this.deferPublicMessage()"))
     public suspend fun acknowledgePublic(): PublicMessageInteractionResponseBehavior = deferPublicMessage()
 
@@ -50,10 +95,53 @@ public interface ActionInteractionBehavior : InteractionBehavior {
      * Acknowledges the interaction publicly with the intent of responding with a public message later by calling
      * [edit][PublicMessageInteractionResponseBehavior.edit] on the returned object. The user will see a 'loading'
      * animation.
+     *
+     * ## This method is deprecated
+     * Replace code like
+     * ```kotlin
+     * val response = interaction.deferPublicMessage()
+     * response.followUp { ... }
+     * response.followUpEphemeral { ... }
+     * ```
+     * or
+     * ```kotlin
+     * val response = interaction.deferPublicMessage()
+     * response.edit { ... }
+     * response.followUpEphemeral { ... }
+     * ```
+     * with
+     * ```kotlin
+     * val deferred = interaction.deferPublicResponse()
+     * val response = deferred.respond { ... }
+     * response.followUpEphemeral { ... }
+     * ```
      */
+    @Deprecated(
+        """
+        Deferring a response now always enforces actually responding before using followups to avoid some strange
+        behavior when using followups before sending an original response.
+        
+        See the documentation of this method for how it should be replaced.
+        """,
+        ReplaceWith("this.deferPublicResponse()"),
+    )
     public suspend fun deferPublicMessage(): PublicMessageInteractionResponseBehavior {
         kord.rest.interaction.deferMessage(id, token, ephemeral = false)
         return PublicMessageInteractionResponseBehavior(applicationId, token, kord)
+    }
+
+    /**
+     * Acknowledges the interaction with the intent of responding with a public message later by calling
+     * [respond][DeferredPublicMessageInteractionResponseBehavior.respond] on the returned object.
+     *
+     * There will be a 'loading' animation that is visible to all users in the [channel][InteractionBehavior.channel]
+     * the interaction was sent from.
+     *
+     * @throws RestRequestException if something went wrong during the request.
+     */
+    public suspend fun deferPublicResponse(): DeferredPublicMessageInteractionResponseBehavior {
+        kord.rest.interaction.deferMessage(id, token, ephemeral = false)
+        return DeferredPublicMessageInteractionResponseBehavior(applicationId, token, kord)
     }
 
     /**

--- a/core/src/main/kotlin/behavior/interaction/response/DeferredEphemeralMessageInteractionBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/response/DeferredEphemeralMessageInteractionBehavior.kt
@@ -1,0 +1,65 @@
+package dev.kord.core.behavior.interaction.response
+
+import dev.kord.common.entity.MessageFlag
+import dev.kord.common.entity.Snowflake
+import dev.kord.core.Kord
+import dev.kord.core.behavior.interaction.ActionInteractionBehavior
+import dev.kord.core.entity.interaction.Interaction
+import dev.kord.core.entity.interaction.response.EphemeralMessageInteractionResponse
+import dev.kord.core.supplier.EntitySupplier
+import dev.kord.core.supplier.EntitySupplyStrategy
+import dev.kord.rest.builder.message.modify.InteractionResponseModifyBuilder
+import dev.kord.rest.request.RestRequestException
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+
+/**
+ * An [InteractionResponseBehavior] returned when using [ActionInteractionBehavior.deferEphemeralResponse].
+ *
+ * The main operation this handle supports is [respond][DeferredEphemeralMessageInteractionResponseBehavior.respond],
+ * the user will see a 'loading' animation until it is invoked.
+ *
+ * The 'loading' animation is only visible to the [user][Interaction.user] who invoked the interaction.
+ *
+ * This handle does not support sending followup messages to the interaction.
+ */
+public interface DeferredEphemeralMessageInteractionResponseBehavior :
+    EphemeralInteractionResponseBehavior,
+    DeferredMessageInteractionResponseBehavior {
+
+    override fun withStrategy(strategy: EntitySupplyStrategy<*>): DeferredEphemeralMessageInteractionResponseBehavior =
+        DeferredEphemeralMessageInteractionResponseBehavior(applicationId, token, kord, strategy.supply(kord))
+}
+
+public fun DeferredEphemeralMessageInteractionResponseBehavior(
+    applicationId: Snowflake,
+    token: String,
+    kord: Kord,
+    supplier: EntitySupplier = kord.defaultSupplier,
+): DeferredEphemeralMessageInteractionResponseBehavior = object : DeferredEphemeralMessageInteractionResponseBehavior {
+    override val applicationId: Snowflake = applicationId
+    override val token: String = token
+    override val kord: Kord = kord
+    override val supplier: EntitySupplier = supplier
+}
+
+/**
+ * Sends an [ephemeral][MessageFlag.Ephemeral] response message that was previously deferred by using
+ * [ActionInteractionBehavior.deferEphemeralResponse].
+ *
+ * The response message is only visible to the [user][Interaction.user] who invoked the interaction.
+ *
+ * This function is supposed to be only invoked once, use the returned [EphemeralMessageInteractionResponse] for more
+ * operations.
+ *
+ * @param builder [InteractionResponseModifyBuilder] used to create the ephemeral response message.
+ * @return [EphemeralMessageInteractionResponse] the ephemeral response message to the interaction.
+ * @throws RestRequestException if something went wrong during the request.
+ */
+public suspend inline fun DeferredEphemeralMessageInteractionResponseBehavior.respond(
+    builder: InteractionResponseModifyBuilder.() -> Unit,
+): EphemeralMessageInteractionResponse {
+    contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
+
+    return editEphemeralOriginalResponse(builder)
+}

--- a/core/src/main/kotlin/behavior/interaction/response/DeferredMessageInteractionResponseBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/response/DeferredMessageInteractionResponseBehavior.kt
@@ -1,0 +1,41 @@
+package dev.kord.core.behavior.interaction.response
+
+import dev.kord.core.behavior.interaction.ActionInteractionBehavior
+import dev.kord.core.entity.interaction.response.MessageInteractionResponse
+import dev.kord.core.supplier.EntitySupplyStrategy
+import dev.kord.rest.builder.message.modify.InteractionResponseModifyBuilder
+import dev.kord.rest.request.RestRequestException
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+
+/**
+ * An [InteractionResponseBehavior] returned when using [ActionInteractionBehavior.deferPublicResponse] or
+ * [ActionInteractionBehavior.deferEphemeralResponse].
+ *
+ * The main operation this handle supports is [respond][DeferredMessageInteractionResponseBehavior.respond], the user
+ * will see a 'loading' animation until it is invoked.
+ *
+ * This handle does not support sending followup messages to the interaction.
+ */
+public sealed interface DeferredMessageInteractionResponseBehavior : InteractionResponseBehavior {
+
+    override fun withStrategy(strategy: EntitySupplyStrategy<*>): DeferredMessageInteractionResponseBehavior
+}
+
+/**
+ * Sends a response message that was previously deferred by using [ActionInteractionBehavior.deferPublicResponse] or
+ * [ActionInteractionBehavior.deferEphemeralResponse].
+ *
+ * This function is supposed to be only invoked once, use the returned [MessageInteractionResponse] for more operations.
+ *
+ * @param builder [InteractionResponseModifyBuilder] used to create the response message.
+ * @return [MessageInteractionResponse] the response message to the interaction.
+ * @throws RestRequestException if something went wrong during the request.
+ */
+public suspend inline fun DeferredMessageInteractionResponseBehavior.respond(
+    builder: InteractionResponseModifyBuilder.() -> Unit,
+): MessageInteractionResponse {
+    contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
+
+    return editOriginalResponseWithUnknownVisibility(builder)
+}

--- a/core/src/main/kotlin/behavior/interaction/response/DeferredPublicMessageInteractionResponseBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/response/DeferredPublicMessageInteractionResponseBehavior.kt
@@ -33,14 +33,14 @@ public interface DeferredPublicMessageInteractionResponseBehavior :
      * The 'loading' animation will stop and any attempt to call
      * [respond][DeferredPublicMessageInteractionResponseBehavior.respond] hereafter will fail.
      *
-     * Returns a [FollowupableInteractionResponseBehavior] that can still be used to send followup messages to the
+     * Returns a [FollowupPermittingInteractionResponseBehavior] that can still be used to send followup messages to the
      * interaction.
      *
      * @throws RestRequestException if something went wrong during the request.
      */
-    public suspend fun delete(): FollowupableInteractionResponseBehavior {
+    public suspend fun delete(): FollowupPermittingInteractionResponseBehavior {
         kord.rest.interaction.deleteOriginalInteractionResponse(applicationId, token)
-        return FollowupableInteractionResponseBehavior(applicationId, token, kord)
+        return FollowupPermittingInteractionResponseBehavior(applicationId, token, kord)
     }
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): DeferredPublicMessageInteractionResponseBehavior =

--- a/core/src/main/kotlin/behavior/interaction/response/DeferredPublicMessageInteractionResponseBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/response/DeferredPublicMessageInteractionResponseBehavior.kt
@@ -1,0 +1,82 @@
+package dev.kord.core.behavior.interaction.response
+
+import dev.kord.common.entity.Snowflake
+import dev.kord.core.Kord
+import dev.kord.core.behavior.interaction.ActionInteractionBehavior
+import dev.kord.core.behavior.interaction.InteractionBehavior
+import dev.kord.core.entity.interaction.response.PublicMessageInteractionResponse
+import dev.kord.core.supplier.EntitySupplier
+import dev.kord.core.supplier.EntitySupplyStrategy
+import dev.kord.rest.builder.message.modify.InteractionResponseModifyBuilder
+import dev.kord.rest.request.RestRequestException
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+
+/**
+ * An [InteractionResponseBehavior] returned when using [ActionInteractionBehavior.deferPublicResponse].
+ *
+ * The main operation this handle supports is [respond][DeferredPublicMessageInteractionResponseBehavior.respond], the
+ * user will see a 'loading' animation until it is invoked.
+ *
+ * The 'loading' animation is visible to all users in the [channel][InteractionBehavior.channel] the interaction was
+ * sent from.
+ *
+ * This handle does not support sending followup messages to the interaction.
+ */
+public interface DeferredPublicMessageInteractionResponseBehavior :
+    PublicInteractionResponseBehavior,
+    DeferredMessageInteractionResponseBehavior {
+
+    /**
+     * Requests to delete the response.
+     *
+     * The 'loading' animation will stop and any attempt to call
+     * [respond][DeferredPublicMessageInteractionResponseBehavior.respond] hereafter will fail.
+     *
+     * Returns a [FollowupableInteractionResponseBehavior] that can still be used to send followup messages to the
+     * interaction.
+     *
+     * @throws RestRequestException if something went wrong during the request.
+     */
+    public suspend fun delete(): FollowupableInteractionResponseBehavior {
+        kord.rest.interaction.deleteOriginalInteractionResponse(applicationId, token)
+        return FollowupableInteractionResponseBehavior(applicationId, token, kord)
+    }
+
+    override fun withStrategy(strategy: EntitySupplyStrategy<*>): DeferredPublicMessageInteractionResponseBehavior =
+        DeferredPublicMessageInteractionResponseBehavior(applicationId, token, kord, strategy.supply(kord))
+}
+
+public fun DeferredPublicMessageInteractionResponseBehavior(
+    applicationId: Snowflake,
+    token: String,
+    kord: Kord,
+    supplier: EntitySupplier = kord.defaultSupplier,
+): DeferredPublicMessageInteractionResponseBehavior = object : DeferredPublicMessageInteractionResponseBehavior {
+    override val applicationId: Snowflake = applicationId
+    override val token: String = token
+    override val kord: Kord = kord
+    override val supplier: EntitySupplier = supplier
+}
+
+/**
+ * Sends a public response message that was previously deferred by using
+ * [ActionInteractionBehavior.deferPublicResponse].
+ *
+ * The response message is visible to all users in the [channel][InteractionBehavior.channel] the interaction was sent
+ * from.
+ *
+ * This function is supposed to be only invoked once, use the returned [PublicMessageInteractionResponse] for more
+ * operations.
+ *
+ * @param builder [InteractionResponseModifyBuilder] used to create the public response message.
+ * @return [PublicMessageInteractionResponse] the public response message to the interaction.
+ * @throws RestRequestException if something went wrong during the request.
+ */
+public suspend inline fun DeferredPublicMessageInteractionResponseBehavior.respond(
+    builder: InteractionResponseModifyBuilder.() -> Unit,
+): PublicMessageInteractionResponse {
+    contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
+
+    return editPublicOriginalResponse(builder)
+}

--- a/core/src/main/kotlin/behavior/interaction/response/EditOriginalResponse.kt
+++ b/core/src/main/kotlin/behavior/interaction/response/EditOriginalResponse.kt
@@ -1,0 +1,66 @@
+package dev.kord.core.behavior.interaction.response
+
+import dev.kord.core.cache.data.toData
+import dev.kord.core.entity.Message
+import dev.kord.core.entity.interaction.response.EphemeralMessageInteractionResponse
+import dev.kord.core.entity.interaction.response.MessageInteractionResponse
+import dev.kord.core.entity.interaction.response.PublicMessageInteractionResponse
+import dev.kord.rest.builder.message.modify.InteractionResponseModifyBuilder
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+
+
+@PublishedApi
+internal suspend inline fun InteractionResponseBehavior.editOriginalResponse(
+    builder: InteractionResponseModifyBuilder.() -> Unit,
+): Message {
+    contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
+
+    val response = kord.rest.interaction.modifyInteractionResponse(applicationId, token, builder)
+    return Message(response.toData(), kord)
+}
+
+
+@PublishedApi
+internal suspend inline fun InteractionResponseBehavior.editOriginalResponseWithUnknownVisibility(
+    builder: InteractionResponseModifyBuilder.() -> Unit,
+): MessageInteractionResponse {
+    contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
+
+    val message = editOriginalResponse(builder)
+
+    return when (this) {
+        is PublicInteractionResponseBehavior ->
+            PublicMessageInteractionResponse(message, applicationId, token, kord)
+
+        is EphemeralInteractionResponseBehavior ->
+            EphemeralMessageInteractionResponse(message, applicationId, token, kord)
+
+        else -> error(
+            "This function can't be called on an InteractionResponseBehavior that implements neither " +
+                    "PublicInteractionResponseBehavior nor EphemeralInteractionResponseBehavior."
+        )
+    }
+}
+
+
+@PublishedApi
+internal suspend inline fun PublicInteractionResponseBehavior.editPublicOriginalResponse(
+    builder: InteractionResponseModifyBuilder.() -> Unit,
+): PublicMessageInteractionResponse {
+    contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
+
+    val message = editOriginalResponse(builder)
+    return PublicMessageInteractionResponse(message, applicationId, token, kord)
+}
+
+
+@PublishedApi
+internal suspend inline fun EphemeralInteractionResponseBehavior.editEphemeralOriginalResponse(
+    builder: InteractionResponseModifyBuilder.() -> Unit,
+): EphemeralMessageInteractionResponse {
+    contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
+
+    val message = editOriginalResponse(builder)
+    return EphemeralMessageInteractionResponse(message, applicationId, token, kord)
+}

--- a/core/src/main/kotlin/behavior/interaction/response/EditOriginalResponse.kt
+++ b/core/src/main/kotlin/behavior/interaction/response/EditOriginalResponse.kt
@@ -31,19 +31,20 @@ internal suspend inline fun InteractionResponseBehavior.editOriginalResponseWith
 ): MessageInteractionResponse {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
 
-    val message = editOriginalResponse(builder)
-
-    return when (this) {
-        is PublicInteractionResponseBehavior ->
-            PublicMessageInteractionResponse(message, applicationId, token, kord)
-
-        is EphemeralInteractionResponseBehavior ->
-            EphemeralMessageInteractionResponse(message, applicationId, token, kord)
-
+    val public = when (this) {
+        is PublicInteractionResponseBehavior -> true
+        is EphemeralInteractionResponseBehavior -> false
         else -> error(
             "This function can't be called on an InteractionResponseBehavior that implements neither " +
                     "PublicInteractionResponseBehavior nor EphemeralInteractionResponseBehavior."
         )
+    }
+
+    val message = editOriginalResponse(builder)
+
+    return when {
+        public -> PublicMessageInteractionResponse(message, applicationId, token, kord)
+        else -> EphemeralMessageInteractionResponse(message, applicationId, token, kord)
     }
 }
 

--- a/core/src/main/kotlin/behavior/interaction/response/EditOriginalResponse.kt
+++ b/core/src/main/kotlin/behavior/interaction/response/EditOriginalResponse.kt
@@ -9,6 +9,10 @@ import dev.kord.rest.builder.message.modify.InteractionResponseModifyBuilder
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
+// internal utility functions to avoid duplications in DeferredMessageInteractionResponseBehavior.respond() and
+// MessageInteractionResponseBehavior.edit() since they are using the same 'Edit Original Interaction Response' endpoint
+// https://discord.com/developers/docs/interactions/receiving-and-responding#edit-original-interaction-response
+
 
 @PublishedApi
 internal suspend inline fun InteractionResponseBehavior.editOriginalResponse(

--- a/core/src/main/kotlin/behavior/interaction/response/EphemeralInteractionResponseBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/response/EphemeralInteractionResponseBehavior.kt
@@ -1,10 +1,12 @@
 package dev.kord.core.behavior.interaction.response
 
+import dev.kord.core.entity.interaction.Interaction
 import dev.kord.core.supplier.EntitySupplyStrategy
 
 /**
- * The behavior of an ephemeral Discord Interaction Response
- * This response is visible to *only* to the user who made the interaction.
+ * An [InteractionResponseBehavior] for an ephemeral response to an [Interaction].
+ *
+ * The response is only visible to the [user][Interaction.user] who invoked the interaction.
  */
 public sealed interface EphemeralInteractionResponseBehavior : InteractionResponseBehavior {
 

--- a/core/src/main/kotlin/behavior/interaction/response/EphemeralInteractionResponseBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/response/EphemeralInteractionResponseBehavior.kt
@@ -1,7 +1,12 @@
 package dev.kord.core.behavior.interaction.response
 
+import dev.kord.core.supplier.EntitySupplyStrategy
+
 /**
  * The behavior of an ephemeral Discord Interaction Response
  * This response is visible to *only* to the user who made the interaction.
  */
-public sealed interface EphemeralInteractionResponseBehavior : InteractionResponseBehavior
+public sealed interface EphemeralInteractionResponseBehavior : InteractionResponseBehavior {
+
+    override fun withStrategy(strategy: EntitySupplyStrategy<*>): EphemeralInteractionResponseBehavior
+}

--- a/core/src/main/kotlin/behavior/interaction/response/EphemeralMessageInteractionResponseBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/response/EphemeralMessageInteractionResponseBehavior.kt
@@ -3,8 +3,7 @@ package dev.kord.core.behavior.interaction.response
 import dev.kord.common.entity.MessageFlag
 import dev.kord.common.entity.Snowflake
 import dev.kord.core.Kord
-import dev.kord.core.behavior.interaction.ActionInteractionBehavior
-import dev.kord.core.behavior.interaction.respondEphemeral
+import dev.kord.core.behavior.interaction.*
 import dev.kord.core.entity.interaction.Interaction
 import dev.kord.core.entity.interaction.response.EphemeralMessageInteractionResponse
 import dev.kord.core.supplier.EntitySupplier
@@ -15,13 +14,15 @@ import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
 /**
- * An [InteractionResponseBehavior] returned when using [ActionInteractionBehavior.respondEphemeral] or
- * [DeferredEphemeralMessageInteractionResponseBehavior.respond].
+ * An [InteractionResponseBehavior] returned when using [respondEphemeral][ActionInteractionBehavior.respondEphemeral],
+ * [respond][DeferredEphemeralMessageInteractionResponseBehavior.respond],
+ * [deferEphemeralMessageUpdate][ComponentInteractionBehavior.deferEphemeralMessageUpdate] or
+ * [updateEphemeralMessage][ComponentInteractionBehavior.updateEphemeralMessage].
  *
- * This is the handle to an [ephemeral][MessageFlag.Ephemeral] response message, it supports
+ * This is the handle to an [ephemeral][MessageFlag.Ephemeral] message, it supports
  * [editing][EphemeralMessageInteractionResponseBehavior.edit] and sending followup messages to the interaction.
  *
- * The response message is only visible to the [user][Interaction.user] who invoked the interaction.
+ * The message is only visible to the [user][Interaction.user] who invoked the interaction.
  */
 public interface EphemeralMessageInteractionResponseBehavior :
     EphemeralInteractionResponseBehavior,

--- a/core/src/main/kotlin/behavior/interaction/response/EphemeralMessageInteractionResponseBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/response/EphemeralMessageInteractionResponseBehavior.kt
@@ -1,7 +1,11 @@
 package dev.kord.core.behavior.interaction.response
 
+import dev.kord.common.entity.MessageFlag
 import dev.kord.common.entity.Snowflake
 import dev.kord.core.Kord
+import dev.kord.core.behavior.interaction.ActionInteractionBehavior
+import dev.kord.core.behavior.interaction.respondEphemeral
+import dev.kord.core.entity.interaction.Interaction
 import dev.kord.core.entity.interaction.response.EphemeralMessageInteractionResponse
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
@@ -10,6 +14,15 @@ import dev.kord.rest.request.RestRequestException
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
+/**
+ * An [InteractionResponseBehavior] returned when using [ActionInteractionBehavior.respondEphemeral] or
+ * [DeferredEphemeralMessageInteractionResponseBehavior.respond].
+ *
+ * This is the handle to an [ephemeral][MessageFlag.Ephemeral] response message, it supports
+ * [editing][EphemeralMessageInteractionResponseBehavior.edit] and sending followup messages to the interaction.
+ *
+ * The response message is only visible to the [user][Interaction.user] who invoked the interaction.
+ */
 public interface EphemeralMessageInteractionResponseBehavior :
     EphemeralInteractionResponseBehavior,
     MessageInteractionResponseBehavior {

--- a/core/src/main/kotlin/behavior/interaction/response/EphemeralMessageInteractionResponseBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/response/EphemeralMessageInteractionResponseBehavior.kt
@@ -1,31 +1,26 @@
 package dev.kord.core.behavior.interaction.response
 
-
 import dev.kord.common.entity.Snowflake
 import dev.kord.core.Kord
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 
-public interface EphemeralMessageInteractionResponseBehavior : EphemeralInteractionResponseBehavior,
+public interface EphemeralMessageInteractionResponseBehavior :
+    EphemeralInteractionResponseBehavior,
     MessageInteractionResponseBehavior {
-    override fun withStrategy(strategy: EntitySupplyStrategy<*>): EphemeralMessageInteractionResponseBehavior {
-        return EphemeralMessageInteractionResponseBehavior(applicationId, token, kord, strategy.supply(kord))
-    }
-}
 
+    override fun withStrategy(strategy: EntitySupplyStrategy<*>): EphemeralMessageInteractionResponseBehavior =
+        EphemeralMessageInteractionResponseBehavior(applicationId, token, kord, strategy.supply(kord))
+}
 
 public fun EphemeralMessageInteractionResponseBehavior(
     applicationId: Snowflake,
     token: String,
     kord: Kord,
     supplier: EntitySupplier = kord.defaultSupplier,
-): EphemeralMessageInteractionResponseBehavior =
-    object : EphemeralMessageInteractionResponseBehavior {
-        override val applicationId: Snowflake = applicationId
-
-        override val token: String = token
-
-        override val kord: Kord = kord
-
-        override val supplier: EntitySupplier = supplier
-    }
+): EphemeralMessageInteractionResponseBehavior = object : EphemeralMessageInteractionResponseBehavior {
+    override val applicationId: Snowflake = applicationId
+    override val token: String = token
+    override val kord: Kord = kord
+    override val supplier: EntitySupplier = supplier
+}

--- a/core/src/main/kotlin/behavior/interaction/response/EphemeralMessageInteractionResponseBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/response/EphemeralMessageInteractionResponseBehavior.kt
@@ -2,8 +2,13 @@ package dev.kord.core.behavior.interaction.response
 
 import dev.kord.common.entity.Snowflake
 import dev.kord.core.Kord
+import dev.kord.core.entity.interaction.response.EphemeralMessageInteractionResponse
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
+import dev.kord.rest.builder.message.modify.InteractionResponseModifyBuilder
+import dev.kord.rest.request.RestRequestException
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 
 public interface EphemeralMessageInteractionResponseBehavior :
     EphemeralInteractionResponseBehavior,
@@ -23,4 +28,19 @@ public fun EphemeralMessageInteractionResponseBehavior(
     override val token: String = token
     override val kord: Kord = kord
     override val supplier: EntitySupplier = supplier
+}
+
+/**
+ * Requests to edit this [EphemeralMessageInteractionResponseBehavior].
+ *
+ * @return The edited [EphemeralMessageInteractionResponse].
+ *
+ * @throws RestRequestException if something went wrong during the request.
+ */
+public suspend inline fun EphemeralMessageInteractionResponseBehavior.edit(
+    builder: InteractionResponseModifyBuilder.() -> Unit,
+): EphemeralMessageInteractionResponse {
+    contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
+
+    return editEphemeralOriginalResponse(builder)
 }

--- a/core/src/main/kotlin/behavior/interaction/response/FollowupPermittingInteractionResponseBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/response/FollowupPermittingInteractionResponseBehavior.kt
@@ -21,18 +21,18 @@ import kotlin.contracts.contract
  * An [InteractionResponseBehavior] that supports sending followup messages to the interaction by using
  * [createPublicFollowup] or [createEphemeralFollowup].
  */
-public interface FollowupableInteractionResponseBehavior : InteractionResponseBehavior {
+public interface FollowupPermittingInteractionResponseBehavior : InteractionResponseBehavior {
 
-    override fun withStrategy(strategy: EntitySupplyStrategy<*>): FollowupableInteractionResponseBehavior =
-        FollowupableInteractionResponseBehavior(applicationId, token, kord, strategy.supply(kord))
+    override fun withStrategy(strategy: EntitySupplyStrategy<*>): FollowupPermittingInteractionResponseBehavior =
+        FollowupPermittingInteractionResponseBehavior(applicationId, token, kord, strategy.supply(kord))
 }
 
-public fun FollowupableInteractionResponseBehavior(
+public fun FollowupPermittingInteractionResponseBehavior(
     applicationId: Snowflake,
     token: String,
     kord: Kord,
     supplier: EntitySupplier = kord.defaultSupplier,
-): FollowupableInteractionResponseBehavior = object : FollowupableInteractionResponseBehavior {
+): FollowupPermittingInteractionResponseBehavior = object : FollowupPermittingInteractionResponseBehavior {
     override val applicationId: Snowflake = applicationId
     override val token: String = token
     override val kord: Kord = kord
@@ -46,7 +46,7 @@ public fun FollowupableInteractionResponseBehavior(
         "dev.kord.core.behavior.interaction.response.createPublicFollowup",
     ),
 )
-public suspend inline fun FollowupableInteractionResponseBehavior.followUp(
+public suspend inline fun FollowupPermittingInteractionResponseBehavior.followUp(
     builder: FollowupMessageCreateBuilder.() -> Unit,
 ): PublicFollowupMessage {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
@@ -62,7 +62,7 @@ public suspend inline fun FollowupableInteractionResponseBehavior.followUp(
  *
  * @throws RestRequestException if something went wrong during the request.
  */
-public suspend inline fun FollowupableInteractionResponseBehavior.createPublicFollowup(
+public suspend inline fun FollowupPermittingInteractionResponseBehavior.createPublicFollowup(
     builder: FollowupMessageCreateBuilder.() -> Unit,
 ): PublicFollowupMessage {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
@@ -80,7 +80,7 @@ public suspend inline fun FollowupableInteractionResponseBehavior.createPublicFo
         "dev.kord.core.behavior.interaction.response.createEphemeralFollowup",
     ),
 )
-public suspend inline fun FollowupableInteractionResponseBehavior.followUpEphemeral(
+public suspend inline fun FollowupPermittingInteractionResponseBehavior.followUpEphemeral(
     builder: FollowupMessageCreateBuilder.() -> Unit,
 ): EphemeralFollowupMessage {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
@@ -94,7 +94,7 @@ public suspend inline fun FollowupableInteractionResponseBehavior.followUpEpheme
  *
  * @throws RestRequestException if something went wrong during the request.
  */
-public suspend inline fun FollowupableInteractionResponseBehavior.createEphemeralFollowup(
+public suspend inline fun FollowupPermittingInteractionResponseBehavior.createEphemeralFollowup(
     builder: FollowupMessageCreateBuilder.() -> Unit,
 ): EphemeralFollowupMessage {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }

--- a/core/src/main/kotlin/behavior/interaction/response/FollowupableInteractionResponseBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/response/FollowupableInteractionResponseBehavior.kt
@@ -18,8 +18,8 @@ import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
 /**
- * An [InteractionResponseBehavior] that supports sending followup messages to the interaction by using [followUpPublic]
- * or [followUpEphemeral].
+ * An [InteractionResponseBehavior] that supports sending followup messages to the interaction by using
+ * [createPublicFollowup] or [createEphemeralFollowup].
  */
 public interface FollowupableInteractionResponseBehavior : InteractionResponseBehavior {
 
@@ -40,14 +40,17 @@ public fun FollowupableInteractionResponseBehavior(
 }
 
 @Deprecated(
-    "Renamed to 'followUpPublic'.",
-    ReplaceWith("this.followUpPublic { builder() }", "dev.kord.core.behavior.interaction.response.followUpPublic"),
+    "Renamed to 'createPublicFollowup'.",
+    ReplaceWith(
+        "this.createPublicFollowup { builder() }",
+        "dev.kord.core.behavior.interaction.response.createPublicFollowup",
+    ),
 )
 public suspend inline fun FollowupableInteractionResponseBehavior.followUp(
     builder: FollowupMessageCreateBuilder.() -> Unit,
 ): PublicFollowupMessage {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
-    return followUpPublic(builder)
+    return createPublicFollowup(builder)
 }
 
 /**
@@ -59,7 +62,7 @@ public suspend inline fun FollowupableInteractionResponseBehavior.followUp(
  *
  * @throws RestRequestException if something went wrong during the request.
  */
-public suspend inline fun FollowupableInteractionResponseBehavior.followUpPublic(
+public suspend inline fun FollowupableInteractionResponseBehavior.createPublicFollowup(
     builder: FollowupMessageCreateBuilder.() -> Unit,
 ): PublicFollowupMessage {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
@@ -70,6 +73,20 @@ public suspend inline fun FollowupableInteractionResponseBehavior.followUpPublic
     return PublicFollowupMessage(message, applicationId, token, kord)
 }
 
+@Deprecated(
+    "Renamed to 'createEphemeralFollowup'.",
+    ReplaceWith(
+        "this.createEphemeralFollowup { builder() }",
+        "dev.kord.core.behavior.interaction.response.createEphemeralFollowup",
+    ),
+)
+public suspend inline fun FollowupableInteractionResponseBehavior.followUpEphemeral(
+    builder: FollowupMessageCreateBuilder.() -> Unit,
+): EphemeralFollowupMessage {
+    contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
+    return createEphemeralFollowup(builder)
+}
+
 /**
  * Follows up an interaction response by sending a [FollowupMessage] with the [Ephemeral flag][MessageFlag.Ephemeral].
  *
@@ -77,7 +94,7 @@ public suspend inline fun FollowupableInteractionResponseBehavior.followUpPublic
  *
  * @throws RestRequestException if something went wrong during the request.
  */
-public suspend inline fun FollowupableInteractionResponseBehavior.followUpEphemeral(
+public suspend inline fun FollowupableInteractionResponseBehavior.createEphemeralFollowup(
     builder: FollowupMessageCreateBuilder.() -> Unit,
 ): EphemeralFollowupMessage {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }

--- a/core/src/main/kotlin/behavior/interaction/response/FollowupableInteractionResponseBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/response/FollowupableInteractionResponseBehavior.kt
@@ -1,0 +1,84 @@
+package dev.kord.core.behavior.interaction.response
+
+import dev.kord.common.entity.MessageFlag
+import dev.kord.common.entity.Snowflake
+import dev.kord.core.Kord
+import dev.kord.core.behavior.interaction.InteractionBehavior
+import dev.kord.core.cache.data.toData
+import dev.kord.core.entity.Message
+import dev.kord.core.entity.interaction.Interaction
+import dev.kord.core.entity.interaction.followup.EphemeralFollowupMessage
+import dev.kord.core.entity.interaction.followup.FollowupMessage
+import dev.kord.core.entity.interaction.followup.PublicFollowupMessage
+import dev.kord.core.supplier.EntitySupplier
+import dev.kord.core.supplier.EntitySupplyStrategy
+import dev.kord.rest.builder.message.create.FollowupMessageCreateBuilder
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+
+/**
+ * An [InteractionResponseBehavior] that supports sending followup messages to the interaction by using [followUpPublic]
+ * or [followUpEphemeral].
+ */
+public interface FollowupableInteractionResponseBehavior : InteractionResponseBehavior {
+
+    override fun withStrategy(strategy: EntitySupplyStrategy<*>): FollowupableInteractionResponseBehavior =
+        FollowupableInteractionResponseBehavior(applicationId, token, kord, strategy.supply(kord))
+}
+
+public fun FollowupableInteractionResponseBehavior(
+    applicationId: Snowflake,
+    token: String,
+    kord: Kord,
+    supplier: EntitySupplier = kord.defaultSupplier,
+): FollowupableInteractionResponseBehavior = object : FollowupableInteractionResponseBehavior {
+    override val applicationId: Snowflake = applicationId
+    override val token: String = token
+    override val kord: Kord = kord
+    override val supplier: EntitySupplier = supplier
+}
+
+@Deprecated(
+    "Renamed to 'followUpPublic'.",
+    ReplaceWith("this.followUpPublic { builder() }", "dev.kord.core.behavior.interaction.response.followUpPublic"),
+)
+public suspend inline fun FollowupableInteractionResponseBehavior.followUp(
+    builder: FollowupMessageCreateBuilder.() -> Unit,
+): PublicFollowupMessage {
+    contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
+    return followUpPublic(builder)
+}
+
+/**
+ * Follows up an interaction response by sending a [FollowupMessage] without the
+ * [Ephemeral flag][MessageFlag.Ephemeral].
+ *
+ * The response message is visible to all users in the [channel][InteractionBehavior.channel] the interaction was sent
+ * from.
+ */
+public suspend inline fun FollowupableInteractionResponseBehavior.followUpPublic(
+    builder: FollowupMessageCreateBuilder.() -> Unit,
+): PublicFollowupMessage {
+    contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
+
+    val response = kord.rest.interaction.createFollowupMessage(applicationId, token, ephemeral = false, builder)
+    val message = Message(response.toData(), kord)
+
+    return PublicFollowupMessage(message, applicationId, token, kord)
+}
+
+/**
+ * Follows up an interaction response by sending a [FollowupMessage] with the [Ephemeral flag][MessageFlag.Ephemeral].
+ *
+ * The followup message is only visible to the [user][Interaction.user] who invoked the interaction.
+ */
+public suspend inline fun FollowupableInteractionResponseBehavior.followUpEphemeral(
+    builder: FollowupMessageCreateBuilder.() -> Unit,
+): EphemeralFollowupMessage {
+    contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
+
+    val response = kord.rest.interaction.createFollowupMessage(applicationId, token, ephemeral = true, builder)
+    val message = Message(response.toData(), kord)
+
+    return EphemeralFollowupMessage(message, applicationId, token, kord)
+}

--- a/core/src/main/kotlin/behavior/interaction/response/FollowupableInteractionResponseBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/response/FollowupableInteractionResponseBehavior.kt
@@ -13,6 +13,7 @@ import dev.kord.core.entity.interaction.followup.PublicFollowupMessage
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 import dev.kord.rest.builder.message.create.FollowupMessageCreateBuilder
+import dev.kord.rest.request.RestRequestException
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -55,6 +56,8 @@ public suspend inline fun FollowupableInteractionResponseBehavior.followUp(
  *
  * The response message is visible to all users in the [channel][InteractionBehavior.channel] the interaction was sent
  * from.
+ *
+ * @throws RestRequestException if something went wrong during the request.
  */
 public suspend inline fun FollowupableInteractionResponseBehavior.followUpPublic(
     builder: FollowupMessageCreateBuilder.() -> Unit,
@@ -71,6 +74,8 @@ public suspend inline fun FollowupableInteractionResponseBehavior.followUpPublic
  * Follows up an interaction response by sending a [FollowupMessage] with the [Ephemeral flag][MessageFlag.Ephemeral].
  *
  * The followup message is only visible to the [user][Interaction.user] who invoked the interaction.
+ *
+ * @throws RestRequestException if something went wrong during the request.
  */
 public suspend inline fun FollowupableInteractionResponseBehavior.followUpEphemeral(
     builder: FollowupMessageCreateBuilder.() -> Unit,

--- a/core/src/main/kotlin/behavior/interaction/response/InteractionResponseBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/response/InteractionResponseBehavior.kt
@@ -5,6 +5,7 @@ import dev.kord.core.KordObject
 import dev.kord.core.cache.data.toData
 import dev.kord.core.entity.Message
 import dev.kord.core.entity.Strategizable
+import dev.kord.core.entity.interaction.Interaction
 import dev.kord.core.entity.interaction.followup.EphemeralFollowupMessage
 import dev.kord.core.entity.interaction.followup.PublicFollowupMessage
 import dev.kord.core.exception.EntityNotFoundException
@@ -15,10 +16,21 @@ import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
 /**
- * The behavior of a [Discord ActionInteraction Response](https://discord.com/developers/docs/interactions/receiving-and-responding#responding-to-an-interaction)
+ * A handle for operations that can follow an
+ * [Interaction Response](https://discord.com/developers/docs/interactions/receiving-and-responding#responding-to-an-interaction).
  */
 public sealed interface InteractionResponseBehavior : KordObject, Strategizable {
+
+    /**
+     * Copied from the [Interaction] the response is for.
+     * @see [Interaction.applicationId].
+     */
     public val applicationId: Snowflake
+
+    /**
+     * Copied from the [Interaction] the response is for.
+     * @see [Interaction.token].
+     */
     public val token: String
 
     /**

--- a/core/src/main/kotlin/behavior/interaction/response/InteractionResponseBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/response/InteractionResponseBehavior.kt
@@ -57,6 +57,15 @@ public sealed interface InteractionResponseBehavior : KordObject, Strategizable 
 /**
  * Follows up an interaction response without the [Ephemeral flag][dev.kord.common.entity.MessageFlag.Ephemeral].
  */
+@Deprecated(
+    "Followups are no longer supported for all 'InteractionResponseBehavior' types.",
+    ReplaceWith(
+        "(this as FollowupableInteractionResponseBehavior).followUpPublic { builder() }",
+        "dev.kord.core.behavior.interaction.response.FollowupableInteractionResponseBehavior",
+        "dev.kord.core.behavior.interaction.response.followUpPublic",
+    ),
+    DeprecationLevel.ERROR,
+)
 public suspend inline fun InteractionResponseBehavior.followUp(builder: FollowupMessageCreateBuilder.() -> Unit): PublicFollowupMessage {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
     val message = kord.rest.interaction.createFollowupMessage(applicationId, token, ephemeral = false, builder)
@@ -66,6 +75,14 @@ public suspend inline fun InteractionResponseBehavior.followUp(builder: Followup
 /**
  * Follows up an interaction response with the [Ephemeral flag][dev.kord.common.entity.MessageFlag.Ephemeral].
  */
+@Deprecated(
+    "Followups are no longer supported for all 'InteractionResponseBehavior' types.",
+    ReplaceWith(
+        "(this as FollowupableInteractionResponseBehavior).followUpEphemeral { builder() }",
+        "dev.kord.core.behavior.interaction.response.FollowupableInteractionResponseBehavior",
+    ),
+    DeprecationLevel.ERROR,
+)
 public suspend inline fun InteractionResponseBehavior.followUpEphemeral(builder: FollowupMessageCreateBuilder.() -> Unit): EphemeralFollowupMessage {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
     val message = kord.rest.interaction.createFollowupMessage(applicationId, token, ephemeral = true, builder)

--- a/core/src/main/kotlin/behavior/interaction/response/InteractionResponseBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/response/InteractionResponseBehavior.kt
@@ -60,8 +60,8 @@ public sealed interface InteractionResponseBehavior : KordObject, Strategizable 
 @Deprecated(
     "Followups are no longer supported for all 'InteractionResponseBehavior' types.",
     ReplaceWith(
-        "if (this is FollowupableInteractionResponseBehavior) this.createPublicFollowup { builder() }",
-        "dev.kord.core.behavior.interaction.response.FollowupableInteractionResponseBehavior",
+        "if (this is FollowupPermittingInteractionResponseBehavior) this.createPublicFollowup { builder() }",
+        "dev.kord.core.behavior.interaction.response.FollowupPermittingInteractionResponseBehavior",
         "dev.kord.core.behavior.interaction.response.createPublicFollowup",
     ),
     DeprecationLevel.ERROR,
@@ -78,8 +78,8 @@ public suspend inline fun InteractionResponseBehavior.followUp(builder: Followup
 @Deprecated(
     "Followups are no longer supported for all 'InteractionResponseBehavior' types.",
     ReplaceWith(
-        "if (this is FollowupableInteractionResponseBehavior) this.createEphemeralFollowup { builder() }",
-        "dev.kord.core.behavior.interaction.response.FollowupableInteractionResponseBehavior",
+        "if (this is FollowupPermittingInteractionResponseBehavior) this.createEphemeralFollowup { builder() }",
+        "dev.kord.core.behavior.interaction.response.FollowupPermittingInteractionResponseBehavior",
         "dev.kord.core.behavior.interaction.response.createEphemeralFollowup",
     ),
     DeprecationLevel.ERROR,

--- a/core/src/main/kotlin/behavior/interaction/response/InteractionResponseBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/response/InteractionResponseBehavior.kt
@@ -60,7 +60,7 @@ public sealed interface InteractionResponseBehavior : KordObject, Strategizable 
 @Deprecated(
     "Followups are no longer supported for all 'InteractionResponseBehavior' types.",
     ReplaceWith(
-        "(this as FollowupableInteractionResponseBehavior).followUpPublic { builder() }",
+        "if (this is FollowupableInteractionResponseBehavior) this.followUpPublic { builder() }",
         "dev.kord.core.behavior.interaction.response.FollowupableInteractionResponseBehavior",
         "dev.kord.core.behavior.interaction.response.followUpPublic",
     ),
@@ -78,7 +78,7 @@ public suspend inline fun InteractionResponseBehavior.followUp(builder: Followup
 @Deprecated(
     "Followups are no longer supported for all 'InteractionResponseBehavior' types.",
     ReplaceWith(
-        "(this as FollowupableInteractionResponseBehavior).followUpEphemeral { builder() }",
+        "if (this is FollowupableInteractionResponseBehavior) this.followUpEphemeral { builder() }",
         "dev.kord.core.behavior.interaction.response.FollowupableInteractionResponseBehavior",
     ),
     DeprecationLevel.ERROR,

--- a/core/src/main/kotlin/behavior/interaction/response/InteractionResponseBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/response/InteractionResponseBehavior.kt
@@ -8,6 +8,7 @@ import dev.kord.core.entity.Strategizable
 import dev.kord.core.entity.interaction.followup.EphemeralFollowupMessage
 import dev.kord.core.entity.interaction.followup.PublicFollowupMessage
 import dev.kord.core.exception.EntityNotFoundException
+import dev.kord.core.supplier.EntitySupplyStrategy
 import dev.kord.rest.builder.message.create.FollowupMessageCreateBuilder
 import dev.kord.rest.request.RestRequestException
 import kotlin.contracts.InvocationKind
@@ -37,6 +38,8 @@ public sealed interface InteractionResponseBehavior : KordObject, Strategizable 
      */
     public suspend fun getFollowupMessage(messageId: Snowflake): PublicFollowupMessage =
         supplier.getFollowupMessage(applicationId, token, messageId)
+
+    override fun withStrategy(strategy: EntitySupplyStrategy<*>): InteractionResponseBehavior
 }
 
 /**

--- a/core/src/main/kotlin/behavior/interaction/response/InteractionResponseBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/response/InteractionResponseBehavior.kt
@@ -60,9 +60,9 @@ public sealed interface InteractionResponseBehavior : KordObject, Strategizable 
 @Deprecated(
     "Followups are no longer supported for all 'InteractionResponseBehavior' types.",
     ReplaceWith(
-        "if (this is FollowupableInteractionResponseBehavior) this.followUpPublic { builder() }",
+        "if (this is FollowupableInteractionResponseBehavior) this.createPublicFollowup { builder() }",
         "dev.kord.core.behavior.interaction.response.FollowupableInteractionResponseBehavior",
-        "dev.kord.core.behavior.interaction.response.followUpPublic",
+        "dev.kord.core.behavior.interaction.response.createPublicFollowup",
     ),
     DeprecationLevel.ERROR,
 )
@@ -78,8 +78,9 @@ public suspend inline fun InteractionResponseBehavior.followUp(builder: Followup
 @Deprecated(
     "Followups are no longer supported for all 'InteractionResponseBehavior' types.",
     ReplaceWith(
-        "if (this is FollowupableInteractionResponseBehavior) this.followUpEphemeral { builder() }",
+        "if (this is FollowupableInteractionResponseBehavior) this.createEphemeralFollowup { builder() }",
         "dev.kord.core.behavior.interaction.response.FollowupableInteractionResponseBehavior",
+        "dev.kord.core.behavior.interaction.response.createEphemeralFollowup",
     ),
     DeprecationLevel.ERROR,
 )

--- a/core/src/main/kotlin/behavior/interaction/response/MessageInteractionResponseBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/response/MessageInteractionResponseBehavior.kt
@@ -20,7 +20,7 @@ import kotlin.contracts.contract
  * This is the handle to a message, it supports [editing][MessageInteractionResponseBehavior.edit] and sending followup
  * messages to the interaction.
  */
-public interface MessageInteractionResponseBehavior : FollowupableInteractionResponseBehavior {
+public interface MessageInteractionResponseBehavior : FollowupPermittingInteractionResponseBehavior {
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): MessageInteractionResponseBehavior
 }

--- a/core/src/main/kotlin/behavior/interaction/response/MessageInteractionResponseBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/response/MessageInteractionResponseBehavior.kt
@@ -1,5 +1,8 @@
 package dev.kord.core.behavior.interaction.response
 
+import dev.kord.core.behavior.interaction.ActionInteractionBehavior
+import dev.kord.core.behavior.interaction.respondEphemeral
+import dev.kord.core.behavior.interaction.respondPublic
 import dev.kord.core.entity.interaction.response.MessageInteractionResponse
 import dev.kord.core.supplier.EntitySupplyStrategy
 import dev.kord.rest.builder.message.modify.InteractionResponseModifyBuilder
@@ -7,6 +10,13 @@ import dev.kord.rest.request.RestRequestException
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
+/**
+ * An [InteractionResponseBehavior] returned when using [ActionInteractionBehavior.respondPublic],
+ * [ActionInteractionBehavior.respondEphemeral] or [DeferredMessageInteractionResponseBehavior.respond].
+ *
+ * This is the handle to a response message, it supports [editing][MessageInteractionResponseBehavior.edit] and sending
+ * followup messages to the interaction.
+ */
 public interface MessageInteractionResponseBehavior : FollowupableInteractionResponseBehavior {
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): MessageInteractionResponseBehavior

--- a/core/src/main/kotlin/behavior/interaction/response/MessageInteractionResponseBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/response/MessageInteractionResponseBehavior.kt
@@ -1,8 +1,6 @@
 package dev.kord.core.behavior.interaction.response
 
-import dev.kord.core.behavior.interaction.ActionInteractionBehavior
-import dev.kord.core.behavior.interaction.respondEphemeral
-import dev.kord.core.behavior.interaction.respondPublic
+import dev.kord.core.behavior.interaction.*
 import dev.kord.core.entity.interaction.response.MessageInteractionResponse
 import dev.kord.core.supplier.EntitySupplyStrategy
 import dev.kord.rest.builder.message.modify.InteractionResponseModifyBuilder
@@ -11,11 +9,16 @@ import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
 /**
- * An [InteractionResponseBehavior] returned when using [ActionInteractionBehavior.respondPublic],
- * [ActionInteractionBehavior.respondEphemeral] or [DeferredMessageInteractionResponseBehavior.respond].
+ * An [InteractionResponseBehavior] returned when using [respondPublic][ActionInteractionBehavior.respondPublic],
+ * [respondEphemeral][ActionInteractionBehavior.respondEphemeral],
+ * [respond][DeferredMessageInteractionResponseBehavior.respond],
+ * [deferPublicMessageUpdate][ComponentInteractionBehavior.deferPublicMessageUpdate],
+ * [deferEphemeralMessageUpdate][ComponentInteractionBehavior.deferEphemeralMessageUpdate],
+ * [updatePublicMessage][ComponentInteractionBehavior.updatePublicMessage] or
+ * [updateEphemeralMessage][ComponentInteractionBehavior.updateEphemeralMessage].
  *
- * This is the handle to a response message, it supports [editing][MessageInteractionResponseBehavior.edit] and sending
- * followup messages to the interaction.
+ * This is the handle to a message, it supports [editing][MessageInteractionResponseBehavior.edit] and sending followup
+ * messages to the interaction.
  */
 public interface MessageInteractionResponseBehavior : FollowupableInteractionResponseBehavior {
 

--- a/core/src/main/kotlin/behavior/interaction/response/MessageInteractionResponseBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/response/MessageInteractionResponseBehavior.kt
@@ -1,7 +1,7 @@
 package dev.kord.core.behavior.interaction.response
 
-import dev.kord.core.cache.data.toData
-import dev.kord.core.entity.Message
+import dev.kord.core.entity.interaction.response.MessageInteractionResponse
+import dev.kord.core.supplier.EntitySupplyStrategy
 import dev.kord.rest.builder.message.modify.InteractionResponseModifyBuilder
 import dev.kord.rest.request.RestRequestException
 import kotlin.contracts.InvocationKind
@@ -13,16 +13,16 @@ public interface MessageInteractionResponseBehavior : InteractionResponseBehavio
 }
 
 /**
- * Requests to edit this interaction response.
+ * Requests to edit this [MessageInteractionResponseBehavior].
  *
- * @return The edited [Message] of the interaction response.
+ * @return The edited [MessageInteractionResponse].
  *
  * @throws RestRequestException if something went wrong during the request.
  */
 public suspend inline fun MessageInteractionResponseBehavior.edit(
     builder: InteractionResponseModifyBuilder.() -> Unit,
-): Message {
+): MessageInteractionResponse {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
-    val message = kord.rest.interaction.modifyInteractionResponse(applicationId, token, builder)
-    return Message(message.toData(), kord)
+
+    return editOriginalResponseWithUnknownVisibility(builder)
 }

--- a/core/src/main/kotlin/behavior/interaction/response/MessageInteractionResponseBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/response/MessageInteractionResponseBehavior.kt
@@ -7,7 +7,11 @@ import dev.kord.rest.request.RestRequestException
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
-public sealed interface  MessageInteractionResponseBehavior : InteractionResponseBehavior
+public interface MessageInteractionResponseBehavior : InteractionResponseBehavior {
+
+    override fun withStrategy(strategy: EntitySupplyStrategy<*>): MessageInteractionResponseBehavior
+}
+
 /**
  * Requests to edit this interaction response.
  *
@@ -22,4 +26,3 @@ public suspend inline fun MessageInteractionResponseBehavior.edit(
     val message = kord.rest.interaction.modifyInteractionResponse(applicationId, token, builder)
     return Message(message.toData(), kord)
 }
-

--- a/core/src/main/kotlin/behavior/interaction/response/MessageInteractionResponseBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/response/MessageInteractionResponseBehavior.kt
@@ -7,7 +7,7 @@ import dev.kord.rest.request.RestRequestException
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
-public interface MessageInteractionResponseBehavior : InteractionResponseBehavior {
+public interface MessageInteractionResponseBehavior : FollowupableInteractionResponseBehavior {
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): MessageInteractionResponseBehavior
 }

--- a/core/src/main/kotlin/behavior/interaction/response/PopupInteractionResponseBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/response/PopupInteractionResponseBehavior.kt
@@ -5,7 +5,7 @@ import dev.kord.core.Kord
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 
-public interface PopupInteractionResponseBehavior : InteractionResponseBehavior {
+public interface PopupInteractionResponseBehavior : FollowupableInteractionResponseBehavior {
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): PopupInteractionResponseBehavior =
         PopupInteractionResponseBehavior(applicationId, token, kord, strategy.supply(kord))

--- a/core/src/main/kotlin/behavior/interaction/response/PopupInteractionResponseBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/response/PopupInteractionResponseBehavior.kt
@@ -2,31 +2,23 @@ package dev.kord.core.behavior.interaction.response
 
 import dev.kord.common.entity.Snowflake
 import dev.kord.core.Kord
-import dev.kord.core.behavior.interaction.ActionInteractionBehavior
-import dev.kord.core.entity.Strategizable
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 
-public  interface PopupInteractionResponseBehavior : InteractionResponseBehavior {
+public interface PopupInteractionResponseBehavior : InteractionResponseBehavior {
 
-    override fun withStrategy(strategy: EntitySupplyStrategy<*>): PopupInteractionResponseBehavior {
-        return PopupInteractionResponseBehavior(applicationId, token, kord, strategy.supply(kord))
-    }
+    override fun withStrategy(strategy: EntitySupplyStrategy<*>): PopupInteractionResponseBehavior =
+        PopupInteractionResponseBehavior(applicationId, token, kord, strategy.supply(kord))
 }
-
 
 public fun PopupInteractionResponseBehavior(
     applicationId: Snowflake,
     token: String,
     kord: Kord,
     supplier: EntitySupplier = kord.defaultSupplier,
-): PopupInteractionResponseBehavior =
-    object : PopupInteractionResponseBehavior {
-        override val applicationId: Snowflake = applicationId
-
-        override val token: String = token
-
-        override val kord: Kord = kord
-
-        override val supplier: EntitySupplier = supplier
-    }
+): PopupInteractionResponseBehavior = object : PopupInteractionResponseBehavior {
+    override val applicationId: Snowflake = applicationId
+    override val token: String = token
+    override val kord: Kord = kord
+    override val supplier: EntitySupplier = supplier
+}

--- a/core/src/main/kotlin/behavior/interaction/response/PopupInteractionResponseBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/response/PopupInteractionResponseBehavior.kt
@@ -12,7 +12,7 @@ import dev.kord.core.supplier.EntitySupplyStrategy
  *
  * This handle supports sending followup messages to the interaction.
  */
-public interface PopupInteractionResponseBehavior : FollowupableInteractionResponseBehavior {
+public interface PopupInteractionResponseBehavior : FollowupPermittingInteractionResponseBehavior {
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): PopupInteractionResponseBehavior =
         PopupInteractionResponseBehavior(applicationId, token, kord, strategy.supply(kord))

--- a/core/src/main/kotlin/behavior/interaction/response/PopupInteractionResponseBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/response/PopupInteractionResponseBehavior.kt
@@ -2,9 +2,16 @@ package dev.kord.core.behavior.interaction.response
 
 import dev.kord.common.entity.Snowflake
 import dev.kord.core.Kord
+import dev.kord.core.behavior.interaction.ModalParentInteractionBehavior
+import dev.kord.core.behavior.interaction.modal
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 
+/**
+ * An [InteractionResponseBehavior] returned when using [ModalParentInteractionBehavior.modal].
+ *
+ * This handle supports sending followup messages to the interaction.
+ */
 public interface PopupInteractionResponseBehavior : FollowupableInteractionResponseBehavior {
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): PopupInteractionResponseBehavior =

--- a/core/src/main/kotlin/behavior/interaction/response/PublicInteractionResponseBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/response/PublicInteractionResponseBehavior.kt
@@ -1,5 +1,7 @@
 package dev.kord.core.behavior.interaction.response
 
+import dev.kord.core.behavior.interaction.InteractionBehavior
+import dev.kord.core.entity.interaction.Interaction
 import dev.kord.core.supplier.EntitySupplyStrategy
 
 /**

--- a/core/src/main/kotlin/behavior/interaction/response/PublicInteractionResponseBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/response/PublicInteractionResponseBehavior.kt
@@ -3,8 +3,9 @@ package dev.kord.core.behavior.interaction.response
 import dev.kord.core.supplier.EntitySupplyStrategy
 
 /**
- * The behavior of a public Discord Interaction Response.
- * This response is visible to all users in the channel.
+ * An [InteractionResponseBehavior] for a public response to an [Interaction].
+ *
+ * The response is visible to all users in the [channel][InteractionBehavior.channel] the interaction was sent from.
  */
 public sealed interface PublicInteractionResponseBehavior : InteractionResponseBehavior {
 

--- a/core/src/main/kotlin/behavior/interaction/response/PublicInteractionResponseBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/response/PublicInteractionResponseBehavior.kt
@@ -1,16 +1,12 @@
 package dev.kord.core.behavior.interaction.response
 
-import dev.kord.common.entity.Snowflake
-import dev.kord.core.Kord
-import dev.kord.core.behavior.interaction.response.InteractionResponseBehavior
-import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
-import dev.kord.rest.request.RestRequestException
-
 
 /**
- * The behavior of a public Discord Interaction Response
+ * The behavior of a public Discord Interaction Response.
  * This response is visible to all users in the channel.
  */
+public sealed interface PublicInteractionResponseBehavior : InteractionResponseBehavior {
 
-public sealed interface PublicInteractionResponseBehavior : InteractionResponseBehavior
+    override fun withStrategy(strategy: EntitySupplyStrategy<*>): PublicInteractionResponseBehavior
+}

--- a/core/src/main/kotlin/behavior/interaction/response/PublicMesageInteractionResponseBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/response/PublicMesageInteractionResponseBehavior.kt
@@ -2,6 +2,9 @@ package dev.kord.core.behavior.interaction.response
 
 import dev.kord.common.entity.Snowflake
 import dev.kord.core.Kord
+import dev.kord.core.behavior.interaction.ActionInteractionBehavior
+import dev.kord.core.behavior.interaction.InteractionBehavior
+import dev.kord.core.behavior.interaction.respondPublic
 import dev.kord.core.entity.interaction.response.PublicMessageInteractionResponse
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
@@ -10,6 +13,17 @@ import dev.kord.rest.request.RestRequestException
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
+/**
+ * An [InteractionResponseBehavior] returned when using [ActionInteractionBehavior.respondPublic] or
+ * [DeferredPublicMessageInteractionResponseBehavior.respond].
+ *
+ * This is the handle to a public response message, it supports
+ * [editing][PublicMessageInteractionResponseBehavior.edit], [deleting][delete] and sending followup messages to the
+ * interaction.
+ *
+ * The response message is visible to all users in the [channel][InteractionBehavior.channel] the interaction was sent
+ * from.
+ */
 public interface PublicMessageInteractionResponseBehavior :
     PublicInteractionResponseBehavior,
     MessageInteractionResponseBehavior {

--- a/core/src/main/kotlin/behavior/interaction/response/PublicMesageInteractionResponseBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/response/PublicMesageInteractionResponseBehavior.kt
@@ -2,9 +2,7 @@ package dev.kord.core.behavior.interaction.response
 
 import dev.kord.common.entity.Snowflake
 import dev.kord.core.Kord
-import dev.kord.core.behavior.interaction.ActionInteractionBehavior
-import dev.kord.core.behavior.interaction.InteractionBehavior
-import dev.kord.core.behavior.interaction.respondPublic
+import dev.kord.core.behavior.interaction.*
 import dev.kord.core.entity.interaction.response.PublicMessageInteractionResponse
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
@@ -14,22 +12,22 @@ import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
 /**
- * An [InteractionResponseBehavior] returned when using [ActionInteractionBehavior.respondPublic] or
- * [DeferredPublicMessageInteractionResponseBehavior.respond].
+ * An [InteractionResponseBehavior] returned when using [respondPublic][ActionInteractionBehavior.respondPublic],
+ * [respond][DeferredPublicMessageInteractionResponseBehavior.respond],
+ * [deferPublicMessageUpdate][ComponentInteractionBehavior.deferPublicMessageUpdate] or
+ * [updatePublicMessage][ComponentInteractionBehavior.updatePublicMessage].
  *
- * This is the handle to a public response message, it supports
- * [editing][PublicMessageInteractionResponseBehavior.edit], [deleting][delete] and sending followup messages to the
- * interaction.
+ * This is the handle to a public message, it supports [editing][PublicMessageInteractionResponseBehavior.edit],
+ * [deleting][delete] and sending followup messages to the interaction.
  *
- * The response message is visible to all users in the [channel][InteractionBehavior.channel] the interaction was sent
- * from.
+ * The message is visible to all users in the [channel][InteractionBehavior.channel] the interaction was sent from.
  */
 public interface PublicMessageInteractionResponseBehavior :
     PublicInteractionResponseBehavior,
     MessageInteractionResponseBehavior {
 
     /**
-     * Requests to delete the response message.
+     * Requests to delete the message.
      *
      * Returns a [FollowupableInteractionResponseBehavior] that can still be used to send followup messages to the
      * interaction.

--- a/core/src/main/kotlin/behavior/interaction/response/PublicMesageInteractionResponseBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/response/PublicMesageInteractionResponseBehavior.kt
@@ -6,7 +6,8 @@ import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 import dev.kord.rest.request.RestRequestException
 
-public interface PublicMessageInteractionResponseBehavior : PublicInteractionResponseBehavior,
+public interface PublicMessageInteractionResponseBehavior :
+    PublicInteractionResponseBehavior,
     MessageInteractionResponseBehavior {
 
     /**
@@ -18,9 +19,8 @@ public interface PublicMessageInteractionResponseBehavior : PublicInteractionRes
         kord.rest.interaction.deleteOriginalInteractionResponse(applicationId, token)
     }
 
-    public override fun withStrategy(strategy: EntitySupplyStrategy<*>): PublicMessageInteractionResponseBehavior {
-        return PublicMessageInteractionResponseBehavior(applicationId, token, kord, strategy.supply(kord))
-    }
+    public override fun withStrategy(strategy: EntitySupplyStrategy<*>): PublicMessageInteractionResponseBehavior =
+        PublicMessageInteractionResponseBehavior(applicationId, token, kord, strategy.supply(kord))
 }
 
 public fun PublicMessageInteractionResponseBehavior(
@@ -28,13 +28,9 @@ public fun PublicMessageInteractionResponseBehavior(
     token: String,
     kord: Kord,
     supplier: EntitySupplier = kord.defaultSupplier,
-): PublicMessageInteractionResponseBehavior =
-    object : PublicMessageInteractionResponseBehavior {
-        override val applicationId: Snowflake = applicationId
-
-        override val token: String = token
-
-        override val kord: Kord = kord
-
-        override val supplier: EntitySupplier = supplier
-    }
+): PublicMessageInteractionResponseBehavior = object : PublicMessageInteractionResponseBehavior {
+    override val applicationId: Snowflake = applicationId
+    override val token: String = token
+    override val kord: Kord = kord
+    override val supplier: EntitySupplier = supplier
+}

--- a/core/src/main/kotlin/behavior/interaction/response/PublicMesageInteractionResponseBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/response/PublicMesageInteractionResponseBehavior.kt
@@ -29,14 +29,12 @@ public interface PublicMessageInteractionResponseBehavior :
     /**
      * Requests to delete the message.
      *
-     * Returns a [FollowupableInteractionResponseBehavior] that can still be used to send followup messages to the
-     * interaction.
+     * This [PublicMessageInteractionResponseBehavior] can still be used to send followup messages to the interaction.
      *
      * @throws RestRequestException if something went wrong during the request.
      */
-    public suspend fun delete(): FollowupableInteractionResponseBehavior {
+    public suspend fun delete() {
         kord.rest.interaction.deleteOriginalInteractionResponse(applicationId, token)
-        return FollowupableInteractionResponseBehavior(applicationId, token, kord)
     }
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): PublicMessageInteractionResponseBehavior =

--- a/core/src/main/kotlin/behavior/interaction/response/PublicMesageInteractionResponseBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/response/PublicMesageInteractionResponseBehavior.kt
@@ -23,7 +23,7 @@ public interface PublicMessageInteractionResponseBehavior :
         kord.rest.interaction.deleteOriginalInteractionResponse(applicationId, token)
     }
 
-    public override fun withStrategy(strategy: EntitySupplyStrategy<*>): PublicMessageInteractionResponseBehavior =
+    override fun withStrategy(strategy: EntitySupplyStrategy<*>): PublicMessageInteractionResponseBehavior =
         PublicMessageInteractionResponseBehavior(applicationId, token, kord, strategy.supply(kord))
 }
 

--- a/core/src/main/kotlin/behavior/interaction/response/PublicMesageInteractionResponseBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/response/PublicMesageInteractionResponseBehavior.kt
@@ -29,12 +29,16 @@ public interface PublicMessageInteractionResponseBehavior :
     MessageInteractionResponseBehavior {
 
     /**
-     * Requests to delete this interaction response.
+     * Requests to delete the response message.
      *
-     * @throws [RestRequestException] if something went wrong during the request.
+     * Returns a [FollowupableInteractionResponseBehavior] that can still be used to send followup messages to the
+     * interaction.
+     *
+     * @throws RestRequestException if something went wrong during the request.
      */
-    public suspend fun delete() {
+    public suspend fun delete(): FollowupableInteractionResponseBehavior {
         kord.rest.interaction.deleteOriginalInteractionResponse(applicationId, token)
+        return FollowupableInteractionResponseBehavior(applicationId, token, kord)
     }
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): PublicMessageInteractionResponseBehavior =

--- a/core/src/main/kotlin/behavior/interaction/response/PublicMesageInteractionResponseBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/response/PublicMesageInteractionResponseBehavior.kt
@@ -2,9 +2,13 @@ package dev.kord.core.behavior.interaction.response
 
 import dev.kord.common.entity.Snowflake
 import dev.kord.core.Kord
+import dev.kord.core.entity.interaction.response.PublicMessageInteractionResponse
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
+import dev.kord.rest.builder.message.modify.InteractionResponseModifyBuilder
 import dev.kord.rest.request.RestRequestException
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 
 public interface PublicMessageInteractionResponseBehavior :
     PublicInteractionResponseBehavior,
@@ -33,4 +37,19 @@ public fun PublicMessageInteractionResponseBehavior(
     override val token: String = token
     override val kord: Kord = kord
     override val supplier: EntitySupplier = supplier
+}
+
+/**
+ * Requests to edit this [PublicMessageInteractionResponseBehavior].
+ *
+ * @return The edited [PublicMessageInteractionResponse].
+ *
+ * @throws RestRequestException if something went wrong during the request.
+ */
+public suspend inline fun PublicMessageInteractionResponseBehavior.edit(
+    builder: InteractionResponseModifyBuilder.() -> Unit,
+): PublicMessageInteractionResponse {
+    contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
+
+    return editPublicOriginalResponse(builder)
 }

--- a/core/src/main/kotlin/entity/interaction/followup/EphemeralFollowupMessage.kt
+++ b/core/src/main/kotlin/entity/interaction/followup/EphemeralFollowupMessage.kt
@@ -11,10 +11,8 @@ import dev.kord.core.supplier.EntitySupplyStrategy
  * Holds the followup [Message] resulting from an ephemeral followup message
  * and behaves on it through [EphemeralFollowupMessageBehavior].
  *
- * @param message The message created by this followup.
- * To use the message behavior your application must be authorized as a bot.
- * Note: Any rest calls made through the [message] object e.g: `message.delete()` will throw since the message
- * is deleted once the client receives it.
+ * @param message The message created by this followup. Any rest calls made through the message behavior, e.g.
+ * `message.delete()`, will throw since ephemeral messages are not accessible through bot authorization.
  */
 public class EphemeralFollowupMessage(
     message: Message,

--- a/core/src/main/kotlin/entity/interaction/response/EphemeralMessageInteractionResponse.kt
+++ b/core/src/main/kotlin/entity/interaction/response/EphemeralMessageInteractionResponse.kt
@@ -1,0 +1,20 @@
+package dev.kord.core.entity.interaction.response
+
+import dev.kord.common.entity.Snowflake
+import dev.kord.core.Kord
+import dev.kord.core.behavior.interaction.response.EphemeralMessageInteractionResponseBehavior
+import dev.kord.core.entity.Message
+import dev.kord.core.supplier.EntitySupplier
+import dev.kord.core.supplier.EntitySupplyStrategy
+
+public class EphemeralMessageInteractionResponse(
+    message: Message,
+    override val applicationId: Snowflake,
+    override val token: String,
+    override val kord: Kord,
+    override val supplier: EntitySupplier = kord.defaultSupplier,
+) : MessageInteractionResponse(message), EphemeralMessageInteractionResponseBehavior {
+
+    override fun withStrategy(strategy: EntitySupplyStrategy<*>): EphemeralMessageInteractionResponse =
+        EphemeralMessageInteractionResponse(message, applicationId, token, kord, strategy.supply(kord))
+}

--- a/core/src/main/kotlin/entity/interaction/response/EphemeralMessageInteractionResponse.kt
+++ b/core/src/main/kotlin/entity/interaction/response/EphemeralMessageInteractionResponse.kt
@@ -7,6 +7,12 @@ import dev.kord.core.entity.Message
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 
+/**
+ * An [EphemeralMessageInteractionResponseBehavior] that holds the response [message].
+ *
+ * @param message The response message. Any rest calls made through the message behavior, e.g. `message.delete()`, will
+ * throw since ephemeral messages are not accessible through bot authorization.
+ */
 public class EphemeralMessageInteractionResponse(
     message: Message,
     override val applicationId: Snowflake,

--- a/core/src/main/kotlin/entity/interaction/response/EphemeralMessageInteractionResponse.kt
+++ b/core/src/main/kotlin/entity/interaction/response/EphemeralMessageInteractionResponse.kt
@@ -8,10 +8,10 @@ import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 
 /**
- * An [EphemeralMessageInteractionResponseBehavior] that holds the response [message].
+ * An [EphemeralMessageInteractionResponseBehavior] that holds the [message] this is a handle to.
  *
- * @param message The response message. Any rest calls made through the message behavior, e.g. `message.delete()`, will
- * throw since ephemeral messages are not accessible through bot authorization.
+ * @param message The message. Any rest calls made through the message behavior, e.g. `message.delete()`, will throw
+ * since ephemeral messages are not accessible through bot authorization.
  */
 public class EphemeralMessageInteractionResponse(
     message: Message,

--- a/core/src/main/kotlin/entity/interaction/response/MessageInteractionResponse.kt
+++ b/core/src/main/kotlin/entity/interaction/response/MessageInteractionResponse.kt
@@ -5,9 +5,9 @@ import dev.kord.core.entity.Message
 import dev.kord.core.supplier.EntitySupplyStrategy
 
 /**
- * A [MessageInteractionResponseBehavior] that holds the response [message].
+ * A [MessageInteractionResponseBehavior] that holds the [message] this is a handle to.
  *
- * @param message The response message. To use the message behavior your application must be authorized as a bot.
+ * @param message The message. To use the message behavior your application must be authorized as a bot.
  */
 public sealed class MessageInteractionResponse(public val message: Message) : MessageInteractionResponseBehavior {
 

--- a/core/src/main/kotlin/entity/interaction/response/MessageInteractionResponse.kt
+++ b/core/src/main/kotlin/entity/interaction/response/MessageInteractionResponse.kt
@@ -1,0 +1,10 @@
+package dev.kord.core.entity.interaction.response
+
+import dev.kord.core.behavior.interaction.response.MessageInteractionResponseBehavior
+import dev.kord.core.entity.Message
+import dev.kord.core.supplier.EntitySupplyStrategy
+
+public sealed class MessageInteractionResponse(public val message: Message) : MessageInteractionResponseBehavior {
+
+    abstract override fun withStrategy(strategy: EntitySupplyStrategy<*>): MessageInteractionResponse
+}

--- a/core/src/main/kotlin/entity/interaction/response/MessageInteractionResponse.kt
+++ b/core/src/main/kotlin/entity/interaction/response/MessageInteractionResponse.kt
@@ -4,6 +4,11 @@ import dev.kord.core.behavior.interaction.response.MessageInteractionResponseBeh
 import dev.kord.core.entity.Message
 import dev.kord.core.supplier.EntitySupplyStrategy
 
+/**
+ * A [MessageInteractionResponseBehavior] that holds the response [message].
+ *
+ * @param message The response message. To use the message behavior your application must be authorized as a bot.
+ */
 public sealed class MessageInteractionResponse(public val message: Message) : MessageInteractionResponseBehavior {
 
     abstract override fun withStrategy(strategy: EntitySupplyStrategy<*>): MessageInteractionResponse

--- a/core/src/main/kotlin/entity/interaction/response/PublicMessageInteractionResponse.kt
+++ b/core/src/main/kotlin/entity/interaction/response/PublicMessageInteractionResponse.kt
@@ -1,0 +1,20 @@
+package dev.kord.core.entity.interaction.response
+
+import dev.kord.common.entity.Snowflake
+import dev.kord.core.Kord
+import dev.kord.core.behavior.interaction.response.PublicMessageInteractionResponseBehavior
+import dev.kord.core.entity.Message
+import dev.kord.core.supplier.EntitySupplier
+import dev.kord.core.supplier.EntitySupplyStrategy
+
+public class PublicMessageInteractionResponse(
+    message: Message,
+    override val applicationId: Snowflake,
+    override val token: String,
+    override val kord: Kord,
+    override val supplier: EntitySupplier = kord.defaultSupplier,
+) : MessageInteractionResponse(message), PublicMessageInteractionResponseBehavior {
+
+    override fun withStrategy(strategy: EntitySupplyStrategy<*>): PublicMessageInteractionResponse =
+        PublicMessageInteractionResponse(message, applicationId, token, kord, strategy.supply(kord))
+}

--- a/core/src/main/kotlin/entity/interaction/response/PublicMessageInteractionResponse.kt
+++ b/core/src/main/kotlin/entity/interaction/response/PublicMessageInteractionResponse.kt
@@ -7,6 +7,11 @@ import dev.kord.core.entity.Message
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 
+/**
+ * A [PublicMessageInteractionResponseBehavior] that holds the response [message].
+ *
+ * @param message The response message. To use the message behavior your application must be authorized as a bot.
+ */
 public class PublicMessageInteractionResponse(
     message: Message,
     override val applicationId: Snowflake,

--- a/core/src/main/kotlin/entity/interaction/response/PublicMessageInteractionResponse.kt
+++ b/core/src/main/kotlin/entity/interaction/response/PublicMessageInteractionResponse.kt
@@ -8,9 +8,9 @@ import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 
 /**
- * A [PublicMessageInteractionResponseBehavior] that holds the response [message].
+ * A [PublicMessageInteractionResponseBehavior] that holds the [message] this is a handle to.
  *
- * @param message The response message. To use the message behavior your application must be authorized as a bot.
+ * @param message The message. To use the message behavior your application must be authorized as a bot.
  */
 public class PublicMessageInteractionResponse(
     message: Message,


### PR DESCRIPTION
## The problem

Right now it is possible to break Kord's type system when using deferred interaction responses, here is an example for this:
```kotlin
val response: EphemeralMessageInteractionResponseBehavior = interaction.deferEphemeralMessage()

// response.edit { /* ... */ }  <- using this before followup would make it safe

val followup: PublicFollowupMessage = response.followUp { /* ... */ }

followup.delete() // this line will throw an exception, it tries to delete the ephemeral original interaction response
```
The reason for this is that when a followup message is sent after an inital interaction response with type [`DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE`](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-interaction-callback-type) (`deferEphemeralMessage()`) but before using [Edit Original Interaction Response](https://discord.com/developers/docs/interactions/receiving-and-responding#edit-original-interaction-response) to stop the loading animation (`edit()`), it takes the place of the original interaction response and ignores the visibility of the followup completely.
This way you end up with an `FollowupMessage` object (with a possibly wrong visibility) when you should actually have an `MessageInteractionResponseBehavior`.

## The solution

To avoid these unclear followup semantics for deferred interaction responses, this PR adds an extra step when working with them. It will now be always required to call the [Edit Original Interaction Response](https://discord.com/developers/docs/interactions/receiving-and-responding#edit-original-interaction-response) endpoint before being able to use followups.

The example from above will now look something like this:
```kotlin
// the `deferred` handle has no support for followups
val deferred: DeferredEphemeralMessageInteractionResponseBehavior = interaction.deferEphemeralResponse()

// sending the original response will return a handle that supports followups
val response: EphemeralMessageInteractionResponse = deferred.respond { /* ... */ }

val followup: PublicFollowupMessage = response.followUpPublic { /* ... */ }

followup.delete() // this now works
```
As you can see this is very similar to the first example but now the user is forced to call the equivalent for `response.edit { /* ... */ }` to be able to send followups.

#### Changes made to make it safe
* deprecate `defer[Public|Ephemeral]Message()` and replace them with `defer[Public|Ephemeral]Response()` that return the new `Deferred[Public|Ephemeral]MessageInteractionResponseBehavior` type
* add `Deferred[Public|Ephemeral]MessageInteractionResponseBehavior.respond()` that essentially does the same as `MessageInteractionResponse.edit()` (also takes the same builder type) but has a more accurate name, this 'edit' actually stops the loading animation and responds with the initial response message
* the public variation of `DeferredMessageInteractionResponseBehavior` also has a `delete()` method that just stops the loading animation without responding, this is not available for ephemerals
* the new `DeferredMessageInteractionResponseBehavior` does not support followup messages but extends `InteractionResponseBehavior` (the type the followup functions were defined on), deprecate those and move them into the new type `FollowupableInteractionResponseBehavior` instead, this is now the supertype of every `InteractionResponseBehavior` that still supports followups

## Other changes
* add `MessageInteractionResponse` (and public/ephemeral variation) that extends `MessageInteractionResponseBehavior` and also holds a `Message` (analogous to `FollowupMessage` and `FollowupMessageBehavior`)
* `MessageInteractionResponseBehavior.edit()` now returns the new `MessageInteractionResponse` instead of `Message` (the `Message` is still available via the `message` property)
* change the return type of `PublicMessageInteractionResponseBehavior.delete()` from `Unit` to `FollowupableInteractionResponseBehavior`, it can still be used to send followups, operations on the original message are no longer possible
* documentation