### PR TITLE
Fix Guild Scheduled Event Gateway Events

### DIFF
--- a/core/src/main/kotlin/event/guild/GuildScheduledEventCreateEvent.kt
+++ b/core/src/main/kotlin/event/guild/GuildScheduledEventCreateEvent.kt
@@ -2,7 +2,6 @@ package dev.kord.core.event.guild
 
 import dev.kord.core.Kord
 import dev.kord.core.entity.GuildScheduledEvent
-import dev.kord.core.entity.Strategizable
 import dev.kord.core.event.kordCoroutineScope
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
@@ -21,6 +20,6 @@ public data class GuildScheduledEventCreateEvent(
     override val supplier: EntitySupplier = kord.defaultSupplier,
     public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
 ) : GuildScheduledEventEvent, CoroutineScope by coroutineScope {
-    override fun withStrategy(strategy: EntitySupplyStrategy<*>): Strategizable =
+    override fun withStrategy(strategy: EntitySupplyStrategy<*>): GuildScheduledEventCreateEvent =
         copy(supplier = strategy.supply(kord))
 }

--- a/core/src/main/kotlin/event/guild/GuildScheduledEventDeleteEvent.kt
+++ b/core/src/main/kotlin/event/guild/GuildScheduledEventDeleteEvent.kt
@@ -2,7 +2,6 @@ package dev.kord.core.event.guild
 
 import dev.kord.core.Kord
 import dev.kord.core.entity.GuildScheduledEvent
-import dev.kord.core.entity.Strategizable
 import dev.kord.core.event.kordCoroutineScope
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
@@ -22,6 +21,6 @@ public data class GuildScheduledEventDeleteEvent(
     override val supplier: EntitySupplier = kord.defaultSupplier,
     public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
 ) : GuildScheduledEventEvent, CoroutineScope by coroutineScope {
-    override fun withStrategy(strategy: EntitySupplyStrategy<*>): Strategizable =
+    override fun withStrategy(strategy: EntitySupplyStrategy<*>): GuildScheduledEventDeleteEvent =
         copy(supplier = strategy.supply(kord))
 }

--- a/core/src/main/kotlin/event/guild/GuildScheduledEventEvent.kt
+++ b/core/src/main/kotlin/event/guild/GuildScheduledEventEvent.kt
@@ -8,6 +8,7 @@ import dev.kord.core.entity.Strategizable
 import dev.kord.core.entity.channel.TopGuildChannel
 import dev.kord.core.event.Event
 import dev.kord.core.exception.EntityNotFoundException
+import dev.kord.core.supplier.EntitySupplyStrategy
 import dev.kord.core.supplier.getChannelOfOrNull
 import kotlinx.coroutines.CoroutineScope
 
@@ -18,7 +19,7 @@ import kotlinx.coroutines.CoroutineScope
  * @see GuildScheduledEventUpdateEvent
  * @see GuildScheduledEventDeleteEvent
  */
