### PR TITLE
Changes of latest docs commits

### DIFF
--- a/common/src/main/kotlin/entity/DiscordGuild.kt
+++ b/common/src/main/kotlin/entity/DiscordGuild.kt
@@ -4,6 +4,7 @@ import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
 import dev.kord.common.entity.optional.OptionalInt
 import dev.kord.common.entity.optional.OptionalSnowflake
+import kotlinx.datetime.Instant
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -364,23 +365,24 @@ public data class DiscordWebhooksUpdateData(
  * A representation of the [Discord Voice State structure](https://discord.com/developers/docs/resources/voice#voice-state-object).
  * Used to represent a user's voice connection status.
  *
- * @param guildId the guild id this voice state is for.
- * @param channelId the channel id this user is connection to.
+ * @param guildId The guild id this voice state is for.
+ * @param channelId The channel id this user is connected to.
  * @param userId The user id this voice state is for.
- * @param member the guild member this voice state is for.
+ * @param member The guild member this voice state is for.
  * @param sessionId The session id for this voice state.
  * @param deaf Whether this user is deafened by the server.
  * @param mute Whether this user is muted by the server.
  * @param selfDeaf Whether this user is locally deafened.
- * @param selfMute Whether this is locally muted
+ * @param selfMute Whether this user is locally muted.
  * @param selfStream Whether this user is stream using "Go Live".
  * @param selfVideo Whether this user's camera is enabled.
  * @param suppress Whether this user is muted by the current user.
+ * @param requestToSpeakTimestamp The time at which the user requested to speak.
  */
 @Serializable
 public data class DiscordVoiceState(
     @SerialName("guild_id") val guildId: OptionalSnowflake = OptionalSnowflake.Missing,
-    @SerialName("channel_id") val channelId: Snowflake?,
+    @SerialName("channel_id") val channelId: OptionalSnowflake = OptionalSnowflake.Missing,
     @SerialName("user_id") val userId: Snowflake,
     @SerialName("guild_member") val member: Optional<DiscordGuildMember> = Optional.Missing(),
     @SerialName("session_id") val sessionId: String,
@@ -391,7 +393,7 @@ public data class DiscordVoiceState(
     @SerialName("self_video") val selfVideo: Boolean,
     @SerialName("self_stream") val selfStream: OptionalBoolean = OptionalBoolean.Missing,
     val suppress: Boolean,
-    @SerialName("request_to_speak_timestamp") val requestToSpeakTimestamp: String?
+    @SerialName("request_to_speak_timestamp") val requestToSpeakTimestamp: Optional<Instant>,
 )
 
 /**

--- a/common/src/main/kotlin/entity/DiscordGuild.kt
+++ b/common/src/main/kotlin/entity/DiscordGuild.kt
@@ -393,7 +393,7 @@ public data class DiscordVoiceState(
     @SerialName("self_video") val selfVideo: Boolean,
     @SerialName("self_stream") val selfStream: OptionalBoolean = OptionalBoolean.Missing,
     val suppress: Boolean,
-    @SerialName("request_to_speak_timestamp") val requestToSpeakTimestamp: Optional<Instant>,
+    @SerialName("request_to_speak_timestamp") val requestToSpeakTimestamp: Optional<Instant> = Optional.Missing(),
 )
 
 /**

--- a/common/src/main/kotlin/entity/DiscordGuildScheduledEvent.kt
+++ b/common/src/main/kotlin/entity/DiscordGuildScheduledEvent.kt
@@ -14,23 +14,27 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
 /**
- * Representation of a [Guild Scheduled Event Structure](ADD LINK).
+ * Representation of a
+ * [Guild Scheduled Event Structure](https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-structure).
  *
- * @property id the id of the event
- * @property guildId the id of the guild the event is on
- * @property channelId the id of the channel the event is in
+ * @property id the id of the scheduled event
+ * @property guildId the guild id which the scheduled event belongs to
+ * @property channelId the channel id in which the scheduled event will be hosted, or `null` if [entityType] is
+ * [External][ScheduledEntityType.External]
  * @property creatorId the id of the user that created the scheduled event
- * @property name the name of the event
- * @property description the description of the event
- * @property scheduledStartTime the [Instant] in which the event will start
- * @property scheduledEndTime the [Instant] in which the event wil stop, if any
- * @property privacyLevel the [event privacy level][GuildScheduledEventPrivacyLevel]
- * @property status the [event status][GuildScheduledEventStatus]
- * @property entityType the [ScheduledEntityType] of the event
- * @property entityId entity id
- * @property entityMetadata [metadata][GuildScheduledEventEntityMetadata] for the event
+ * @property name the name of the scheduled event
+ * @property description the description of the scheduled event
+ * @property scheduledStartTime the [Instant] in which the scheduled event will start
+ * @property scheduledEndTime the [Instant] in which the scheduled event will end, if any
+ * @property privacyLevel the [privacy level][GuildScheduledEventPrivacyLevel] of the scheduled event
+ * @property status the [status][GuildScheduledEventStatus] of the scheduled event
+ * @property entityType the [type][ScheduledEntityType] of the scheduled event
+ * @property entityId the id of an entity associated with a guild scheduled event
+ * @property entityMetadata additional [metadata][GuildScheduledEventEntityMetadata] for the guild scheduled event
  * @property creator the [user][DiscordUser] that created the scheduled event
- * @property userCount users subscribed to the event
+ * @property userCount the number of users subscribed to the scheduled event
+ * @property image the [cover image hash](https://discord.com/developers/docs/reference#image-formatting) of the
+ * scheduled event
  */
 @Serializable
 public data class DiscordGuildScheduledEvent(
@@ -59,6 +63,7 @@ public data class DiscordGuildScheduledEvent(
     val creator: Optional<DiscordUser> = Optional.Missing(),
     @SerialName("user_count")
     val userCount: OptionalInt = OptionalInt.Missing,
+    val image: Optional<String?> = Optional.Missing(),
 )
 
 /** Privacy level of a [DiscordGuildScheduledEvent]. */

--- a/common/src/main/kotlin/entity/DiscordGuildScheduledEvent.kt
+++ b/common/src/main/kotlin/entity/DiscordGuildScheduledEvent.kt
@@ -17,24 +17,24 @@ import kotlinx.serialization.encoding.Encoder
  * Representation of a
  * [Guild Scheduled Event Structure](https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-structure).
  *
- * @property id the id of the scheduled event
- * @property guildId the guild id which the scheduled event belongs to
- * @property channelId the channel id in which the scheduled event will be hosted, or `null` if [entityType] is
- * [External][ScheduledEntityType.External]
- * @property creatorId the id of the user that created the scheduled event
- * @property name the name of the scheduled event
- * @property description the description of the scheduled event
- * @property scheduledStartTime the [Instant] in which the scheduled event will start
- * @property scheduledEndTime the [Instant] in which the scheduled event will end, if any
- * @property privacyLevel the [privacy level][GuildScheduledEventPrivacyLevel] of the scheduled event
- * @property status the [status][GuildScheduledEventStatus] of the scheduled event
- * @property entityType the [type][ScheduledEntityType] of the scheduled event
- * @property entityId the id of an entity associated with a guild scheduled event
- * @property entityMetadata additional [metadata][GuildScheduledEventEntityMetadata] for the guild scheduled event
- * @property creator the [user][DiscordUser] that created the scheduled event
- * @property userCount the number of users subscribed to the scheduled event
- * @property image the [cover image hash](https://discord.com/developers/docs/reference#image-formatting) of the
- * scheduled event
+ * @property id The id of the scheduled event.
+ * @property guildId The guild id which the scheduled event belongs to.
+ * @property channelId The channel id in which the scheduled event will be hosted, or `null` if [entityType] is
+ * [External][ScheduledEntityType.External].
+ * @property creatorId The id of the user that created the scheduled event.
+ * @property name The name of the scheduled event.
+ * @property description The description of the scheduled event.
+ * @property scheduledStartTime The [Instant] in which the scheduled event will start.
+ * @property scheduledEndTime The [Instant] in which the scheduled event will end, if any.
+ * @property privacyLevel The [privacy level][GuildScheduledEventPrivacyLevel] of the scheduled event.
+ * @property status The [status][GuildScheduledEventStatus] of the scheduled event.
+ * @property entityType The [type][ScheduledEntityType] of the scheduled event.
+ * @property entityId The id of an entity associated with a guild scheduled event.
+ * @property entityMetadata Additional [metadata][GuildScheduledEventEntityMetadata] for the guild scheduled event.
+ * @property creator The [user][DiscordUser] that created the scheduled event.
+ * @property userCount The number of users subscribed to the scheduled event.
+ * @property image The [cover image hash](https://discord.com/developers/docs/reference#image-formatting) of the
+ * scheduled event.
  */
 @Serializable
 public data class DiscordGuildScheduledEvent(

--- a/common/src/main/kotlin/entity/DiscordStageInstance.kt
+++ b/common/src/main/kotlin/entity/DiscordStageInstance.kt
@@ -11,14 +11,16 @@ import kotlinx.serialization.encoding.Encoder
 
 
 /**
- * A _Stage Instance_ holds information about a live stage.
+ * A [_Stage Instance_](https://discord.com/developers/docs/resources/stage-instance) holds information about a live
+ * stage.
  *
- * @property id The id of this Stage instance
- * @property guildId The guild id of the associated Stage channel
- * @property channelId The id of the associated Stage channel
- * @property topic The topic of the Stage instance (1-120 characters)
- * @property privacyLevel The [privacy level][StageInstancePrivacyLevel] of the Stage instance
- * @property discoverableDisabled Whether or not Stage Discovery is disabled
+ * @property id The id of this Stage instance.
+ * @property guildId The guild id of the associated Stage channel.
+ * @property channelId The id of the associated Stage channel.
+ * @property topic The topic of the Stage instance.
+ * @property privacyLevel The [privacy level][StageInstancePrivacyLevel] of the Stage instance.
+ * @property discoverableDisabled Whether or not Stage Discovery is disabled.
+ * @property guildScheduledEventId The id of the scheduled event for this Stage instance.
  */
 @Serializable
 public data class DiscordStageInstance(
@@ -32,7 +34,9 @@ public data class DiscordStageInstance(
     val privacyLevel: StageInstancePrivacyLevel,
     @Deprecated("Stages are no longer discoverable")
     @SerialName("discoverable_disabled")
-    val discoverableDisabled: Boolean
+    val discoverableDisabled: Boolean,
+    @SerialName("guild_scheduled_event_id")
+    val guildScheduledEventId: Snowflake?,
 )
 
 /**

--- a/common/src/test/kotlin/json/VoiceStateTest.kt
+++ b/common/src/test/kotlin/json/VoiceStateTest.kt
@@ -1,31 +1,32 @@
 package json
 
 import dev.kord.common.entity.DiscordVoiceState
+import kotlinx.datetime.Instant
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Test
-import kotlin.test.Ignore
 
 private fun file(name: String): String {
     val loader = ChannelTest::class.java.classLoader
-    return loader.getResource("json/voice/$name.json").readText()
+    return loader.getResource("json/voice/$name.json")!!.readText()
 }
 
 class VoiceStateTest {
 
     @Test
-    @Ignore("official documentation example is incorrect")
     fun `VoiceState serialization`() {
         val state = Json.decodeFromString(DiscordVoiceState.serializer(), file("voicestate"))
 
         with(state) {
-            channelId!!.toString() shouldBe "157733188964188161"
+            channelId.value.toString() shouldBe "157733188964188161"
             userId.toString() shouldBe "80351110224678912"
             sessionId shouldBe "90326bd25d71d39b9ef95b299e3872ff"
             deaf shouldBe false
             mute shouldBe false
             selfDeaf shouldBe false
+            selfVideo shouldBe true
             selfMute shouldBe true
             suppress shouldBe false
+            requestToSpeakTimestamp shouldBe Instant.parse("2021-03-31T18:45:31.297561+00:00")
         }
 
     }

--- a/common/src/test/resources/json/voice/voicestate.json
+++ b/common/src/test/resources/json/voice/voicestate.json
@@ -5,6 +5,8 @@
   "deaf": false,
   "mute": false,
   "self_deaf": false,
+  "self_video": true,
   "self_mute": true,
-  "suppress": false
+  "suppress": false,
+  "request_to_speak_timestamp": "2021-03-31T18:45:31.297561+00:00"
 }

--- a/core/src/main/kotlin/behavior/StageInstanceBehavior.kt
+++ b/core/src/main/kotlin/behavior/StageInstanceBehavior.kt
@@ -7,12 +7,15 @@ import dev.kord.core.cache.data.StageInstanceData
 import dev.kord.core.entity.KordEntity
 import dev.kord.core.entity.StageInstance
 import dev.kord.core.entity.Strategizable
+import dev.kord.core.entity.channel.StageChannel
 import dev.kord.core.exception.EntityNotFoundException
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 import dev.kord.rest.json.request.StageInstanceUpdateRequest
 
 public interface StageInstanceBehavior : KordEntity, Strategizable {
+
+    /** The id of the associated [StageChannel]. */
     public val channelId: Snowflake
 
     public suspend fun delete(reason: String? = null): Unit = kord.rest.stageInstance.deleteStageInstance(channelId, reason)
@@ -25,7 +28,7 @@ public interface StageInstanceBehavior : KordEntity, Strategizable {
     }
 
     /**
-     * Requests to get the this behavior as a [StageInstance] if it's not an instance of a [StageInstance].
+     * Requests to get this behavior as a [StageInstance] if it's not an instance of a [StageInstance].
      *
      * @throws [RequestException] if anything went wrong during the request.
      * @throws [EntityNotFoundException] if the user wasn't present.
@@ -33,8 +36,8 @@ public interface StageInstanceBehavior : KordEntity, Strategizable {
     public suspend fun asStageInstance(): StageInstance = supplier.getStageInstance(channelId)
 
     /**
-     * Requests to get this behavior as a [StageInstance] if its not an instance of a [StageInstance],
-     * returns null if the user isn't present.
+     * Requests to get this behavior as a [StageInstance] if it's not an instance of a [StageInstance],
+     * returns null if the stage instance isn't present.
      *
      * @throws [RequestException] if anything went wrong during the request.
      */

--- a/core/src/main/kotlin/cache/data/GuildScheduledEventData.kt
+++ b/core/src/main/kotlin/cache/data/GuildScheduledEventData.kt
@@ -25,24 +25,28 @@ public data class GuildScheduledEventData(
     val entityMetadata: GuildScheduledEventEntityMetadata?,
     val creator: Optional<UserData> = Optional.Missing(),
     val userCount: OptionalInt = OptionalInt.Missing,
+    val image: Optional<String?> = Optional.Missing(),
 ) {
     public companion object {
-        public fun from(event: DiscordGuildScheduledEvent): GuildScheduledEventData = GuildScheduledEventData(
-            event.id,
-            event.guildId,
-            event.channelId,
-            event.creatorId,
-            event.name,
-            event.description,
-            event.scheduledStartTime,
-            event.scheduledEndTime,
-            event.privacyLevel,
-            event.status,
-            event.entityId,
-            event.entityType,
-            event.entityMetadata,
-            event.creator.map { UserData.from(it) },
-            event.userCount
-        )
+        public fun from(event: DiscordGuildScheduledEvent): GuildScheduledEventData = with(event) {
+            GuildScheduledEventData(
+                id = id,
+                guildId = guildId,
+                channelId = channelId,
+                creatorId = creatorId,
+                name = name,
+                description = description,
+                scheduledStartTime = scheduledStartTime,
+                scheduledEndTime = scheduledEndTime,
+                privacyLevel = privacyLevel,
+                status = status,
+                entityId = entityId,
+                entityType = entityType,
+                entityMetadata = entityMetadata,
+                creator = creator.map { UserData.from(it) },
+                userCount = userCount,
+                image = image,
+            )
+        }
     }
 }

--- a/core/src/main/kotlin/cache/data/StageInstanceData.kt
+++ b/core/src/main/kotlin/cache/data/StageInstanceData.kt
@@ -2,6 +2,7 @@ package dev.kord.core.cache.data
 
 import dev.kord.common.entity.DiscordStageInstance
 import dev.kord.common.entity.Snowflake
+import dev.kord.common.entity.StageInstancePrivacyLevel
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -9,11 +10,20 @@ public data class StageInstanceData(
     val id: Snowflake,
     val guildId: Snowflake,
     val channelId: Snowflake,
-    val topic: String
+    val topic: String,
+    val privacyLevel: StageInstancePrivacyLevel,
+    val guildScheduledEventId: Snowflake?,
 ) {
     public companion object {
         public fun from(stageInstance: DiscordStageInstance): StageInstanceData = with(stageInstance) {
-            StageInstanceData(id, guildId, channelId, topic)
+            StageInstanceData(
+                id = id,
+                guildId = guildId,
+                channelId = channelId,
+                topic = topic,
+                privacyLevel = privacyLevel,
+                guildScheduledEventId = guildScheduledEventId,
+            )
         }
     }
 }

--- a/core/src/main/kotlin/cache/data/VoiceStateData.kt
+++ b/core/src/main/kotlin/cache/data/VoiceStateData.kt
@@ -4,9 +4,11 @@ import dev.kord.cache.api.data.DataDescription
 import dev.kord.cache.api.data.description
 import dev.kord.common.entity.DiscordVoiceState
 import dev.kord.common.entity.Snowflake
+import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
 import dev.kord.common.entity.optional.OptionalSnowflake
 import dev.kord.common.entity.optional.mapSnowflake
+import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
 
 public val VoiceStateData.id: String
@@ -20,7 +22,7 @@ public data class VoiceStateData(
      (And not just because this code would break).
      */
     val guildId: Snowflake,
-    val channelId: Snowflake? = null,
+    val channelId: OptionalSnowflake = OptionalSnowflake.Missing,
     val userId: Snowflake,
     val memberId: OptionalSnowflake = OptionalSnowflake.Missing,
     val sessionId: String,
@@ -31,7 +33,7 @@ public data class VoiceStateData(
     val suppress: Boolean,
     val selfVideo: Boolean,
     val selfStream: OptionalBoolean = OptionalBoolean.Missing,
-    val requestToSpeakTimestamp: String?
+    val requestToSpeakTimestamp: Optional<Instant> = Optional.Missing(),
 ) {
     public companion object {
         public val description: DataDescription<VoiceStateData, String> = description(VoiceStateData::id)

--- a/core/src/main/kotlin/entity/GuildScheduledEvent.kt
+++ b/core/src/main/kotlin/entity/GuildScheduledEvent.kt
@@ -15,7 +15,9 @@ import dev.kord.core.supplier.getChannelOfOrNull
 import kotlinx.datetime.Instant
 
 /**
- * An instance of a [Guild scheduled event](ADD LINK) belonging to a specific guild.
+ * An instance of a
+ * [Guild scheduled event](https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event)
+ * belonging to a specific guild.
  */
 public class GuildScheduledEvent(
     public val data: GuildScheduledEventData,
@@ -30,19 +32,20 @@ public class GuildScheduledEvent(
         get() = data.id
 
     /**
-     * The id of the guild this event is on.
+     * The id of the guild this event belongs to.
      */
     public override val guildId: Snowflake
         get() = data.guildId
 
     /**
-     * The id of the channel this event is in, if any.
+     * The id of the channel this event will be hosted in, or `null` if [entityType] is
+     * [External][ScheduledEntityType.External].
      */
     public val channelId: Snowflake?
         get() = data.channelId
 
     /**
-     * The id of the user that created the scheduled event.
+     * The id of the user that created this event.
      *
      * This is only available for events created after 2021-10-25.
      */
@@ -85,21 +88,23 @@ public class GuildScheduledEvent(
     public val status: GuildScheduledEventStatus
         get() = data.status
 
+    /** The id of an entity associated with this event. */
     public val entityId: Snowflake?
         get() = data.entityId
 
     /**
-     * The [scheduled entity type][ScheduledEntityType] for this event.
+     * The [type][ScheduledEntityType] of this event.
      */
     public val entityType: ScheduledEntityType
         get() = data.entityType
 
     /**
-     * The [entity metadata][GuildScheduledEventEntityMetadata] for the scheduled event
+     * Additional [metadata][GuildScheduledEventEntityMetadata] for this event.
      */
     public val entityMetadata: GuildScheduledEventEntityMetadata?
         get() = data.entityMetadata
 
+    /** The [user][User] that created this event. */
     public val creator: User?
         get() = data.creator.unwrap { User(it, kord, supplier) }
 
@@ -109,8 +114,11 @@ public class GuildScheduledEvent(
     public val userCount: Int?
         get() = data.userCount.value
 
+    /** The cover image hash of this event. */
+    public val imageHash: String? get() = data.image.value
+
     /**
-     * Requests the [Guild] this event is on.
+     * Requests the [Guild] this event belongs to.
      *
      * @throws [RequestException] if anything went wrong during the request.
      * @throws [EntityNotFoundException] if the [Guild] wasn't present.
@@ -118,7 +126,7 @@ public class GuildScheduledEvent(
     public suspend fun getGuild(): Guild = supplier.getGuild(guildId)
 
     /**
-     * Requests the [Guild] this event is on,
+     * Requests the [Guild] this event belongs to,
      * returns null if the [Guild] isn't present.
      *
      * @throws [RequestException] if anything went wrong during the request.
@@ -126,16 +134,17 @@ public class GuildScheduledEvent(
     public suspend fun getGuildOrNull(): Guild? = supplier.getGuildOrNull(guildId)
 
     /**
-     * Requests the [TopGuildChannel] this event is in,
-     * returns null if the [TopGuildChannel] isn't present or not set.
+     * Requests the [TopGuildChannel] this event will be hosted in,
+     * returns null if the [TopGuildChannel] isn't present or [entityType] is [External][ScheduledEntityType.External].
      *
      * @throws [RequestException] if anything went wrong during the request.
      */
     public suspend fun getChannelOrNull(): TopGuildChannel? = data.channelId?.let { supplier.getChannelOfOrNull(it) }
 
     /**
-     * Requests the channel this event is in, if it is of type [T],
-     * returns `null` if the channel is not set, not present or not of type [T]
+     * Requests the channel this event will be hosted in, if it is of type [T],
+     * returns `null` if [entityType] is [External][ScheduledEntityType.External], the channel is not present or not of
+     * type [T].
      *
      * @throws [RequestException] if anything went wrong during the request.
      */

--- a/core/src/main/kotlin/entity/StageInstance.kt
+++ b/core/src/main/kotlin/entity/StageInstance.kt
@@ -1,9 +1,11 @@
 package dev.kord.core.entity
 
 import dev.kord.common.entity.Snowflake
+import dev.kord.common.entity.StageInstancePrivacyLevel
 import dev.kord.core.Kord
 import dev.kord.core.behavior.StageInstanceBehavior
 import dev.kord.core.cache.data.StageInstanceData
+import dev.kord.core.entity.channel.StageChannel
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 
@@ -13,11 +15,21 @@ public class StageInstance(
     override val supplier: EntitySupplier = kord.defaultSupplier
 ) : StageInstanceBehavior {
     override val id: Snowflake get() = data.id
+
+    /** The guild id of the associated [StageChannel]. */
     public val guildId: Snowflake get() = data.guildId
     override val channelId: Snowflake get() = data.channelId
+
+    /** The topic of this Stage Instance. */
     public val topic: String get() = data.topic
 
-    override fun withStrategy(strategy: EntitySupplyStrategy<*>): StageInstanceBehavior =
+    /** The [privacy level][StageInstancePrivacyLevel] of this Stage Instance.  */
+    public val privacyLevel: StageInstancePrivacyLevel get() = data.privacyLevel
+
+    /** The id of the [GuildScheduledEvent] for this Stage Instance, if it belongs to an event. */
+    public val guildScheduledEventId: Snowflake? get() = data.guildScheduledEventId
+
+    override fun withStrategy(strategy: EntitySupplyStrategy<*>): StageInstance =
         StageInstance(data, kord, strategy.supply(kord))
 
     override suspend fun asStageInstance(): StageInstance = this

--- a/core/src/main/kotlin/entity/VoiceState.kt
+++ b/core/src/main/kotlin/entity/VoiceState.kt
@@ -12,6 +12,7 @@ import dev.kord.core.exception.EntityNotFoundException
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 import dev.kord.core.supplier.getChannelOfOrNull
+import kotlinx.datetime.Instant
 
 public class VoiceState(
     public val data: VoiceStateData,
@@ -19,32 +20,46 @@ public class VoiceState(
     override val supplier: EntitySupplier = kord.defaultSupplier
 ) : KordObject, Strategizable {
 
+    /** The guild id this voice state is for. */
     public val guildId: Snowflake get() = data.guildId
 
-    public val channelId: Snowflake? get() = data.channelId
+    /** The channel id this user is connected to. */
+    public val channelId: Snowflake? get() = data.channelId.value
 
+    /** The user id this voice state is for. */
     public val userId: Snowflake get() = data.userId
 
+    /** The session id for this voice state. */
     public val sessionId: String get() = data.sessionId
 
+    /** Whether this user is deafened by the server. */
     public val isDeafened: Boolean get() = data.deaf
 
+    /** Whether this user is muted by the server. */
     public val isMuted: Boolean get() = data.mute
 
+    /** Whether this user is locally deafened. */
     public val isSelfDeafened: Boolean get() = data.selfDeaf
 
+    /** Whether this user is locally muted. */
     public val isSelfMuted: Boolean get() = data.selfMute
 
+    /** Whether this user is streaming using "Go Live". */
+    public val isSelfStreaming: Boolean get() = data.selfStream.discordBoolean
+
+    /** Whether this user's camera is enabled. */
     public val isSelfVideo: Boolean get() = data.selfVideo
 
+    /** Whether this user is muted by the current user. */
     public val isSuppressed: Boolean get() = data.suppress
 
-    public val requestToSpeakTimestamp: String? get() = data.requestToSpeakTimestamp
+    /** The [Instant] at which the user requested to speak. */
+    public val requestToSpeakTimestamp: Instant? get() = data.requestToSpeakTimestamp.value
 
-    /**
-     * Whether this user is streaming using "Go Live".
-     */
-    public val isSelfSteaming: Boolean get() = data.selfStream.orElse(false)
+    /** Discord does not support anger detection. */
+    @Deprecated("I can't see any steam...", ReplaceWith("this.isSelfStreaming"), DeprecationLevel.ERROR)
+    public val isSelfSteaming: Boolean
+        get() = isSelfStreaming
 
     /**
      * Requests to get the voice channel of this voice state.

--- a/core/src/test/kotlin/live/LiveGuildTest.kt
+++ b/core/src/test/kotlin/live/LiveGuildTest.kt
@@ -3,6 +3,7 @@ package live
 import dev.kord.common.annotation.KordPreview
 import dev.kord.common.entity.*
 import dev.kord.common.entity.optional.Optional
+import dev.kord.common.entity.optional.OptionalSnowflake
 import dev.kord.common.entity.optional.optionalSnowflake
 import dev.kord.core.cache.data.GuildData
 import dev.kord.core.entity.Guild
@@ -205,7 +206,7 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
                 VoiceStateUpdate(
                     DiscordVoiceState(
                         guildId = it.optionalSnowflake(),
-                        channelId = null,
+                        channelId = OptionalSnowflake.Missing,
                         userId = randomId(),
                         sessionId = "",
                         deaf = false,
@@ -214,7 +215,7 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
                         selfMute = false,
                         selfVideo = false,
                         suppress = false,
-                        requestToSpeakTimestamp = null
+                        requestToSpeakTimestamp = Optional.Missing(),
                     ),
                     0
                 )

--- a/rest/src/main/kotlin/builder/component/SelectMenuBuilder.kt
+++ b/rest/src/main/kotlin/builder/component/SelectMenuBuilder.kt
@@ -35,7 +35,7 @@ public class SelectMenuBuilder(
     private var _placeholder: Optional<String> = Optional.Missing()
 
     /**
-     * Custom placeholder if no value is selected, max 100 characters.
+     * Custom placeholder if no value is selected, max 150 characters.
      *
      * [Option defaults][SelectOptionBuilder.default] have priority over placeholders,
      * if any option is marked as default then that label will be shown instead.

--- a/rest/src/main/kotlin/builder/guild/ScheduledEventCreateBuilder.kt
+++ b/rest/src/main/kotlin/builder/guild/ScheduledEventCreateBuilder.kt
@@ -7,38 +7,58 @@ import dev.kord.common.entity.Snowflake
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalSnowflake
 import dev.kord.common.entity.optional.delegate.delegate
+import dev.kord.common.entity.optional.map
+import dev.kord.rest.Image
 import dev.kord.rest.builder.AuditRequestBuilder
 import dev.kord.rest.json.request.GuildScheduledEventCreateRequest
 import kotlinx.datetime.Instant
 
 public class ScheduledEventCreateBuilder(
+    /** The name of the scheduled event. */
     public var name: String,
+    /** The [privacy level][GuildScheduledEventPrivacyLevel] of the scheduled event. */
     public var privacyLevel: GuildScheduledEventPrivacyLevel,
+    /** The [Instant] to schedule the scheduled event. */
     public var scheduledStartTime: Instant,
+    /** The [entity type][ScheduledEntityType] of the scheduled event. */
     public var entityType: ScheduledEntityType,
 ) : AuditRequestBuilder<GuildScheduledEventCreateRequest> {
     override var reason: String? = null
 
     private var _channelId: OptionalSnowflake = OptionalSnowflake.Missing
+
+    /** The channel id of the scheduled event. */
     public var channelId: Snowflake? by ::_channelId.delegate()
 
     private var _description: Optional<String> = Optional.Missing()
+
+    /** The description of the scheduled event. */
     public var description: String? by ::_description.delegate()
 
     private var _entityMetadata: Optional<GuildScheduledEventEntityMetadata> = Optional.Missing()
+
+    /** The [entity metadata][GuildScheduledEventEntityMetadata] of the scheduled event. */
     public var entityMetadata: GuildScheduledEventEntityMetadata? by ::_entityMetadata.delegate()
 
     private var _scheduledEndTime: Optional<Instant> = Optional.Missing()
+
+    /** The [Instant] when the scheduled event is scheduled to end. */
     public var scheduledEndTime: Instant? by ::_scheduledEndTime.delegate()
 
+    private var _image: Optional<Image> = Optional.Missing()
+
+    /** The cover image of the scheduled event. */
+    public var image: Image? by ::_image.delegate()
+
     override fun toRequest(): GuildScheduledEventCreateRequest = GuildScheduledEventCreateRequest(
-        _channelId,
-        _entityMetadata,
-        name,
-        privacyLevel,
-        scheduledStartTime,
-        _scheduledEndTime,
-        _description,
-        entityType
+        channelId = _channelId,
+        entityMetadata = _entityMetadata,
+        name = name,
+        privacyLevel = privacyLevel,
+        scheduledStartTime = scheduledStartTime,
+        scheduledEndTime = _scheduledEndTime,
+        description = _description,
+        entityType = entityType,
+        image = _image.map { it.dataUri },
     )
 }

--- a/rest/src/main/kotlin/builder/role/RoleCreateBuilder.kt
+++ b/rest/src/main/kotlin/builder/role/RoleCreateBuilder.kt
@@ -2,6 +2,7 @@ package dev.kord.rest.builder.role
 
 import dev.kord.common.Color
 import dev.kord.common.annotation.KordDsl
+import dev.kord.common.entity.GuildFeature
 import dev.kord.common.entity.Permissions
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
@@ -16,29 +17,46 @@ public class RoleCreateBuilder : AuditRequestBuilder<GuildRoleCreateRequest> {
     override var reason: String? = null
 
     private var _color: Optional<Color> = Optional.Missing()
+
+    /** Color of the role, no color by default. */
     public var color: Color? by ::_color.delegate()
 
     private var _hoist: OptionalBoolean = OptionalBoolean.Missing
+
+    /** Whether the role should be displayed separately in the sidebar, `false` by default. */
     public var hoist: Boolean? by ::_hoist.delegate()
 
-    private var _icon: Optional<Image> = Optional.Missing()
+    private var _icon: Optional<Image?> = Optional.Missing()
+
+    /** The role's icon image (if the guild has the [RoleIcons][GuildFeature.RoleIcons] feature), `null` by default. */
     public var icon: Image? by ::_icon.delegate()
 
-    private var _unicodeEmoji: Optional<String> = Optional.Missing()
+    private var _unicodeEmoji: Optional<String?> = Optional.Missing()
+
+    /**
+     * The role's unicode emoji as a [standard emoji](https://discord.com/developers/docs/reference#message-formatting)
+     * (if the guild has the [RoleIcons][GuildFeature.RoleIcons] feature), `null` by default.
+     */
     public var unicodeEmoji: String? by ::_unicodeEmoji.delegate()
 
     private var _name: Optional<String> = Optional.Missing()
+
+    /** Name of the role, "new role" by default. */
     public var name: String? by ::_name.delegate()
 
     private var _mentionable: OptionalBoolean = OptionalBoolean.Missing
+
+    /** Whether the role should be mentionable, `false` by default. */
     public var mentionable: Boolean? by ::_mentionable.delegate()
 
     private var _permissions: Optional<Permissions> = Optional.Missing()
+
+    /** Permissions for the role, @everyone permissions in the guild by default. */
     public var permissions: Permissions? by ::_permissions.delegate()
 
     override fun toRequest(): GuildRoleCreateRequest = GuildRoleCreateRequest(
         color = _color,
-        separate = _hoist,
+        hoist = _hoist,
         icon = _icon.map { it.dataUri },
         unicodeEmoji = _unicodeEmoji,
         name = _name,

--- a/rest/src/main/kotlin/builder/role/RoleModifyBuilder.kt
+++ b/rest/src/main/kotlin/builder/role/RoleModifyBuilder.kt
@@ -2,6 +2,7 @@ package dev.kord.rest.builder.role
 
 import dev.kord.common.Color
 import dev.kord.common.annotation.KordDsl
+import dev.kord.common.entity.GuildFeature
 import dev.kord.common.entity.Permissions
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
@@ -16,30 +17,47 @@ public class RoleModifyBuilder : AuditRequestBuilder<GuildRoleModifyRequest> {
     override var reason: String? = null
 
     private var _color: Optional<Color?> = Optional.Missing()
+
+    /** Color of the role. */
     public var color: Color? by ::_color.delegate()
 
     private var _hoist: OptionalBoolean? = OptionalBoolean.Missing
+
+    /** Whether the role should be displayed separately in the sidebar. */
     public var hoist: Boolean? by ::_hoist.delegate()
 
-    private var _icon: Optional<Image> = Optional.Missing()
+    private var _icon: Optional<Image?> = Optional.Missing()
+
+    /** The role's icon image (if the guild has the [RoleIcons][GuildFeature.RoleIcons] feature). */
     public var icon: Image? by ::_icon.delegate()
 
-    private var _unicodeEmoji: Optional<String> = Optional.Missing()
+    private var _unicodeEmoji: Optional<String?> = Optional.Missing()
+
+    /**
+     * The role's unicode emoji as a [standard emoji](https://discord.com/developers/docs/reference#message-formatting)
+     * (if the guild has the [RoleIcons][GuildFeature.RoleIcons] feature).
+     */
     public var unicodeEmoji: String? by ::_unicodeEmoji.delegate()
 
     private var _name: Optional<String?> = Optional.Missing()
+
+    /** Name of the role. */
     public var name: String? by ::_name.delegate()
 
     private var _mentionable: OptionalBoolean? = OptionalBoolean.Missing
+
+    /** Whether the role should be mentionable. */
     public var mentionable: Boolean? by ::_mentionable.delegate()
 
     private var _permissions: Optional<Permissions?> = Optional.Missing()
+
+    /** Permissions for the role. */
     public var permissions: Permissions? by ::_permissions.delegate()
 
     override fun toRequest(): GuildRoleModifyRequest = GuildRoleModifyRequest(
         name = _name,
         color = _color,
-        separate = _hoist,
+        hoist = _hoist,
         icon = _icon.map { it.dataUri },
         unicodeEmoji = _unicodeEmoji,
         mentionable = _mentionable,

--- a/rest/src/main/kotlin/builder/scheduled_events/ScheduledEventModifyBuilder.kt
+++ b/rest/src/main/kotlin/builder/scheduled_events/ScheduledEventModifyBuilder.kt
@@ -4,6 +4,8 @@ import dev.kord.common.entity.*
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalSnowflake
 import dev.kord.common.entity.optional.delegate.delegate
+import dev.kord.common.entity.optional.map
+import dev.kord.rest.Image
 import dev.kord.rest.builder.AuditRequestBuilder
 import dev.kord.rest.json.request.ScheduledEventModifyRequest
 import kotlinx.datetime.Instant
@@ -12,42 +14,68 @@ public class ScheduledEventModifyBuilder : AuditRequestBuilder<ScheduledEventMod
     override var reason: String? = null
 
     private var _channelId: OptionalSnowflake? = OptionalSnowflake.Missing
+
+    /**
+     * The channel id of the scheduled event, set to `null` if changing [entityType] to
+     * [External][ScheduledEntityType.External].
+     */
     public var channelId: Snowflake? by ::_channelId.delegate()
 
     private var _name: Optional<String> = Optional.Missing()
+
+    /** The name of the scheduled event. */
     public var name: String? by ::_name.delegate()
 
     private var _privacyLevel: Optional<GuildScheduledEventPrivacyLevel> = Optional.Missing()
+
+    /** The [privacy level][GuildScheduledEventPrivacyLevel] of the scheduled event. */
     public var privacyLevel: GuildScheduledEventPrivacyLevel? by ::_privacyLevel.delegate()
 
     private var _scheduledStartTime: Optional<Instant> = Optional.Missing()
+
+    /** The [Instant] to schedule the scheduled event. */
     public var scheduledStartTime: Instant? by ::_scheduledStartTime.delegate()
 
-    private var _description: Optional<String> = Optional.Missing()
+    private var _description: Optional<String?> = Optional.Missing()
+
+    /** The description of the scheduled event. */
     public var description: String? by ::_description.delegate()
 
     private var _entityType: Optional<ScheduledEntityType> = Optional.Missing()
+
+    /** The [entity type][ScheduledEntityType] of the scheduled event. */
     public var entityType: ScheduledEntityType? by ::_entityType.delegate()
 
-    private var _entityMetadata: Optional<GuildScheduledEventEntityMetadata> = Optional.Missing()
+    private var _entityMetadata: Optional<GuildScheduledEventEntityMetadata?> = Optional.Missing()
+
+    /** The [entity metadata][GuildScheduledEventEntityMetadata] of the scheduled event. */
     public var entityMetadata: GuildScheduledEventEntityMetadata? by ::_entityMetadata.delegate()
 
     private var _scheduledEndTime: Optional<Instant> = Optional.Missing()
+
+    /** The [Instant] when the scheduled event is scheduled to end. */
     public var scheduledEndTime: Instant? by ::_scheduledEndTime.delegate()
 
     private var _status: Optional<GuildScheduledEventStatus> = Optional.Missing()
+
+    /** The [status][GuildScheduledEventStatus] of the scheduled event. */
     public var status: GuildScheduledEventStatus? by ::_status.delegate()
 
+    private var _image: Optional<Image> = Optional.Missing()
+
+    /** The cover image of the scheduled event. */
+    public var image: Image? by ::_image.delegate()
 
     override fun toRequest(): ScheduledEventModifyRequest = ScheduledEventModifyRequest(
-        _channelId,
-        _entityMetadata,
-        _name,
-        _privacyLevel,
-        _scheduledStartTime,
-        _scheduledEndTime,
-        _description,
-        _entityType,
-        _status
+        channelId = _channelId,
+        entityMetadata = _entityMetadata,
+        name = _name,
+        privacyLevel = _privacyLevel,
+        scheduledStartTime = _scheduledStartTime,
+        scheduledEndTime = _scheduledEndTime,
+        description = _description,
+        entityType = _entityType,
+        status = _status,
+        image = _image.map { it.dataUri },
     )
 }

--- a/rest/src/main/kotlin/json/JsonErrorCode.kt
+++ b/rest/src/main/kotlin/json/JsonErrorCode.kt
@@ -298,8 +298,8 @@ public enum class JsonErrorCode(public val code: Int) {
     /** Cannot send messages to this user. */
     CannotSendMessagesToUser(50007),
 
-    /** Cannot send messages in a voice channel. */
-    CannotSendMessagesInVoiceChannel(50008),
+    /** Cannot send messages in a non-text channel. */
+    CannotSendMessagesInNonTextChannel(50008),
 
     /** Channel verification level is too high for you to gain access. */
     ChannelVerificationTooHigh(50009),
@@ -502,6 +502,14 @@ public enum class JsonErrorCode(public val code: Int) {
         )
         @JvmField
         public val InvalidThreadBefore: JsonErrorCode = BeforeValueBeforeThreadCreate
+
+        @Deprecated(
+            "'JsonErrorCode.CannotSendMessagesInVoiceChannel' was renamed to JsonErrorCode.CannotSendMessagesInNonTextChannel",
+            ReplaceWith("JsonErrorCode.CannotSendMessagesInNonTextChannel"),
+            DeprecationLevel.ERROR,
+        )
+        @JvmField
+        public val CannotSendMessagesInVoiceChannel: JsonErrorCode = CannotSendMessagesInNonTextChannel
 
         @Deprecated(
             "Object JsonErrorCode.JsonErrorCodeSerializer is internal now, use JsonErrorCode.serializer() instead.",

--- a/rest/src/main/kotlin/json/request/GuildRequests.kt
+++ b/rest/src/main/kotlin/json/request/GuildRequests.kt
@@ -126,14 +126,18 @@ public data class GuildRoleCreateRequest(
     val name: Optional<String> = Optional.Missing(),
     val permissions: Optional<Permissions> = Optional.Missing(),
     val color: Optional<Color> = Optional.Missing(),
-    @SerialName("hoist")
-    val separate: OptionalBoolean = OptionalBoolean.Missing,
-    val icon: Optional<String> = Optional.Missing(),
+    val hoist: OptionalBoolean = OptionalBoolean.Missing,
+    val icon: Optional<String?> = Optional.Missing(),
     @SerialName("unicode_emoji")
-    val unicodeEmoji: Optional<String> = Optional.Missing(),
+    val unicodeEmoji: Optional<String?> = Optional.Missing(),
     val mentionable: OptionalBoolean = OptionalBoolean.Missing,
+    @Deprecated("This is not part of Discord's current documentation.")
     val id: OptionalSnowflake = OptionalSnowflake.Missing,
-)
+) {
+    @Deprecated("Renamed to 'hoist'.", ReplaceWith("this.hoist"), DeprecationLevel.ERROR)
+    public val separate: OptionalBoolean
+        get() = hoist
+}
 
 
 @Serializable(with = GuildRolePositionModifyRequest.Serializer::class)
@@ -166,13 +170,16 @@ public data class GuildRoleModifyRequest(
     val name: Optional<String?> = Optional.Missing(),
     val permissions: Optional<Permissions?> = Optional.Missing(),
     val color: Optional<Color?> = Optional.Missing(),
-    @SerialName("hoist")
-    val separate: OptionalBoolean? = OptionalBoolean.Missing,
-    val icon: Optional<String> = Optional.Missing(),
+    val hoist: OptionalBoolean? = OptionalBoolean.Missing,
+    val icon: Optional<String?> = Optional.Missing(),
     @SerialName("unicode_emoji")
-    val unicodeEmoji: Optional<String> = Optional.Missing(),
+    val unicodeEmoji: Optional<String?> = Optional.Missing(),
     val mentionable: OptionalBoolean? = OptionalBoolean.Missing,
-)
+) {
+    @Deprecated("Renamed to 'hoist'.", ReplaceWith("this.hoist"), DeprecationLevel.ERROR)
+    public val separate: OptionalBoolean?
+        get() = hoist
+}
 
 @Serializable
 public data class GuildIntegrationCreateRequest(val type: Int, val id: String)

--- a/rest/src/main/kotlin/json/request/ScheduledEventRequests.kt
+++ b/rest/src/main/kotlin/json/request/ScheduledEventRequests.kt
@@ -26,6 +26,7 @@ public data class GuildScheduledEventCreateRequest(
     val description: Optional<String> = Optional.Missing(),
     @SerialName("entity_type")
     val entityType: ScheduledEntityType,
+    val image: Optional<String> = Optional.Missing(),
 )
 
 @Serializable
@@ -33,7 +34,7 @@ public data class ScheduledEventModifyRequest(
     @SerialName("channel_id")
     val channelId: OptionalSnowflake? = OptionalSnowflake.Missing,
     @SerialName("entity_metadata")
-    val entityMetadata: Optional<GuildScheduledEventEntityMetadata> = Optional.Missing(),
+    val entityMetadata: Optional<GuildScheduledEventEntityMetadata?> = Optional.Missing(),
     val name: Optional<String> = Optional.Missing(),
     @SerialName("privacy_level")
     val privacyLevel: Optional<GuildScheduledEventPrivacyLevel> = Optional.Missing(),
@@ -41,8 +42,9 @@ public data class ScheduledEventModifyRequest(
     val scheduledStartTime: Optional<Instant> = Optional.Missing(),
     @SerialName("scheduled_end_time")
     val scheduledEndTime: Optional<Instant> = Optional.Missing(),
-    val description: Optional<String> = Optional.Missing(),
+    val description: Optional<String?> = Optional.Missing(),
     @SerialName("entity_type")
     val entityType: Optional<ScheduledEntityType> = Optional.Missing(),
-    val status: Optional<GuildScheduledEventStatus> = Optional.Missing()
+    val status: Optional<GuildScheduledEventStatus> = Optional.Missing(),
+    val image: Optional<String> = Optional.Missing(),
 )


### PR DESCRIPTION
Discord made a lot of commits to their Docs today, this PR brings the corresponding changes to Kord.

## Changes for https://github.com/discord/discord-api-docs/pull/4564 committed in https://github.com/discord/discord-api-docs/commit/074e9305b45f3102266e79513c9f84ddb5697a05
- `RoleCreateBuilder` / `GuildRoleCreateRequest`: nullable `icon` and `unicodeEmoji`
- `RoleModifyBuilder` / `GuildRoleModifyRequest`: change all parameters to be [optional and nullable](https://discord.com/developers/docs/resources/guild#modify-guild-role)
- Guild Scheduled Event: add `image`, [optional and nullable](https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-user-object-json-params) `entityMetadata` and `description` in modify

## Changes for https://github.com/discord/discord-api-docs/pull/4551 committed in https://github.com/discord/discord-api-docs/commit/c5b0eabe072254a3c9c4a720c5be3d35985e5476
- `SelectMenuBuilder`: update docs about `placeholder` length

## Changes for https://github.com/discord/discord-api-docs/pull/4565 committed in https://github.com/discord/discord-api-docs/commit/d7b47a33dcb6e4d9de8f3ab3e463e855eed6150b
- `VoiceState`: optional instead of nullable `channelId` and `requestToSpeakTimestamp`, make `requestToSpeakTimestamp` `Instant`
- fix `isSelfSteaming` typo

## Changes for https://github.com/discord/discord-api-docs/pull/4533 committed in https://github.com/discord/discord-api-docs/commit/19ca14c1fa4659f901d9390fc356edfb9b57d51c
- rename `JsonErrorCode.CannotSendMessagesInVoiceChannel` to `JsonErrorCode.CannotSendMessagesInNonTextChannel`

## Changes for  https://github.com/discord/discord-api-docs/pull/4583 committed in https://github.com/discord/discord-api-docs/commit/42a20aed751e0ad61d3aee31c08c98a7d2606df5
- Stage Instance: add `guildScheduledEventId`