### PR TITLE
User Agent header

### DIFF
--- a/common/src/main/kotlin/KordConstants.kt
+++ b/common/src/main/kotlin/KordConstants.kt
@@ -3,5 +3,5 @@ package dev.kord.common
 public object KordConstants {
 
     /** Kord's value for the [User Agent header](https://discord.com/developers/docs/reference#user-agent). */
-    public const val UserAgent: String = "DiscordBot (https://kord.dev/, 0.8.0-M12)"
+    public const val UserAgent: String = "DiscordBot (https://github.com/kordlib/kord, 0.8.0-M12)"
 }

--- a/common/src/main/kotlin/KordConstants.kt
+++ b/common/src/main/kotlin/KordConstants.kt
@@ -1,0 +1,7 @@
+package dev.kord.common
+
+public object KordConstants {
+
+    /** Kord's value for the [User Agent header](https://discord.com/developers/docs/reference#user-agent). */
+    public const val UserAgent: String = "DiscordBot (https://kord.dev/, 0.8.0-M11)"
+}

--- a/common/src/main/kotlin/KordConstants.kt
+++ b/common/src/main/kotlin/KordConstants.kt
@@ -3,5 +3,5 @@ package dev.kord.common
 public object KordConstants {
 
     /** Kord's value for the [User Agent header](https://discord.com/developers/docs/reference#user-agent). */
-    public const val UserAgent: String = "DiscordBot (https://kord.dev/, 0.8.0-M11)"
+    public const val UserAgent: String = "DiscordBot (https://kord.dev/, 0.8.0-M12)"
 }

--- a/core/src/main/kotlin/builder/kord/KordBuilder.kt
+++ b/core/src/main/kotlin/builder/kord/KordBuilder.kt
@@ -1,6 +1,7 @@
 package dev.kord.core.builder.kord
 
 import dev.kord.cache.api.DataCache
+import dev.kord.common.KordConstants
 import dev.kord.common.entity.Snowflake
 import dev.kord.common.ratelimit.BucketRateLimiter
 import dev.kord.core.ClientResources
@@ -30,6 +31,7 @@ import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.http.HttpHeaders.Authorization
+import io.ktor.http.HttpHeaders.UserAgent
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -185,6 +187,7 @@ public class KordBuilder(public val token: String) {
      */
     private suspend fun HttpClient.getGatewayInfo(): BotGatewayResponse {
         val response = get<HttpResponse>("${Route.baseUrl}${Route.GatewayBotGet.path}") {
+            header(UserAgent, KordConstants.UserAgent)
             header(Authorization, "Bot $token")
         }
         val responseBody = response.readText()

--- a/rest/src/main/kotlin/service/RestService.kt
+++ b/rest/src/main/kotlin/service/RestService.kt
@@ -1,9 +1,11 @@
 package dev.kord.rest.service
 
+import dev.kord.common.KordConstants
 import dev.kord.rest.request.RequestBuilder
 import dev.kord.rest.request.RequestHandler
 import dev.kord.rest.route.Route
 import io.ktor.http.HttpHeaders.Authorization
+import io.ktor.http.HttpHeaders.UserAgent
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -17,6 +19,7 @@ public abstract class RestService(@PublishedApi internal val requestHandler: Req
         val request = RequestBuilder(route)
             .apply(builder)
             .apply {
+                unencodedHeader(UserAgent, KordConstants.UserAgent)
                 if (route.requiresAuthorizationHeader) {
                     unencodedHeader(Authorization, "Bot ${requestHandler.token}")
                 }


### PR DESCRIPTION
Discord's documentation states that "clients using the HTTP API must provide a valid User Agent" (https://discord.com/developers/docs/reference#user-agent) but Kord currently does not provide this header.

This PR adds this header.