### PR TITLE
Version constant injection

### DIFF
--- a/.github/workflows/deployment-ci.yml
+++ b/.github/workflows/deployment-ci.yml
@@ -68,6 +68,9 @@ jobs:
         with:
           java-version: 8
 
+      - name: Set SHORT_SHA environment variable to short commit hash
+        run: echo "SHORT_SHA=$(git rev-parse --short ${{ github.sha }})" >> $GITHUB_ENV
+
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
         with:

--- a/.github/workflows/deployment-ci.yml
+++ b/.github/workflows/deployment-ci.yml
@@ -31,6 +31,9 @@ jobs:
         with:
           java-version: 8
 
+      - name: Set SHORT_SHA environment variable to short commit hash
+        run: echo "SHORT_SHA=$(git rev-parse --short ${{ github.sha }})" >> $GITHUB_ENV
+
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
         with:

--- a/buildSrc/src/main/kotlin/Projects.kt
+++ b/buildSrc/src/main/kotlin/Projects.kt
@@ -1,23 +1,7 @@
-import org.gradle.api.Project
-import java.io.ByteArrayOutputStream
-
 /**
  * whether the process has been invoked by JitPack
  */
 val isJitPack get() = "true" == System.getenv("JITPACK")
-
-val Project.commitHash: String
-    get() = try {
-        ByteArrayOutputStream().use { out ->
-            exec {
-                commandLine("git", "rev-parse", "--short", "HEAD")
-                standardOutput = out
-            }
-            out.toString().trim()
-        }
-    } catch (e: Throwable) {
-        System.getenv("GITHUB_SHA") ?: "unknown"
-    }
 
 object Library {
     const val name = "kord"
@@ -35,6 +19,11 @@ object Library {
             }
 
         }
+
+    val commitHash get() = System.getenv("GITHUB_SHA") ?: "unknown"
+
+    // this environment variable isn't available out of the box, we set it ourselves
+    val shortCommitHash get() = System.getenv("SHORT_SHA") ?: "unknown"
 
     const val description = "Idiomatic Kotlin Wrapper for The Discord API"
     const val projectUrl = "https://github.com/kordlib/kord"

--- a/buildSrc/src/main/kotlin/Projects.kt
+++ b/buildSrc/src/main/kotlin/Projects.kt
@@ -1,10 +1,23 @@
-import org.gradle.kotlin.dsl.DependencyHandlerScope
-import org.gradle.kotlin.dsl.project
+import org.gradle.api.Project
+import java.io.ByteArrayOutputStream
 
 /**
  * whether the process has been invoked by JitPack
  */
 val isJitPack get() = "true" == System.getenv("JITPACK")
