### PR TITLE
Update `enableEvent()`

### DIFF
--- a/core/src/main/kotlin/Util.kt
+++ b/core/src/main/kotlin/Util.kt
@@ -1,11 +1,13 @@
 package dev.kord.core
 
+import dev.kord.common.annotation.KordPreview
 import dev.kord.common.entity.Snowflake
 import dev.kord.core.entity.Entity
 import dev.kord.core.entity.KordEntity
 import dev.kord.core.entity.channel.thread.ThreadChannel
 import dev.kord.core.event.Event
 import dev.kord.core.event.channel.*
+import dev.kord.core.event.channel.thread.*
 import dev.kord.core.event.guild.*
 import dev.kord.core.event.message.*
 import dev.kord.core.event.role.RoleCreateEvent
@@ -305,9 +307,15 @@ public inline fun <reified T : Event> Intents.IntentsBuilder.enableEvent(): Unit
 public fun Intents.IntentsBuilder.enableEvents(events: Iterable<KClass<out Event>>): Unit = events.forEach { enableEvent(it) }
 public fun Intents.IntentsBuilder.enableEvents(vararg events: KClass<out Event>): Unit = events.forEach { enableEvent(it) }
 
-@OptIn(PrivilegedIntent::class)
+@OptIn(PrivilegedIntent::class, KordPreview::class)
 public fun Intents.IntentsBuilder.enableEvent(event: KClass<out Event>): Unit = when (event) {
+
+    /*
+     * events requiring a single intent:
+     */
+
     GuildCreateEvent::class,
+    GuildUpdateEvent::class,
     GuildDeleteEvent::class,
     RoleCreateEvent::class,
     RoleUpdateEvent::class,
@@ -317,31 +325,52 @@ public fun Intents.IntentsBuilder.enableEvent(event: KClass<out Event>): Unit = 
     CategoryCreateEvent::class,
     DMChannelCreateEvent::class,
     NewsChannelCreateEvent::class,
+    StageChannelCreateEvent::class,
     StoreChannelCreateEvent::class,
     TextChannelCreateEvent::class,
+    UnknownChannelCreateEvent::class,
     VoiceChannelCreateEvent::class,
 
     ChannelUpdateEvent::class,
     CategoryUpdateEvent::class,
     DMChannelUpdateEvent::class,
     NewsChannelUpdateEvent::class,
+    StageChannelUpdateEvent::class,
     StoreChannelUpdateEvent::class,
     TextChannelUpdateEvent::class,
+    UnknownChannelUpdateEvent::class,
     VoiceChannelUpdateEvent::class,
 
     ChannelDeleteEvent::class,
     CategoryDeleteEvent::class,
     DMChannelDeleteEvent::class,
     NewsChannelDeleteEvent::class,
+    StageChannelDeleteEvent::class,
     StoreChannelDeleteEvent::class,
     TextChannelDeleteEvent::class,
+    UnknownChannelDeleteEvent::class,
     VoiceChannelDeleteEvent::class,
 
-    ChannelPinsUpdateEvent::class,
-    -> {
-        +Guilds
-        +DirectMessages
-    }
+    ThreadChannelCreateEvent::class,
+    NewsChannelThreadCreateEvent::class,
+    TextChannelThreadCreateEvent::class,
+    UnknownChannelThreadCreateEvent::class,
+
+    ThreadUpdateEvent::class,
+    NewsChannelThreadUpdateEvent::class,
+    TextChannelThreadUpdateEvent::class,
+    UnknownChannelThreadUpdateEvent::class,
+
+    ThreadChannelDeleteEvent::class,
+    NewsChannelThreadDeleteEvent::class,
+    TextChannelThreadDeleteEvent::class,
+    UnknownChannelThreadDeleteEvent::class,
+
+    ThreadListSyncEvent::class,
+
+    ThreadMemberUpdateEvent::class,
+    -> +Guilds
+
 
     MemberJoinEvent::class, MemberUpdateEvent::class, MemberLeaveEvent::class -> +GuildMembers
 
@@ -359,6 +388,35 @@ public fun Intents.IntentsBuilder.enableEvent(event: KClass<out Event>): Unit = 
 
     PresenceUpdateEvent::class -> +GuildPresences
 
+
+    MessageBulkDeleteEvent::class -> +GuildMessages
+
+
+    GuildScheduledEventEvent::class,
+    GuildScheduledEventCreateEvent::class,
+    GuildScheduledEventUpdateEvent::class,
+    GuildScheduledEventDeleteEvent::class,
+
+    GuildScheduledEventUserEvent::class,
+    GuildScheduledEventUserAddEvent::class,
+    GuildScheduledEventUserRemoveEvent::class,
+    -> +GuildScheduledEvents
+
+
+    /*
+     * events requiring multiple intents:
+     */
+
+    ChannelPinsUpdateEvent::class -> {
+        +Guilds
+        +DirectMessages
+    }
+
+    ThreadMembersUpdateEvent::class -> {
+        +Guilds
+        +GuildMembers
+    }
+
     MessageCreateEvent::class, MessageUpdateEvent::class, MessageDelete::class -> {
         +GuildMessages
         +DirectMessages
@@ -369,7 +427,11 @@ public fun Intents.IntentsBuilder.enableEvent(event: KClass<out Event>): Unit = 
         +DirectMessagesReactions
     }
 
-    TypingStartEvent::class -> +GuildMessageTyping
+    TypingStartEvent::class -> {
+        +GuildMessageTyping
+        +DirectMessageTyping
+    }
+
 
     else -> Unit
 

--- a/core/src/main/kotlin/Util.kt
+++ b/core/src/main/kotlin/Util.kt
@@ -313,6 +313,7 @@ public fun Intents.IntentsBuilder.enableEvents(vararg events: KClass<out Event>)
 
 @OptIn(PrivilegedIntent::class, KordPreview::class)
 public fun Intents.IntentsBuilder.enableEvent(event: KClass<out Event>): Unit = when (event) {
+// see https://discord.com/developers/docs/topics/gateway#list-of-intents
 
     /*
      * events requiring a single intent:

--- a/core/src/main/kotlin/Util.kt
+++ b/core/src/main/kotlin/Util.kt
@@ -302,10 +302,14 @@ internal fun paginateThreads(
     request,
 )
 
+
 public inline fun <reified T : Event> Intents.IntentsBuilder.enableEvent(): Unit = enableEvent(T::class)
 
-public fun Intents.IntentsBuilder.enableEvents(events: Iterable<KClass<out Event>>): Unit = events.forEach { enableEvent(it) }
-public fun Intents.IntentsBuilder.enableEvents(vararg events: KClass<out Event>): Unit = events.forEach { enableEvent(it) }
+public fun Intents.IntentsBuilder.enableEvents(events: Iterable<KClass<out Event>>): Unit =
+    events.forEach { enableEvent(it) }
+
+public fun Intents.IntentsBuilder.enableEvents(vararg events: KClass<out Event>): Unit =
+    events.forEach { enableEvent(it) }
 
 @OptIn(PrivilegedIntent::class, KordPreview::class)
 public fun Intents.IntentsBuilder.enableEvent(event: KClass<out Event>): Unit = when (event) {
@@ -317,6 +321,7 @@ public fun Intents.IntentsBuilder.enableEvent(event: KClass<out Event>): Unit = 
     GuildCreateEvent::class,
     GuildUpdateEvent::class,
     GuildDeleteEvent::class,
+
     RoleCreateEvent::class,
     RoleUpdateEvent::class,
     RoleDeleteEvent::class,
@@ -374,17 +379,24 @@ public fun Intents.IntentsBuilder.enableEvent(event: KClass<out Event>): Unit = 
 
     MemberJoinEvent::class, MemberUpdateEvent::class, MemberLeaveEvent::class -> +GuildMembers
 
+
     BanAddEvent::class, BanRemoveEvent::class -> +GuildBans
+
 
     EmojisUpdateEvent::class -> +GuildEmojis
 
+
     IntegrationsUpdateEvent::class -> +GuildIntegrations
+
 
     WebhookUpdateEvent::class -> +GuildWebhooks
 
+
     InviteCreateEvent::class, InviteDeleteEvent::class -> +GuildInvites
 
+
     VoiceStateUpdateEvent::class -> +GuildVoiceStates
+
 
     PresenceUpdateEvent::class -> +GuildPresences
 
@@ -434,5 +446,4 @@ public fun Intents.IntentsBuilder.enableEvent(event: KClass<out Event>): Unit = 
 
 
     else -> Unit
-
 }

--- a/core/src/main/kotlin/Util.kt
+++ b/core/src/main/kotlin/Util.kt
@@ -16,6 +16,7 @@ import dev.kord.core.event.role.RoleUpdateEvent
 import dev.kord.core.event.user.PresenceUpdateEvent
 import dev.kord.core.event.user.VoiceStateUpdateEvent
 import dev.kord.gateway.Intent.*
+import dev.kord.gateway.Intent
 import dev.kord.gateway.Intents
 import dev.kord.gateway.MessageDelete
 import dev.kord.gateway.PrivilegedIntent
@@ -303,14 +304,38 @@ internal fun paginateThreads(
 )
 
 
+/**
+ * Adds the necessary [Intent]s to receive the specified type of event.
+ *
+ * Might add multiple intents if this is required to receive all events e.g. [MessageCreateEvent] will add the
+ * [GuildMessages] and [DirectMessages] intents to receive messages in Guilds and DMs.
+ */
 public inline fun <reified T : Event> Intents.IntentsBuilder.enableEvent(): Unit = enableEvent(T::class)
 
+/**
+ * Adds the necessary [Intent]s to receive the specified types of [events].
+ *
+ * Might add multiple intents if this is required to receive all events e.g. [MessageCreateEvent] will add the
+ * [GuildMessages] and [DirectMessages] intents to receive messages in Guilds and DMs.
+ */
 public fun Intents.IntentsBuilder.enableEvents(events: Iterable<KClass<out Event>>): Unit =
     events.forEach { enableEvent(it) }
 
+/**
+ * Adds the necessary [Intent]s to receive the specified types of [events].
+ *
+ * Might add multiple intents if this is required to receive all events e.g. [MessageCreateEvent] will add the
+ * [GuildMessages] and [DirectMessages] intents to receive messages in Guilds and DMs.
+ */
 public fun Intents.IntentsBuilder.enableEvents(vararg events: KClass<out Event>): Unit =
     events.forEach { enableEvent(it) }
 
+/**
+ * Adds the necessary [Intent]s to receive the specified type of [event].
+ *
+ * Might add multiple intents if this is required to receive all events e.g. [MessageCreateEvent] will add the
+ * [GuildMessages] and [DirectMessages] intents to receive messages in Guilds and DMs.
+ */
 @OptIn(PrivilegedIntent::class, KordPreview::class)
 public fun Intents.IntentsBuilder.enableEvent(event: KClass<out Event>): Unit = when (event) {
 // see https://discord.com/developers/docs/topics/gateway#list-of-intents

--- a/gateway/src/main/kotlin/Intent.kt
+++ b/gateway/src/main/kotlin/Intent.kt
@@ -30,7 +30,8 @@ import kotlin.contracts.contract
 public annotation class PrivilegedIntent
 
 /**
- * Values that enable a group of events as [defined by Discord](https://github.com/discord/discord-api-docs/blob/feature/gateway-intents/docs/topics/Gateway.md#gateway-intents).
+ * Values that enable a group of events as
+ * [defined by Discord](https://discord.com/developers/docs/topics/gateway#gateway-intents).
  */
 public sealed class Intent(public val code: DiscordBitSet) {
     protected constructor(vararg code: Long) : this(DiscordBitSet(code))
@@ -39,6 +40,7 @@ public sealed class Intent(public val code: DiscordBitSet) {
     /**
      * Enables the following events:
      * - [GuildCreate]
+     * - [GuildUpdate]
      * - [GuildDelete]
      * - [GuildRoleCreate]
      * - [GuildRoleUpdate]
@@ -47,6 +49,13 @@ public sealed class Intent(public val code: DiscordBitSet) {
      * - [ChannelUpdate]
      * - [ChannelDelete]
      * - [ChannelPinsUpdate]
+     * - [ThreadCreate]
+     * - [ThreadUpdate]
+     * - [ThreadDelete]
+     * - [ThreadListSync]
+     * - [ThreadMemberUpdate]
+     * - [ThreadMembersUpdate] (contains different data depending on which intents are used, see
+     * [here](https://discord.com/developers/docs/topics/gateway#thread-members-update))
      */
     public object Guilds : Intent(1 shl 0)
 
@@ -55,6 +64,8 @@ public sealed class Intent(public val code: DiscordBitSet) {
      * - [GuildMemberAdd]
      * - [GuildMemberUpdate]
      * - [GuildMemberRemove]
+     * - [ThreadMembersUpdate] (contains different data depending on which intents are used, see
+     * [here](https://discord.com/developers/docs/topics/gateway#thread-members-update))
      */
     @PrivilegedIntent
     public object GuildMembers : Intent(1 shl 1)
@@ -86,8 +97,8 @@ public sealed class Intent(public val code: DiscordBitSet) {
 
     /**
      * Enables the following events:
-     * - INVITE_CREATE
-     * - INVITE_DELETE
+     * - [InviteCreate]
+     * - [InviteDelete]
      */
     public object GuildInvites : Intent(1 shl 6)
 
@@ -118,7 +129,7 @@ public sealed class Intent(public val code: DiscordBitSet) {
      * - [MessageReactionAdd]
      * - [MessageReactionRemove]
      * - [MessageReactionRemoveAll]
-     * - MESSAGE_REACTION_REMOVE_EMOJI
+     * - [MessageReactionRemoveEmoji]
      */
     public object GuildMessageReactions : Intent(1 shl 10)
 
@@ -130,10 +141,10 @@ public sealed class Intent(public val code: DiscordBitSet) {
 
     /**
      * Enables the following events:
-     * - [ChannelCreate]
-     * - [ChannelDelete]
+     * - [MessageCreate]
      * - [MessageUpdate]
      * - [MessageDelete]
+     * - [ChannelPinsUpdate]
      */
     public object DirectMessages : Intent(1 shl 12)
 
@@ -142,7 +153,7 @@ public sealed class Intent(public val code: DiscordBitSet) {
      * - [MessageReactionAdd]
      * - [MessageReactionRemove]
      * - [MessageReactionRemoveAll]
-     * - MESSAGE_REACTION_REMOVE_EMOJI
+     * - [MessageReactionRemoveEmoji]
      */
     public object DirectMessagesReactions : Intent(1 shl 13)
 

--- a/gateway/src/main/kotlin/builder/LoginBuilder.kt
+++ b/gateway/src/main/kotlin/builder/LoginBuilder.kt
@@ -15,8 +15,13 @@ public class LoginBuilder {
     public var intents: Intents = Intents.nonPrivileged
     public var name: String = "Kord"
 
-    public fun presence(builder: PresenceBuilder.() -> Unit) {
+    public inline fun presence(builder: PresenceBuilder.() -> Unit) {
         contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
         this.presence = PresenceBuilder().apply(builder).toPresence()
+    }
+
+    public inline fun intents(builder: Intents.IntentsBuilder.() -> Unit) {
+        contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
+        this.intents = Intents(builder)
     }
 }


### PR DESCRIPTION
Updates the extension function `enableEvents()` for `Intents.IntentsBuilder` to support all new events that were added to Kord to match [this list](https://discord.com/developers/docs/topics/gateway#list-of-intents).

This also includes little fixes:
- the `DirectMessages` intent will no longer be added to events that only need the `Guilds` intent
- `TypingStartEvent` will now add both `GuildMessageTyping` and `DirectMessageTyping`

Other changes:
- add `LoginBuilder.intents()` convenience function