### PR TITLE
Deserialize time as `Duration`

### DIFF
--- a/common/src/main/kotlin/entity/AuditLog.kt
+++ b/common/src/main/kotlin/entity/AuditLog.kt
@@ -3,6 +3,7 @@ package dev.kord.common.entity
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalSnowflake
 import dev.kord.common.entity.optional.orEmpty
+import dev.kord.common.serialization.DurationInWholeDaysSerializer
 import dev.kord.common.serialization.DurationInWholeSecondsSerializer
 import kotlinx.datetime.Instant
 import kotlinx.serialization.*
@@ -348,7 +349,7 @@ public sealed class AuditLogChangeKey<T>(public val name: String, public val ser
     public object ExpireBehavior : AuditLogChangeKey<IntegrationExpireBehavior>("expire_behavior", serializer())
 
     @SerialName("expire_grace_period")
-    public object ExpireGracePeriod : AuditLogChangeKey<Int>("expire_grace_period", serializer())
+    public object ExpireGracePeriod : AuditLogChangeKey<Duration>("expire_grace_period", DurationInWholeDaysSerializer)
 
     @SerialName("user_limit")
     public object UserLimit : AuditLogChangeKey<Int>("user_limit", serializer())

--- a/common/src/main/kotlin/entity/AuditLog.kt
+++ b/common/src/main/kotlin/entity/AuditLog.kt
@@ -3,8 +3,8 @@ package dev.kord.common.entity
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalSnowflake
 import dev.kord.common.entity.optional.orEmpty
-import dev.kord.common.serialization.DurationInWholeDaysSerializer
-import dev.kord.common.serialization.DurationInWholeSecondsSerializer
+import dev.kord.common.serialization.DurationInDaysSerializer
+import dev.kord.common.serialization.DurationInSecondsSerializer
 import kotlinx.datetime.Instant
 import kotlinx.serialization.*
 import kotlinx.serialization.builtins.serializer
@@ -184,7 +184,7 @@ public sealed class AuditLogChangeKey<T>(public val name: String, public val ser
     public object AfkChannelId : AuditLogChangeKey<Snowflake>("afk_channel_id", serializer())
 
     @SerialName("afk_timeout")
-    public object AfkTimeout : AuditLogChangeKey<Duration>("afk_timeout", DurationInWholeSecondsSerializer)
+    public object AfkTimeout : AuditLogChangeKey<Duration>("afk_timeout", DurationInSecondsSerializer)
 
     @SerialName("mfa_level")
     public object MFALevel : AuditLogChangeKey<CommonMFALevel>("mfa_level", serializer())
@@ -240,8 +240,7 @@ public sealed class AuditLogChangeKey<T>(public val name: String, public val ser
     public object ApplicationId : AuditLogChangeKey<Snowflake>("application_id", serializer())
 
     @SerialName("rate_limit_per_user")
-    public object RateLimitPerUser :
-        AuditLogChangeKey<Duration>("rate_limit_per_user", DurationInWholeSecondsSerializer)
+    public object RateLimitPerUser : AuditLogChangeKey<Duration>("rate_limit_per_user", DurationInSecondsSerializer)
 
     @SerialName("permissions")
     public object Permissions : AuditLogChangeKey<CommonPermissions>("permissions", serializer())
@@ -283,7 +282,7 @@ public sealed class AuditLogChangeKey<T>(public val name: String, public val ser
     public object Uses : AuditLogChangeKey<Int>("uses", serializer())
 
     @SerialName("max_age")
-    public object MaxAges : AuditLogChangeKey<Duration>("max_age", DurationInWholeSecondsSerializer)
+    public object MaxAges : AuditLogChangeKey<Duration>("max_age", DurationInSecondsSerializer)
 
     @SerialName("temporary")
     public object Temporary : AuditLogChangeKey<Boolean>("temporary", serializer())
@@ -349,7 +348,7 @@ public sealed class AuditLogChangeKey<T>(public val name: String, public val ser
     public object ExpireBehavior : AuditLogChangeKey<IntegrationExpireBehavior>("expire_behavior", serializer())
 
     @SerialName("expire_grace_period")
-    public object ExpireGracePeriod : AuditLogChangeKey<Duration>("expire_grace_period", DurationInWholeDaysSerializer)
+    public object ExpireGracePeriod : AuditLogChangeKey<Duration>("expire_grace_period", DurationInDaysSerializer)
 
     @SerialName("user_limit")
     public object UserLimit : AuditLogChangeKey<Int>("user_limit", serializer())

--- a/common/src/main/kotlin/entity/AuditLog.kt
+++ b/common/src/main/kotlin/entity/AuditLog.kt
@@ -282,7 +282,7 @@ public sealed class AuditLogChangeKey<T>(public val name: String, public val ser
     public object Uses : AuditLogChangeKey<Int>("uses", serializer())
 
     @SerialName("max_age")
-    public object MaxAges : AuditLogChangeKey<Int>("max_age", serializer())
+    public object MaxAges : AuditLogChangeKey<Duration>("max_age", DurationInWholeSecondsSerializer)
 
     @SerialName("temporary")
     public object Temporary : AuditLogChangeKey<Boolean>("temporary", serializer())

--- a/common/src/main/kotlin/entity/AuditLog.kt
+++ b/common/src/main/kotlin/entity/AuditLog.kt
@@ -183,7 +183,7 @@ public sealed class AuditLogChangeKey<T>(public val name: String, public val ser
     public object AfkChannelId : AuditLogChangeKey<Snowflake>("afk_channel_id", serializer())
 
     @SerialName("afk_timeout")
-    public object AfkTimeout : AuditLogChangeKey<Int>("afk_timeout", serializer())
+    public object AfkTimeout : AuditLogChangeKey<Duration>("afk_timeout", DurationInWholeSecondsSerializer)
 
     @SerialName("mfa_level")
     public object MFALevel : AuditLogChangeKey<CommonMFALevel>("mfa_level", serializer())

--- a/common/src/main/kotlin/entity/AuditLog.kt
+++ b/common/src/main/kotlin/entity/AuditLog.kt
@@ -3,12 +3,14 @@ package dev.kord.common.entity
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalSnowflake
 import dev.kord.common.entity.optional.orEmpty
+import dev.kord.common.serialization.DurationInWholeSecondsSerializer
 import kotlinx.datetime.Instant
 import kotlinx.serialization.*
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*
 import kotlinx.serialization.json.*
+import kotlin.time.Duration
 import dev.kord.common.Color as CommonColor
 import dev.kord.common.entity.DefaultMessageNotificationLevel as CommonDefaultMessageNotificationLevel
 import dev.kord.common.entity.ExplicitContentFilter as CommonExplicitContentFilter
@@ -237,7 +239,8 @@ public sealed class AuditLogChangeKey<T>(public val name: String, public val ser
     public object ApplicationId : AuditLogChangeKey<Snowflake>("application_id", serializer())
 
     @SerialName("rate_limit_per_user")
-    public object RateLimitPerUser : AuditLogChangeKey<Int>("rate_limit_per_user", serializer())
+    public object RateLimitPerUser :
+        AuditLogChangeKey<Duration>("rate_limit_per_user", DurationInWholeSecondsSerializer)
 
     @SerialName("permissions")
     public object Permissions : AuditLogChangeKey<CommonPermissions>("permissions", serializer())

--- a/common/src/main/kotlin/entity/DiscordChannel.kt
+++ b/common/src/main/kotlin/entity/DiscordChannel.kt
@@ -220,11 +220,12 @@ public sealed class ArchiveDuration(public val duration: Duration) {
     }
 
     public companion object {
-        public val values: Set<ArchiveDuration> = setOf(
-            Hour,
-            Day,
-            ThreeDays,
-            Week,
-        )
+        public val values: Set<ArchiveDuration>
+            get() = setOf(
+                Hour,
+                Day,
+                ThreeDays,
+                Week,
+            )
     }
 }

--- a/common/src/main/kotlin/entity/DiscordChannel.kt
+++ b/common/src/main/kotlin/entity/DiscordChannel.kt
@@ -14,6 +14,8 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlin.DeprecationLevel.WARNING
+import kotlin.time.Duration
+import dev.kord.common.serialization.DurationInWholeSecondsSerializer as InWholeSeconds
 
 /**
  * A representation of a [Discord Channel Structure](https://discord.com/developers/docs/resources/channel).
@@ -29,7 +31,7 @@ import kotlin.DeprecationLevel.WARNING
  * @param lastMessageId The id of the last message sent in this channel (may not point to an existing or valid message).
  * @param bitrate The bitrate (in bits) of the voice channel.
  * @param userLimit The user limit of the voice channel.
- * @param rateLimitPerUser amount of seconds a user has to wait before sending another message; bots,
+ * @param rateLimitPerUser amount of time a user has to wait before sending another message; bots,
  * as well as users with the permission [Permission.ManageMessages] or [Permission.ManageChannels] are unaffected.
  * @param recipients The recipients of the DM.
  * @param icon The icon hash.
@@ -56,7 +58,7 @@ public data class DiscordChannel(
     @SerialName("user_limit")
     val userLimit: OptionalInt = OptionalInt.Missing,
     @SerialName("rate_limit_per_user")
-    val rateLimitPerUser: OptionalInt = OptionalInt.Missing,
+    val rateLimitPerUser: Optional<@Serializable(InWholeSeconds::class) Duration> = Optional.Missing(),
     val recipients: Optional<List<DiscordUser>> = Optional.Missing(),
     val icon: Optional<String?> = Optional.Missing(),
     @SerialName("owner_id")

--- a/common/src/main/kotlin/entity/DiscordChannel.kt
+++ b/common/src/main/kotlin/entity/DiscordChannel.kt
@@ -4,8 +4,8 @@ import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
 import dev.kord.common.entity.optional.OptionalInt
 import dev.kord.common.entity.optional.OptionalSnowflake
-import dev.kord.common.serialization.DurationInWholeMinutesSerializer
-import dev.kord.common.serialization.DurationInWholeSeconds
+import dev.kord.common.serialization.DurationInMinutesSerializer
+import dev.kord.common.serialization.DurationInSeconds
 import kotlinx.datetime.Instant
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
@@ -60,7 +60,7 @@ public data class DiscordChannel(
     @SerialName("user_limit")
     val userLimit: OptionalInt = OptionalInt.Missing,
     @SerialName("rate_limit_per_user")
-    val rateLimitPerUser: Optional<DurationInWholeSeconds> = Optional.Missing(),
+    val rateLimitPerUser: Optional<DurationInSeconds> = Optional.Missing(),
     val recipients: Optional<List<DiscordUser>> = Optional.Missing(),
     val icon: Optional<String?> = Optional.Missing(),
     @SerialName("owner_id")
@@ -207,15 +207,15 @@ public sealed class ArchiveDuration(public val duration: Duration) {
 
     public object Serializer : KSerializer<ArchiveDuration> {
 
-        override val descriptor: SerialDescriptor get() = DurationInWholeMinutesSerializer.descriptor
+        override val descriptor: SerialDescriptor get() = DurationInMinutesSerializer.descriptor
 
         override fun deserialize(decoder: Decoder): ArchiveDuration {
-            val value = decoder.decodeSerializableValue(DurationInWholeMinutesSerializer)
+            val value = decoder.decodeSerializableValue(DurationInMinutesSerializer)
             return values.firstOrNull { it.duration == value } ?: Unknown(value)
         }
 
         override fun serialize(encoder: Encoder, value: ArchiveDuration) {
-            encoder.encodeSerializableValue(DurationInWholeMinutesSerializer, value.duration)
+            encoder.encodeSerializableValue(DurationInMinutesSerializer, value.duration)
         }
     }
 

--- a/common/src/main/kotlin/entity/DiscordChannel.kt
+++ b/common/src/main/kotlin/entity/DiscordChannel.kt
@@ -5,6 +5,7 @@ import dev.kord.common.entity.optional.OptionalBoolean
 import dev.kord.common.entity.optional.OptionalInt
 import dev.kord.common.entity.optional.OptionalSnowflake
 import dev.kord.common.serialization.DurationInWholeMinutesSerializer
+import dev.kord.common.serialization.DurationInWholeSeconds
 import kotlinx.datetime.Instant
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
@@ -17,7 +18,6 @@ import kotlinx.serialization.encoding.Encoder
 import kotlin.DeprecationLevel.WARNING
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
-import dev.kord.common.serialization.DurationInWholeSecondsSerializer as InWholeSeconds
 
 /**
  * A representation of a [Discord Channel Structure](https://discord.com/developers/docs/resources/channel).
@@ -60,7 +60,7 @@ public data class DiscordChannel(
     @SerialName("user_limit")
     val userLimit: OptionalInt = OptionalInt.Missing,
     @SerialName("rate_limit_per_user")
-    val rateLimitPerUser: Optional<@Serializable(InWholeSeconds::class) Duration> = Optional.Missing(),
+    val rateLimitPerUser: Optional<DurationInWholeSeconds> = Optional.Missing(),
     val recipients: Optional<List<DiscordUser>> = Optional.Missing(),
     val icon: Optional<String?> = Optional.Missing(),
     @SerialName("owner_id")

--- a/common/src/main/kotlin/entity/DiscordGuild.kt
+++ b/common/src/main/kotlin/entity/DiscordGuild.kt
@@ -4,7 +4,7 @@ import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
 import dev.kord.common.entity.optional.OptionalInt
 import dev.kord.common.entity.optional.OptionalSnowflake
-import dev.kord.common.serialization.DurationInWholeSecondsSerializer
+import dev.kord.common.serialization.DurationInWholeSeconds
 import kotlinx.datetime.Instant
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
@@ -14,7 +14,6 @@ import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
-import kotlin.time.Duration
 
 /**
  * A partial representation of a [DiscordGuild] that may be [unavailable].
@@ -95,9 +94,7 @@ public data class DiscordGuild(
         ReplaceWith("DiscordChannel#rtcRegion")
     ) val region: String,
     @SerialName("afk_channel_id") val afkChannelId: Snowflake?,
-    @SerialName("afk_timeout")
-    @Serializable(with = DurationInWholeSecondsSerializer::class)
-    val afkTimeout: Duration,
+    @SerialName("afk_timeout") val afkTimeout: DurationInWholeSeconds,
     @SerialName("widget_enabled") val widgetEnabled: OptionalBoolean = OptionalBoolean.Missing,
     @SerialName("widget_channel_id") val widgetChannelId: OptionalSnowflake? = OptionalSnowflake.Missing,
     @SerialName("verification_level") val verificationLevel: VerificationLevel,

--- a/common/src/main/kotlin/entity/DiscordGuild.kt
+++ b/common/src/main/kotlin/entity/DiscordGuild.kt
@@ -4,7 +4,7 @@ import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
 import dev.kord.common.entity.optional.OptionalInt
 import dev.kord.common.entity.optional.OptionalSnowflake
-import dev.kord.common.serialization.DurationInWholeSeconds
+import dev.kord.common.serialization.DurationInSeconds
 import kotlinx.datetime.Instant
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
@@ -94,7 +94,7 @@ public data class DiscordGuild(
         ReplaceWith("DiscordChannel#rtcRegion")
     ) val region: String,
     @SerialName("afk_channel_id") val afkChannelId: Snowflake?,
-    @SerialName("afk_timeout") val afkTimeout: DurationInWholeSeconds,
+    @SerialName("afk_timeout") val afkTimeout: DurationInSeconds,
     @SerialName("widget_enabled") val widgetEnabled: OptionalBoolean = OptionalBoolean.Missing,
     @SerialName("widget_channel_id") val widgetChannelId: OptionalSnowflake? = OptionalSnowflake.Missing,
     @SerialName("verification_level") val verificationLevel: VerificationLevel,

--- a/common/src/main/kotlin/entity/DiscordGuild.kt
+++ b/common/src/main/kotlin/entity/DiscordGuild.kt
@@ -4,6 +4,7 @@ import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
 import dev.kord.common.entity.optional.OptionalInt
 import dev.kord.common.entity.optional.OptionalSnowflake
+import dev.kord.common.serialization.DurationInWholeSecondsSerializer
 import kotlinx.datetime.Instant
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
@@ -13,6 +14,7 @@ import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
+import kotlin.time.Duration
 
 /**
  * A partial representation of a [DiscordGuild] that may be [unavailable].
@@ -40,7 +42,7 @@ public data class DiscordUnavailableGuild(
  * @param permissions The total permissions for [DiscordUser] in the guild (excludes [overwrites][Overwrite]).
  * @param region [DiscordVoiceRegion] id for the guild.
  * @param afkChannelId The id of afk channel.
- * @param afkTimeout The afk timeout in seconds.
+ * @param afkTimeout The afk timeout.
  * @param widgetEnabled True if the server widget is enabled.
  * @param widgetChannelId The channel id that the widget will generate an invite to, or `null` if set to no invite.
  * @param verificationLevel [VerificationLevel] required for the guild.
@@ -93,7 +95,9 @@ public data class DiscordGuild(
         ReplaceWith("DiscordChannel#rtcRegion")
     ) val region: String,
     @SerialName("afk_channel_id") val afkChannelId: Snowflake?,
-    @SerialName("afk_timeout") val afkTimeout: Int,
+    @SerialName("afk_timeout")
+    @Serializable(with = DurationInWholeSecondsSerializer::class)
+    val afkTimeout: Duration,
     @SerialName("widget_enabled") val widgetEnabled: OptionalBoolean = OptionalBoolean.Missing,
     @SerialName("widget_channel_id") val widgetChannelId: OptionalSnowflake? = OptionalSnowflake.Missing,
     @SerialName("verification_level") val verificationLevel: VerificationLevel,

--- a/common/src/main/kotlin/entity/DiscordIntegration.kt
+++ b/common/src/main/kotlin/entity/DiscordIntegration.kt
@@ -2,6 +2,7 @@ package dev.kord.common.entity
 
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
+import dev.kord.common.serialization.DurationInWholeDaysSerializer
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -10,6 +11,7 @@ import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
+import kotlin.time.Duration
 
 @Serializable
 public data class DiscordIntegration(
@@ -25,7 +27,8 @@ public data class DiscordIntegration(
     @SerialName("expire_behavior")
     val expireBehavior: IntegrationExpireBehavior,
     @SerialName("expire_grace_period")
-    val expireGracePeriod: Int,
+    @Serializable(with = DurationInWholeDaysSerializer::class)
+    val expireGracePeriod: Duration,
     val user: DiscordUser,
     val account: DiscordIntegrationsAccount,
     @SerialName("synced_at")

--- a/common/src/main/kotlin/entity/DiscordIntegration.kt
+++ b/common/src/main/kotlin/entity/DiscordIntegration.kt
@@ -2,7 +2,7 @@ package dev.kord.common.entity
 
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
-import dev.kord.common.serialization.DurationInWholeDays
+import dev.kord.common.serialization.DurationInDays
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -26,7 +26,7 @@ public data class DiscordIntegration(
     @SerialName("expire_behavior")
     val expireBehavior: IntegrationExpireBehavior,
     @SerialName("expire_grace_period")
-    val expireGracePeriod: DurationInWholeDays,
+    val expireGracePeriod: DurationInDays,
     val user: DiscordUser,
     val account: DiscordIntegrationsAccount,
     @SerialName("synced_at")

--- a/common/src/main/kotlin/entity/DiscordIntegration.kt
+++ b/common/src/main/kotlin/entity/DiscordIntegration.kt
@@ -2,7 +2,7 @@ package dev.kord.common.entity
 
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
-import dev.kord.common.serialization.DurationInWholeDaysSerializer
+import dev.kord.common.serialization.DurationInWholeDays
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -11,7 +11,6 @@ import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
-import kotlin.time.Duration
 
 @Serializable
 public data class DiscordIntegration(
@@ -27,8 +26,7 @@ public data class DiscordIntegration(
     @SerialName("expire_behavior")
     val expireBehavior: IntegrationExpireBehavior,
     @SerialName("expire_grace_period")
-    @Serializable(with = DurationInWholeDaysSerializer::class)
-    val expireGracePeriod: Duration,
+    val expireGracePeriod: DurationInWholeDays,
     val user: DiscordUser,
     val account: DiscordIntegrationsAccount,
     @SerialName("synced_at")

--- a/common/src/main/kotlin/entity/DiscordInvite.kt
+++ b/common/src/main/kotlin/entity/DiscordInvite.kt
@@ -2,6 +2,7 @@ package dev.kord.common.entity
 
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalInt
+import dev.kord.common.serialization.DurationInWholeSecondsSerializer
 import kotlinx.datetime.Instant
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
@@ -11,6 +12,7 @@ import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
+import kotlin.time.Duration
 
 public sealed interface BaseDiscordInvite {
     public val code: String
@@ -78,7 +80,8 @@ public data class DiscordInviteWithMetadata(
     @SerialName("max_uses")
     val maxUses: Int,
     @SerialName("max_age")
-    val maxAge: Int,
+    @Serializable(with = DurationInWholeSecondsSerializer::class)
+    val maxAge: Duration,
     val temporary: Boolean,
     @SerialName("created_at")
     val createdAt: Instant,

--- a/common/src/main/kotlin/entity/DiscordInvite.kt
+++ b/common/src/main/kotlin/entity/DiscordInvite.kt
@@ -2,7 +2,7 @@ package dev.kord.common.entity
 
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalInt
-import dev.kord.common.serialization.DurationInWholeSeconds
+import dev.kord.common.serialization.DurationInSeconds
 import kotlinx.datetime.Instant
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
@@ -79,7 +79,7 @@ public data class DiscordInviteWithMetadata(
     @SerialName("max_uses")
     val maxUses: Int,
     @SerialName("max_age")
-    val maxAge: DurationInWholeSeconds,
+    val maxAge: DurationInSeconds,
     val temporary: Boolean,
     @SerialName("created_at")
     val createdAt: Instant,

--- a/common/src/main/kotlin/entity/DiscordInvite.kt
+++ b/common/src/main/kotlin/entity/DiscordInvite.kt
@@ -2,7 +2,7 @@ package dev.kord.common.entity
 
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalInt
-import dev.kord.common.serialization.DurationInWholeSecondsSerializer
+import dev.kord.common.serialization.DurationInWholeSeconds
 import kotlinx.datetime.Instant
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
@@ -12,7 +12,6 @@ import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
-import kotlin.time.Duration
 
 public sealed interface BaseDiscordInvite {
     public val code: String
@@ -80,8 +79,7 @@ public data class DiscordInviteWithMetadata(
     @SerialName("max_uses")
     val maxUses: Int,
     @SerialName("max_age")
-    @Serializable(with = DurationInWholeSecondsSerializer::class)
-    val maxAge: Duration,
+    val maxAge: DurationInWholeSeconds,
     val temporary: Boolean,
     @SerialName("created_at")
     val createdAt: Instant,

--- a/common/src/main/kotlin/serialization/DurationSerializers.kt
+++ b/common/src/main/kotlin/serialization/DurationSerializers.kt
@@ -1,6 +1,7 @@
 package dev.kord.common.serialization
 
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
@@ -28,23 +29,64 @@ public sealed class DurationSerializer(private val unit: DurationUnit, name: Str
 }
 
 
+// nanoseconds
+
 /** Serializer that encodes and decodes [Duration]s in [whole nanoseconds][Duration.inWholeNanoseconds]. */
 public object DurationInWholeNanosecondsSerializer : DurationSerializer(NANOSECONDS, "DurationInWholeNanoseconds")
+
+/** A [Duration] that is [serializable][Serializable] with [DurationInWholeNanosecondsSerializer]. */
+public typealias DurationInWholeNanoseconds = @Serializable(with = DurationInWholeNanosecondsSerializer::class) Duration
+
+
+// microseconds
 
 /** Serializer that encodes and decodes [Duration]s in [whole microseconds][Duration.inWholeMicroseconds]. */
 public object DurationInWholeMicrosecondsSerializer : DurationSerializer(MICROSECONDS, "DurationInWholeMicroseconds")
 
+/** A [Duration] that is [serializable][Serializable] with [DurationInWholeMicrosecondsSerializer]. */
+public typealias DurationInWholeMicroseconds = @Serializable(with = DurationInWholeMicrosecondsSerializer::class) Duration
+
+
+// milliseconds
+
 /** Serializer that encodes and decodes [Duration]s in [whole milliseconds][Duration.inWholeMilliseconds]. */
 public object DurationInWholeMillisecondsSerializer : DurationSerializer(MILLISECONDS, "DurationInWholeMilliseconds")
+
+/** A [Duration] that is [serializable][Serializable] with [DurationInWholeMillisecondsSerializer]. */
+public typealias DurationInWholeMilliseconds = @Serializable(with = DurationInWholeMillisecondsSerializer::class) Duration
+
+
+// seconds
 
 /** Serializer that encodes and decodes [Duration]s in [whole seconds][Duration.inWholeSeconds]. */
 public object DurationInWholeSecondsSerializer : DurationSerializer(SECONDS, "DurationInWholeSeconds")
 
+/** A [Duration] that is [serializable][Serializable] with [DurationInWholeSecondsSerializer]. */
+public typealias DurationInWholeSeconds = @Serializable(with = DurationInWholeSecondsSerializer::class) Duration
+
+
+// minutes
+
 /** Serializer that encodes and decodes [Duration]s in [whole minutes][Duration.inWholeMinutes]. */
 public object DurationInWholeMinutesSerializer : DurationSerializer(MINUTES, "DurationInWholeMinutes")
+
+/** A [Duration] that is [serializable][Serializable] with [DurationInWholeMinutesSerializer]. */
+public typealias DurationInWholeMinutes = @Serializable(with = DurationInWholeMinutesSerializer::class) Duration
+
+
+// hours
 
 /** Serializer that encodes and decodes [Duration]s in [whole hours][Duration.inWholeHours]. */
 public object DurationInWholeHoursSerializer : DurationSerializer(HOURS, "DurationInWholeHours")
 
+/** A [Duration] that is [serializable][Serializable] with [DurationInWholeHoursSerializer]. */
+public typealias DurationInWholeHours = @Serializable(with = DurationInWholeHoursSerializer::class) Duration
+
+
+// days
+
 /** Serializer that encodes and decodes [Duration]s in [whole days][Duration.inWholeDays]. */
 public object DurationInWholeDaysSerializer : DurationSerializer(DAYS, "DurationInWholeDays")
+
+/** A [Duration] that is [serializable][Serializable] with [DurationInWholeDaysSerializer]. */
+public typealias DurationInWholeDays = @Serializable(with = DurationInWholeDaysSerializer::class) Duration

--- a/common/src/main/kotlin/serialization/DurationSerializers.kt
+++ b/common/src/main/kotlin/serialization/DurationSerializers.kt
@@ -13,8 +13,8 @@ import kotlin.time.DurationUnit.*
 import kotlin.time.toDuration
 
 
-/** Serializer that encodes and decodes [Duration]s. */
-public sealed class DurationSerializer(private val unit: DurationUnit, name: String) : KSerializer<Duration> {
+/** Serializer that encodes and decodes [Duration]s as a [Long] number of the specified [unit]. */
+public sealed class DurationAsLongSerializer(public val unit: DurationUnit, name: String) : KSerializer<Duration> {
 
     final override val descriptor: SerialDescriptor =
         PrimitiveSerialDescriptor("dev.kord.common.serialization.$name", PrimitiveKind.LONG)
@@ -32,61 +32,61 @@ public sealed class DurationSerializer(private val unit: DurationUnit, name: Str
 // nanoseconds
 
 /** Serializer that encodes and decodes [Duration]s in [whole nanoseconds][Duration.inWholeNanoseconds]. */
-public object DurationInWholeNanosecondsSerializer : DurationSerializer(NANOSECONDS, "DurationInWholeNanoseconds")
+public object DurationInNanosecondsSerializer : DurationAsLongSerializer(NANOSECONDS, "DurationInNanoseconds")
 
-/** A [Duration] that is [serializable][Serializable] with [DurationInWholeNanosecondsSerializer]. */
-public typealias DurationInWholeNanoseconds = @Serializable(with = DurationInWholeNanosecondsSerializer::class) Duration
+/** A [Duration] that is [serializable][Serializable] with [DurationInNanosecondsSerializer]. */
+public typealias DurationInNanoseconds = @Serializable(with = DurationInNanosecondsSerializer::class) Duration
 
 
 // microseconds
 
 /** Serializer that encodes and decodes [Duration]s in [whole microseconds][Duration.inWholeMicroseconds]. */
-public object DurationInWholeMicrosecondsSerializer : DurationSerializer(MICROSECONDS, "DurationInWholeMicroseconds")
+public object DurationInMicrosecondsSerializer : DurationAsLongSerializer(MICROSECONDS, "DurationInMicroseconds")
 
-/** A [Duration] that is [serializable][Serializable] with [DurationInWholeMicrosecondsSerializer]. */
-public typealias DurationInWholeMicroseconds = @Serializable(with = DurationInWholeMicrosecondsSerializer::class) Duration
+/** A [Duration] that is [serializable][Serializable] with [DurationInMicrosecondsSerializer]. */
+public typealias DurationInMicroseconds = @Serializable(with = DurationInMicrosecondsSerializer::class) Duration
 
 
 // milliseconds
 
 /** Serializer that encodes and decodes [Duration]s in [whole milliseconds][Duration.inWholeMilliseconds]. */
-public object DurationInWholeMillisecondsSerializer : DurationSerializer(MILLISECONDS, "DurationInWholeMilliseconds")
+public object DurationInMillisecondsSerializer : DurationAsLongSerializer(MILLISECONDS, "DurationInMilliseconds")
 
-/** A [Duration] that is [serializable][Serializable] with [DurationInWholeMillisecondsSerializer]. */
-public typealias DurationInWholeMilliseconds = @Serializable(with = DurationInWholeMillisecondsSerializer::class) Duration
+/** A [Duration] that is [serializable][Serializable] with [DurationInMillisecondsSerializer]. */
+public typealias DurationInMilliseconds = @Serializable(with = DurationInMillisecondsSerializer::class) Duration
 
 
 // seconds
 
 /** Serializer that encodes and decodes [Duration]s in [whole seconds][Duration.inWholeSeconds]. */
-public object DurationInWholeSecondsSerializer : DurationSerializer(SECONDS, "DurationInWholeSeconds")
+public object DurationInSecondsSerializer : DurationAsLongSerializer(SECONDS, "DurationInSeconds")
 
-/** A [Duration] that is [serializable][Serializable] with [DurationInWholeSecondsSerializer]. */
-public typealias DurationInWholeSeconds = @Serializable(with = DurationInWholeSecondsSerializer::class) Duration
+/** A [Duration] that is [serializable][Serializable] with [DurationInSecondsSerializer]. */
+public typealias DurationInSeconds = @Serializable(with = DurationInSecondsSerializer::class) Duration
 
 
 // minutes
 
 /** Serializer that encodes and decodes [Duration]s in [whole minutes][Duration.inWholeMinutes]. */
-public object DurationInWholeMinutesSerializer : DurationSerializer(MINUTES, "DurationInWholeMinutes")
+public object DurationInMinutesSerializer : DurationAsLongSerializer(MINUTES, "DurationInMinutes")
 
-/** A [Duration] that is [serializable][Serializable] with [DurationInWholeMinutesSerializer]. */
-public typealias DurationInWholeMinutes = @Serializable(with = DurationInWholeMinutesSerializer::class) Duration
+/** A [Duration] that is [serializable][Serializable] with [DurationInMinutesSerializer]. */
+public typealias DurationInMinutes = @Serializable(with = DurationInMinutesSerializer::class) Duration
 
 
 // hours
 
 /** Serializer that encodes and decodes [Duration]s in [whole hours][Duration.inWholeHours]. */
-public object DurationInWholeHoursSerializer : DurationSerializer(HOURS, "DurationInWholeHours")
+public object DurationInHoursSerializer : DurationAsLongSerializer(HOURS, "DurationInHours")
 
-/** A [Duration] that is [serializable][Serializable] with [DurationInWholeHoursSerializer]. */
-public typealias DurationInWholeHours = @Serializable(with = DurationInWholeHoursSerializer::class) Duration
+/** A [Duration] that is [serializable][Serializable] with [DurationInHoursSerializer]. */
+public typealias DurationInHours = @Serializable(with = DurationInHoursSerializer::class) Duration
 
 
 // days
 
 /** Serializer that encodes and decodes [Duration]s in [whole days][Duration.inWholeDays]. */
-public object DurationInWholeDaysSerializer : DurationSerializer(DAYS, "DurationInWholeDays")
+public object DurationInDaysSerializer : DurationAsLongSerializer(DAYS, "DurationInDays")
 
-/** A [Duration] that is [serializable][Serializable] with [DurationInWholeDaysSerializer]. */
-public typealias DurationInWholeDays = @Serializable(with = DurationInWholeDaysSerializer::class) Duration
+/** A [Duration] that is [serializable][Serializable] with [DurationInDaysSerializer]. */
+public typealias DurationInDays = @Serializable(with = DurationInDaysSerializer::class) Duration

--- a/common/src/main/kotlin/serialization/DurationSerializers.kt
+++ b/common/src/main/kotlin/serialization/DurationSerializers.kt
@@ -18,10 +18,8 @@ public sealed class DurationSerializer(private val unit: DurationUnit, name: Str
     final override val descriptor: SerialDescriptor =
         PrimitiveSerialDescriptor("dev.kord.common.serialization.$name", PrimitiveKind.LONG)
 
-    protected abstract fun Duration.convert(): Long
-
     final override fun serialize(encoder: Encoder, value: Duration) {
-        encoder.encodeLong(value.convert())
+        encoder.encodeLong(value.toLong(unit))
     }
 
     final override fun deserialize(decoder: Decoder): Duration {
@@ -31,36 +29,22 @@ public sealed class DurationSerializer(private val unit: DurationUnit, name: Str
 
 
 /** Serializer that encodes and decodes [Duration]s in [whole nanoseconds][Duration.inWholeNanoseconds]. */
-public object DurationInWholeNanosecondsSerializer : DurationSerializer(NANOSECONDS, "DurationInWholeNanoseconds") {
-    override fun Duration.convert(): Long = inWholeNanoseconds
-}
+public object DurationInWholeNanosecondsSerializer : DurationSerializer(NANOSECONDS, "DurationInWholeNanoseconds")
 
 /** Serializer that encodes and decodes [Duration]s in [whole microseconds][Duration.inWholeMicroseconds]. */
-public object DurationInWholeMicrosecondsSerializer : DurationSerializer(MICROSECONDS, "DurationInWholeMicroseconds") {
-    override fun Duration.convert(): Long = inWholeMicroseconds
-}
+public object DurationInWholeMicrosecondsSerializer : DurationSerializer(MICROSECONDS, "DurationInWholeMicroseconds")
 
 /** Serializer that encodes and decodes [Duration]s in [whole milliseconds][Duration.inWholeMilliseconds]. */
-public object DurationInWholeMillisecondsSerializer : DurationSerializer(MILLISECONDS, "DurationInWholeMilliseconds") {
-    override fun Duration.convert(): Long = inWholeMilliseconds
-}
+public object DurationInWholeMillisecondsSerializer : DurationSerializer(MILLISECONDS, "DurationInWholeMilliseconds")
 
 /** Serializer that encodes and decodes [Duration]s in [whole seconds][Duration.inWholeSeconds]. */
-public object DurationInWholeSecondsSerializer : DurationSerializer(SECONDS, "DurationInWholeSeconds") {
-    override fun Duration.convert(): Long = inWholeSeconds
-}
+public object DurationInWholeSecondsSerializer : DurationSerializer(SECONDS, "DurationInWholeSeconds")
 
 /** Serializer that encodes and decodes [Duration]s in [whole minutes][Duration.inWholeMinutes]. */
-public object DurationInWholeMinutesSerializer : DurationSerializer(MINUTES, "DurationInWholeMinutes") {
-    override fun Duration.convert(): Long = inWholeMinutes
-}
+public object DurationInWholeMinutesSerializer : DurationSerializer(MINUTES, "DurationInWholeMinutes")
 
 /** Serializer that encodes and decodes [Duration]s in [whole hours][Duration.inWholeHours]. */
-public object DurationInWholeHoursSerializer : DurationSerializer(HOURS, "DurationInWholeHours") {
-    override fun Duration.convert(): Long = inWholeHours
-}
+public object DurationInWholeHoursSerializer : DurationSerializer(HOURS, "DurationInWholeHours")
 
 /** Serializer that encodes and decodes [Duration]s in [whole days][Duration.inWholeDays]. */
-public object DurationInWholeDaysSerializer : DurationSerializer(DAYS, "DurationInWholeDays") {
-    override fun Duration.convert(): Long = inWholeDays
-}
+public object DurationInWholeDaysSerializer : DurationSerializer(DAYS, "DurationInWholeDays")

--- a/common/src/main/kotlin/serialization/DurationSerializers.kt
+++ b/common/src/main/kotlin/serialization/DurationSerializers.kt
@@ -1,0 +1,66 @@
+package dev.kord.common.serialization
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlin.time.Duration
+import kotlin.time.DurationUnit
+import kotlin.time.DurationUnit.*
+import kotlin.time.toDuration
+
+
+/** Serializer that encodes and decodes [Duration]s. */
+public sealed class DurationSerializer(private val unit: DurationUnit, name: String) : KSerializer<Duration> {
+
+    final override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("dev.kord.common.serialization.$name", PrimitiveKind.LONG)
+
+    protected abstract fun Duration.convert(): Long
+
+    final override fun serialize(encoder: Encoder, value: Duration) {
+        encoder.encodeLong(value.convert())
+    }
+
+    final override fun deserialize(decoder: Decoder): Duration {
+        return decoder.decodeLong().toDuration(unit)
+    }
+}
+
+
+/** Serializer that encodes and decodes [Duration]s in [whole nanoseconds][Duration.inWholeNanoseconds]. */
+public object DurationInWholeNanosecondsSerializer : DurationSerializer(NANOSECONDS, "DurationInWholeNanoseconds") {
+    override fun Duration.convert(): Long = inWholeNanoseconds
+}
+
+/** Serializer that encodes and decodes [Duration]s in [whole microseconds][Duration.inWholeMicroseconds]. */
+public object DurationInWholeMicrosecondsSerializer : DurationSerializer(MICROSECONDS, "DurationInWholeMicroseconds") {
+    override fun Duration.convert(): Long = inWholeMicroseconds
+}
+
+/** Serializer that encodes and decodes [Duration]s in [whole milliseconds][Duration.inWholeMilliseconds]. */
+public object DurationInWholeMillisecondsSerializer : DurationSerializer(MILLISECONDS, "DurationInWholeMilliseconds") {
+    override fun Duration.convert(): Long = inWholeMilliseconds
+}
+
+/** Serializer that encodes and decodes [Duration]s in [whole seconds][Duration.inWholeSeconds]. */
+public object DurationInWholeSecondsSerializer : DurationSerializer(SECONDS, "DurationInWholeSeconds") {
+    override fun Duration.convert(): Long = inWholeSeconds
+}
+
+/** Serializer that encodes and decodes [Duration]s in [whole minutes][Duration.inWholeMinutes]. */
+public object DurationInWholeMinutesSerializer : DurationSerializer(MINUTES, "DurationInWholeMinutes") {
+    override fun Duration.convert(): Long = inWholeMinutes
+}
+
+/** Serializer that encodes and decodes [Duration]s in [whole hours][Duration.inWholeHours]. */
+public object DurationInWholeHoursSerializer : DurationSerializer(HOURS, "DurationInWholeHours") {
+    override fun Duration.convert(): Long = inWholeHours
+}
+
+/** Serializer that encodes and decodes [Duration]s in [whole days][Duration.inWholeDays]. */
+public object DurationInWholeDaysSerializer : DurationSerializer(DAYS, "DurationInWholeDays") {
+    override fun Duration.convert(): Long = inWholeDays
+}

--- a/common/src/test/kotlin/json/ChannelTest.kt
+++ b/common/src/test/kotlin/json/ChannelTest.kt
@@ -4,6 +4,7 @@ import dev.kord.common.entity.DiscordChannel
 import dev.kord.common.entity.optional.value
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Test
+import kotlin.time.Duration.Companion.seconds
 
 private fun file(name: String): String {
     val loader = ChannelTest::class.java.classLoader
@@ -106,7 +107,7 @@ class ChannelTest {
             type.value shouldBe 0
             position.asNullable!! shouldBe 6
             permissionOverwrites.value shouldBe emptyList()
-            rateLimitPerUser.asNullable shouldBe 2
+            rateLimitPerUser.value shouldBe 2.seconds
             nsfw.value shouldBe true
             topic.value shouldBe "24/7 chat about how to gank Mike #2"
             lastMessageId.value?.toString() shouldBe "155117677105512449"

--- a/common/src/test/kotlin/json/GuildTest.kt
+++ b/common/src/test/kotlin/json/GuildTest.kt
@@ -3,6 +3,7 @@ package json
 import dev.kord.common.entity.*
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Test
+import kotlin.time.Duration.Companion.seconds
 
 
 private fun file(name: String): String {
@@ -40,7 +41,7 @@ class GuildTest {
             @Suppress("DEPRECATION")
             region shouldBe "us-west"
             afkChannelId shouldBe null
-            afkTimeout shouldBe 300
+            afkTimeout shouldBe 300.seconds
             systemChannelId shouldBe null
             widgetEnabled shouldBe true
             widgetChannelId shouldBe null

--- a/common/src/test/kotlin/serialization/DurationSerializersTests.kt
+++ b/common/src/test/kotlin/serialization/DurationSerializersTests.kt
@@ -1,0 +1,128 @@
+package serialization
+
+import dev.kord.common.serialization.*
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.microseconds
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.nanoseconds
+import kotlin.time.Duration.Companion.seconds
+
+abstract class DurationSerializerTest(
+    private val json: String,
+    private val duration: Duration,
+    private val durationToRound: Duration,
+    private val serializer: KSerializer<Duration>,
+) {
+    init {
+        require(duration.isPositive())
+        require(durationToRound.isPositive())
+    }
+
+
+    @Test
+    fun `zero Duration can be serialized`() {
+        val serialized = Json.encodeToString(serializer, Duration.ZERO)
+        assertEquals(expected = "0", actual = serialized)
+    }
+
+    @Test
+    fun `zero Duration can be deserialized`() {
+        val deserialized = Json.decodeFromString(serializer, "0")
+        assertEquals(expected = Duration.ZERO, actual = deserialized)
+    }
+
+
+    @Test
+    fun `positive Duration can be serialized`() {
+        val serialized = Json.encodeToString(serializer, duration)
+        assertEquals(expected = json, actual = serialized)
+    }
+
+    @Test
+    fun `positive Duration can be rounded and serialized`() {
+        val serialized = Json.encodeToString(serializer, durationToRound)
+        assertEquals(expected = json, actual = serialized)
+    }
+
+    @Test
+    fun `positive Duration can be deserialized`() {
+        val deserialized = Json.decodeFromString(serializer, json)
+        assertEquals(expected = duration, actual = deserialized)
+    }
+
+
+    @Test
+    fun `negative Duration can be serialized`() {
+        val serialized = Json.encodeToString(serializer, -duration)
+        assertEquals(expected = "-$json", actual = serialized)
+    }
+
+    @Test
+    fun `negative Duration can be rounded and serialized`() {
+        val serialized = Json.encodeToString(serializer, -durationToRound)
+        assertEquals(expected = "-$json", actual = serialized)
+    }
+
+    @Test
+    fun `negative Duration can be deserialized`() {
+        val deserialized = Json.decodeFromString(serializer, "-$json")
+        assertEquals(expected = -duration, actual = deserialized)
+    }
+}
+
+
+class DurationInWholeNanosecondsSerializerTest : DurationSerializerTest(
+    json = "84169",
+    duration = 84169.nanoseconds,
+    durationToRound = 84169.48.nanoseconds,
+    serializer = DurationInWholeNanosecondsSerializer,
+)
+
+class DurationInWholeMicrosecondsSerializerTest : DurationSerializerTest(
+    json = "25622456",
+    duration = 25622456.microseconds,
+    durationToRound = 25622456.4.microseconds,
+    serializer = DurationInWholeMicrosecondsSerializer,
+)
+
+class DurationInWholeMillisecondsSerializerTest : DurationSerializerTest(
+    json = "3495189",
+    duration = 3495189.milliseconds,
+    durationToRound = 3495189.24.milliseconds,
+    serializer = DurationInWholeMillisecondsSerializer,
+)
+
+class DurationInWholeSecondsSerializerTest : DurationSerializerTest(
+    json = "987465",
+    duration = 987465.seconds,
+    durationToRound = 987465.489.seconds,
+    serializer = DurationInWholeSecondsSerializer,
+)
+
+class DurationInWholeMinutesSerializerTest : DurationSerializerTest(
+    json = "24905",
+    duration = 24905.minutes,
+    durationToRound = 24905.164.minutes,
+    serializer = DurationInWholeMinutesSerializer,
+)
+
+class DurationInWholeHoursSerializerTest : DurationSerializerTest(
+    json = "7245",
+    duration = 7245.hours,
+    durationToRound = 7245.24.hours,
+    serializer = DurationInWholeHoursSerializer,
+)
+
+class DurationInWholeDaysSerializerTest : DurationSerializerTest(
+    json = "92",
+    duration = 92.days,
+    durationToRound = 92.12.days,
+    serializer = DurationInWholeDaysSerializer,
+)

--- a/common/src/test/kotlin/serialization/DurationSerializersTests.kt
+++ b/common/src/test/kotlin/serialization/DurationSerializersTests.kt
@@ -1,10 +1,11 @@
 package serialization
 
 import dev.kord.common.serialization.*
-import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
@@ -13,67 +14,106 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.nanoseconds
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.DurationUnit.MILLISECONDS
 
 abstract class DurationSerializerTest(
     private val json: String,
     private val duration: Duration,
     private val durationToRound: Duration,
-    private val serializer: KSerializer<Duration>,
+    private val durationThatWouldOverflowInTargetUnit: Duration? = null,
+    private val largeJson: String? = null,
+    private val serializer: DurationAsLongSerializer,
 ) {
     init {
         require(duration.isPositive())
         require(durationToRound.isPositive())
+
+        if (serializer.unit < MILLISECONDS) {
+            require(durationThatWouldOverflowInTargetUnit != null)
+            require(largeJson == null)
+        } else {
+            require(durationThatWouldOverflowInTargetUnit == null)
+            require(largeJson != null)
+        }
     }
+
+    private fun serialize(duration: Duration) = Json.encodeToString(serializer, duration)
+    private fun deserialize(json: String) = Json.decodeFromString(serializer, json)
 
 
     @Test
     fun `zero Duration can be serialized`() {
-        val serialized = Json.encodeToString(serializer, Duration.ZERO)
-        assertEquals(expected = "0", actual = serialized)
+        assertEquals(expected = "0", actual = serialize(Duration.ZERO))
     }
 
     @Test
     fun `zero Duration can be deserialized`() {
-        val deserialized = Json.decodeFromString(serializer, "0")
-        assertEquals(expected = Duration.ZERO, actual = deserialized)
+        assertEquals(expected = Duration.ZERO, actual = deserialize("0"))
+    }
+
+
+    @Test
+    fun `infinite Durations cannot be serialized`() {
+        assertFailsWith<SerializationException> { serialize(Duration.INFINITE) }
+        assertFailsWith<SerializationException> { serialize(-Duration.INFINITE) }
     }
 
 
     @Test
     fun `positive Duration can be serialized`() {
-        val serialized = Json.encodeToString(serializer, duration)
-        assertEquals(expected = json, actual = serialized)
+        assertEquals(expected = json, actual = serialize(duration))
     }
 
     @Test
     fun `positive Duration can be rounded and serialized`() {
-        val serialized = Json.encodeToString(serializer, durationToRound)
-        assertEquals(expected = json, actual = serialized)
+        assertEquals(expected = json, actual = serialize(durationToRound))
     }
 
     @Test
     fun `positive Duration can be deserialized`() {
-        val deserialized = Json.decodeFromString(serializer, json)
-        assertEquals(expected = duration, actual = deserialized)
+        assertEquals(expected = duration, actual = deserialize(json))
     }
 
 
     @Test
     fun `negative Duration can be serialized`() {
-        val serialized = Json.encodeToString(serializer, -duration)
-        assertEquals(expected = "-$json", actual = serialized)
+        assertEquals(expected = "-$json", actual = serialize(-duration))
     }
 
     @Test
     fun `negative Duration can be rounded and serialized`() {
-        val serialized = Json.encodeToString(serializer, -durationToRound)
-        assertEquals(expected = "-$json", actual = serialized)
+        assertEquals(expected = "-$json", actual = serialize(-durationToRound))
     }
 
     @Test
     fun `negative Duration can be deserialized`() {
-        val deserialized = Json.decodeFromString(serializer, "-$json")
-        assertEquals(expected = -duration, actual = deserialized)
+        assertEquals(expected = -duration, actual = deserialize("-$json"))
+    }
+
+
+    @Test
+    fun `positive Duration that would overflow in target unit cannot be serialized`() {
+        if (durationThatWouldOverflowInTargetUnit != null) assertFailsWith<SerializationException> {
+            serialize(durationThatWouldOverflowInTargetUnit)
+        }
+    }
+
+    @Test
+    fun `negative Duration that would overflow in target unit cannot be serialized`() {
+        if (durationThatWouldOverflowInTargetUnit != null) assertFailsWith<SerializationException> {
+            serialize(-durationThatWouldOverflowInTargetUnit)
+        }
+    }
+
+
+    @Test
+    fun `large positive Duration gets deserialized as Infinity`() {
+        if (largeJson != null) assertEquals(expected = Duration.INFINITE, deserialize(largeJson))
+    }
+
+    @Test
+    fun `large negative Duration gets deserialized as -Infinity`() {
+        if (largeJson != null) assertEquals(expected = -Duration.INFINITE, deserialize("-$largeJson"))
     }
 }
 
@@ -82,6 +122,9 @@ class DurationInNanosecondsSerializerTest : DurationSerializerTest(
     json = "84169",
     duration = 84169.nanoseconds,
     durationToRound = 84169.48.nanoseconds,
+    // use Long.MAX_VALUE / 1_000_000 + 1 (the smallest value that would overflow when multiplied by 1_000_000)
+    //                      Long.MAX_VALUE: 9_223_372_036_854_775_807
+    durationThatWouldOverflowInTargetUnit = 9_223_372_036_855.milliseconds,
     serializer = DurationInNanosecondsSerializer,
 )
 
@@ -89,6 +132,9 @@ class DurationInMicrosecondsSerializerTest : DurationSerializerTest(
     json = "25622456",
     duration = 25622456.microseconds,
     durationToRound = 25622456.4.microseconds,
+    // use Long.MAX_VALUE / 1_000 + 1 (the smallest value that would overflow when multiplied by 1_000)
+    //                      Long.MAX_VALUE: 9_223_372_036_854_775_807
+    durationThatWouldOverflowInTargetUnit = 9_223_372_036_854_776.milliseconds,
     serializer = DurationInMicrosecondsSerializer,
 )
 
@@ -96,6 +142,7 @@ class DurationInMillisecondsSerializerTest : DurationSerializerTest(
     json = "3495189",
     duration = 3495189.milliseconds,
     durationToRound = 3495189.24.milliseconds,
+    largeJson = "4611686018427387903", // the Duration implementation internal `MAX_MILLIS`
     serializer = DurationInMillisecondsSerializer,
 )
 
@@ -103,6 +150,7 @@ class DurationInSecondsSerializerTest : DurationSerializerTest(
     json = "987465",
     duration = 987465.seconds,
     durationToRound = 987465.489.seconds,
+    largeJson = "4611686018427388", // MAX_MILLIS / 1_000 + 1
     serializer = DurationInSecondsSerializer,
 )
 
@@ -110,6 +158,7 @@ class DurationInMinutesSerializerTest : DurationSerializerTest(
     json = "24905",
     duration = 24905.minutes,
     durationToRound = 24905.164.minutes,
+    largeJson = "76861433640457", // MAX_MILLIS / 1_000 / 60 + 1
     serializer = DurationInMinutesSerializer,
 )
 
@@ -117,6 +166,7 @@ class DurationInHoursSerializerTest : DurationSerializerTest(
     json = "7245",
     duration = 7245.hours,
     durationToRound = 7245.24.hours,
+    largeJson = "1281023894008", // MAX_MILLIS / 1_000 / 60 / 60 + 1
     serializer = DurationInHoursSerializer,
 )
 
@@ -124,5 +174,6 @@ class DurationInDaysSerializerTest : DurationSerializerTest(
     json = "92",
     duration = 92.days,
     durationToRound = 92.12.days,
+    largeJson = "53375995584", // MAX_MILLIS / 1_000 / 60 / 60 / 24 + 1
     serializer = DurationInDaysSerializer,
 )

--- a/common/src/test/kotlin/serialization/DurationSerializersTests.kt
+++ b/common/src/test/kotlin/serialization/DurationSerializersTests.kt
@@ -30,6 +30,7 @@ abstract class DurationSerializerTest(
 
         if (serializer.unit < MILLISECONDS) {
             require(durationThatWouldOverflowInTargetUnit != null)
+            require(durationThatWouldOverflowInTargetUnit.isPositive())
             require(largeJson == null)
         } else {
             require(durationThatWouldOverflowInTargetUnit == null)

--- a/common/src/test/kotlin/serialization/DurationSerializersTests.kt
+++ b/common/src/test/kotlin/serialization/DurationSerializersTests.kt
@@ -78,51 +78,51 @@ abstract class DurationSerializerTest(
 }
 
 
-class DurationInWholeNanosecondsSerializerTest : DurationSerializerTest(
+class DurationInNanosecondsSerializerTest : DurationSerializerTest(
     json = "84169",
     duration = 84169.nanoseconds,
     durationToRound = 84169.48.nanoseconds,
-    serializer = DurationInWholeNanosecondsSerializer,
+    serializer = DurationInNanosecondsSerializer,
 )
 
-class DurationInWholeMicrosecondsSerializerTest : DurationSerializerTest(
+class DurationInMicrosecondsSerializerTest : DurationSerializerTest(
     json = "25622456",
     duration = 25622456.microseconds,
     durationToRound = 25622456.4.microseconds,
-    serializer = DurationInWholeMicrosecondsSerializer,
+    serializer = DurationInMicrosecondsSerializer,
 )
 
-class DurationInWholeMillisecondsSerializerTest : DurationSerializerTest(
+class DurationInMillisecondsSerializerTest : DurationSerializerTest(
     json = "3495189",
     duration = 3495189.milliseconds,
     durationToRound = 3495189.24.milliseconds,
-    serializer = DurationInWholeMillisecondsSerializer,
+    serializer = DurationInMillisecondsSerializer,
 )
 
-class DurationInWholeSecondsSerializerTest : DurationSerializerTest(
+class DurationInSecondsSerializerTest : DurationSerializerTest(
     json = "987465",
     duration = 987465.seconds,
     durationToRound = 987465.489.seconds,
-    serializer = DurationInWholeSecondsSerializer,
+    serializer = DurationInSecondsSerializer,
 )
 
-class DurationInWholeMinutesSerializerTest : DurationSerializerTest(
+class DurationInMinutesSerializerTest : DurationSerializerTest(
     json = "24905",
     duration = 24905.minutes,
     durationToRound = 24905.164.minutes,
-    serializer = DurationInWholeMinutesSerializer,
+    serializer = DurationInMinutesSerializer,
 )
 
-class DurationInWholeHoursSerializerTest : DurationSerializerTest(
+class DurationInHoursSerializerTest : DurationSerializerTest(
     json = "7245",
     duration = 7245.hours,
     durationToRound = 7245.24.hours,
-    serializer = DurationInWholeHoursSerializer,
+    serializer = DurationInHoursSerializer,
 )
 
-class DurationInWholeDaysSerializerTest : DurationSerializerTest(
+class DurationInDaysSerializerTest : DurationSerializerTest(
     json = "92",
     duration = 92.days,
     durationToRound = 92.12.days,
-    serializer = DurationInWholeDaysSerializer,
+    serializer = DurationInDaysSerializer,
 )

--- a/core/src/main/kotlin/cache/data/ChannelData.kt
+++ b/core/src/main/kotlin/cache/data/ChannelData.kt
@@ -4,7 +4,7 @@ import dev.kord.cache.api.data.DataDescription
 import dev.kord.cache.api.data.description
 import dev.kord.common.entity.*
 import dev.kord.common.entity.optional.*
-import dev.kord.common.serialization.DurationInWholeSeconds
+import dev.kord.common.serialization.DurationInSeconds
 import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
 
@@ -21,7 +21,7 @@ public data class ChannelData(
     val lastMessageId: OptionalSnowflake? = OptionalSnowflake.Missing,
     val bitrate: OptionalInt = OptionalInt.Missing,
     val userLimit: OptionalInt = OptionalInt.Missing,
-    val rateLimitPerUser: Optional<DurationInWholeSeconds> = Optional.Missing(),
+    val rateLimitPerUser: Optional<DurationInSeconds> = Optional.Missing(),
     val recipients: Optional<List<Snowflake>> = Optional.Missing(),
     val icon: Optional<String?> = Optional.Missing(),
     val ownerId: OptionalSnowflake = OptionalSnowflake.Missing,

--- a/core/src/main/kotlin/cache/data/ChannelData.kt
+++ b/core/src/main/kotlin/cache/data/ChannelData.kt
@@ -4,10 +4,9 @@ import dev.kord.cache.api.data.DataDescription
 import dev.kord.cache.api.data.description
 import dev.kord.common.entity.*
 import dev.kord.common.entity.optional.*
+import dev.kord.common.serialization.DurationInWholeSeconds
 import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
-import kotlin.time.Duration
-import dev.kord.common.serialization.DurationInWholeSecondsSerializer as InWholeSeconds
 
 @Serializable
 public data class ChannelData(
@@ -22,7 +21,7 @@ public data class ChannelData(
     val lastMessageId: OptionalSnowflake? = OptionalSnowflake.Missing,
     val bitrate: OptionalInt = OptionalInt.Missing,
     val userLimit: OptionalInt = OptionalInt.Missing,
-    val rateLimitPerUser: Optional<@Serializable(InWholeSeconds::class) Duration> = Optional.Missing(),
+    val rateLimitPerUser: Optional<DurationInWholeSeconds> = Optional.Missing(),
     val recipients: Optional<List<Snowflake>> = Optional.Missing(),
     val icon: Optional<String?> = Optional.Missing(),
     val ownerId: OptionalSnowflake = OptionalSnowflake.Missing,

--- a/core/src/main/kotlin/cache/data/ChannelData.kt
+++ b/core/src/main/kotlin/cache/data/ChannelData.kt
@@ -6,6 +6,8 @@ import dev.kord.common.entity.*
 import dev.kord.common.entity.optional.*
 import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
+import kotlin.time.Duration
+import dev.kord.common.serialization.DurationInWholeSecondsSerializer as InWholeSeconds
 
 @Serializable
 public data class ChannelData(
@@ -20,7 +22,7 @@ public data class ChannelData(
     val lastMessageId: OptionalSnowflake? = OptionalSnowflake.Missing,
     val bitrate: OptionalInt = OptionalInt.Missing,
     val userLimit: OptionalInt = OptionalInt.Missing,
-    val rateLimitPerUser: OptionalInt = OptionalInt.Missing,
+    val rateLimitPerUser: Optional<@Serializable(InWholeSeconds::class) Duration> = Optional.Missing(),
     val recipients: Optional<List<Snowflake>> = Optional.Missing(),
     val icon: Optional<String?> = Optional.Missing(),
     val ownerId: OptionalSnowflake = OptionalSnowflake.Missing,

--- a/core/src/main/kotlin/cache/data/GuildData.kt
+++ b/core/src/main/kotlin/cache/data/GuildData.kt
@@ -4,7 +4,9 @@ import dev.kord.cache.api.data.DataDescription
 import dev.kord.cache.api.data.description
 import dev.kord.common.entity.*
 import dev.kord.common.entity.optional.*
+import dev.kord.common.serialization.DurationInWholeSecondsSerializer
 import kotlinx.serialization.Serializable
+import kotlin.time.Duration
 
 private val MessageData.nullableGuildId get() = guildId.value
 private val ChannelData.nullableGuildId get() = guildId.value
@@ -24,7 +26,8 @@ public data class GuildData(
     @Deprecated("The region field has been moved to Channel#rtcRegion in Discord API v9", ReplaceWith("ChannelData#rtcRegion"))
     val region: String,
     val afkChannelId: Snowflake? = null,
-    val afkTimeout: Int,
+    @Serializable(with = DurationInWholeSecondsSerializer::class)
+    val afkTimeout: Duration,
     val widgetEnabled: OptionalBoolean = OptionalBoolean.Missing,
     val widgetChannelId: OptionalSnowflake? = OptionalSnowflake.Missing,
     val verificationLevel: VerificationLevel,

--- a/core/src/main/kotlin/cache/data/GuildData.kt
+++ b/core/src/main/kotlin/cache/data/GuildData.kt
@@ -4,9 +4,8 @@ import dev.kord.cache.api.data.DataDescription
 import dev.kord.cache.api.data.description
 import dev.kord.common.entity.*
 import dev.kord.common.entity.optional.*
-import dev.kord.common.serialization.DurationInWholeSecondsSerializer
+import dev.kord.common.serialization.DurationInWholeSeconds
 import kotlinx.serialization.Serializable
-import kotlin.time.Duration
 
 private val MessageData.nullableGuildId get() = guildId.value
 private val ChannelData.nullableGuildId get() = guildId.value
@@ -26,8 +25,7 @@ public data class GuildData(
     @Deprecated("The region field has been moved to Channel#rtcRegion in Discord API v9", ReplaceWith("ChannelData#rtcRegion"))
     val region: String,
     val afkChannelId: Snowflake? = null,
-    @Serializable(with = DurationInWholeSecondsSerializer::class)
-    val afkTimeout: Duration,
+    val afkTimeout: DurationInWholeSeconds,
     val widgetEnabled: OptionalBoolean = OptionalBoolean.Missing,
     val widgetChannelId: OptionalSnowflake? = OptionalSnowflake.Missing,
     val verificationLevel: VerificationLevel,

--- a/core/src/main/kotlin/cache/data/GuildData.kt
+++ b/core/src/main/kotlin/cache/data/GuildData.kt
@@ -4,7 +4,7 @@ import dev.kord.cache.api.data.DataDescription
 import dev.kord.cache.api.data.description
 import dev.kord.common.entity.*
 import dev.kord.common.entity.optional.*
-import dev.kord.common.serialization.DurationInWholeSeconds
+import dev.kord.common.serialization.DurationInSeconds
 import kotlinx.serialization.Serializable
 
 private val MessageData.nullableGuildId get() = guildId.value
@@ -25,7 +25,7 @@ public data class GuildData(
     @Deprecated("The region field has been moved to Channel#rtcRegion in Discord API v9", ReplaceWith("ChannelData#rtcRegion"))
     val region: String,
     val afkChannelId: Snowflake? = null,
-    val afkTimeout: DurationInWholeSeconds,
+    val afkTimeout: DurationInSeconds,
     val widgetEnabled: OptionalBoolean = OptionalBoolean.Missing,
     val widgetChannelId: OptionalSnowflake? = OptionalSnowflake.Missing,
     val verificationLevel: VerificationLevel,

--- a/core/src/main/kotlin/cache/data/IntegrationData.kt
+++ b/core/src/main/kotlin/cache/data/IntegrationData.kt
@@ -2,7 +2,9 @@ package dev.kord.core.cache.data
 
 import dev.kord.common.entity.*
 import dev.kord.common.entity.optional.OptionalBoolean
+import dev.kord.common.serialization.DurationInWholeDaysSerializer
 import kotlinx.serialization.Serializable
+import kotlin.time.Duration
 
 @Serializable
 public data class IntegrationData(
@@ -15,7 +17,8 @@ public data class IntegrationData(
     val roleId: Snowflake,
     val enableEmoticons: OptionalBoolean = OptionalBoolean.Missing,
     val expireBehavior: IntegrationExpireBehavior,
-    val expireGracePeriod: Int,
+    @Serializable(with = DurationInWholeDaysSerializer::class)
+    val expireGracePeriod: Duration,
     val user: DiscordUser,
     val account: IntegrationsAccountData,
     val syncedAt: String,

--- a/core/src/main/kotlin/cache/data/IntegrationData.kt
+++ b/core/src/main/kotlin/cache/data/IntegrationData.kt
@@ -2,7 +2,7 @@ package dev.kord.core.cache.data
 
 import dev.kord.common.entity.*
 import dev.kord.common.entity.optional.OptionalBoolean
-import dev.kord.common.serialization.DurationInWholeDays
+import dev.kord.common.serialization.DurationInDays
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -16,7 +16,7 @@ public data class IntegrationData(
     val roleId: Snowflake,
     val enableEmoticons: OptionalBoolean = OptionalBoolean.Missing,
     val expireBehavior: IntegrationExpireBehavior,
-    val expireGracePeriod: DurationInWholeDays,
+    val expireGracePeriod: DurationInDays,
     val user: DiscordUser,
     val account: IntegrationsAccountData,
     val syncedAt: String,

--- a/core/src/main/kotlin/cache/data/IntegrationData.kt
+++ b/core/src/main/kotlin/cache/data/IntegrationData.kt
@@ -2,9 +2,8 @@ package dev.kord.core.cache.data
 
 import dev.kord.common.entity.*
 import dev.kord.common.entity.optional.OptionalBoolean
-import dev.kord.common.serialization.DurationInWholeDaysSerializer
+import dev.kord.common.serialization.DurationInWholeDays
 import kotlinx.serialization.Serializable
-import kotlin.time.Duration
 
 @Serializable
 public data class IntegrationData(
@@ -17,8 +16,7 @@ public data class IntegrationData(
     val roleId: Snowflake,
     val enableEmoticons: OptionalBoolean = OptionalBoolean.Missing,
     val expireBehavior: IntegrationExpireBehavior,
-    @Serializable(with = DurationInWholeDaysSerializer::class)
-    val expireGracePeriod: Duration,
+    val expireGracePeriod: DurationInWholeDays,
     val user: DiscordUser,
     val account: IntegrationsAccountData,
     val syncedAt: String,

--- a/core/src/main/kotlin/cache/data/InviteCreateData.kt
+++ b/core/src/main/kotlin/cache/data/InviteCreateData.kt
@@ -6,10 +6,9 @@ import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalSnowflake
 import dev.kord.common.entity.optional.map
 import dev.kord.common.entity.optional.mapSnowflake
-import dev.kord.common.serialization.DurationInWholeSecondsSerializer
+import dev.kord.common.serialization.DurationInWholeSeconds
 import dev.kord.gateway.DiscordCreatedInvite
 import kotlinx.serialization.Serializable
-import kotlin.time.Duration
 
 @Serializable
 public data class InviteCreateData(
@@ -18,8 +17,7 @@ public data class InviteCreateData(
     val createdAt: String,
     val guildId: OptionalSnowflake = OptionalSnowflake.Missing,
     val inviterId: OptionalSnowflake = OptionalSnowflake.Missing,
-    @Serializable(with = DurationInWholeSecondsSerializer::class)
-    val maxAge: Duration,
+    val maxAge: DurationInWholeSeconds,
     val maxUses: Int,
     val targetType: Optional<InviteTargetType> = Optional.Missing(),
     val targetUserId: OptionalSnowflake = OptionalSnowflake.Missing,

--- a/core/src/main/kotlin/cache/data/InviteCreateData.kt
+++ b/core/src/main/kotlin/cache/data/InviteCreateData.kt
@@ -6,8 +6,10 @@ import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalSnowflake
 import dev.kord.common.entity.optional.map
 import dev.kord.common.entity.optional.mapSnowflake
+import dev.kord.common.serialization.DurationInWholeSecondsSerializer
 import dev.kord.gateway.DiscordCreatedInvite
 import kotlinx.serialization.Serializable
+import kotlin.time.Duration
 
 @Serializable
 public data class InviteCreateData(
@@ -16,7 +18,8 @@ public data class InviteCreateData(
     val createdAt: String,
     val guildId: OptionalSnowflake = OptionalSnowflake.Missing,
     val inviterId: OptionalSnowflake = OptionalSnowflake.Missing,
-    val maxAge: Int,
+    @Serializable(with = DurationInWholeSecondsSerializer::class)
+    val maxAge: Duration,
     val maxUses: Int,
     val targetType: Optional<InviteTargetType> = Optional.Missing(),
     val targetUserId: OptionalSnowflake = OptionalSnowflake.Missing,

--- a/core/src/main/kotlin/cache/data/InviteCreateData.kt
+++ b/core/src/main/kotlin/cache/data/InviteCreateData.kt
@@ -6,7 +6,7 @@ import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalSnowflake
 import dev.kord.common.entity.optional.map
 import dev.kord.common.entity.optional.mapSnowflake
-import dev.kord.common.serialization.DurationInWholeSeconds
+import dev.kord.common.serialization.DurationInSeconds
 import dev.kord.gateway.DiscordCreatedInvite
 import kotlinx.serialization.Serializable
 
@@ -17,7 +17,7 @@ public data class InviteCreateData(
     val createdAt: String,
     val guildId: OptionalSnowflake = OptionalSnowflake.Missing,
     val inviterId: OptionalSnowflake = OptionalSnowflake.Missing,
-    val maxAge: DurationInWholeSeconds,
+    val maxAge: DurationInSeconds,
     val maxUses: Int,
     val targetType: Optional<InviteTargetType> = Optional.Missing(),
     val targetUserId: OptionalSnowflake = OptionalSnowflake.Missing,

--- a/core/src/main/kotlin/cache/data/InviteData.kt
+++ b/core/src/main/kotlin/cache/data/InviteData.kt
@@ -2,8 +2,10 @@ package dev.kord.core.cache.data
 
 import dev.kord.common.entity.*
 import dev.kord.common.entity.optional.*
+import dev.kord.common.serialization.DurationInWholeSecondsSerializer
 import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
+import kotlin.time.Duration
 
 public sealed interface BaseInviteData {
     public val code: String
@@ -73,7 +75,8 @@ public data class InviteWithMetadataData(
     override val guildScheduledEvent: Optional<GuildScheduledEventData> = Optional.Missing(),
     val uses: Int,
     val maxUses: Int,
-    val maxAge: Int,
+    @Serializable(with = DurationInWholeSecondsSerializer::class)
+    val maxAge: Duration,
     val temporary: Boolean,
     val createdAt: Instant,
 ) : BaseInviteData {

--- a/core/src/main/kotlin/cache/data/InviteData.kt
+++ b/core/src/main/kotlin/cache/data/InviteData.kt
@@ -2,7 +2,7 @@ package dev.kord.core.cache.data
 
 import dev.kord.common.entity.*
 import dev.kord.common.entity.optional.*
-import dev.kord.common.serialization.DurationInWholeSeconds
+import dev.kord.common.serialization.DurationInSeconds
 import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
 
@@ -74,7 +74,7 @@ public data class InviteWithMetadataData(
     override val guildScheduledEvent: Optional<GuildScheduledEventData> = Optional.Missing(),
     val uses: Int,
     val maxUses: Int,
-    val maxAge: DurationInWholeSeconds,
+    val maxAge: DurationInSeconds,
     val temporary: Boolean,
     val createdAt: Instant,
 ) : BaseInviteData {

--- a/core/src/main/kotlin/cache/data/InviteData.kt
+++ b/core/src/main/kotlin/cache/data/InviteData.kt
@@ -2,10 +2,9 @@ package dev.kord.core.cache.data
 
 import dev.kord.common.entity.*
 import dev.kord.common.entity.optional.*
-import dev.kord.common.serialization.DurationInWholeSecondsSerializer
+import dev.kord.common.serialization.DurationInWholeSeconds
 import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
-import kotlin.time.Duration
 
 public sealed interface BaseInviteData {
     public val code: String
@@ -75,8 +74,7 @@ public data class InviteWithMetadataData(
     override val guildScheduledEvent: Optional<GuildScheduledEventData> = Optional.Missing(),
     val uses: Int,
     val maxUses: Int,
-    @Serializable(with = DurationInWholeSecondsSerializer::class)
-    val maxAge: Duration,
+    val maxAge: DurationInWholeSeconds,
     val temporary: Boolean,
     val createdAt: Instant,
 ) : BaseInviteData {

--- a/core/src/main/kotlin/entity/Guild.kt
+++ b/core/src/main/kotlin/entity/Guild.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.datetime.Instant
 import kotlinx.datetime.toInstant
 import java.util.*
+import kotlin.time.Duration
 
 /**
  * An instance of a [Discord Guild](https://discord.com/developers/docs/resources/guild).
@@ -60,9 +61,9 @@ public class Guild(
         }
 
     /**
-     * The afk timeout in seconds.
+     * The afk timeout.
      */
-    public val afkTimeout: Int get() = data.afkTimeout
+    public val afkTimeout: Duration get() = data.afkTimeout
 
     /**
      *  The id of the guild creator if it is bot-created.

--- a/core/src/main/kotlin/entity/Integration.kt
+++ b/core/src/main/kotlin/entity/Integration.kt
@@ -19,7 +19,6 @@ import java.util.*
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.days
 
 /**
  * A [Discord integration](https://discord.com/developers/docs/resources/guild#get-guild-integrations).
@@ -95,10 +94,9 @@ public class Integration(
         get() = data.expireBehavior
 
     /**
-     * The grace period in days before expiring subscribers.
+     * The grace period before expiring subscribers.
      */
-    public val expireGracePeriod: Duration
-        get() = data.expireGracePeriod.days
+    public val expireGracePeriod: Duration get() = data.expireGracePeriod
 
     /**
      * The id of the [user][User] for this integration.

--- a/core/src/main/kotlin/entity/Invite.kt
+++ b/core/src/main/kotlin/entity/Invite.kt
@@ -17,8 +17,6 @@ import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 import kotlinx.datetime.Instant
 import kotlin.time.Duration
-import kotlin.time.DurationUnit.SECONDS
-import kotlin.time.toDuration
 
 /**
  * An instance of a [Discord Invite](https://discord.com/developers/docs/resources/invite).
@@ -180,7 +178,7 @@ public class InviteWithMetadata(
     public val maxUses: Int get() = data.maxUses
 
     /** Duration after which the invite expires. */
-    public val maxAge: Duration get() = data.maxAge.toDuration(unit = SECONDS)
+    public val maxAge: Duration get() = data.maxAge
 
     /** Whether this invite only grants temporary membership. */
     public val temporary: Boolean get() = data.temporary

--- a/core/src/main/kotlin/entity/channel/TextChannel.kt
+++ b/core/src/main/kotlin/entity/channel/TextChannel.kt
@@ -1,6 +1,7 @@
 package dev.kord.core.entity.channel
 
-import dev.kord.common.entity.optional.getOrThrow
+import dev.kord.common.entity.Permission.ManageChannels
+import dev.kord.common.entity.Permission.ManageMessages
 import dev.kord.core.Kord
 import dev.kord.core.behavior.channel.ChannelBehavior
 import dev.kord.core.behavior.channel.GuildChannelBehavior
@@ -9,6 +10,7 @@ import dev.kord.core.cache.data.ChannelData
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 import java.util.*
+import kotlin.time.Duration
 
 /**
  * An instance of a Discord Text Channel associated to a guild.
@@ -25,9 +27,11 @@ public class TextChannel(
     public val isNsfw: Boolean get() = data.nsfw.discordBoolean
 
     /**
-     * The amount of seconds a user has to wait before sending another message.
+     * The amount of time a user has to wait before sending another message.
+     *
+     * Bots, as well as users with the permission [ManageMessages] or [ManageChannels], are unaffected.
      */
-    public val userRateLimit: Int get() = data.rateLimitPerUser.getOrThrow()
+    public val userRateLimit: Duration? get() = data.rateLimitPerUser.value
 
     /**
      * returns a new [TextChannel] with the given [strategy].

--- a/core/src/main/kotlin/entity/channel/thread/ThreadChannel.kt
+++ b/core/src/main/kotlin/entity/channel/thread/ThreadChannel.kt
@@ -1,6 +1,8 @@
 package dev.kord.core.entity.channel.thread
 
 import dev.kord.common.entity.ArchiveDuration
+import dev.kord.common.entity.Permission.ManageChannels
+import dev.kord.common.entity.Permission.ManageMessages
 import dev.kord.common.entity.Snowflake
 import dev.kord.common.entity.optional.OptionalInt
 import dev.kord.common.entity.optional.unwrap
@@ -14,6 +16,7 @@ import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 import kotlinx.datetime.Instant
 import kotlinx.datetime.toInstant
+import kotlin.time.Duration
 
 public interface ThreadChannel : GuildMessageChannel, ThreadChannelBehavior {
 
@@ -80,11 +83,11 @@ public interface ThreadChannel : GuildMessageChannel, ThreadChannelBehavior {
     public val createTimestamp: Instant? get() = threadData.createTimestamp.value
 
     /**
-     * amount of seconds a user has to wait before sending another message
-     * bots, users with the permission [Manage Messages][dev.kord.common.entity.Permission.ManageMessages] or
-     * [Manage Messages][dev.kord.common.entity.Permission.ManageChannels]  are unaffected.
+     * The amount of time a user has to wait before sending another message.
+     *
+     * Bots, as well as users with the permission [ManageMessages] or [ManageChannels], are unaffected.
      */
-    public val rateLimitPerUser: Int? get() = data.rateLimitPerUser.value
+    public val rateLimitPerUser: Duration? get() = data.rateLimitPerUser.value
 
     /**
      * member count for this thread.

--- a/core/src/main/kotlin/event/guild/InviteCreateEvent.kt
+++ b/core/src/main/kotlin/event/guild/InviteCreateEvent.kt
@@ -22,8 +22,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.datetime.Instant
 import kotlinx.datetime.toInstant
 import kotlin.time.Duration
-import kotlin.time.DurationUnit.SECONDS
-import kotlin.time.toDuration
 
 /**
  * Sent when a new invite to a channel is created.
@@ -87,7 +85,7 @@ public class InviteCreateEvent(
     /**
      * How long the invite is valid for.
      */
-    public val maxAge: Duration get() = data.maxAge.toDuration(unit = SECONDS)
+    public val maxAge: Duration get() = data.maxAge
 
     /**
      * The maximum number of times the invite can be used.

--- a/core/src/test/kotlin/live/LiveGuildTest.kt
+++ b/core/src/test/kotlin/live/LiveGuildTest.kt
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeUnit
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.seconds
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @OptIn(KordPreview::class)
@@ -39,7 +40,7 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
                     name = "",
                     ownerId = randomId(),
                     region = "",
-                    afkTimeout = 0,
+                    afkTimeout = 0.seconds,
                     verificationLevel = VerificationLevel.None,
                     defaultMessageNotifications = DefaultMessageNotificationLevel.AllMessages,
                     explicitContentFilter = ExplicitContentFilter.Disabled,
@@ -697,7 +698,7 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
                         ownerId = randomId(),
                         region = "",
                         afkChannelId = null,
-                        afkTimeout = 0,
+                        afkTimeout = 0.seconds,
                         verificationLevel = VerificationLevel.None,
                         defaultMessageNotifications = DefaultMessageNotificationLevel.AllMessages,
                         explicitContentFilter = ExplicitContentFilter.Disabled,
@@ -741,7 +742,7 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
                         ownerId = randomId(),
                         region = "",
                         afkChannelId = null,
-                        afkTimeout = 0,
+                        afkTimeout = 0.seconds,
                         verificationLevel = VerificationLevel.None,
                         defaultMessageNotifications = DefaultMessageNotificationLevel.AllMessages,
                         explicitContentFilter = ExplicitContentFilter.Disabled,

--- a/core/src/test/kotlin/performance/KordEventDropTest.kt
+++ b/core/src/test/kotlin/performance/KordEventDropTest.kt
@@ -26,6 +26,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 
 class KordEventDropTest {
 
@@ -64,7 +65,7 @@ class KordEventDropTest {
             DiscordGuild(
                 Snowflake("1337"),
                 "discord guild",
-                afkTimeout = 0,
+                afkTimeout = 0.seconds,
                 defaultMessageNotifications = DefaultMessageNotificationLevel.AllMessages,
                 emojis = emptyList(),
                 explicitContentFilter = ExplicitContentFilter.AllMembers,

--- a/gateway/src/main/kotlin/Event.kt
+++ b/gateway/src/main/kotlin/Event.kt
@@ -4,7 +4,7 @@ import dev.kord.common.entity.*
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
 import dev.kord.common.entity.optional.OptionalSnowflake
-import dev.kord.common.serialization.DurationInWholeSeconds
+import dev.kord.common.serialization.DurationInSeconds
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
@@ -630,7 +630,7 @@ public data class DiscordCreatedInvite(
     val guildId: OptionalSnowflake = OptionalSnowflake.Missing,
     val inviter: Optional<DiscordUser> = Optional.Missing(),
     @SerialName("max_age")
-    val maxAge: DurationInWholeSeconds,
+    val maxAge: DurationInSeconds,
     @SerialName("max_uses")
     val maxUses: Int,
     @SerialName("target_type")

--- a/gateway/src/main/kotlin/Event.kt
+++ b/gateway/src/main/kotlin/Event.kt
@@ -4,6 +4,7 @@ import dev.kord.common.entity.*
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
 import dev.kord.common.entity.optional.OptionalSnowflake
+import dev.kord.common.serialization.DurationInWholeSecondsSerializer
 import kotlinx.serialization.*
 import kotlinx.serialization.builtins.nullable
 import kotlinx.serialization.builtins.serializer
@@ -17,6 +18,7 @@ import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import mu.KotlinLogging
+import kotlin.time.Duration
 import kotlinx.serialization.DeserializationStrategy as KDeserializationStrategy
 
 private val jsonLogger = KotlinLogging.logger { }
@@ -626,7 +628,8 @@ public data class DiscordCreatedInvite(
     val guildId: OptionalSnowflake = OptionalSnowflake.Missing,
     val inviter: Optional<DiscordUser> = Optional.Missing(),
     @SerialName("max_age")
-    val maxAge: Int,
+    @Serializable(with = DurationInWholeSecondsSerializer::class)
+    val maxAge: Duration,
     @SerialName("max_uses")
     val maxUses: Int,
     @SerialName("target_type")

--- a/gateway/src/main/kotlin/Event.kt
+++ b/gateway/src/main/kotlin/Event.kt
@@ -4,8 +4,11 @@ import dev.kord.common.entity.*
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
 import dev.kord.common.entity.optional.OptionalSnowflake
-import dev.kord.common.serialization.DurationInWholeSecondsSerializer
-import kotlinx.serialization.*
+import dev.kord.common.serialization.DurationInWholeSeconds
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.nullable
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.descriptors.PrimitiveKind
@@ -18,7 +21,6 @@ import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import mu.KotlinLogging
-import kotlin.time.Duration
 import kotlinx.serialization.DeserializationStrategy as KDeserializationStrategy
 
 private val jsonLogger = KotlinLogging.logger { }
@@ -628,8 +630,7 @@ public data class DiscordCreatedInvite(
     val guildId: OptionalSnowflake = OptionalSnowflake.Missing,
     val inviter: Optional<DiscordUser> = Optional.Missing(),
     @SerialName("max_age")
-    @Serializable(with = DurationInWholeSecondsSerializer::class)
-    val maxAge: Duration,
+    val maxAge: DurationInWholeSeconds,
     @SerialName("max_uses")
     val maxUses: Int,
     @SerialName("target_type")

--- a/gateway/src/test/kotlin/json/SerializationTest.kt
+++ b/gateway/src/test/kotlin/json/SerializationTest.kt
@@ -6,10 +6,11 @@ import dev.kord.common.entity.optional.value
 import dev.kord.gateway.*
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Test
+import kotlin.time.Duration.Companion.seconds
 
 private fun file(name: String): String {
     val loader = SerializationTest::class.java.classLoader
-    return loader.getResource("json/event/$name.json").readText()
+    return loader.getResource("json/event/$name.json")!!.readText()
 }
 
 class SerializationTest {
@@ -102,7 +103,7 @@ class SerializationTest {
             type.value shouldBe 0
             position.value shouldBe 6
             permissionOverwrites.value shouldBe emptyList()
-            rateLimitPerUser.value shouldBe 2
+            rateLimitPerUser.value shouldBe 2.seconds
             nsfw.value shouldBe true
             topic.value shouldBe "24/7 chat about how to gank Mike #2"
             lastMessageId.value?.toString() shouldBe "155117677105512449"
@@ -121,7 +122,7 @@ class SerializationTest {
             type.value shouldBe 0
             position.value shouldBe 6
             permissionOverwrites.value shouldBe emptyList()
-            rateLimitPerUser.value shouldBe 2
+            rateLimitPerUser.value shouldBe 2.seconds
             nsfw.value shouldBe true
             topic.value shouldBe "24/7 chat about how to gank Mike #2"
             lastMessageId.value?.toString() shouldBe "155117677105512449"
@@ -139,7 +140,7 @@ class SerializationTest {
             type.value shouldBe 0
             position.value shouldBe 6
             permissionOverwrites.value shouldBe emptyList()
-            rateLimitPerUser.value shouldBe 2
+            rateLimitPerUser.value shouldBe 2.seconds
             nsfw.value shouldBe true
             topic.value shouldBe "24/7 chat about how to gank Mike #2"
             lastMessageId.value?.toString() shouldBe "155117677105512449"

--- a/rest/src/main/kotlin/builder/channel/EditGuildChannelBuilder.kt
+++ b/rest/src/main/kotlin/builder/channel/EditGuildChannelBuilder.kt
@@ -11,6 +11,7 @@ import dev.kord.common.entity.optional.delegate.delegate
 import dev.kord.rest.builder.AuditRequestBuilder
 import dev.kord.rest.json.request.ChannelModifyPatchRequest
 import kotlin.DeprecationLevel.WARNING
+import kotlin.time.Duration
 
 @KordDsl
 public class TextChannelModifyBuilder : PermissionOverwritesModifyBuilder,
@@ -32,8 +33,8 @@ public class TextChannelModifyBuilder : PermissionOverwritesModifyBuilder,
     private var _parentId: OptionalSnowflake? = OptionalSnowflake.Missing
     public var parentId: Snowflake? by ::_parentId.delegate()
 
-    private var _rateLimitPerUser: OptionalInt? = OptionalInt.Missing
-    public var rateLimitPerUser: Int? by ::_rateLimitPerUser.delegate()
+    private var _rateLimitPerUser: Optional<Duration?> = Optional.Missing()
+    public var rateLimitPerUser: Duration? by ::_rateLimitPerUser.delegate()
 
     private var _permissionOverwrites: Optional<MutableSet<Overwrite>> = Optional.Missing()
     override var permissionOverwrites: MutableSet<Overwrite>? by ::_permissionOverwrites.delegate()
@@ -140,8 +141,8 @@ public class NewsChannelModifyBuilder : AuditRequestBuilder<ChannelModifyPatchRe
     private var _parentId: OptionalSnowflake? = OptionalSnowflake.Missing
     public var parentId: Snowflake? by ::_parentId.delegate()
 
-    private var _rateLimitPerUser: OptionalInt? = OptionalInt.Missing
-    public var rateLimitPerUser: Int? by ::_rateLimitPerUser.delegate()
+    private var _rateLimitPerUser: Optional<Duration?> = Optional.Missing()
+    public var rateLimitPerUser: Duration? by ::_rateLimitPerUser.delegate()
 
     private var _permissionOverwrites: Optional<MutableSet<Overwrite>?> = Optional.Missing()
     public var permissionOverwrites: MutableSet<Overwrite>? by ::_permissionOverwrites.delegate()
@@ -151,8 +152,9 @@ public class NewsChannelModifyBuilder : AuditRequestBuilder<ChannelModifyPatchRe
         position = _position,
         topic = _topic,
         nsfw = _nsfw,
+        parentId = _parentId,
+        rateLimitPerUser = _rateLimitPerUser,
         permissionOverwrites = _permissionOverwrites,
-        parentId = _parentId
     )
 }
 

--- a/rest/src/main/kotlin/builder/channel/InviteCreateBuilder.kt
+++ b/rest/src/main/kotlin/builder/channel/InviteCreateBuilder.kt
@@ -16,25 +16,22 @@ import kotlin.time.toDuration
 public class InviteCreateBuilder : AuditRequestBuilder<InviteCreateRequest> {
     override var reason: String? = null
 
-    private var _maxAge: OptionalInt = OptionalInt.Missing
+    private var _maxAge: Optional<Duration> = Optional.Missing()
 
     /**
      * The duration of invite in seconds before expiry, or 0 for never. 86400 (24 hours) by default.
      */
     @Deprecated("'age' was renamed to 'maxAge'", ReplaceWith("this.maxAge"))
-    public var age: Int? by ::_maxAge.delegate()
+    public var age: Int?
+        get() = _maxAge.value?.inWholeSeconds?.toInt()
+        set(value) {
+            _maxAge = value?.toDuration(unit = SECONDS)?.optional() ?: Optional.Missing()
+        }
 
     /**
      * The duration before invite expiry, or 0 for never. Between 0 and 604800 seconds (7 days). 24 hours by default.
      */
-    public var maxAge: Duration?
-        get() = _maxAge.value?.toDuration(unit = SECONDS)
-        set(value) {
-            _maxAge = when (value) {
-                null -> OptionalInt.Missing
-                else -> OptionalInt.Value(value.inWholeSeconds.coerceIn(intValues).toInt())
-            }
-        }
+    public var maxAge: Duration? by ::_maxAge.delegate()
 
     private var _maxUses: OptionalInt = OptionalInt.Missing
 
@@ -124,4 +121,3 @@ public class InviteCreateBuilder : AuditRequestBuilder<InviteCreateRequest> {
 
 private inline val OptionalSnowflake.isMissing get() = this == OptionalSnowflake.Missing
 private inline val OptionalSnowflake.isPresent get() = this != OptionalSnowflake.Missing
-private inline val intValues get() = Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong()

--- a/rest/src/main/kotlin/builder/channel/TextChannelCreateBuilder.kt
+++ b/rest/src/main/kotlin/builder/channel/TextChannelCreateBuilder.kt
@@ -11,6 +11,7 @@ import dev.kord.common.entity.optional.OptionalSnowflake
 import dev.kord.common.entity.optional.delegate.delegate
 import dev.kord.rest.builder.AuditRequestBuilder
 import dev.kord.rest.json.request.GuildChannelCreateRequest
+import kotlin.time.Duration
 
 @KordDsl
 public class TextChannelCreateBuilder(public var name: String) :
@@ -21,8 +22,8 @@ public class TextChannelCreateBuilder(public var name: String) :
     private var _topic: Optional<String> = Optional.Missing()
     public var topic: String? by ::_topic.delegate()
 
-    private var _rateLimitPerUser: OptionalInt = OptionalInt.Missing
-    public var rateLimitPerUser: Int? by ::_rateLimitPerUser.delegate()
+    private var _rateLimitPerUser: Optional<Duration> = Optional.Missing()
+    public var rateLimitPerUser: Duration? by ::_rateLimitPerUser.delegate()
 
     private var _position: OptionalInt = OptionalInt.Missing
     public var position: Int? by ::_position.delegate()
@@ -36,11 +37,11 @@ public class TextChannelCreateBuilder(public var name: String) :
     override var permissionOverwrites: MutableSet<Overwrite> = mutableSetOf()
 
     override fun toRequest(): GuildChannelCreateRequest = GuildChannelCreateRequest(
-        name,
-        ChannelType.GuildText,
-        _topic,
-        _rateLimitPerUser,
-        _position,
+        name = name,
+        type = ChannelType.GuildText,
+        topic = _topic,
+        rateLimitPerUser = _rateLimitPerUser,
+        position = _position,
         parentId = _parentId,
         nsfw = _nsfw,
         permissionOverwrite = Optional.missingOnEmpty(permissionOverwrites),

--- a/rest/src/main/kotlin/builder/channel/thread/ThreadModifyBuilder.kt
+++ b/rest/src/main/kotlin/builder/channel/thread/ThreadModifyBuilder.kt
@@ -6,6 +6,7 @@ import dev.kord.common.entity.optional.OptionalInt
 import dev.kord.common.entity.optional.delegate.delegate
 import dev.kord.rest.builder.AuditRequestBuilder
 import dev.kord.rest.json.request.ChannelModifyPatchRequest
+import kotlin.time.Duration
 
 public class ThreadModifyBuilder : AuditRequestBuilder<ChannelModifyPatchRequest> {
 
@@ -18,8 +19,8 @@ public class ThreadModifyBuilder : AuditRequestBuilder<ChannelModifyPatchRequest
     private var _locked: OptionalBoolean = OptionalBoolean.Missing
     public var locked: Boolean? by ::_locked.delegate()
 
-    private var _rateLimitPerUser: OptionalInt? = OptionalInt.Missing
-    public var rateLimitPerUser: Int? by ::_rateLimitPerUser.delegate()
+    private var _rateLimitPerUser: Optional<Duration?> = Optional.Missing()
+    public var rateLimitPerUser: Duration? by ::_rateLimitPerUser.delegate()
 
     private var _autoArchiveDuration: OptionalInt = OptionalInt.Missing
     public var autoArchiveDuration: Int? by ::_autoArchiveDuration.delegate()

--- a/rest/src/main/kotlin/builder/channel/thread/ThreadModifyBuilder.kt
+++ b/rest/src/main/kotlin/builder/channel/thread/ThreadModifyBuilder.kt
@@ -1,8 +1,8 @@
 package dev.kord.rest.builder.channel.thread
 
+import dev.kord.common.entity.ArchiveDuration
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
-import dev.kord.common.entity.optional.OptionalInt
 import dev.kord.common.entity.optional.delegate.delegate
 import dev.kord.rest.builder.AuditRequestBuilder
 import dev.kord.rest.json.request.ChannelModifyPatchRequest
@@ -22,8 +22,8 @@ public class ThreadModifyBuilder : AuditRequestBuilder<ChannelModifyPatchRequest
     private var _rateLimitPerUser: Optional<Duration?> = Optional.Missing()
     public var rateLimitPerUser: Duration? by ::_rateLimitPerUser.delegate()
 
-    private var _autoArchiveDuration: OptionalInt = OptionalInt.Missing
-    public var autoArchiveDuration: Int? by ::_autoArchiveDuration.delegate()
+    private var _autoArchiveDuration: Optional<ArchiveDuration> = Optional.Missing()
+    public var autoArchiveDuration: ArchiveDuration? by ::_autoArchiveDuration.delegate()
 
     private var _invitable: OptionalBoolean = OptionalBoolean.Missing
     public var invitable: Boolean? by ::_invitable.delegate()

--- a/rest/src/main/kotlin/builder/guild/GuildCreateBuilder.kt
+++ b/rest/src/main/kotlin/builder/guild/GuildCreateBuilder.kt
@@ -6,7 +6,6 @@ import dev.kord.common.entity.ExplicitContentFilter
 import dev.kord.common.entity.Snowflake
 import dev.kord.common.entity.VerificationLevel
 import dev.kord.common.entity.optional.Optional
-import dev.kord.common.entity.optional.OptionalInt
 import dev.kord.common.entity.optional.OptionalSnowflake
 import dev.kord.common.entity.optional.delegate.delegate
 import dev.kord.common.entity.optional.map
@@ -23,6 +22,7 @@ import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 import kotlin.random.Random
 import kotlin.random.nextULong
+import kotlin.time.Duration
 
 @KordDsl
 public class GuildCreateBuilder(public var name: String) : RequestBuilder<GuildCreateRequest> {
@@ -75,12 +75,12 @@ public class GuildCreateBuilder(public var name: String) : RequestBuilder<GuildC
      */
     public var afkChannelId: Snowflake? by ::_afkChannelId.delegate()
 
-    private var _afkTimeout: OptionalInt = OptionalInt.Missing
+    private var _afkTimeout: Optional<Duration> = Optional.Missing()
 
     /**
-     * The afk timeout in seconds.
+     * The afk timeout.
      */
-    public var afkTimeout: Int? by ::_afkTimeout.delegate()
+    public var afkTimeout: Duration? by ::_afkTimeout.delegate()
 
     private var _systemChannelId: OptionalSnowflake = OptionalSnowflake.Missing
 

--- a/rest/src/main/kotlin/builder/guild/GuildModifyBuilder.kt
+++ b/rest/src/main/kotlin/builder/guild/GuildModifyBuilder.kt
@@ -6,7 +6,6 @@ import dev.kord.common.entity.ExplicitContentFilter
 import dev.kord.common.entity.Snowflake
 import dev.kord.common.entity.VerificationLevel
 import dev.kord.common.entity.optional.Optional
-import dev.kord.common.entity.optional.OptionalInt
 import dev.kord.common.entity.optional.OptionalSnowflake
 import dev.kord.common.entity.optional.delegate.delegate
 import dev.kord.common.entity.optional.map
@@ -14,6 +13,7 @@ import dev.kord.rest.Image
 import dev.kord.rest.builder.AuditRequestBuilder
 import dev.kord.rest.json.request.GuildModifyRequest
 import java.util.*
+import kotlin.time.Duration
 
 @KordDsl
 public class GuildModifyBuilder : AuditRequestBuilder<GuildModifyRequest> {
@@ -37,8 +37,8 @@ public class GuildModifyBuilder : AuditRequestBuilder<GuildModifyRequest> {
     private var _afkChannelId: OptionalSnowflake? = OptionalSnowflake.Missing
     public var afkChannelId: Snowflake? by ::_afkChannelId.delegate()
 
-    private var _afkTimeout: OptionalInt = OptionalInt.Missing
-    public var afkTimeout: Int? by ::_afkTimeout.delegate()
+    private var _afkTimeout: Optional<Duration> = Optional.Missing()
+    public var afkTimeout: Duration? by ::_afkTimeout.delegate()
 
     private var _icon: Optional<Image?> = Optional.Missing()
     public var icon: Image? by ::_icon.delegate()

--- a/rest/src/main/kotlin/json/request/ChannelRequests.kt
+++ b/rest/src/main/kotlin/json/request/ChannelRequests.kt
@@ -5,11 +5,10 @@ import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
 import dev.kord.common.entity.optional.OptionalInt
 import dev.kord.common.entity.optional.OptionalSnowflake
+import dev.kord.common.serialization.DurationInWholeSeconds
 import kotlinx.datetime.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlin.time.Duration
-import dev.kord.common.serialization.DurationInWholeSecondsSerializer as InWholeSeconds
 
 @Serializable
 public data class ChannelModifyPutRequest(
@@ -35,7 +34,7 @@ public data class ChannelModifyPatchRequest(
     val topic: Optional<String?> = Optional.Missing(),
     val nsfw: OptionalBoolean? = OptionalBoolean.Missing,
     @SerialName("rate_limit_per_user")
-    val rateLimitPerUser: Optional<@Serializable(InWholeSeconds::class) Duration?> = Optional.Missing(),
+    val rateLimitPerUser: Optional<DurationInWholeSeconds?> = Optional.Missing(),
     val bitrate: OptionalInt? = OptionalInt.Missing,
     @SerialName("user_limit")
     val userLimit: OptionalInt? = OptionalInt.Missing,

--- a/rest/src/main/kotlin/json/request/ChannelRequests.kt
+++ b/rest/src/main/kotlin/json/request/ChannelRequests.kt
@@ -5,7 +5,7 @@ import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
 import dev.kord.common.entity.optional.OptionalInt
 import dev.kord.common.entity.optional.OptionalSnowflake
-import dev.kord.common.serialization.DurationInWholeSeconds
+import dev.kord.common.serialization.DurationInSeconds
 import kotlinx.datetime.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -34,7 +34,7 @@ public data class ChannelModifyPatchRequest(
     val topic: Optional<String?> = Optional.Missing(),
     val nsfw: OptionalBoolean? = OptionalBoolean.Missing,
     @SerialName("rate_limit_per_user")
-    val rateLimitPerUser: Optional<DurationInWholeSeconds?> = Optional.Missing(),
+    val rateLimitPerUser: Optional<DurationInSeconds?> = Optional.Missing(),
     val bitrate: OptionalInt? = OptionalInt.Missing,
     @SerialName("user_limit")
     val userLimit: OptionalInt? = OptionalInt.Missing,

--- a/rest/src/main/kotlin/json/request/ChannelRequests.kt
+++ b/rest/src/main/kotlin/json/request/ChannelRequests.kt
@@ -45,7 +45,7 @@ public data class ChannelModifyPatchRequest(
     val parentId: OptionalSnowflake? = OptionalSnowflake.Missing,
     val archived: OptionalBoolean = OptionalBoolean.Missing,
     @SerialName("auto_archive_duration")
-    val autoArchiveDuration: OptionalInt = OptionalInt.Missing,
+    val autoArchiveDuration: Optional<ArchiveDuration> = Optional.Missing(),
     val locked: OptionalBoolean = OptionalBoolean.Missing,
     @SerialName("rtc_region")
     val rtcRegion: Optional<String?> = Optional.Missing(),

--- a/rest/src/main/kotlin/json/request/ChannelRequests.kt
+++ b/rest/src/main/kotlin/json/request/ChannelRequests.kt
@@ -8,6 +8,8 @@ import dev.kord.common.entity.optional.OptionalSnowflake
 import kotlinx.datetime.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlin.time.Duration
+import dev.kord.common.serialization.DurationInWholeSecondsSerializer as InWholeSeconds
 
 @Serializable
 public data class ChannelModifyPutRequest(
@@ -33,7 +35,7 @@ public data class ChannelModifyPatchRequest(
     val topic: Optional<String?> = Optional.Missing(),
     val nsfw: OptionalBoolean? = OptionalBoolean.Missing,
     @SerialName("rate_limit_per_user")
-    val rateLimitPerUser: OptionalInt? = OptionalInt.Missing,
+    val rateLimitPerUser: Optional<@Serializable(InWholeSeconds::class) Duration?> = Optional.Missing(),
     val bitrate: OptionalInt? = OptionalInt.Missing,
     @SerialName("user_limit")
     val userLimit: OptionalInt? = OptionalInt.Missing,

--- a/rest/src/main/kotlin/json/request/GuildRequests.kt
+++ b/rest/src/main/kotlin/json/request/GuildRequests.kt
@@ -8,6 +8,7 @@ import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
 import dev.kord.common.entity.optional.OptionalInt
 import dev.kord.common.entity.optional.OptionalSnowflake
+import dev.kord.common.serialization.DurationInWholeSeconds
 import kotlinx.datetime.Instant
 import kotlinx.serialization.*
 import kotlinx.serialization.builtins.ListSerializer
@@ -15,8 +16,6 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.listSerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
-import kotlin.time.Duration
-import dev.kord.common.serialization.DurationInWholeSecondsSerializer as InWholeSeconds
 
 @Serializable
 public data class GuildCreateRequest(
@@ -33,7 +32,7 @@ public data class GuildCreateRequest(
     @SerialName("afk_channel_id")
     val afkChannelId: OptionalSnowflake = OptionalSnowflake.Missing,
     @SerialName("afk_timeout")
-    val afkTimeout: Optional<@Serializable(InWholeSeconds::class) Duration> = Optional.Missing(),
+    val afkTimeout: Optional<DurationInWholeSeconds> = Optional.Missing(),
     @SerialName("system_channel_id")
     val systemChannelId: OptionalSnowflake = OptionalSnowflake.Missing
 )
@@ -47,7 +46,7 @@ public data class GuildChannelCreateRequest(
     @SerialName("user_limit")
     val userLimit: OptionalInt = OptionalInt.Missing,
     @SerialName("rate_limit_per_user")
-    val rateLimitPerUser: Optional<@Serializable(InWholeSeconds::class) Duration> = Optional.Missing(),
+    val rateLimitPerUser: Optional<DurationInWholeSeconds> = Optional.Missing(),
     val position: OptionalInt = OptionalInt.Missing,
     @SerialName("permission_overwrites")
     val permissionOverwrite: Optional<Set<Overwrite>> = Optional.Missing(),
@@ -230,7 +229,7 @@ public data class GuildModifyRequest(
     @SerialName("afk_channel_id")
     val afkChannelId: OptionalSnowflake? = OptionalSnowflake.Missing,
     @SerialName("afk_timeout")
-    val afkTimeout: Optional<@Serializable(InWholeSeconds::class) Duration> = Optional.Missing(),
+    val afkTimeout: Optional<DurationInWholeSeconds> = Optional.Missing(),
     val icon: Optional<String?> = Optional.Missing(),
     @SerialName("owner_id")
     val ownerId: OptionalSnowflake = OptionalSnowflake.Missing,

--- a/rest/src/main/kotlin/json/request/GuildRequests.kt
+++ b/rest/src/main/kotlin/json/request/GuildRequests.kt
@@ -33,7 +33,7 @@ public data class GuildCreateRequest(
     @SerialName("afk_channel_id")
     val afkChannelId: OptionalSnowflake = OptionalSnowflake.Missing,
     @SerialName("afk_timeout")
-    val afkTimeout: OptionalInt = OptionalInt.Missing,
+    val afkTimeout: Optional<@Serializable(InWholeSeconds::class) Duration> = Optional.Missing(),
     @SerialName("system_channel_id")
     val systemChannelId: OptionalSnowflake = OptionalSnowflake.Missing
 )
@@ -230,7 +230,7 @@ public data class GuildModifyRequest(
     @SerialName("afk_channel_id")
     val afkChannelId: OptionalSnowflake? = OptionalSnowflake.Missing,
     @SerialName("afk_timeout")
-    val afkTimeout: OptionalInt = OptionalInt.Missing,
+    val afkTimeout: Optional<@Serializable(InWholeSeconds::class) Duration> = Optional.Missing(),
     val icon: Optional<String?> = Optional.Missing(),
     @SerialName("owner_id")
     val ownerId: OptionalSnowflake = OptionalSnowflake.Missing,

--- a/rest/src/main/kotlin/json/request/GuildRequests.kt
+++ b/rest/src/main/kotlin/json/request/GuildRequests.kt
@@ -8,7 +8,7 @@ import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
 import dev.kord.common.entity.optional.OptionalInt
 import dev.kord.common.entity.optional.OptionalSnowflake
-import dev.kord.common.serialization.DurationInWholeSeconds
+import dev.kord.common.serialization.DurationInSeconds
 import kotlinx.datetime.Instant
 import kotlinx.serialization.*
 import kotlinx.serialization.builtins.ListSerializer
@@ -32,7 +32,7 @@ public data class GuildCreateRequest(
     @SerialName("afk_channel_id")
     val afkChannelId: OptionalSnowflake = OptionalSnowflake.Missing,
     @SerialName("afk_timeout")
-    val afkTimeout: Optional<DurationInWholeSeconds> = Optional.Missing(),
+    val afkTimeout: Optional<DurationInSeconds> = Optional.Missing(),
     @SerialName("system_channel_id")
     val systemChannelId: OptionalSnowflake = OptionalSnowflake.Missing
 )
@@ -46,7 +46,7 @@ public data class GuildChannelCreateRequest(
     @SerialName("user_limit")
     val userLimit: OptionalInt = OptionalInt.Missing,
     @SerialName("rate_limit_per_user")
-    val rateLimitPerUser: Optional<DurationInWholeSeconds> = Optional.Missing(),
+    val rateLimitPerUser: Optional<DurationInSeconds> = Optional.Missing(),
     val position: OptionalInt = OptionalInt.Missing,
     @SerialName("permission_overwrites")
     val permissionOverwrite: Optional<Set<Overwrite>> = Optional.Missing(),
@@ -229,7 +229,7 @@ public data class GuildModifyRequest(
     @SerialName("afk_channel_id")
     val afkChannelId: OptionalSnowflake? = OptionalSnowflake.Missing,
     @SerialName("afk_timeout")
-    val afkTimeout: Optional<DurationInWholeSeconds> = Optional.Missing(),
+    val afkTimeout: Optional<DurationInSeconds> = Optional.Missing(),
     val icon: Optional<String?> = Optional.Missing(),
     @SerialName("owner_id")
     val ownerId: OptionalSnowflake = OptionalSnowflake.Missing,

--- a/rest/src/main/kotlin/json/request/GuildRequests.kt
+++ b/rest/src/main/kotlin/json/request/GuildRequests.kt
@@ -15,6 +15,8 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.listSerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
+import kotlin.time.Duration
+import dev.kord.common.serialization.DurationInWholeSecondsSerializer as InWholeSeconds
 
 @Serializable
 public data class GuildCreateRequest(
@@ -45,7 +47,7 @@ public data class GuildChannelCreateRequest(
     @SerialName("user_limit")
     val userLimit: OptionalInt = OptionalInt.Missing,
     @SerialName("rate_limit_per_user")
-    val rateLimitPerUser: Optional<Int> = Optional.Missing(),
+    val rateLimitPerUser: Optional<@Serializable(InWholeSeconds::class) Duration> = Optional.Missing(),
     val position: OptionalInt = OptionalInt.Missing,
     @SerialName("permission_overwrites")
     val permissionOverwrite: Optional<Set<Overwrite>> = Optional.Missing(),

--- a/rest/src/main/kotlin/json/request/InviteCreateRequest.kt
+++ b/rest/src/main/kotlin/json/request/InviteCreateRequest.kt
@@ -2,15 +2,14 @@ package dev.kord.rest.json.request
 
 import dev.kord.common.entity.InviteTargetType
 import dev.kord.common.entity.optional.*
+import dev.kord.common.serialization.DurationInWholeSeconds
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlin.time.Duration
-import dev.kord.common.serialization.DurationInWholeSecondsSerializer as InWholeSeconds
 
 @Serializable
 public data class InviteCreateRequest(
     @SerialName("max_age")
-    val maxAge: Optional<@Serializable(InWholeSeconds::class) Duration> = Optional.Missing(),
+    val maxAge: Optional<DurationInWholeSeconds> = Optional.Missing(),
     @SerialName("max_uses")
     val maxUses: OptionalInt = OptionalInt.Missing,
     val temporary: OptionalBoolean = OptionalBoolean.Missing,

--- a/rest/src/main/kotlin/json/request/InviteCreateRequest.kt
+++ b/rest/src/main/kotlin/json/request/InviteCreateRequest.kt
@@ -1,17 +1,16 @@
 package dev.kord.rest.json.request
 
 import dev.kord.common.entity.InviteTargetType
-import dev.kord.common.entity.optional.Optional
-import dev.kord.common.entity.optional.OptionalBoolean
-import dev.kord.common.entity.optional.OptionalInt
-import dev.kord.common.entity.optional.OptionalSnowflake
+import dev.kord.common.entity.optional.*
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlin.time.Duration
+import dev.kord.common.serialization.DurationInWholeSecondsSerializer as InWholeSeconds
 
 @Serializable
 public data class InviteCreateRequest(
     @SerialName("max_age")
-    val maxAge: OptionalInt = OptionalInt.Missing,
+    val maxAge: Optional<@Serializable(InWholeSeconds::class) Duration> = Optional.Missing(),
     @SerialName("max_uses")
     val maxUses: OptionalInt = OptionalInt.Missing,
     val temporary: OptionalBoolean = OptionalBoolean.Missing,
@@ -31,7 +30,7 @@ public data class InviteCreateRequest(
 ) {
     @Deprecated("'age' was renamed to 'maxAge'", ReplaceWith("this.maxAge"))
     public val age: OptionalInt
-        get() = maxAge
+        get() = maxAge.value?.inWholeSeconds?.toInt()?.optionalInt() ?: OptionalInt.Missing
 
     @Deprecated("'uses' was renamed to 'maxUses'", ReplaceWith("this.maxUses"))
     public val uses: OptionalInt

--- a/rest/src/main/kotlin/json/request/InviteCreateRequest.kt
+++ b/rest/src/main/kotlin/json/request/InviteCreateRequest.kt
@@ -2,14 +2,14 @@ package dev.kord.rest.json.request
 
 import dev.kord.common.entity.InviteTargetType
 import dev.kord.common.entity.optional.*
-import dev.kord.common.serialization.DurationInWholeSeconds
+import dev.kord.common.serialization.DurationInSeconds
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 public data class InviteCreateRequest(
     @SerialName("max_age")
-    val maxAge: Optional<DurationInWholeSeconds> = Optional.Missing(),
+    val maxAge: Optional<DurationInSeconds> = Optional.Missing(),
     @SerialName("max_uses")
     val maxUses: OptionalInt = OptionalInt.Missing,
     val temporary: OptionalBoolean = OptionalBoolean.Missing,

--- a/rest/src/main/kotlin/json/response/Gateway.kt
+++ b/rest/src/main/kotlin/json/response/Gateway.kt
@@ -1,7 +1,9 @@
 package dev.kord.rest.json.response
 
+import dev.kord.common.serialization.DurationInWholeMillisecondsSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlin.time.Duration
 
 @Serializable
 public data class GatewayResponse(val url: String)
@@ -19,7 +21,8 @@ public data class SessionStartLimitResponse(
     val total: Int,
     val remaining: Int,
     @SerialName("reset_after")
-    val resetAfter: Int,
+    @Serializable(with = DurationInWholeMillisecondsSerializer::class)
+    val resetAfter: Duration,
     @SerialName("max_concurrency")
     val maxConcurrency: Int
 )

--- a/rest/src/main/kotlin/json/response/Gateway.kt
+++ b/rest/src/main/kotlin/json/response/Gateway.kt
@@ -1,6 +1,6 @@
 package dev.kord.rest.json.response
 
-import dev.kord.common.serialization.DurationInWholeMilliseconds
+import dev.kord.common.serialization.DurationInMilliseconds
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -20,7 +20,7 @@ public data class SessionStartLimitResponse(
     val total: Int,
     val remaining: Int,
     @SerialName("reset_after")
-    val resetAfter: DurationInWholeMilliseconds,
+    val resetAfter: DurationInMilliseconds,
     @SerialName("max_concurrency")
     val maxConcurrency: Int
 )

--- a/rest/src/main/kotlin/json/response/Gateway.kt
+++ b/rest/src/main/kotlin/json/response/Gateway.kt
@@ -1,9 +1,8 @@
 package dev.kord.rest.json.response
 
-import dev.kord.common.serialization.DurationInWholeMillisecondsSerializer
+import dev.kord.common.serialization.DurationInWholeMilliseconds
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlin.time.Duration
 
 @Serializable
 public data class GatewayResponse(val url: String)
@@ -21,8 +20,7 @@ public data class SessionStartLimitResponse(
     val total: Int,
     val remaining: Int,
     @SerialName("reset_after")
-    @Serializable(with = DurationInWholeMillisecondsSerializer::class)
-    val resetAfter: Duration,
+    val resetAfter: DurationInWholeMilliseconds,
     @SerialName("max_concurrency")
     val maxConcurrency: Int
 )


### PR DESCRIPTION
The `Duration` type is Kotlin's way to express time amounts.
However, it is not serializable by default and time is serialized in different units across Discord's API.

To make `Duration` usable in serializable classes, this PR introduces a serializer for every `DurationUnit` that (de-)serializes `Duration`s as an integer number of the respective `DurationUnit`.

It also changes the types of `rate_limt_per_user`, `max_age` and `afk_timeout` to `Duration`, using the new serializers. `ArchiveDuration` now also uses `Duration` as the backing value.