### PR TITLE
Deprecate nickname mentions

### DIFF
--- a/core/src/main/kotlin/behavior/MemberBehavior.kt
+++ b/core/src/main/kotlin/behavior/MemberBehavior.kt
@@ -39,7 +39,7 @@ public interface MemberBehavior : KordEntity, UserBehavior {
      * The raw mention for this member's nickname.
      */
     @Deprecated(
-        "User nickname mentions display the same way as user mentions, see https://github.com/discord/discord-api-docs/issues/4734",
+        "Nickname mentions are deprecated and handled the same way as regular user mentions, see https://discord.com/developers/docs/reference#message-formatting-formats",
         ReplaceWith("this.mention"),
     )
     public val nicknameMention: String get() = "<@!$id>"

--- a/core/src/main/kotlin/behavior/MemberBehavior.kt
+++ b/core/src/main/kotlin/behavior/MemberBehavior.kt
@@ -39,7 +39,8 @@ public interface MemberBehavior : KordEntity, UserBehavior {
      * The raw mention for this member's nickname.
      */
     @Deprecated(
-        "Nickname mentions are deprecated and handled the same way as regular user mentions, see https://discord.com/developers/docs/reference#message-formatting-formats",
+        "Nickname mentions are deprecated and should be handled the same way as regular user mentions, " +
+                "see https://discord.com/developers/docs/reference#message-formatting-formats",
         ReplaceWith("this.mention"),
     )
     public val nicknameMention: String get() = "<@!$id>"

--- a/core/src/main/kotlin/behavior/MemberBehavior.kt
+++ b/core/src/main/kotlin/behavior/MemberBehavior.kt
@@ -38,6 +38,10 @@ public interface MemberBehavior : KordEntity, UserBehavior {
     /**
      * The raw mention for this member's nickname.
      */
+    @Deprecated(
+        "User nickname mentions display the same way as user mentions, see https://github.com/discord/discord-api-docs/issues/4734",
+        ReplaceWith("this.mention"),
+    )
     public val nicknameMention: String get() = "<@!$id>"
 
     /**

--- a/core/src/main/kotlin/behavior/channel/ChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/ChannelBehavior.kt
@@ -23,7 +23,7 @@ public interface ChannelBehavior : KordEntity, Strategizable {
      * This channel [formatted as a mention](https://discord.com/developers/docs/reference#message-formatting)
      * as used by the Discord API.
      */
-    public val mention: String get() = "<#${id.value}>"
+    public val mention: String get() = "<#$id>"
 
     /**
      * Requests to get this behavior as a [Channel] .


### PR DESCRIPTION
See:
https://github.com/discord/discord-api-docs/issues/4734
https://github.com/discord/discord-api-docs/commit/a8f7638e79391bb70e15996d1d88488a3b6364b2
https://github.com/discord/discord-api-docs/commit/e3921e168aa167503ae193439abe70106b58d914

Note:
Only sending this form of mention should be considered deprecated, you should still expect to receive them (e.g. from old messages) and just handle them as any other user mention.