+
+val Project.commitHash: String
+    get() = try {
+        ByteArrayOutputStream().use { out ->
+            exec {
+                commandLine("git", "rev-parse", "--short", "HEAD")
+                standardOutput = out
+            }
+            out.toString().trim()
+        }
+    } catch (e: Throwable) {
+        System.getenv("GITHUB_SHA") ?: "unknown"
+    }
 
 object Library {
     const val name = "kord"

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -2,6 +2,9 @@ plugins {
     `kord-module`
     `kord-sampled-module`
     `kord-publishing`
+
+    // see https://github.com/gmazzo/gradle-buildconfig-plugin
+    id("com.github.gmazzo.buildconfig") version "3.0.3"
 }
 
 dependencies {
@@ -10,4 +13,27 @@ dependencies {
     api(libs.bundles.common)
     testImplementation(libs.bundles.test.implementation)
     testRuntimeOnly(libs.bundles.test.runtime)
+}
+
+/*
+This will generate a file named "BuildConfigGenerated.kt" that looks like:
+
+package dev.kord.common
+
+internal const val BUILD_CONFIG_GENERATED_LIBRARY_VERSION: String = "<version>"
+*/
+buildConfig {
+    packageName("dev.kord.common")
+    className("BuildConfigGenerated")
+
+    useKotlinOutput {
+        topLevelConstants = true
+        internalVisibility = true
+    }
+
+    buildConfigField(
+        type = "String",
+        name = "BUILD_CONFIG_GENERATED_LIBRARY_VERSION",
+        value = "\"${Library.version}\"",
+    )
 }

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -27,6 +27,7 @@ This will generate a file named "BuildConfigGenerated.kt" that looks like:
 package dev.kord.common
 
 internal const val BUILD_CONFIG_GENERATED_LIBRARY_VERSION: String = "<version>"
+internal const val BUILD_CONFIG_GENERATED_COMMIT_HASH: String = "<commit hash>"
 */
 buildConfig {
     packageName("dev.kord.common")
@@ -37,9 +38,6 @@ buildConfig {
         internalVisibility = true
     }
 
-    buildConfigField(
-        type = "String",
-        name = "BUILD_CONFIG_GENERATED_LIBRARY_VERSION",
-        value = "\"${Library.version}\"",
-    )
+    buildConfigField(type = "String", name = "BUILD_CONFIG_GENERATED_LIBRARY_VERSION", value = "\"${Library.version}\"")
+    buildConfigField(type = "String", name = "BUILD_CONFIG_GENERATED_COMMIT_HASH", value = "\"$commitHash\"")
 }

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
 }
 
 repositories {
+    gradlePluginPortal()
     mavenCentral()
 }
 

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -7,6 +7,10 @@ plugins {
     id("com.github.gmazzo.buildconfig") version "3.0.3"
 }
 
+repositories {
+    mavenCentral()
+}
+
 dependencies {
     api(libs.kotlinx.datetime)
 

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -1,3 +1,9 @@
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+}
+
 plugins {
     `kord-module`
     `kord-sampled-module`
@@ -5,11 +11,6 @@ plugins {
 
     // see https://github.com/gmazzo/gradle-buildconfig-plugin
     id("com.github.gmazzo.buildconfig") version "3.0.3"
-}
-
-repositories {
-    gradlePluginPortal()
-    mavenCentral()
 }
 
 dependencies {

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -28,6 +28,7 @@ package dev.kord.common
 
 internal const val BUILD_CONFIG_GENERATED_LIBRARY_VERSION: String = "<version>"
 internal const val BUILD_CONFIG_GENERATED_COMMIT_HASH: String = "<commit hash>"
+internal const val BUILD_CONFIG_GENERATED_SHORT_COMMIT_HASH: String = "<short commit hash>"
 */
 buildConfig {
     packageName("dev.kord.common")
@@ -38,6 +39,7 @@ buildConfig {
         internalVisibility = true
     }
 
-    buildConfigField(type = "String", name = "BUILD_CONFIG_GENERATED_LIBRARY_VERSION", value = "\"${Library.version}\"")
-    buildConfigField(type = "String", name = "BUILD_CONFIG_GENERATED_COMMIT_HASH", value = "\"$commitHash\"")
+    buildConfigField("String", "BUILD_CONFIG_GENERATED_LIBRARY_VERSION", "\"${Library.version}\"")
+    buildConfigField("String", "BUILD_CONFIG_GENERATED_COMMIT_HASH", "\"${Library.commitHash}\"")
+    buildConfigField("String", "BUILD_CONFIG_GENERATED_SHORT_COMMIT_HASH", "\"${Library.shortCommitHash}\"")
 }

--- a/common/src/main/kotlin/KordConstants.kt
+++ b/common/src/main/kotlin/KordConstants.kt
@@ -8,6 +8,8 @@ public object KordConstants {
     /** Kord's version. */
     public val KORD_VERSION: String = BUILD_CONFIG_GENERATED_LIBRARY_VERSION
 
+    public val KORD_COMMIT_HASH: String = BUILD_CONFIG_GENERATED_COMMIT_HASH
+
     /** URL for Kord's GitHub repository. */
     public val KORD_GITHUB_URL: String = "https://github.com/kordlib/kord"
 

--- a/common/src/main/kotlin/KordConstants.kt
+++ b/common/src/main/kotlin/KordConstants.kt
@@ -1,7 +1,16 @@
+// No const vals, they are inlined, so recompiling would be required when values change.
+@file:Suppress("MayBeConstant")
+
 package dev.kord.common
 
 public object KordConstants {
 
+    /** Kord's version. */
+    public val KORD_VERSION: String = BUILD_CONFIG_GENERATED_LIBRARY_VERSION
+
+    /** URL for Kord's GitHub repository. */
+    public val KORD_GITHUB_URL: String = "https://github.com/kordlib/kord"
+
     /** Kord's value for the [User Agent header](https://discord.com/developers/docs/reference#user-agent). */
-    public const val USER_AGENT: String = "DiscordBot (https://github.com/kordlib/kord, 0.8.0-M12)"
+    public val USER_AGENT: String = "DiscordBot ($KORD_GITHUB_URL, $KORD_VERSION)"
 }

--- a/common/src/main/kotlin/KordConstants.kt
+++ b/common/src/main/kotlin/KordConstants.kt
@@ -11,6 +11,9 @@ public object KordConstants {
     /** The hash of the commit from which this Kord version was built. */
     public val KORD_COMMIT_HASH: String = BUILD_CONFIG_GENERATED_COMMIT_HASH
 
+    /** Short variant of [KORD_COMMIT_HASH]. */
+    public val KORD_SHORT_COMMIT_HASH: String = BUILD_CONFIG_GENERATED_SHORT_COMMIT_HASH
+
     /** URL for Kord's GitHub repository. */
     public val KORD_GITHUB_URL: String = "https://github.com/kordlib/kord"
 

--- a/common/src/main/kotlin/KordConstants.kt
+++ b/common/src/main/kotlin/KordConstants.kt
@@ -8,6 +8,7 @@ public object KordConstants {
     /** Kord's version. */
     public val KORD_VERSION: String = BUILD_CONFIG_GENERATED_LIBRARY_VERSION
 
+    /** The hash of the commit from which this Kord version was built. */
     public val KORD_COMMIT_HASH: String = BUILD_CONFIG_GENERATED_COMMIT_HASH
 
     /** URL for Kord's GitHub repository. */

--- a/common/src/main/kotlin/KordConstants.kt
+++ b/common/src/main/kotlin/KordConstants.kt
@@ -3,20 +3,28 @@
 
 package dev.kord.common
 
+import dev.kord.common.annotation.KordExperimental
+
+@KordExperimental
 public object KordConstants {
 
     /** Kord's version. */
+    @KordExperimental
     public val KORD_VERSION: String = BUILD_CONFIG_GENERATED_LIBRARY_VERSION
 
     /** The hash of the commit from which this Kord version was built. */
+    @KordExperimental
     public val KORD_COMMIT_HASH: String = BUILD_CONFIG_GENERATED_COMMIT_HASH
 
     /** Short variant of [KORD_COMMIT_HASH]. */
+    @KordExperimental
     public val KORD_SHORT_COMMIT_HASH: String = BUILD_CONFIG_GENERATED_SHORT_COMMIT_HASH
 
     /** URL for Kord's GitHub repository. */
+    @KordExperimental
     public val KORD_GITHUB_URL: String = "https://github.com/kordlib/kord"
 
     /** Kord's value for the [User Agent header](https://discord.com/developers/docs/reference#user-agent). */
+    @KordExperimental
     public val USER_AGENT: String = "DiscordBot ($KORD_GITHUB_URL, $KORD_VERSION)"
 }

--- a/core/src/main/kotlin/builder/kord/KordBuilder.kt
+++ b/core/src/main/kotlin/builder/kord/KordBuilder.kt
@@ -2,6 +2,7 @@ package dev.kord.core.builder.kord
 
 import dev.kord.cache.api.DataCache
 import dev.kord.common.KordConstants
+import dev.kord.common.annotation.KordExperimental
 import dev.kord.common.entity.Snowflake
 import dev.kord.common.ratelimit.BucketRateLimiter
 import dev.kord.core.ClientResources
@@ -195,6 +196,7 @@ public class KordBuilder(public val token: String) {
      */
     private suspend fun HttpClient.getGatewayInfo(): BotGatewayResponse {
         val response = get<HttpResponse>("${Route.baseUrl}${Route.GatewayBotGet.path}") {
+            @OptIn(KordExperimental::class)
             header(UserAgent, KordConstants.USER_AGENT)
             header(Authorization, "Bot $token")
         }

--- a/rest/src/main/kotlin/service/RestService.kt
+++ b/rest/src/main/kotlin/service/RestService.kt
@@ -1,6 +1,7 @@
 package dev.kord.rest.service
 
 import dev.kord.common.KordConstants
+import dev.kord.common.annotation.KordExperimental
 import dev.kord.rest.request.RequestBuilder
 import dev.kord.rest.request.RequestHandler
 import dev.kord.rest.route.Route
@@ -19,6 +20,7 @@ public abstract class RestService(@PublishedApi internal val requestHandler: Req
         val request = RequestBuilder(route)
             .apply(builder)
             .apply {
+                @OptIn(KordExperimental::class)
                 unencodedHeader(UserAgent, KordConstants.USER_AGENT)
                 if (route.requiresAuthorizationHeader) {
                     unencodedHeader(Authorization, "Bot ${requestHandler.token}")


### PR DESCRIPTION
This PR changes the version used in the user agent header from being hard-coded to being generated at build time using [this gradle plugin](https://github.com/gmazzo/gradle-buildconfig-plugin).

The plugin will generate the internal top-level property `dev.kord.common.BUILD_CONFIG_GENERATED_LIBRARY_VERSION` and assign the value of [`Library.version`](https://github.com/kordlib/kord/blob/features/version-injection/buildSrc/src/main/kotlin/Projects.kt#L12) to it. `KordConstants.KORD_VERSION` then makes this publicly accessible.