### PR TITLE
Audit Log Change Key "type" can have integer or string values

### DIFF
--- a/common/src/main/kotlin/entity/AuditLog.kt
+++ b/common/src/main/kotlin/entity/AuditLog.kt
@@ -309,10 +309,18 @@ public sealed class AuditLogChangeKey<T>(public val name: String, public val ser
         private object IntOrStringSerializer : KSerializer<String> {
             private val backingSerializer = JsonPrimitive.serializer()
 
-            @OptIn(ExperimentalSerializationApi::class)
-            override val descriptor = SerialDescriptor(
+            /*
+             * Delegating serializers should not reuse descriptors:
+             * https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/serializers.md#delegating-serializers
+             *
+             * however `SerialDescriptor("...", backingSerializer.descriptor)` will throw since
+             * `JsonPrimitive.serializer().kind` is `PrimitiveKind.STRING` (`SerialDescriptor()` does not allow
+             * `PrimitiveKind`)
+             * -> use `PrimitiveSerialDescriptor("...", PrimitiveKind.STRING)` instead
+             */
+            override val descriptor = PrimitiveSerialDescriptor(
                 serialName = "dev.kord.common.entity.AuditLogChangeKey.Type.IntOrString",
-                original = backingSerializer.descriptor,
+                PrimitiveKind.STRING,
             )
 
             override fun serialize(encoder: Encoder, value: String) {

--- a/common/src/main/kotlin/entity/AuditLog.kt
+++ b/common/src/main/kotlin/entity/AuditLog.kt
@@ -309,7 +309,11 @@ public sealed class AuditLogChangeKey<T>(public val name: String, public val ser
         private object IntOrStringSerializer : KSerializer<String> {
             private val backingSerializer = JsonPrimitive.serializer()
 
-            override val descriptor: SerialDescriptor get() = backingSerializer.descriptor
+            @OptIn(ExperimentalSerializationApi::class)
+            override val descriptor = SerialDescriptor(
+                serialName = "dev.kord.common.entity.AuditLogChangeKey.Type.IntOrString",
+                original = backingSerializer.descriptor,
+            )
 
             override fun serialize(encoder: Encoder, value: String) {
                 val jsonPrimitive = value.toIntOrNull()?.let { JsonPrimitive(it) } ?: JsonPrimitive(value)


### PR DESCRIPTION
In the case of some audit log events (e.g. `action_type` 80: `INTEGRATION_CREATE`) Audit Log Change for key `type` is of type string, in some other audit log events (e.g. `action_type` 13: `CHANNEL_OVERWRITE_CREATE`) Audit Log Change for key `type` is of type integer (see the [list of Audit Log Change Keys](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-change-key) for key name `type`).

This is the only Audit Log Change Key that can have different types for its value.