### PR TITLE
Deprecate `IntegrationApplication.summary`

### DIFF
--- a/common/src/main/kotlin/entity/DiscordIntegration.kt
+++ b/common/src/main/kotlin/entity/DiscordIntegration.kt
@@ -10,6 +10,7 @@ import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
+import kotlin.DeprecationLevel.ERROR
 
 @Serializable
 public data class DiscordIntegration(
@@ -49,6 +50,7 @@ public data class IntegrationApplication(
     val name: String,
     val icon: String?,
     val description: String,
+    @Deprecated("This is deprecated and will always be empty.", level = ERROR)
     val summary: String,
     val bot: Optional<DiscordUser> = Optional.Missing(),
 )

--- a/common/src/main/kotlin/entity/DiscordIntegration.kt
+++ b/common/src/main/kotlin/entity/DiscordIntegration.kt
@@ -10,7 +10,6 @@ import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
-import kotlin.DeprecationLevel.ERROR
 
 @Serializable
 public data class DiscordIntegration(
@@ -50,7 +49,7 @@ public data class IntegrationApplication(
     val name: String,
     val icon: String?,
     val description: String,
-    @Deprecated("This is deprecated and will always be empty.", level = ERROR)
+    @Deprecated("This is deprecated and will always be empty.")
     val summary: String,
     val bot: Optional<DiscordUser> = Optional.Missing(),
 )


### PR DESCRIPTION
see https://github.com/discord/discord-api-docs/pull/4686, merged in https://github.com/discord/discord-api-docs/commit/bada30b7ac4c06c4faec527e0547f9513b78c27f