-public interface GuildScheduledEventEvent : Event, CoroutineScope, Strategizable {
+public sealed interface GuildScheduledEventEvent : Event, CoroutineScope, Strategizable {
 
     /**
      * The [GuildScheduledEvent].
@@ -63,4 +64,6 @@ public interface GuildScheduledEventEvent : Event, CoroutineScope, Strategizable
      * @throws [RequestException] if anything went wrong during the request.
      */
     public suspend fun getChannelOrNull(): TopGuildChannel? = channelId?.let { supplier.getChannelOfOrNull(it) }
+
+    override fun withStrategy(strategy: EntitySupplyStrategy<*>): GuildScheduledEventEvent
 }

--- a/core/src/main/kotlin/event/guild/GuildScheduledEventUpdateEvent.kt
+++ b/core/src/main/kotlin/event/guild/GuildScheduledEventUpdateEvent.kt
@@ -4,7 +4,6 @@ import dev.kord.common.entity.Snowflake
 import dev.kord.common.exception.RequestException
 import dev.kord.core.Kord
 import dev.kord.core.entity.GuildScheduledEvent
-import dev.kord.core.entity.Strategizable
 import dev.kord.core.entity.channel.TopGuildChannel
 import dev.kord.core.event.kordCoroutineScope
 import dev.kord.core.supplier.EntitySupplier
@@ -46,6 +45,6 @@ public data class GuildScheduledEventUpdateEvent(
      */
     override suspend fun getChannelOrNull(): TopGuildChannel? = super.getChannelOrNull()
 
-    override fun withStrategy(strategy: EntitySupplyStrategy<*>): Strategizable =
+    override fun withStrategy(strategy: EntitySupplyStrategy<*>): GuildScheduledEventUpdateEvent =
         copy(supplier = strategy.supply(kord))
 }

--- a/core/src/main/kotlin/event/guild/GuildScheduledEventUserEvent.kt
+++ b/core/src/main/kotlin/event/guild/GuildScheduledEventUserEvent.kt
@@ -1,12 +1,8 @@
 package dev.kord.core.event.guild
 
-import dev.kord.common.annotation.KordPreview
 import dev.kord.common.entity.Snowflake
 import dev.kord.core.Kord
-import dev.kord.core.entity.Guild
-import dev.kord.core.entity.GuildScheduledEvent
-import dev.kord.core.entity.Strategizable
-import dev.kord.core.entity.User
+import dev.kord.core.entity.*
 import dev.kord.core.event.Event
 import dev.kord.core.event.kordCoroutineScope
 import dev.kord.core.supplier.EntitySupplier
@@ -14,10 +10,10 @@ import dev.kord.core.supplier.EntitySupplyStrategy
 import kotlinx.coroutines.CoroutineScope
 
 /**
- * NOTE: this event is currently experimental and not officially supported
+ * Sent when a user has [subscribed to][GuildScheduledEventUserAddEvent] or
+ * [unsubscribed from][GuildScheduledEventUserRemoveEvent] a [GuildScheduledEvent].
  */
-@KordPreview
-public interface GuildScheduledEventUserEvent : Event, Strategizable {
+public sealed interface GuildScheduledEventUserEvent : Event, CoroutineScope, Strategizable {
     public val scheduledEventId: Snowflake
     public val userId: Snowflake
     public val guildId: Snowflake
@@ -25,18 +21,20 @@ public interface GuildScheduledEventUserEvent : Event, Strategizable {
     public suspend fun getUser(): User = supplier.getUser(userId)
     public suspend fun getUserOrNull(): User? = supplier.getUserOrNull(userId)
 
+    public suspend fun getMember(): Member = supplier.getMember(guildId, userId)
+    public suspend fun getMemberOrNull(): Member? = supplier.getMemberOrNull(guildId, userId)
+
     public suspend fun getGuild(): Guild = supplier.getGuild(guildId)
     public suspend fun getGuildOrNull(): Guild? = supplier.getGuildOrNull(guildId)
 
     public suspend fun getEvent(): GuildScheduledEvent = supplier.getGuildScheduledEvent(guildId, scheduledEventId)
     public suspend fun getEventOrNull(): GuildScheduledEvent? =
         supplier.getGuildScheduledEventOrNull(guildId, scheduledEventId)
+
+    override fun withStrategy(strategy: EntitySupplyStrategy<*>): GuildScheduledEventUserEvent
 }
 
-/**
- * NOTE: this event is currently experimental and not officially supported
- */
-@KordPreview
+/** Sent when a user has subscribed to a [GuildScheduledEvent]. */
 public data class GuildScheduledEventUserAddEvent(
     override val scheduledEventId: Snowflake,
     override val userId: Snowflake,
@@ -46,15 +44,11 @@ public data class GuildScheduledEventUserAddEvent(
     override val supplier: EntitySupplier = kord.defaultSupplier,
     public val coroutineScope: CoroutineScope = kordCoroutineScope(kord),
 ) : GuildScheduledEventUserEvent, CoroutineScope by coroutineScope {
-    override fun withStrategy(strategy: EntitySupplyStrategy<*>): Strategizable = GuildScheduledEventUserAddEvent(
-        scheduledEventId, userId, guildId, kord, shard, strategy.supply(kord)
-    )
+    override fun withStrategy(strategy: EntitySupplyStrategy<*>): GuildScheduledEventUserAddEvent =
+        GuildScheduledEventUserAddEvent(scheduledEventId, userId, guildId, kord, shard, strategy.supply(kord))
 }
 
-/**
- * NOTE: this event is currently experimental and not officially supported
- */
-@KordPreview
+/** Sent when a user has unsubscribed from a [GuildScheduledEvent]. */
 public data class GuildScheduledEventUserRemoveEvent(
     override val scheduledEventId: Snowflake,
     override val userId: Snowflake,
@@ -64,7 +58,6 @@ public data class GuildScheduledEventUserRemoveEvent(
     override val supplier: EntitySupplier = kord.defaultSupplier,
     public val coroutineScope: CoroutineScope = kordCoroutineScope(kord),
 ) : GuildScheduledEventUserEvent, CoroutineScope by coroutineScope {
-    override fun withStrategy(strategy: EntitySupplyStrategy<*>): Strategizable = GuildScheduledEventUserAddEvent(
-        scheduledEventId, userId, guildId, kord, shard, strategy.supply(kord)
-    )
+    override fun withStrategy(strategy: EntitySupplyStrategy<*>): GuildScheduledEventUserRemoveEvent =
+        GuildScheduledEventUserRemoveEvent(scheduledEventId, userId, guildId, kord, shard, strategy.supply(kord))
 }

--- a/core/src/main/kotlin/gateway/handler/GuildEventHandler.kt
+++ b/core/src/main/kotlin/gateway/handler/GuildEventHandler.kt
@@ -7,43 +7,10 @@ import dev.kord.cache.api.query
 import dev.kord.common.entity.optional.optionalSnowflake
 import dev.kord.common.entity.optional.orEmpty
 import dev.kord.core.Kord
-import dev.kord.core.cache.data.ChannelData
-import dev.kord.core.cache.data.EmojiData
-import dev.kord.core.cache.data.GuildData
-import dev.kord.core.cache.data.GuildScheduledEventData
-import dev.kord.core.cache.data.InviteCreateData
-import dev.kord.core.cache.data.InviteDeleteData
-import dev.kord.core.cache.data.MemberData
-import dev.kord.core.cache.data.MembersChunkData
-import dev.kord.core.cache.data.PresenceData
-import dev.kord.core.cache.data.RoleData
-import dev.kord.core.cache.data.UserData
-import dev.kord.core.cache.data.VoiceStateData
-import dev.kord.core.cache.data.id
+import dev.kord.core.cache.data.*
 import dev.kord.core.cache.idEq
-import dev.kord.core.entity.Guild
-import dev.kord.core.entity.GuildEmoji
-import dev.kord.core.entity.GuildScheduledEvent
-import dev.kord.core.entity.Member
-import dev.kord.core.entity.Presence
-import dev.kord.core.entity.Role
-import dev.kord.core.entity.User
-import dev.kord.core.event.guild.BanAddEvent
-import dev.kord.core.event.guild.BanRemoveEvent
-import dev.kord.core.event.guild.EmojisUpdateEvent
-import dev.kord.core.event.guild.GuildCreateEvent
-import dev.kord.core.event.guild.GuildDeleteEvent
-import dev.kord.core.event.guild.GuildScheduledEventCreateEvent
-import dev.kord.core.event.guild.GuildScheduledEventDeleteEvent
-import dev.kord.core.event.guild.GuildScheduledEventUpdateEvent
-import dev.kord.core.event.guild.GuildUpdateEvent
-import dev.kord.core.event.guild.IntegrationsUpdateEvent
-import dev.kord.core.event.guild.InviteCreateEvent
-import dev.kord.core.event.guild.InviteDeleteEvent
-import dev.kord.core.event.guild.MemberJoinEvent
-import dev.kord.core.event.guild.MemberLeaveEvent
-import dev.kord.core.event.guild.MemberUpdateEvent
-import dev.kord.core.event.guild.MembersChunkEvent
+import dev.kord.core.entity.*
+import dev.kord.core.event.guild.*
 import dev.kord.core.event.role.RoleCreateEvent
 import dev.kord.core.event.role.RoleDeleteEvent
 import dev.kord.core.event.role.RoleUpdateEvent
@@ -79,6 +46,8 @@ internal class GuildEventHandler(
             is GuildScheduledEventCreate -> handle(event, shard, kord, coroutineScope)
             is GuildScheduledEventUpdate -> handle(event, shard, kord, coroutineScope)
             is GuildScheduledEventDelete -> handle(event, shard, kord, coroutineScope)
+            is GuildScheduledEventUserAdd -> handle(event, shard, kord, coroutineScope)
+            is GuildScheduledEventUserRemove -> handle(event, shard, kord, coroutineScope)
             is PresenceUpdate -> handle(event, shard, kord, coroutineScope)
             is InviteCreate -> handle(event, shard, kord, coroutineScope)
             is InviteDelete -> handle(event, shard, kord, coroutineScope)
@@ -386,6 +355,38 @@ internal class GuildEventHandler(
         val scheduledEvent = GuildScheduledEvent(eventData, kord)
 
         return GuildScheduledEventDeleteEvent(scheduledEvent, kord, shard, coroutineScope = coroutineScope)
+    }
+
+    private fun handle(
+        event: GuildScheduledEventUserAdd,
+        shard: Int,
+        kord: Kord,
+        coroutineScope: CoroutineScope,
+    ): GuildScheduledEventUserAddEvent = with(event.data) {
+        GuildScheduledEventUserAddEvent(
+            guildScheduledEventId,
+            userId,
+            guildId,
+            kord,
+            shard,
+            coroutineScope = coroutineScope,
+        )
+    }
+
+    private fun handle(
+        event: GuildScheduledEventUserRemove,
+        shard: Int,
+        kord: Kord,
+        coroutineScope: CoroutineScope,
+    ): GuildScheduledEventUserRemoveEvent = with(event.data) {
+        GuildScheduledEventUserRemoveEvent(
+            guildScheduledEventId,
+            userId,
+            guildId,
+            kord,
+            shard,
+            coroutineScope = coroutineScope,
+        )
     }
 
     private suspend fun handle(

--- a/gateway/src/main/kotlin/Event.kt
+++ b/gateway/src/main/kotlin/Event.kt
@@ -427,15 +427,19 @@ public sealed class Event {
                     sequence
                 )
                 "GUILD_SCHEDULED_EVENT_USER_ADD" -> GuildScheduledEventUserAdd(
-                    decoder.decodeSerializableElement(descriptor, index, Snowflake.serializer()),
-                    decoder.decodeSerializableElement(descriptor, index, Snowflake.serializer()),
-                    decoder.decodeSerializableElement(descriptor, index, Snowflake.serializer()),
+                    data = decoder.decodeSerializableElement(
+                        descriptor,
+                        index,
+                        GuildScheduledEventUserAdd.Data.serializer(),
+                    ),
                     sequence
                 )
                 "GUILD_SCHEDULED_EVENT_USER_REMOVE" -> GuildScheduledEventUserRemove(
-                    decoder.decodeSerializableElement(descriptor, index, Snowflake.serializer()),
-                    decoder.decodeSerializableElement(descriptor, index, Snowflake.serializer()),
-                    decoder.decodeSerializableElement(descriptor, index, Snowflake.serializer()),
+                    data = decoder.decodeSerializableElement(
+                        descriptor,
+                        index,
+                        GuildScheduledEventUserRemove.Data.serializer(),
+                    ),
                     sequence
                 )
 
@@ -734,19 +738,31 @@ public data class GuildScheduledEventUpdate(val event: DiscordGuildScheduledEven
 public data class GuildScheduledEventDelete(val event: DiscordGuildScheduledEvent, override val sequence: Int?) :
     DispatchEvent()
 
-public data class GuildScheduledEventUserAdd(
-    val eventId: Snowflake,
-    val userId: Snowflake,
-    val guildId: Snowflake,
-    override val sequence: Int?,
-) : DispatchEvent()
+public data class GuildScheduledEventUserAdd(val data: Data, override val sequence: Int?) : DispatchEvent() {
 
-public data class GuildScheduledEventUserRemove(
-    val eventId: Snowflake,
-    val userId: Snowflake,
-    val guildId: Snowflake,
-    override val sequence: Int?,
-) : DispatchEvent()
+    @Serializable
+    public data class Data(
+        @SerialName("guild_scheduled_event_id")
+        val guildScheduledEventId: Snowflake,
+        @SerialName("user_id")
+        val userId: Snowflake,
+        @SerialName("guild_id")
+        val guildId: Snowflake,
+    )
+}
+
+public data class GuildScheduledEventUserRemove(val data: Data, override val sequence: Int?) : DispatchEvent() {
+
+    @Serializable
+    public data class Data(
+        @SerialName("guild_scheduled_event_id")
+        val guildScheduledEventId: Snowflake,
+        @SerialName("user_id")
+        val userId: Snowflake,
+        @SerialName("guild_id")
+        val guildId: Snowflake,
+    )
+}
 
 @Serializable
 public data class DiscordThreadListSync(

--- a/gateway/src/main/kotlin/Event.kt
+++ b/gateway/src/main/kotlin/Event.kt
@@ -430,7 +430,7 @@ public sealed class Event {
                     data = decoder.decodeSerializableElement(
                         descriptor,
                         index,
-                        GuildScheduledEventUserAdd.Data.serializer(),
+                        GuildScheduledEventUserMetadata.serializer(),
                     ),
                     sequence
                 )
@@ -438,7 +438,7 @@ public sealed class Event {
                     data = decoder.decodeSerializableElement(
                         descriptor,
                         index,
-                        GuildScheduledEventUserRemove.Data.serializer(),
+                        GuildScheduledEventUserMetadata.serializer(),
                     ),
                     sequence
                 )
@@ -738,31 +738,25 @@ public data class GuildScheduledEventUpdate(val event: DiscordGuildScheduledEven
 public data class GuildScheduledEventDelete(val event: DiscordGuildScheduledEvent, override val sequence: Int?) :
     DispatchEvent()
 
-public data class GuildScheduledEventUserAdd(val data: Data, override val sequence: Int?) : DispatchEvent() {
+public data class GuildScheduledEventUserAdd(
+    val data: GuildScheduledEventUserMetadata,
+    override val sequence: Int?,
+) : DispatchEvent()
 
-    @Serializable
-    public data class Data(
-        @SerialName("guild_scheduled_event_id")
-        val guildScheduledEventId: Snowflake,
-        @SerialName("user_id")
-        val userId: Snowflake,
-        @SerialName("guild_id")
-        val guildId: Snowflake,
-    )
-}
+public data class GuildScheduledEventUserRemove(
+    val data: GuildScheduledEventUserMetadata,
+    override val sequence: Int?,
+) : DispatchEvent()
 
-public data class GuildScheduledEventUserRemove(val data: Data, override val sequence: Int?) : DispatchEvent() {
-
-    @Serializable
-    public data class Data(
-        @SerialName("guild_scheduled_event_id")
-        val guildScheduledEventId: Snowflake,
-        @SerialName("user_id")
-        val userId: Snowflake,
-        @SerialName("guild_id")
-        val guildId: Snowflake,
-    )
-}
+@Serializable
+public data class GuildScheduledEventUserMetadata(
+    @SerialName("guild_scheduled_event_id")
+    val guildScheduledEventId: Snowflake,
+    @SerialName("user_id")
+    val userId: Snowflake,
+    @SerialName("guild_id")
+    val guildId: Snowflake,
+)
 
 @Serializable
 public data class DiscordThreadListSync(


### PR DESCRIPTION
- fix deserialization of `GuildScheduledEventUserAdd` and `GuildScheduledEventUserRemove` in gateway module (deserialize object with 3 snowflakes instead of 3 flat snowflakes)
- actually dispatch `GuildScheduledEventUserAddEvent` and `GuildScheduledEventUserRemoveEvent` in core module
- add `getMember` and `getMemberOrNull` to `GuildScheduledEventUserEvent`
- fix return types of `withStrategy`