### PR TITLE
Change "dev.kord.rest.version" to be retrieved via `getProperty`, not `getenv`

### DIFF
--- a/rest/src/main/kotlin/route/Route.kt
+++ b/rest/src/main/kotlin/route/Route.kt
@@ -17,7 +17,7 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.json.Json
 
 internal const val REST_VERSION_PROPERTY_NAME = "dev.kord.rest.version"
-internal val restVersion get() = System.getenv(REST_VERSION_PROPERTY_NAME) ?: "v10"
+internal val restVersion get() = System.getProperty(REST_VERSION_PROPERTY_NAME) ?: "v10"
 
 public sealed interface ResponseMapper<T> {
     public fun deserialize(json: Json, body: String): T


### PR DESCRIPTION
`dev.kord.rest.version` looks and sounds like a Java System Property... but it is retrieved via `getenv`.

However environment variables use `UPPERCASED_VARIABLES` as the convention, so I don't think this was meant to be retrieved via `getenv`.