### PR TITLE
Discord only accepts language IDs separated by dashes when registering application command localizations

### DIFF
--- a/common/src/main/kotlin/Locale.kt
+++ b/common/src/main/kotlin/Locale.kt
@@ -236,7 +236,7 @@ public data class Locale(val language: String, val country: String? = null) {
         override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("Locale", PrimitiveKind.STRING)
 
         override fun serialize(encoder: Encoder, value: Locale) {
-            encoder.encodeString("${value.language}${if (value.country != null) "_${value.country}" else ""}")
+            encoder.encodeString("${value.language}${if (value.country != null) "-${value.country}" else ""}")
         }
 
         override fun deserialize(decoder: Decoder): Locale = fromString(decoder.decodeString())


### PR DESCRIPTION
```
Invalid Form Body {"1":{"options":{"0":{"description_localizations":{"pt_BR":{"_errors":[{"code":"BASE_TYPE_CHOICES","message":"Value must be one of ('fi', 'cs', 'th', 'it', 'hi', 'bg', 'da', 'hu', 'en-GB', 'pt-BR', 'ru', 'ja', 'uk', 'es-ES', 'hr', 'ro', 'fr', 'nl', 'de', 'no', 'zh-TW', 'ko', 'el', 'tr', 'zh-CN', 'pl', 'en-US', 'vi', 'lt', 'sv-SE')."}]}}},"1":{"description_localizations":{"pt_BR":{"_errors":[{"code":"BASE_TYPE_CHOICES","message":"Value must be one of ('fi', 'cs', 'th', 'it', 'hi', 'bg', 'da', 'hu', 'en-GB', 'pt-BR', 'ru', 'ja', 'uk', 'es-ES', 'hr', 'ro', 'fr', 'nl', 'de', 'no', 'zh-TW', 'ko', 'el', 'tr', 'zh-CN', 'pl', 'en-US', 'vi', 'lt', 'sv-SE')."}]}}}}}}
```