### PR TITLE
Unsafe deferred responding

### DIFF
--- a/core/src/main/kotlin/behavior/interaction/ActionInteractionBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/ActionInteractionBehavior.kt
@@ -1,5 +1,6 @@
 package dev.kord.core.behavior.interaction
 
+import dev.kord.common.annotation.KordUnsafe
 import dev.kord.common.entity.MessageFlag
 import dev.kord.common.entity.Snowflake
 import dev.kord.core.Kord
@@ -58,11 +59,31 @@ public interface ActionInteractionBehavior : InteractionBehavior {
         Deferring a response now always enforces actually responding before using followups to avoid some strange
         behavior when using followups before sending an original response.
         
+        If you need to keep using followups directly after deferring a response you can use
+        'deferEphemeralResponseUnsafe()'.
+        
         See the documentation of this method for how it should be replaced.
         """,
         ReplaceWith("this.deferEphemeralResponse()"),
     )
-    public suspend fun deferEphemeralMessage(): EphemeralMessageInteractionResponseBehavior {
+    @OptIn(KordUnsafe::class)
+    public suspend fun deferEphemeralMessage(): EphemeralMessageInteractionResponseBehavior =
+        deferEphemeralResponseUnsafe()
+
+    /**
+     * Acknowledges the interaction with the intent of responding with an [ephemeral][MessageFlag.Ephemeral] message
+     * later by calling [edit][EphemeralMessageInteractionResponseBehavior.edit] on the returned object.
+     *
+     * There will be a 'loading' animation that is only visible to the [user][Interaction.user] who invoked the
+     * interaction.
+     *
+     * This method is marked as [unsafe][KordUnsafe] since it can result in strange behavior when followups are used
+     * incorrectly, you probably want to use [deferEphemeralResponse] instead.
+     *
+     * @throws RestRequestException if something went wrong during the request.
+     */
+    @KordUnsafe
+    public suspend fun deferEphemeralResponseUnsafe(): EphemeralMessageInteractionResponseBehavior {
         kord.rest.interaction.deferMessage(id, token, ephemeral = true)
         return EphemeralMessageInteractionResponseBehavior(applicationId, token, kord)
     }
@@ -120,11 +141,30 @@ public interface ActionInteractionBehavior : InteractionBehavior {
         Deferring a response now always enforces actually responding before using followups to avoid some strange
         behavior when using followups before sending an original response.
         
+        If you need to keep using followups directly after deferring a response you can use
+        'deferPublicResponseUnsafe()'.
+        
         See the documentation of this method for how it should be replaced.
         """,
         ReplaceWith("this.deferPublicResponse()"),
     )
-    public suspend fun deferPublicMessage(): PublicMessageInteractionResponseBehavior {
+    @OptIn(KordUnsafe::class)
+    public suspend fun deferPublicMessage(): PublicMessageInteractionResponseBehavior = deferPublicResponseUnsafe()
+
+    /**
+     * Acknowledges the interaction with the intent of responding with a public message later by calling
+     * [edit][PublicMessageInteractionResponseBehavior.edit] on the returned object.
+     *
+     * There will be a 'loading' animation that is visible to all users in the [channel][InteractionBehavior.channel]
+     * the interaction was sent from.
+     *
+     * This method is marked as [unsafe][KordUnsafe] since it can result in strange behavior when followups are used
+     * incorrectly, you probably want to use [deferPublicResponse] instead.
+     *
+     * @throws RestRequestException if something went wrong during the request.
+     */
+    @KordUnsafe
+    public suspend fun deferPublicResponseUnsafe(): PublicMessageInteractionResponseBehavior {
         kord.rest.interaction.deferMessage(id, token, ephemeral = false)
         return PublicMessageInteractionResponseBehavior(applicationId, token, kord)
     }

--- a/core/src/main/kotlin/behavior/interaction/ActionInteractionBehavior.kt
+++ b/core/src/main/kotlin/behavior/interaction/ActionInteractionBehavior.kt
@@ -26,7 +26,11 @@ public interface ActionInteractionBehavior : InteractionBehavior {
      * Call [edit][EphemeralMessageInteractionResponseBehavior.edit] on the returned object to edit the response later.
      */
     @Suppress("DEPRECATION")
-    @Deprecated("Renamed to 'deferEphemeralMessage'.", ReplaceWith("this.deferEphemeralMessage()"))
+    @Deprecated(
+        "Renamed to 'deferEphemeralMessage'.",
+        ReplaceWith("this.deferEphemeralMessage()"),
+        DeprecationLevel.ERROR,
+    )
     public suspend fun acknowledgeEphemeral(): EphemeralMessageInteractionResponseBehavior = deferEphemeralMessage()
 
     /**
@@ -108,7 +112,11 @@ public interface ActionInteractionBehavior : InteractionBehavior {
      * Call [edit][PublicMessageInteractionResponseBehavior.edit] on the returned object to edit the response later.
      */
     @Suppress("DEPRECATION")
-    @Deprecated("Renamed to 'deferPublicMessage'.", ReplaceWith("this.deferPublicMessage()"))
+    @Deprecated(
+        "Renamed to 'deferPublicMessage'.",
+        ReplaceWith("this.deferPublicMessage()"),
+        DeprecationLevel.ERROR,
+    )
     public suspend fun acknowledgePublic(): PublicMessageInteractionResponseBehavior = deferPublicMessage()
 
     /**


### PR DESCRIPTION
Introduces `deferPublicResponseUnsafe()` and `deferEphemeralResponseUnsafe()` marked with `@KordUnsafe` to allow using the same operations as pre https://github.com/kordlib/kord/pull/546.

Also bumps deprecation level of `acknowledgeEphemeral` and `acknowledgePublic` to help remove them faster.