### PR TITLE
voice: fix encryption buffer size

### DIFF
--- a/voice/src/main/kotlin/encryption/XSalsa20Poly1305Encryption.kt
+++ b/voice/src/main/kotlin/encryption/XSalsa20Poly1305Encryption.kt
@@ -5,9 +5,14 @@ import com.iwebpp.crypto.TweetNaclFast.SecretBox.boxzerobytesLength
 import com.iwebpp.crypto.TweetNaclFast.SecretBox.zerobytesLength
 import dev.kord.voice.io.MutableByteArrayCursor
 
+// https://datatracker.ietf.org/doc/html/rfc6716#section-3.2.1
+private const val OPUS_MAX_LENGTH = 1276
+
 internal class XSalsa20Poly1305Encryption(private val key: ByteArray) {
-    private val m: ByteArray = ByteArray(984)
-    private val c: ByteArray = ByteArray(984)
+    // this class is only used internally and is used for encrypting opus packets.
+    // we can know the maximum sized buffer required to store any opus packet.
+    private val m: ByteArray = ByteArray(OPUS_MAX_LENGTH + zerobytesLength)
+    private val c: ByteArray = ByteArray(OPUS_MAX_LENGTH + zerobytesLength)
 
     fun box(message: ByteArray, mOffset: Int, mLength: Int, nonce: ByteArray, output: MutableByteArrayCursor): Boolean {
         m.fill(0)


### PR DESCRIPTION
During the initial implementation, I used the length 968 for the max buffer size during encryption of OPUS packets... I'm not sure how I came up with the number, and it is incorrect. The buffer should be able to hold the largest size of an OPUS packet, which is 1276 according to [the RFC spec for the Opus Audio Codec](https://datatracker.ietf.org/doc/html/rfc6716#section-3.2.1). This commit updates this value to adhere to the Opus spec.