### PR TITLE
Fix conflict between property name and class discriminator

### DIFF
--- a/core/src/main/kotlin/cache/data/ComponentData.kt
+++ b/core/src/main/kotlin/cache/data/ComponentData.kt
@@ -5,9 +5,13 @@ import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
 import dev.kord.common.entity.optional.OptionalInt
 import dev.kord.common.entity.optional.mapList
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonClassDiscriminator
 
 @Serializable
+@OptIn(ExperimentalSerializationApi::class)
+@JsonClassDiscriminator("_type") // would otherwise conflict with `type` property
 public sealed class ComponentData {
     public abstract val type: ComponentType
     public abstract val label: Optional<String>

--- a/core/src/test/kotlin/cache/data/ComponentDataTest.kt
+++ b/core/src/test/kotlin/cache/data/ComponentDataTest.kt
@@ -1,0 +1,22 @@
+package cache.data
+
+import dev.kord.common.entity.ComponentType
+import dev.kord.core.cache.data.ChatComponentData
+import dev.kord.core.cache.data.ComponentData
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ComponentDataTest {
+
+    @Test
+    fun `polymorphic ComponentData can be serialized`() {
+        val type = ComponentType.ActionRow
+        val data: ComponentData = ChatComponentData(type)
+        assertEquals(
+            expected = """{"_type":"dev.kord.core.cache.data.ChatComponentData","type":${type.value}}""",
+            actual = Json.encodeToString(data),
+        )
+    }
+}


### PR DESCRIPTION
Trying to serialize polymorphic `ComponentData` with `Json` results in an exception because it has a property with the same name as the default `classDiscriminator` (`"type"`).
Adding `@JsonClassDiscriminator` overrides this default name.