### PR TITLE
Small cleanup

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -17,7 +17,6 @@ dependencies {
     api(libs.kord.cache.api)
     api(libs.kord.cache.map)
 
-    @Suppress("UnstableApiUsage")
     samplesImplementation(libs.slf4j.simple)
     testImplementation(libs.mockk)
     testImplementation(libs.bundles.test.implementation)

--- a/core/src/main/kotlin/Util.kt
+++ b/core/src/main/kotlin/Util.kt
@@ -26,6 +26,7 @@ import kotlinx.datetime.Instant
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 import kotlin.reflect.KClass
+import kotlinx.coroutines.flow.firstOrNull as coroutinesFirstOrNull
 
 internal fun Long.toInstant() = Instant.fromEpochMilliseconds(this)
 
@@ -57,10 +58,15 @@ internal inline fun <T> catchDiscordError(vararg codes: JsonErrorCode, block: ()
 }
 
 
-public fun <T : Entity> Flow<T>.sorted(): Flow<T> = flow {
-    for (entity in toList().sorted()) {
-        emit(entity)
-    }
+@Deprecated(
+    "This is an internal utility function.",
+    ReplaceWith("this.toList().sorted()", "kotlinx.coroutines.flow.toList"),
+)
+public fun <T : Entity> Flow<T>.sorted(): Flow<T> = internalSorted()
+
+// TODO rename to `sorted` once the public version is fully deprecated and removed, use import alias for now
+internal fun <T : Comparable<T>> Flow<T>.internalSorted(): Flow<T> = flow {
+    toList().sorted().forEach { emit(it) }
 }
 
 /**
@@ -68,15 +74,32 @@ public fun <T : Entity> Flow<T>.sorted(): Flow<T> = flow {
  * and then cancels flow's collection.
  * Returns `null` if the flow was empty.
  */
+@Deprecated(
+    "Use the function with the same name from kotlinx.coroutines.flow instead.",
+    ReplaceWith("this.firstOrNull(predicate)", "kotlinx.coroutines.flow.firstOrNull"),
+)
 public suspend inline fun <T : Any> Flow<T>.firstOrNull(crossinline predicate: suspend (T) -> Boolean): T? =
-    filter { predicate(it) }.firstOrNull()
+    filter { predicate(it) }.coroutinesFirstOrNull()
 
 /**
  * The terminal operator that returns `true` if any of the elements match [predicate].
  * The flow's collection is cancelled when a match is found.
  */
+@Suppress("DEPRECATION")
+@Deprecated(
+    "This is an internal utility function.",
+    ReplaceWith("this.firstOrNull(predicate) != null", "kotlinx.coroutines.flow.firstOrNull"),
+)
 public suspend inline fun <T : Any> Flow<T>.any(crossinline predicate: suspend (T) -> Boolean): Boolean =
     firstOrNull(predicate) != null
+
+// TODO rename this to `any` once the public version is fully deprecated and removed, use import alias for now
+/**
+ * The terminal operator that returns `true` if any of the elements match [predicate].
+ * The flow's collection is cancelled when a match is found.
+ */
+internal suspend inline fun <T : Any> Flow<T>.internalAny(crossinline predicate: suspend (T) -> Boolean): Boolean =
+    coroutinesFirstOrNull { predicate(it) } != null
 
 /**
  * The non-terminal operator that returns a new flow that will emit values of the second [flow] only after the first

--- a/core/src/main/kotlin/Util.kt
+++ b/core/src/main/kotlin/Util.kt
@@ -27,17 +27,6 @@ import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 import kotlin.reflect.KClass
 
-internal fun String?.toSnowflakeOrNull(): Snowflake? = when {
-    this == null -> null
-    else -> Snowflake(this)
-}
-
-internal fun ULong?.toSnowflakeOrNull(): Snowflake? = when {
-    this == null -> null
-    else -> Snowflake(this)
-}
-
-internal fun Int.toInstant() = Instant.fromEpochMilliseconds(toLong())
 internal fun Long.toInstant() = Instant.fromEpochMilliseconds(this)
 
 internal inline fun <T> catchNotFound(block: () -> T): T? {

--- a/core/src/main/kotlin/Util.kt
+++ b/core/src/main/kotlin/Util.kt
@@ -61,6 +61,7 @@ internal inline fun <T> catchDiscordError(vararg codes: JsonErrorCode, block: ()
 @Deprecated(
     "This is an internal utility function.",
     ReplaceWith("this.toList().sorted()", "kotlinx.coroutines.flow.toList"),
+    DeprecationLevel.ERROR,
 )
 public fun <T : Entity> Flow<T>.sorted(): Flow<T> = internalSorted()
 
@@ -77,6 +78,7 @@ internal fun <T : Comparable<T>> Flow<T>.internalSorted(): Flow<T> = flow {
 @Deprecated(
     "Use the function with the same name from kotlinx.coroutines.flow instead.",
     ReplaceWith("this.firstOrNull(predicate)", "kotlinx.coroutines.flow.firstOrNull"),
+    DeprecationLevel.ERROR,
 )
 public suspend inline fun <T : Any> Flow<T>.firstOrNull(crossinline predicate: suspend (T) -> Boolean): T? =
     filter { predicate(it) }.coroutinesFirstOrNull()
@@ -89,9 +91,10 @@ public suspend inline fun <T : Any> Flow<T>.firstOrNull(crossinline predicate: s
 @Deprecated(
     "This is an internal utility function.",
     ReplaceWith("this.firstOrNull(predicate) != null", "kotlinx.coroutines.flow.firstOrNull"),
+    DeprecationLevel.ERROR,
 )
 public suspend inline fun <T : Any> Flow<T>.any(crossinline predicate: suspend (T) -> Boolean): Boolean =
-    firstOrNull(predicate) != null
+    coroutinesFirstOrNull { predicate(it) } != null
 
 // TODO rename this to `any` once the public version is fully deprecated and removed, use import alias for now
 /**

--- a/core/src/main/kotlin/behavior/GuildBehavior.kt
+++ b/core/src/main/kotlin/behavior/GuildBehavior.kt
@@ -23,7 +23,6 @@ import dev.kord.core.entity.channel.*
 import dev.kord.core.entity.channel.thread.ThreadChannel
 import dev.kord.core.event.guild.MembersChunkEvent
 import dev.kord.core.exception.EntityNotFoundException
-import dev.kord.core.sorted
 import dev.kord.core.supplier.*
 import dev.kord.core.supplier.EntitySupplyStrategy.Companion.rest
 import dev.kord.gateway.Gateway
@@ -32,6 +31,7 @@ import dev.kord.gateway.RequestGuildMembers
 import dev.kord.gateway.builder.RequestGuildMembersBuilder
 import dev.kord.gateway.start
 import dev.kord.rest.Image
+import kotlinx.coroutines.flow.toList
 import dev.kord.rest.NamedFile
 import dev.kord.rest.builder.auditlog.AuditLogGetRequestBuilder
 import dev.kord.rest.builder.ban.BanCreateBuilder
@@ -87,7 +87,7 @@ public interface GuildBehavior : KordEntity, Strategizable {
 
     /**
      * Requests to get all present channels in this guild in an unspecified order,
-     * call [sorted] to get a consistent order.
+     * call [toList()][toList].[sorted()][sorted] on the returned [Flow] to get a consistent order.
      *
      * The returned flow is lazily executed, any [RequestException] will be thrown on
      * [terminal operators](https://kotlinlang.org/docs/reference/coroutines/flow.html#terminal-flow-operators) instead.
@@ -880,7 +880,8 @@ public suspend inline fun GuildBehavior.swapChannelPositions(builder: GuildChann
  *
  * This request will execute regardless of the consumption of the return value.
  *
- * @return the roles of this guild after the update in an unspecified order, call [sorted] to get a consistent order.
+ * @return the roles of this guild after the update in an unspecified order, call [toList()][toList].[sorted()][sorted]
+ * on the returned [Flow] to get a consistent order.
  *
  * @throws [RestRequestException] if something went wrong during the request.
  */

--- a/core/src/main/kotlin/behavior/RoleBehavior.kt
+++ b/core/src/main/kotlin/behavior/RoleBehavior.kt
@@ -9,7 +9,6 @@ import dev.kord.core.entity.Role
 import dev.kord.core.entity.Strategizable
 import dev.kord.core.exception.EntityNotFoundException
 import dev.kord.core.indexOfFirstOrNull
-import dev.kord.core.sorted
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 import dev.kord.rest.builder.role.RoleModifyBuilder
@@ -20,6 +19,7 @@ import kotlinx.coroutines.flow.map
 import java.util.*
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
+import dev.kord.core.internalSorted as sorted
 
 /**
  * The behavior of a [Discord Role](https://discord.com/developers/docs/topics/permissions#role-object) associated to a [guild].

--- a/core/src/main/kotlin/entity/VoiceState.kt
+++ b/core/src/main/kotlin/entity/VoiceState.kt
@@ -2,16 +2,16 @@ package dev.kord.core.entity
 
 import dev.kord.common.annotation.DeprecatedSinceKord
 import dev.kord.common.entity.Snowflake
+import dev.kord.common.exception.RequestException
 import dev.kord.core.Kord
 import dev.kord.core.KordObject
 import dev.kord.core.behavior.channel.BaseVoiceChannelBehavior
 import dev.kord.core.cache.data.VoiceStateData
 import dev.kord.core.entity.channel.VoiceChannel
+import dev.kord.core.exception.EntityNotFoundException
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
-import dev.kord.core.supplier.getChannelOf
 import dev.kord.core.supplier.getChannelOfOrNull
-import dev.kord.core.toSnowflakeOrNull
 
 public class VoiceState(
     public val data: VoiceStateData,
@@ -57,8 +57,7 @@ public class VoiceState(
     public suspend fun getChannel(): BaseVoiceChannelBehavior? = channelId?.let { supplier.getChannelOfOrNull(it) }
 
     /**
-     * Requests to get the voice channel through the [strategy],
-     * returns null if the [VoiceChannel] isn't present.
+     * Requests to get the voice channel, returns null if the [VoiceChannel] isn't present.
      *
      * @throws [RequestException] if anything went wrong during the request.
      */

--- a/core/src/main/kotlin/entity/channel/VoiceChannel.kt
+++ b/core/src/main/kotlin/entity/channel/VoiceChannel.kt
@@ -9,13 +9,10 @@ import dev.kord.core.behavior.channel.VoiceChannelBehavior
 import dev.kord.core.cache.data.ChannelData
 import dev.kord.core.entity.Region
 import dev.kord.core.exception.EntityNotFoundException
-import dev.kord.core.exception.GatewayNotFoundException
-import dev.kord.core.firstOrNull
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
-import dev.kord.voice.VoiceConnection
-import dev.kord.voice.VoiceConnectionBuilder
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 import java.util.*
 
 /**
@@ -64,13 +61,13 @@ public class VoiceChannel(
     /**
      * returns a new [VoiceChannel] with the given [strategy].
      *
-     * @param strategy the strategy to use for the new instance. By default [EntitySupplyStrategy.CacheWithRestFallback].
+     * @param strategy the strategy to use for the new instance. By default [EntitySupplyStrategy.cacheWithRestFallback].
      */
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): VoiceChannel =
         VoiceChannel(data, kord, strategy.supply(kord))
 
     override suspend fun asChannel(): VoiceChannel = this
-    
+
     override suspend fun asChannelOrNull(): VoiceChannel = this
 
     override fun hashCode(): Int = Objects.hash(id, guildId)

--- a/core/src/main/kotlin/supplier/CacheEntitySupplier.kt
+++ b/core/src/main/kotlin/supplier/CacheEntitySupplier.kt
@@ -7,7 +7,6 @@ import dev.kord.common.entity.Snowflake
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.exception.RequestException
 import dev.kord.core.Kord
-import dev.kord.core.any
 import dev.kord.core.cache.data.*
 import dev.kord.core.cache.idEq
 import dev.kord.core.cache.idGt
@@ -26,6 +25,7 @@ import dev.kord.gateway.Gateway
 import kotlinx.coroutines.flow.*
 import kotlinx.datetime.Instant
 import kotlinx.datetime.toInstant
+import dev.kord.core.internalAny as any
 
 /**
  * [EntitySupplier] that uses a [DataCache] to resolve entities.

--- a/gateway/src/main/kotlin/Event.kt
+++ b/gateway/src/main/kotlin/Event.kt
@@ -52,12 +52,9 @@ public sealed class Event {
         override fun deserialize(decoder: Decoder): Event? {
             var op: OpCode? = null
             var data: Event? = null
+            var sequence: Int? = null
+            var eventName: String? = null
 
-            @Suppress("UNUSED_VARIABLE")
-            var sequence: Int? = null //this isn't actually unused but seems to be a compiler bug
-
-            @Suppress("UNUSED_VARIABLE")
-            var eventName: String? = null //this isn't actually unused but seems to be a compiler bug
             with(decoder.beginStructure(descriptor)) {
                 loop@ while (true) {
                     when (val index =
@@ -65,7 +62,6 @@ public sealed class Event {
                         CompositeDecoder.DECODE_DONE -> break@loop
                         0 -> {
                             op = OpCode.serializer().deserialize(decoder)
-                            @Suppress("NON_EXHAUSTIVE_WHEN")
                             when (op) {
                                 OpCode.HeartbeatACK -> data = HeartbeatACK
                                 OpCode.Reconnect -> data = Reconnect


### PR DESCRIPTION
* remove unused internal `toSnowflakeOrNull()` and `toInstant()` functions
* deprecate public utility functions that seem like they should be internal (generic flow operators are not a thing that kord advertises)
* remove some unnecessary `@Suppress` annotations