### PR TITLE
Fix oversights in #561

### DIFF
--- a/rest/src/main/kotlin/json/request/GuildRequests.kt
+++ b/rest/src/main/kotlin/json/request/GuildRequests.kt
@@ -131,7 +131,7 @@ public data class GuildRoleCreateRequest(
     @SerialName("unicode_emoji")
     val unicodeEmoji: Optional<String?> = Optional.Missing(),
     val mentionable: OptionalBoolean = OptionalBoolean.Missing,
-    @Deprecated("This is not part of Discord's current documentation.")
+    /** Only use this when creating a guild. */
     val id: OptionalSnowflake = OptionalSnowflake.Missing,
 ) {
     @Deprecated("Renamed to 'hoist'.", ReplaceWith("this.hoist"), DeprecationLevel.ERROR)


### PR DESCRIPTION
`DiscordVoiceState.channelId` changed its type to `OptionalSnowflake` in https://github.com/kordlib/kord/pull/561, a check in `VoiceUpdateEventHandler` compared it to `null` which it can never happen after the change, replace it with check for `OptionalSnowflake` subtypes instead.

I also wrongly deprecated `GuildRoleRequest.id`, it's actually used and necessary when creating a guild with roles.