### PR TITLE
Add strategy to mitigate loss of stacktrace through Ktors SuspendFunctionGun

### DIFF
--- a/core/src/main/kotlin/builder/kord/KordBuilder.kt
+++ b/core/src/main/kotlin/builder/kord/KordBuilder.kt
@@ -21,9 +21,7 @@ import dev.kord.gateway.retry.LinearRetry
 import dev.kord.gateway.retry.Retry
 import dev.kord.rest.json.response.BotGatewayResponse
 import dev.kord.rest.ratelimit.ExclusionRequestRateLimiter
-import dev.kord.rest.request.KtorRequestHandler
-import dev.kord.rest.request.RequestHandler
-import dev.kord.rest.request.isError
+import dev.kord.rest.request.*
 import dev.kord.rest.route.Route
 import dev.kord.rest.service.RestClient
 import io.ktor.client.*
@@ -157,6 +155,23 @@ public class KordBuilder(public val token: String) {
      */
     public fun requestHandler(handlerBuilder: (resources: ClientResources) -> RequestHandler) {
         this.handlerBuilder = handlerBuilder
+    }
+
+    /**
+     * Enables stack trace recovery on the currently defined [RequestHandler].
+     *
+     * @throws IllegalStateException if the [RequestHandler] is not a [KtorRequestHandler]
+     *
+     * @see StackTraceRecoveringKtorRequestHandler
+     * @see withStackTraceRecovery
+     */
+    public fun enableStackTraceRecovery() {
+        val parentBuilder = handlerBuilder
+        requestHandler {
+            val ktorRequestHandler = parentBuilder(it) as? KtorRequestHandler
+                ?: error("Stack trace recovery only works with KtorRequestHandlers")
+            ktorRequestHandler.withStackTraceRecovery()
+        }
     }
 
     /**

--- a/rest/src/main/kotlin/request/StackTraceRecoveringKtorRequestHandler.kt
+++ b/rest/src/main/kotlin/request/StackTraceRecoveringKtorRequestHandler.kt
@@ -24,7 +24,7 @@ public class StackTraceRecoveringKtorRequestHandler(private val delegate: KtorRe
 
         return try {
             delegate.handle(request)
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
             throw stacktrace.apply {
                 sanitizeStackTrace()
                 initCause(e)
@@ -42,7 +42,8 @@ public class ContextException internal constructor() : RuntimeException() {
 
     internal fun sanitizeStackTrace() {
         // Remove artifacts of stack trace capturing
-        // at dev.kord.rest.request.StackTraceRecoveringKtorRequestHandler.handle(StackTraceRecoveringKtorRequestHandler.kt:7)
+        // This is the stack trace element is the creation of the ContextException
+        // at dev.kord.rest.request.StackTraceRecoveringKtorRequestHandler.handle(StackTraceRecoveringKtorRequestHandler.kt:23)
         stackTrace = stackTrace.copyOfRange(1, stackTrace.size)
     }
 }

--- a/rest/src/main/kotlin/request/StackTraceRecoveringKtorRequestHandler.kt
+++ b/rest/src/main/kotlin/request/StackTraceRecoveringKtorRequestHandler.kt
@@ -27,7 +27,7 @@ public class StackTraceRecoveringKtorRequestHandler(private val delegate: KtorRe
         } catch (e: Throwable) {
             throw stacktrace.apply {
                 sanitizeStackTrace()
-                cause = e
+                initCause(e)
             }
         }
     }
@@ -39,8 +39,6 @@ public class StackTraceRecoveringKtorRequestHandler(private val delegate: KtorRe
  * @see StackTraceRecoveringKtorRequestHandler
  */
 public class ContextException internal constructor() : RuntimeException() {
-    override var cause: Throwable? = null
-        internal set
 
     internal fun sanitizeStackTrace() {
         // Remove artifacts of stack trace capturing

--- a/rest/src/main/kotlin/request/StackTraceRecoveringKtorRequestHandler.kt
+++ b/rest/src/main/kotlin/request/StackTraceRecoveringKtorRequestHandler.kt
@@ -1,0 +1,58 @@
+package dev.kord.rest.request
+
+
+/**
+ * Extension of [KtorRequestHandler] which tries to recover stack trace information lost through Ktor's
+ * [io.ktor.util.pipeline.SuspendFunctionGun].
+ *
+ * This is done by creating a [ContextException] to capture the stack trace up until the point just before
+ * [KtorRequestHandler.handle] gets called, then if that call throws any type of [Throwable] the [ContextException] gets
+ * thrown instead (See [ContextException.cause])
+ *
+ * @see ContextException
+ * @see withStackTraceRecovery
+ */
+public class StackTraceRecoveringKtorRequestHandler(private val delegate: KtorRequestHandler) :
+    RequestHandler by delegate {
+
+    /**
+     * @throws ContextException if any exception occurs (this is also the only exception which can be thrown)
+     * @see KtorRequestHandler.handle
+     */
+    override suspend fun <B : Any, R> handle(request: Request<B, R>): R {
+        val stacktrace = ContextException()
+
+        return try {
+            delegate.handle(request)
+        } catch (e: Throwable) {
+            throw stacktrace.apply {
+                sanitizeStackTrace()
+                cause = e
+            }
+        }
+    }
+}
+
+/**
+ * Exception used to save the current stack trace before executing a request.
+ *
+ * @see StackTraceRecoveringKtorRequestHandler
+ */
+public class ContextException internal constructor() : RuntimeException() {
+    override var cause: Throwable? = null
+        internal set
+
+    internal fun sanitizeStackTrace() {
+        // Remove artifacts of stack trace capturing
+        // at dev.kord.rest.request.StackTraceRecoveringKtorRequestHandler.handle(StackTraceRecoveringKtorRequestHandler.kt:7)
+        stackTrace = stackTrace.copyOfRange(1, stackTrace.size)
+    }
+}
+
+/**
+ * Returns a new [RequestHandler] with stack trace recovery enabled.
+ *
+ * @see StackTraceRecoveringKtorRequestHandler
+ */
+public fun KtorRequestHandler.withStackTraceRecovery(): StackTraceRecoveringKtorRequestHandler =
+    StackTraceRecoveringKtorRequestHandler(this)

--- a/rest/src/test/kotlin/request/StackTraceRecoveryTest.kt
+++ b/rest/src/test/kotlin/request/StackTraceRecoveryTest.kt
@@ -1,0 +1,51 @@
+package dev.kord.rest.request
+
+import dev.kord.rest.json.response.GatewayResponse
+import dev.kord.rest.route.Route
+import io.ktor.client.*
+import io.ktor.client.engine.mock.*
+import io.ktor.http.*
+import io.ktor.util.*
+import io.ktor.utils.io.*
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class StackTraceRecoveryTest {
+
+    @Test
+    fun `test stack trace recovery`() = runTest {
+        val mockEngine = MockEngine {
+            respond(
+                content = ByteReadChannel.Empty,
+                status = HttpStatusCode.NotFound
+            )
+        }
+
+        val client = HttpClient(mockEngine)
+        val handler = KtorRequestHandler(client = client, token = "")
+            .withStackTraceRecovery()
+
+        val request = JsonRequest<GatewayResponse, GatewayResponse>(
+            Route.GatewayGet, // The mock engine will 404 for any request, so we just use an endpoint without params
+            emptyMap(),
+            StringValues.Empty,
+            StringValues.Empty,
+            null
+        )
+
+        val stackTrace = Thread.currentThread().stackTrace[1] // 1st one would be Thread.run for some reason
+        try {
+            handler.handle(request)
+        } catch (e: ContextException) {
+            e.printStackTrace()
+            //at dev.kord.rest.request.StackTraceRecoveryTest$test stack trace recovery$1.invokeSuspend(StackTraceRecoveryTest.kt:39)
+            with(e.stackTrace.first()) {
+                assertEquals(stackTrace.className, className)
+                assertEquals(stackTrace.fileName, fileName)
+                assertEquals(stackTrace.lineNumber + 2, lineNumber) // +2 because capture is two lines deeper
+                assertEquals(stackTrace.methodName, methodName)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Ktors SuspendFunctionGun often removes any useful information from a stacktrace

This PR tries to mitigate that by capturing the Stacktrace before Ktor gets called
AS discussed with @Lukellmann this is opt-in﻿
