### PR TITLE
Update stage instance requests

### DIFF
--- a/core/src/main/kotlin/behavior/StageInstanceBehavior.kt
+++ b/core/src/main/kotlin/behavior/StageInstanceBehavior.kt
@@ -11,7 +11,7 @@ import dev.kord.core.entity.channel.StageChannel
 import dev.kord.core.exception.EntityNotFoundException
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
-import dev.kord.rest.json.request.StageInstanceUpdateRequest
+import dev.kord.rest.builder.stage.StageInstanceModifyBuilder
 
 public interface StageInstanceBehavior : KordEntity, Strategizable {
 
@@ -20,8 +20,10 @@ public interface StageInstanceBehavior : KordEntity, Strategizable {
 
     public suspend fun delete(reason: String? = null): Unit = kord.rest.stageInstance.deleteStageInstance(channelId, reason)
 
+    @Suppress("DEPRECATION")
+    @Deprecated("Replaced by 'edit'.", ReplaceWith("this.edit {\nthis@edit.topic = topic\n}"))
     public suspend fun update(topic: String): StageInstance {
-        val instance = kord.rest.stageInstance.updateStageInstance(channelId, StageInstanceUpdateRequest(topic))
+        val instance = kord.rest.stageInstance.updateStageInstance(channelId, dev.kord.rest.json.request.StageInstanceUpdateRequest(topic))
         val data = StageInstanceData.from(instance)
 
         return StageInstance(data, kord, supplier)
@@ -63,6 +65,13 @@ public interface StageInstanceBehavior : KordEntity, Strategizable {
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): StageInstanceBehavior =
         StageInstanceBehavior(id, channelId, kord, strategy.supply(kord))
 }
+
+public suspend inline fun StageInstanceBehavior.edit(builder: StageInstanceModifyBuilder.() -> Unit): StageInstance {
+    val instance = kord.rest.stageInstance.modifyStageInstance(channelId, builder)
+    val data = StageInstanceData.from(instance)
+    return StageInstance(data, kord, supplier)
+}
+
 
 internal fun StageInstanceBehavior(id: Snowflake, channelId: Snowflake, kord: Kord, supplier: EntitySupplier) =
     object : StageInstanceBehavior {

--- a/core/src/main/kotlin/behavior/StageInstanceBehavior.kt
+++ b/core/src/main/kotlin/behavior/StageInstanceBehavior.kt
@@ -12,6 +12,8 @@ import dev.kord.core.exception.EntityNotFoundException
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 import dev.kord.rest.builder.stage.StageInstanceModifyBuilder
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 
 public interface StageInstanceBehavior : KordEntity, Strategizable {
 
@@ -67,6 +69,8 @@ public interface StageInstanceBehavior : KordEntity, Strategizable {
 }
 
 public suspend inline fun StageInstanceBehavior.edit(builder: StageInstanceModifyBuilder.() -> Unit): StageInstance {
+    contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
+
     val instance = kord.rest.stageInstance.modifyStageInstance(channelId, builder)
     val data = StageInstanceData.from(instance)
     return StageInstance(data, kord, supplier)

--- a/core/src/main/kotlin/behavior/channel/StageChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/StageChannelBehavior.kt
@@ -41,6 +41,8 @@ public suspend inline fun StageChannelBehavior.createStageInstance(
     topic: String,
     builder: StageInstanceCreateBuilder.() -> Unit = {},
 ): StageInstance {
+    contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
+
     val instance = kord.rest.stageInstance.createStageInstance(id, topic, builder)
     val data = StageInstanceData.from(instance)
     return StageInstance(data, kord, supplier)

--- a/core/src/main/kotlin/behavior/channel/StageChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/StageChannelBehavior.kt
@@ -17,6 +17,7 @@ import dev.kord.rest.request.RestRequestException
 import dev.kord.rest.service.modifyCurrentVoiceState
 import dev.kord.rest.service.modifyVoiceState
 import dev.kord.rest.service.patchStageVoiceChannel
+import kotlin.DeprecationLevel.HIDDEN
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -29,6 +30,14 @@ public interface StageChannelBehavior : BaseVoiceChannelBehavior {
         strategy: EntitySupplyStrategy<*>
     ): StageChannelBehavior {
         return StageChannelBehavior(id, guildId, kord, strategy.supply(kord))
+    }
+
+    @Deprecated("Binary compatibility.", level = HIDDEN)
+    public suspend fun createStageInstance(topic: String): StageInstance {
+        val instance = kord.rest.stageInstance.createStageInstance(id, topic)
+        val data = StageInstanceData.from(instance)
+
+        return StageInstance(data, kord, supplier)
     }
 
     public suspend fun getStageInstanceOrNull(): StageInstance? = supplier.getStageInstanceOrNull(id)

--- a/core/src/main/kotlin/behavior/channel/StageChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/StageChannelBehavior.kt
@@ -12,8 +12,8 @@ import dev.kord.core.supplier.EntitySupplyStrategy
 import dev.kord.rest.builder.channel.StageVoiceChannelModifyBuilder
 import dev.kord.rest.builder.guild.CurrentVoiceStateModifyBuilder
 import dev.kord.rest.builder.guild.VoiceStateModifyBuilder
+import dev.kord.rest.builder.stage.StageInstanceCreateBuilder
 import dev.kord.rest.request.RestRequestException
-import dev.kord.rest.service.createStageInstance
 import dev.kord.rest.service.modifyCurrentVoiceState
 import dev.kord.rest.service.modifyVoiceState
 import dev.kord.rest.service.patchStageVoiceChannel
@@ -31,17 +31,19 @@ public interface StageChannelBehavior : BaseVoiceChannelBehavior {
         return StageChannelBehavior(id, guildId, kord, strategy.supply(kord))
     }
 
-    public suspend fun createStageInstance(topic: String): StageInstance {
-        val instance = kord.rest.stageInstance.createStageInstance(id, topic)
-        val data = StageInstanceData.from(instance)
-
-        return StageInstance(data, kord, supplier)
-    }
-
     public suspend fun getStageInstanceOrNull(): StageInstance? = supplier.getStageInstanceOrNull(id)
 
     public suspend fun getStageInstance(): StageInstance = supplier.getStageInstance(id)
 
+}
+
+public suspend inline fun StageChannelBehavior.createStageInstance(
+    topic: String,
+    builder: StageInstanceCreateBuilder.() -> Unit = {},
+): StageInstance {
+    val instance = kord.rest.stageInstance.createStageInstance(id, topic, builder)
+    val data = StageInstanceData.from(instance)
+    return StageInstance(data, kord, supplier)
 }
 
 /**

--- a/rest/src/main/kotlin/builder/stage/StageInstanceCreateBuilder.kt
+++ b/rest/src/main/kotlin/builder/stage/StageInstanceCreateBuilder.kt
@@ -1,0 +1,39 @@
+package dev.kord.rest.builder.stage
+
+import dev.kord.common.annotation.KordDsl
+import dev.kord.common.entity.Snowflake
+import dev.kord.common.entity.StageInstancePrivacyLevel
+import dev.kord.common.entity.StageInstancePrivacyLevel.GuildOnly
+import dev.kord.common.entity.optional.Optional
+import dev.kord.common.entity.optional.OptionalBoolean
+import dev.kord.common.entity.optional.delegate.delegate
+import dev.kord.rest.builder.AuditRequestBuilder
+import dev.kord.rest.json.request.StageInstanceCreateRequest
+
+@KordDsl
+public class StageInstanceCreateBuilder(
+    /** The id of the Stage channel. */
+    public var channelId: Snowflake,
+    /** The topic of the Stage instance (1-120 characters). */
+    public var topic: String,
+) : AuditRequestBuilder<StageInstanceCreateRequest> {
+
+    override var reason: String? = null
+
+    private var _privacyLevel: Optional<StageInstancePrivacyLevel> = Optional.Missing()
+
+    /** The [privacy level][StageInstancePrivacyLevel] of the Stage instance (default [GuildOnly]). */
+    public var privacyLevel: StageInstancePrivacyLevel? by ::_privacyLevel.delegate()
+
+    private var _sendStartNotification: OptionalBoolean = OptionalBoolean.Missing
+
+    /** Notify @everyone that a Stage instance has started. */
+    public var sendStartNotification: Boolean? by ::_sendStartNotification.delegate()
+
+    override fun toRequest(): StageInstanceCreateRequest = StageInstanceCreateRequest(
+        channelId,
+        topic,
+        _privacyLevel,
+        _sendStartNotification,
+    )
+}

--- a/rest/src/main/kotlin/builder/stage/StageInstanceModifyBuilder.kt
+++ b/rest/src/main/kotlin/builder/stage/StageInstanceModifyBuilder.kt
@@ -1,0 +1,29 @@
+package dev.kord.rest.builder.stage
+
+import dev.kord.common.annotation.KordDsl
+import dev.kord.common.entity.StageInstancePrivacyLevel
+import dev.kord.common.entity.optional.Optional
+import dev.kord.common.entity.optional.delegate.delegate
+import dev.kord.rest.builder.AuditRequestBuilder
+import dev.kord.rest.json.request.StageInstanceModifyRequest
+
+@KordDsl
+public class StageInstanceModifyBuilder : AuditRequestBuilder<StageInstanceModifyRequest> {
+
+    override var reason: String? = null
+
+    private var _topic: Optional<String> = Optional.Missing()
+
+    /** The topic of the Stage instance (1-120 characters). */
+    public var topic: String? by ::_topic.delegate()
+
+    private var _privacyLevel: Optional<StageInstancePrivacyLevel> = Optional.Missing()
+
+    /** The [privacy level][StageInstancePrivacyLevel] of the Stage instance. */
+    public var privacyLevel: StageInstancePrivacyLevel? by ::_privacyLevel.delegate()
+
+    override fun toRequest(): StageInstanceModifyRequest = StageInstanceModifyRequest(
+        _topic,
+        _privacyLevel,
+    )
+}

--- a/rest/src/main/kotlin/json/request/StageInstanceRequests.kt
+++ b/rest/src/main/kotlin/json/request/StageInstanceRequests.kt
@@ -1,6 +1,9 @@
 package dev.kord.rest.json.request
 
 import dev.kord.common.entity.Snowflake
+import dev.kord.common.entity.StageInstancePrivacyLevel
+import dev.kord.common.entity.optional.Optional
+import dev.kord.common.entity.optional.OptionalBoolean
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -8,7 +11,11 @@ import kotlinx.serialization.Serializable
 public data class StageInstanceCreateRequest(
     @SerialName("channel_id")
     val channelId: Snowflake,
-    val topic: String
+    val topic: String,
+    @SerialName("privacy_level")
+    val privacyLevel: Optional<StageInstancePrivacyLevel> = Optional.Missing(),
+    @SerialName("send_start_notification")
+    val sendStartNotification: OptionalBoolean = OptionalBoolean.Missing,
 )
 
 @Serializable

--- a/rest/src/main/kotlin/json/request/StageInstanceRequests.kt
+++ b/rest/src/main/kotlin/json/request/StageInstanceRequests.kt
@@ -18,7 +18,10 @@ public data class StageInstanceCreateRequest(
     val sendStartNotification: OptionalBoolean = OptionalBoolean.Missing,
 )
 
-@Deprecated("Replaced by 'StageInstanceModifyRequest'.")
+@Deprecated(
+    "Replaced by 'StageInstanceModifyRequest'.",
+    ReplaceWith("StageInstanceModifyRequest", "dev.kord.rest.json.request.StageInstanceModifyRequest"),
+)
 @Serializable
 public data class StageInstanceUpdateRequest(val topic: String)
 

--- a/rest/src/main/kotlin/json/request/StageInstanceRequests.kt
+++ b/rest/src/main/kotlin/json/request/StageInstanceRequests.kt
@@ -18,5 +18,13 @@ public data class StageInstanceCreateRequest(
     val sendStartNotification: OptionalBoolean = OptionalBoolean.Missing,
 )
 
+@Deprecated("Replaced by 'StageInstanceModifyRequest'.")
 @Serializable
 public data class StageInstanceUpdateRequest(val topic: String)
+
+@Serializable
+public data class StageInstanceModifyRequest(
+    val topic: Optional<String> = Optional.Missing(),
+    @SerialName("privacy_level")
+    val privacyLevel: Optional<StageInstancePrivacyLevel> = Optional.Missing(),
+)

--- a/rest/src/main/kotlin/service/StageInstanceService.kt
+++ b/rest/src/main/kotlin/service/StageInstanceService.kt
@@ -2,8 +2,10 @@ package dev.kord.rest.service
 
 import dev.kord.common.entity.DiscordStageInstance
 import dev.kord.common.entity.Snowflake
+import dev.kord.rest.builder.stage.StageInstanceCreateBuilder
+import dev.kord.rest.builder.stage.StageInstanceModifyBuilder
 import dev.kord.rest.json.request.StageInstanceCreateRequest
-import dev.kord.rest.json.request.StageInstanceUpdateRequest
+import dev.kord.rest.json.request.StageInstanceModifyRequest
 import dev.kord.rest.request.RequestHandler
 import dev.kord.rest.request.auditLogReason
 import dev.kord.rest.route.Route
@@ -22,14 +24,47 @@ public class StageInstanceService(requestHandler: RequestHandler) : RestService(
         auditLogReason(reason)
     }
 
-    public suspend fun updateStageInstance(
+    public suspend inline fun createStageInstance(
         channelId: Snowflake,
-        request: StageInstanceUpdateRequest,
+        topic: String,
+        builder: StageInstanceCreateBuilder.() -> Unit = {},
+    ): DiscordStageInstance {
+        val appliedBuilder = StageInstanceCreateBuilder(channelId, topic).apply(builder)
+        return createStageInstance(appliedBuilder.toRequest(), appliedBuilder.reason)
+    }
+
+    public suspend fun modifyStageInstance(
+        channelId: Snowflake,
+        request: StageInstanceModifyRequest,
         reason: String? = null,
-    ): DiscordStageInstance = call(Route.StageInstancePost) {
+    ): DiscordStageInstance = call(Route.StageInstancePatch) {
         keys[Route.ChannelId] = channelId
 
-        body(StageInstanceUpdateRequest.serializer(), request)
+        body(StageInstanceModifyRequest.serializer(), request)
+        auditLogReason(reason)
+    }
+
+    public suspend inline fun modifyStageInstance(
+        channelId: Snowflake,
+        builder: StageInstanceModifyBuilder.() -> Unit,
+    ): DiscordStageInstance {
+        val appliedBuilder = StageInstanceModifyBuilder().apply(builder)
+        return modifyStageInstance(channelId, appliedBuilder.toRequest(), appliedBuilder.reason)
+    }
+
+    @Suppress("DEPRECATION")
+    @Deprecated(
+        "Replaced by 'modifyStageInstance'.",
+        ReplaceWith("this.modifyStageInstance(channelId, request, reason)"),
+    )
+    public suspend fun updateStageInstance(
+        channelId: Snowflake,
+        request: dev.kord.rest.json.request.StageInstanceUpdateRequest,
+        reason: String? = null,
+    ): DiscordStageInstance = call(Route.StageInstancePatch) {
+        keys[Route.ChannelId] = channelId
+
+        body(dev.kord.rest.json.request.StageInstanceUpdateRequest.serializer(), request)
         auditLogReason(reason)
     }
 
@@ -40,6 +75,10 @@ public class StageInstanceService(requestHandler: RequestHandler) : RestService(
         }
 }
 
+@Deprecated(
+    "Replaced by builder overload.",
+    ReplaceWith("this.createStageInstance(channelId, topic) {\nthis@createStageInstance.reason = reason\n}"),
+)
 public suspend fun StageInstanceService.createStageInstance(
     channelId: Snowflake,
     topic: String,
@@ -48,12 +87,19 @@ public suspend fun StageInstanceService.createStageInstance(
     StageInstanceCreateRequest(channelId, topic), reason
 )
 
+@Suppress("DEPRECATION")
+@Deprecated(
+    "Replaced by 'modifyStageInstance'.",
+    ReplaceWith(
+        "this.modifyStageInstance(channelId) {\nthis@modifyStageInstance.topic = topic\nthis@modifyStageInstance.reason = reason\n}"
+    ),
+)
 public suspend fun StageInstanceService.updateStageInstance(
     channelId: Snowflake,
     topic: String,
     reason: String? = null,
 ): DiscordStageInstance = updateStageInstance(
     channelId,
-    StageInstanceUpdateRequest(topic),
+    dev.kord.rest.json.request.StageInstanceUpdateRequest(topic),
     reason
 )

--- a/rest/src/main/kotlin/service/StageInstanceService.kt
+++ b/rest/src/main/kotlin/service/StageInstanceService.kt
@@ -9,6 +9,8 @@ import dev.kord.rest.json.request.StageInstanceModifyRequest
 import dev.kord.rest.request.RequestHandler
 import dev.kord.rest.request.auditLogReason
 import dev.kord.rest.route.Route
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 
 public class StageInstanceService(requestHandler: RequestHandler) : RestService(requestHandler) {
 
@@ -29,6 +31,8 @@ public class StageInstanceService(requestHandler: RequestHandler) : RestService(
         topic: String,
         builder: StageInstanceCreateBuilder.() -> Unit = {},
     ): DiscordStageInstance {
+        contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
+
         val appliedBuilder = StageInstanceCreateBuilder(channelId, topic).apply(builder)
         return createStageInstance(appliedBuilder.toRequest(), appliedBuilder.reason)
     }
@@ -48,6 +52,8 @@ public class StageInstanceService(requestHandler: RequestHandler) : RestService(
         channelId: Snowflake,
         builder: StageInstanceModifyBuilder.() -> Unit,
     ): DiscordStageInstance {
+        contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
+
         val appliedBuilder = StageInstanceModifyBuilder().apply(builder)
         return modifyStageInstance(channelId, appliedBuilder.toRequest(), appliedBuilder.reason)
     }


### PR DESCRIPTION
- add `send_start_notification` parameter, see https://github.com/discord/discord-api-docs/pull/4706, merged in https://github.com/discord/discord-api-docs/commit/68d862bb59c1482e49012f174cbce4a9bcc666e2
- add `StageInstanceCreateBuilder` and `StageInstanceModifyBuilder` and replace functions to use these builders
- fix: use `PATCH` instead of `POST` route in (now deprecated) `StageInstanceService.updateStageInstance()`