### PR TITLE
Use gateway v10

### DIFF
--- a/core/src/main/kotlin/Util.kt
+++ b/core/src/main/kotlin/Util.kt
@@ -310,6 +310,9 @@ internal fun paginateThreads(
  *
  * E.g. [MessageCreateEvent] will add the [GuildMessages], [DirectMessages] and [MessageContent] intents to receive
  * messages in Guilds and DMs with the full [content][Message.content].
+ *
+ * Note that enabling one type of event might also enable several other types of events since most [Intent]s enable more
+ * than one event.
  */
 public inline fun <reified T : Event> Intents.IntentsBuilder.enableEvent(): Unit = enableEvent(T::class)
 
@@ -319,6 +322,9 @@ public inline fun <reified T : Event> Intents.IntentsBuilder.enableEvent(): Unit
  *
  * E.g. [MessageCreateEvent] will add the [GuildMessages], [DirectMessages] and [MessageContent] intents to receive
  * messages in Guilds and DMs with the full [content][Message.content].
+ *
+ * Note that enabling one type of event might also enable several other types of events since most [Intent]s enable more
+ * than one event.
  */
 public fun Intents.IntentsBuilder.enableEvents(events: Iterable<KClass<out Event>>): Unit =
     events.forEach { enableEvent(it) }
@@ -329,6 +335,9 @@ public fun Intents.IntentsBuilder.enableEvents(events: Iterable<KClass<out Event
  *
  * E.g. [MessageCreateEvent] will add the [GuildMessages], [DirectMessages] and [MessageContent] intents to receive
  * messages in Guilds and DMs with the full [content][Message.content].
+ *
+ * Note that enabling one type of event might also enable several other types of events since most [Intent]s enable more
+ * than one event.
  */
 public fun Intents.IntentsBuilder.enableEvents(vararg events: KClass<out Event>): Unit =
     events.forEach { enableEvent(it) }
@@ -338,6 +347,9 @@ public fun Intents.IntentsBuilder.enableEvents(vararg events: KClass<out Event>)
  *
  * E.g. [MessageCreateEvent] will add the [GuildMessages], [DirectMessages] and [MessageContent] intents to receive
  * messages in Guilds and DMs with the full [content][Message.content].
+ *
+ * Note that enabling one type of event might also enable several other types of events since most [Intent]s enable more
+ * than one event.
  */
 @OptIn(PrivilegedIntent::class, KordPreview::class)
 public fun Intents.IntentsBuilder.enableEvent(event: KClass<out Event>): Unit = when (event) {

--- a/core/src/main/kotlin/Util.kt
+++ b/core/src/main/kotlin/Util.kt
@@ -4,6 +4,7 @@ import dev.kord.common.annotation.KordPreview
 import dev.kord.common.entity.Snowflake
 import dev.kord.core.entity.Entity
 import dev.kord.core.entity.KordEntity
+import dev.kord.core.entity.Message
 import dev.kord.core.entity.channel.thread.ThreadChannel
 import dev.kord.core.event.Event
 import dev.kord.core.event.channel.*
@@ -305,36 +306,38 @@ internal fun paginateThreads(
 
 
 /**
- * Adds the necessary [Intent]s to receive the specified type of event.
+ * Adds the necessary [Intent]s to receive the specified type of event in all variations and with all data available.
  *
- * Might add multiple intents if this is required to receive all events e.g. [MessageCreateEvent] will add the
- * [GuildMessages] and [DirectMessages] intents to receive messages in Guilds and DMs.
+ * E.g. [MessageCreateEvent] will add the [GuildMessages], [DirectMessages] and [MessageContent] intents to receive
+ * messages in Guilds and DMs with the full [content][Message.content].
  */
 public inline fun <reified T : Event> Intents.IntentsBuilder.enableEvent(): Unit = enableEvent(T::class)
 
 /**
- * Adds the necessary [Intent]s to receive the specified types of [events].
+ * Adds the necessary [Intent]s to receive the specified types of [events] in all variations and with all data
+ * available.
  *
- * Might add multiple intents if this is required to receive all events e.g. [MessageCreateEvent] will add the
- * [GuildMessages] and [DirectMessages] intents to receive messages in Guilds and DMs.
+ * E.g. [MessageCreateEvent] will add the [GuildMessages], [DirectMessages] and [MessageContent] intents to receive
+ * messages in Guilds and DMs with the full [content][Message.content].
  */
 public fun Intents.IntentsBuilder.enableEvents(events: Iterable<KClass<out Event>>): Unit =
     events.forEach { enableEvent(it) }
 
 /**
- * Adds the necessary [Intent]s to receive the specified types of [events].
+ * Adds the necessary [Intent]s to receive the specified types of [events] in all variations and with all data
+ * available.
  *
- * Might add multiple intents if this is required to receive all events e.g. [MessageCreateEvent] will add the
- * [GuildMessages] and [DirectMessages] intents to receive messages in Guilds and DMs.
+ * E.g. [MessageCreateEvent] will add the [GuildMessages], [DirectMessages] and [MessageContent] intents to receive
+ * messages in Guilds and DMs with the full [content][Message.content].
  */
 public fun Intents.IntentsBuilder.enableEvents(vararg events: KClass<out Event>): Unit =
     events.forEach { enableEvent(it) }
 
 /**
- * Adds the necessary [Intent]s to receive the specified type of [event].
+ * Adds the necessary [Intent]s to receive the specified type of [event] in all variations and with all data available.
  *
- * Might add multiple intents if this is required to receive all events e.g. [MessageCreateEvent] will add the
- * [GuildMessages] and [DirectMessages] intents to receive messages in Guilds and DMs.
+ * E.g. [MessageCreateEvent] will add the [GuildMessages], [DirectMessages] and [MessageContent] intents to receive
+ * messages in Guilds and DMs with the full [content][Message.content].
  */
 @OptIn(PrivilegedIntent::class, KordPreview::class)
 public fun Intents.IntentsBuilder.enableEvent(event: KClass<out Event>): Unit = when (event) {
@@ -427,7 +430,7 @@ public fun Intents.IntentsBuilder.enableEvent(event: KClass<out Event>): Unit = 
     PresenceUpdateEvent::class -> +GuildPresences
 
 
-    MessageBulkDeleteEvent::class -> +GuildMessages
+    MessageBulkDeleteEvent::class -> +GuildMessages // no message content
 
 
     GuildScheduledEventEvent::class,
@@ -455,9 +458,16 @@ public fun Intents.IntentsBuilder.enableEvent(event: KClass<out Event>): Unit = 
         +GuildMembers
     }
 
-    MessageCreateEvent::class, MessageUpdateEvent::class, MessageDelete::class -> {
+    MessageCreateEvent::class, MessageUpdateEvent::class -> {
         +GuildMessages
         +DirectMessages
+        +MessageContent
+    }
+
+    MessageDelete::class -> {
+        +GuildMessages
+        +DirectMessages
+        // no message content
     }
 
     ReactionAddEvent::class, ReactionRemoveEvent::class, ReactionRemoveAllEvent::class, ReactionRemoveEmojiEvent::class -> {

--- a/gateway/src/main/kotlin/DefaultGatewayBuilder.kt
+++ b/gateway/src/main/kotlin/DefaultGatewayBuilder.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlin.time.Duration.Companion.seconds
 
 public class DefaultGatewayBuilder {
-    public var url: String = "wss://gateway.discord.gg/?v=9&encoding=json&compress=zlib-stream"
+    public var url: String = "wss://gateway.discord.gg/?v=10&encoding=json&compress=zlib-stream"
     public var client: HttpClient? = null
     public var reconnectRetry: Retry? = null
     public var sendRateLimiter: RateLimiter? = null


### PR DESCRIPTION
The default rest version was bumped to 10 but we missed to also bump it for gateway.

`MessageCreateEvent` and `MessageUpdateEvent` now also add the `MessageContent` intent in `enableEvent()`.