### PR TITLE
Hotfix: revert nullable to optional changes in VoiceState

### DIFF
--- a/common/src/main/kotlin/entity/DiscordGuild.kt
+++ b/common/src/main/kotlin/entity/DiscordGuild.kt
@@ -382,7 +382,7 @@ public data class DiscordWebhooksUpdateData(
 @Serializable
 public data class DiscordVoiceState(
     @SerialName("guild_id") val guildId: OptionalSnowflake = OptionalSnowflake.Missing,
-    @SerialName("channel_id") val channelId: OptionalSnowflake = OptionalSnowflake.Missing,
+    @SerialName("channel_id") val channelId: Snowflake?,
     @SerialName("user_id") val userId: Snowflake,
     @SerialName("guild_member") val member: Optional<DiscordGuildMember> = Optional.Missing(),
     @SerialName("session_id") val sessionId: String,
@@ -393,7 +393,7 @@ public data class DiscordVoiceState(
     @SerialName("self_video") val selfVideo: Boolean,
     @SerialName("self_stream") val selfStream: OptionalBoolean = OptionalBoolean.Missing,
     val suppress: Boolean,
-    @SerialName("request_to_speak_timestamp") val requestToSpeakTimestamp: Optional<Instant?> = Optional.Missing(),
+    @SerialName("request_to_speak_timestamp") val requestToSpeakTimestamp: Instant?,
 )
 
 /**

--- a/common/src/test/kotlin/json/VoiceStateTest.kt
+++ b/common/src/test/kotlin/json/VoiceStateTest.kt
@@ -17,8 +17,8 @@ class VoiceStateTest {
         val state = Json.decodeFromString(DiscordVoiceState.serializer(), file("voicestate"))
 
         with(state) {
-            channelId.value.toString() shouldBe "157733188964188161"
-            userId.toString() shouldBe "80351110224678912"
+            channelId shouldBe "157733188964188161"
+            userId shouldBe "80351110224678912"
             sessionId shouldBe "90326bd25d71d39b9ef95b299e3872ff"
             deaf shouldBe false
             mute shouldBe false

--- a/core/src/main/kotlin/cache/data/VoiceStateData.kt
+++ b/core/src/main/kotlin/cache/data/VoiceStateData.kt
@@ -4,7 +4,6 @@ import dev.kord.cache.api.data.DataDescription
 import dev.kord.cache.api.data.description
 import dev.kord.common.entity.DiscordVoiceState
 import dev.kord.common.entity.Snowflake
-import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
 import dev.kord.common.entity.optional.OptionalSnowflake
 import dev.kord.common.entity.optional.mapSnowflake
@@ -22,7 +21,7 @@ public data class VoiceStateData(
      (And not just because this code would break).
      */
     val guildId: Snowflake,
-    val channelId: OptionalSnowflake = OptionalSnowflake.Missing,
+    val channelId: Snowflake?,
     val userId: Snowflake,
     val memberId: OptionalSnowflake = OptionalSnowflake.Missing,
     val sessionId: String,
@@ -33,7 +32,7 @@ public data class VoiceStateData(
     val suppress: Boolean,
     val selfVideo: Boolean,
     val selfStream: OptionalBoolean = OptionalBoolean.Missing,
-    val requestToSpeakTimestamp: Optional<Instant?> = Optional.Missing(),
+    val requestToSpeakTimestamp: Instant?,
 ) {
     public companion object {
         public val description: DataDescription<VoiceStateData, String> = description(VoiceStateData::id)

--- a/core/src/main/kotlin/entity/VoiceState.kt
+++ b/core/src/main/kotlin/entity/VoiceState.kt
@@ -24,7 +24,7 @@ public class VoiceState(
     public val guildId: Snowflake get() = data.guildId
 
     /** The channel id this user is connected to. */
-    public val channelId: Snowflake? get() = data.channelId.value
+    public val channelId: Snowflake? get() = data.channelId
 
     /** The user id this voice state is for. */
     public val userId: Snowflake get() = data.userId
@@ -54,7 +54,7 @@ public class VoiceState(
     public val isSuppressed: Boolean get() = data.suppress
 
     /** The [Instant] at which the user requested to speak. */
-    public val requestToSpeakTimestamp: Instant? get() = data.requestToSpeakTimestamp.value
+    public val requestToSpeakTimestamp: Instant? get() = data.requestToSpeakTimestamp
 
     /** Discord does not support anger detection. */
     @Deprecated("I can't see any steam...", ReplaceWith("this.isSelfStreaming"), DeprecationLevel.ERROR)

--- a/core/src/test/kotlin/live/LiveGuildTest.kt
+++ b/core/src/test/kotlin/live/LiveGuildTest.kt
@@ -3,7 +3,6 @@ package live
 import dev.kord.common.annotation.KordPreview
 import dev.kord.common.entity.*
 import dev.kord.common.entity.optional.Optional
-import dev.kord.common.entity.optional.OptionalSnowflake
 import dev.kord.common.entity.optional.optionalSnowflake
 import dev.kord.core.cache.data.GuildData
 import dev.kord.core.entity.Guild
@@ -206,7 +205,7 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
                 VoiceStateUpdate(
                     DiscordVoiceState(
                         guildId = it.optionalSnowflake(),
-                        channelId = OptionalSnowflake.Missing,
+                        channelId = null,
                         userId = randomId(),
                         sessionId = "",
                         deaf = false,
@@ -215,7 +214,7 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
                         selfMute = false,
                         selfVideo = false,
                         suppress = false,
-                        requestToSpeakTimestamp = Optional.Missing(),
+                        requestToSpeakTimestamp = null,
                     ),
                     0
                 )

--- a/voice/src/main/kotlin/handlers/VoiceUpdateEventHandler.kt
+++ b/voice/src/main/kotlin/handlers/VoiceUpdateEventHandler.kt
@@ -1,7 +1,6 @@
 package dev.kord.voice.handlers
 
 import dev.kord.common.annotation.KordVoice
-import dev.kord.common.entity.optional.OptionalSnowflake
 import dev.kord.gateway.VoiceServerUpdate
 import dev.kord.gateway.VoiceStateUpdate
 import dev.kord.voice.VoiceConnection
@@ -33,27 +32,22 @@ internal class VoiceUpdateEventHandler(
         on<VoiceStateUpdate> { event ->
             if (!event.isRelatedToConnection(connection)) return@on
 
-            when (event.voiceState.channelId) {
+            // we're not in a voice channel anymore. anything might've happened
+            // discord doesn't tell us whether the channel was deleted or if we were just moved
+            // let's just detach in 5 seconds and let it be cancelled if we join a new voice channel in that time.
+            if (event.voiceState.channelId == null) {
+                voiceUpdateLogger.trace { "detected a change to a null voice channel for guild ${connection.data.guildId}. waiting ${CONNECTION_DETACH_DURATION_IN_MILLIS}ms before shutdown to see if we were moved." }
 
-                // we're not in a voice channel anymore. anything might've happened
-                // discord doesn't tell us whether the channel was deleted or if we were just moved
-                // let's just detach in 5 seconds and let it be cancelled if we join a new voice channel in that time.
-                OptionalSnowflake.Missing -> {
-                    voiceUpdateLogger.trace { "detected a change to a null voice channel for guild ${connection.data.guildId}. waiting ${CONNECTION_DETACH_DURATION_IN_MILLIS}ms before shutdown to see if we were moved." }
+                detachJob?.cancel()
+                detachJob = launch {
+                    delay(CONNECTION_DETACH_DURATION_IN_MILLIS)
 
-                    detachJob?.cancel()
-                    detachJob = launch {
-                        delay(CONNECTION_DETACH_DURATION_IN_MILLIS)
-
-                        connection.shutdown()
-                    }
+                    connection.shutdown()
                 }
-
-                is OptionalSnowflake.Value -> {
-                    voiceUpdateLogger.trace { "detected a voice channel change for guild ${connection.data.guildId}, cancelling detachment." }
-                    detachJob?.cancel()
-                    detachJob = null
-                }
+            } else {
+                voiceUpdateLogger.trace { "detected a voice channel change for guild ${connection.data.guildId}, cancelling detachment." }
+                detachJob?.cancel()
+                detachJob = null
             }
         }
 


### PR DESCRIPTION
https://github.com/discord/discord-api-docs/pull/4565 got reverted in https://github.com/discord/discord-api-docs/commit/168eb706b5cb5e6444a0d678b88fce6664ceb958

This PR reverts the according changes to Kord
- changes to `DiscordVoiceState` and `VoiceStateData` in https://github.com/kordlib/kord/pull/561
- changes to `VoiceUpdateEventHandler` in https://github.com/kordlib/kord/pull/565