### PR TITLE
Stricter Locale parsing

### DIFF
--- a/common/src/main/kotlin/Locale.kt
+++ b/common/src/main/kotlin/Locale.kt
@@ -219,11 +219,12 @@ public data class Locale(val language: String, val country: String? = null) {
          * Decodes the language from a `languageCode-countryCode` or `languageCode` format.
          *
          * This does not validate the actually languages and countries, it just validates the format.
+         *
+         * @throws IllegalArgumentException if [string] is not a valid format.
          */
         public fun fromString(string: String): Locale {
-            val match = languageTagFormat.matchEntire(string) ?: error("$string is not a valid Locale")
-            val (language) = match.destructured
-            val country = match.groupValues[2]
+            val match = requireNotNull(languageTagFormat.matchEntire(string)) { "$string is not a valid Locale" }
+            val (language, country) = match.destructured
 
             return ALL.firstOrNull { (l, c) ->
                 language == l && country == (c ?: "")
@@ -235,7 +236,7 @@ public data class Locale(val language: String, val country: String? = null) {
         override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("Locale", PrimitiveKind.STRING)
 
         override fun serialize(encoder: Encoder, value: Locale) {
-            encoder.encodeString("${value.language}${if (value.country != null) "-${value.country}" else ""}")
+            encoder.encodeString("${value.language}${value.country?.let { "-$it" } ?: ""}")
         }
 
         override fun deserialize(decoder: Decoder): Locale = fromString(decoder.decodeString())

--- a/common/src/main/kotlin/Locale.kt
+++ b/common/src/main/kotlin/Locale.kt
@@ -212,12 +212,11 @@ public data class Locale(val language: String, val country: String? = null) {
             KOREAN,
         )
 
-        // We accept both "_" and "-" as a separator, because Discord doesn't really document it
-        // https://regex101.com/r/fVPdR8/2
-        private val languageTagFormat = "(\\w{2})(?:[_\\-](\\w{2}))?".toRegex()
+        // https://regex101.com/r/KCHTj8/1
+        private val languageTagFormat = "([a-z]{2})(?:-([A-Z]{2}))?".toRegex()
 
         /**
-         * Decodes the language from a `languageCode_countryCode` or `languageCode` format.
+         * Decodes the language from a `languageCode-countryCode` or `languageCode` format.
          *
          * This does not validate the actually languages and countries, it just validates the format.
          */

--- a/common/src/main/kotlin/Locale.kt
+++ b/common/src/main/kotlin/Locale.kt
@@ -247,4 +247,4 @@ public data class Locale(val language: String, val country: String? = null) {
  * Converts this into a [Locale].
  */
 public val JLocale.kLocale: Locale
-    get() = Locale(language, country)
+    get() = Locale(language, country.takeIf { it.isNotEmpty() })

--- a/common/src/main/kotlin/Locale.kt
+++ b/common/src/main/kotlin/Locale.kt
@@ -228,7 +228,7 @@ public data class Locale(val language: String, val country: String? = null) {
 
             return ALL.firstOrNull { (l, c) ->
                 language == l && country == (c ?: "")
-            } ?: Locale(language, country.takeIf { it.isNotEmpty() })
+            } ?: Locale(language, country.ifBlank { null })
         }
     }
 
@@ -247,4 +247,4 @@ public data class Locale(val language: String, val country: String? = null) {
  * Converts this into a [Locale].
  */
 public val JLocale.kLocale: Locale
-    get() = Locale(language, country.takeIf { it.isNotEmpty() })
+    get() = Locale(language, country.ifBlank { null })

--- a/common/src/main/kotlin/Locale.kt
+++ b/common/src/main/kotlin/Locale.kt
@@ -227,7 +227,7 @@ public data class Locale(val language: String, val country: String? = null) {
 
             return ALL.firstOrNull { (l, c) ->
                 language == l && country == (c ?: "")
-            } ?: Locale(language, country)
+            } ?: Locale(language, country.takeIf { it.isNotEmpty() })
         }
     }
 

--- a/common/src/test/kotlin/LocaleTest.kt
+++ b/common/src/test/kotlin/LocaleTest.kt
@@ -1,0 +1,63 @@
+import dev.kord.common.Locale
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class LocaleTest {
+
+    private val all = with(Locale) {
+        listOf(
+            "da" to DANISH,
+            "de" to GERMAN,
+            "en-GB" to ENGLISH_GREAT_BRITAIN,
+            "en-US" to ENGLISH_UNITED_STATES,
+            "es-ES" to SPANISH_SPAIN,
+            "fr" to FRENCH,
+            "hr" to CROATIAN,
+            "it" to ITALIAN,
+            "lt" to LITHUANIAN,
+            "hu" to HUNGARIAN,
+            "nl" to DUTCH,
+            "no" to NORWEGIAN,
+            "pl" to POLISH,
+            "pt-BR" to PORTUGUESE_BRAZIL,
+            "ro" to ROMANIAN,
+            "fi" to FINNISH,
+            "sv-SE" to SWEDISH,
+            "vi" to VIETNAMESE,
+            "tr" to TURKISH,
+            "cs" to CZECH,
+            "el" to GREEK,
+            "bg" to BULGARIAN,
+            "ru" to RUSSIAN,
+            "uk" to UKRAINIAN,
+            "hi" to HINDI,
+            "th" to THAI,
+            "zh-CN" to CHINESE_CHINA,
+            "ja" to JAPANESE,
+            "zh-TW" to CHINESE_TAIWAN,
+            "ko" to KOREAN,
+        )
+    }
+
+    init {
+        require(all.size == Locale.ALL.size)
+    }
+
+
+    @Test
+    fun `all documented Locales can be deserialized`() {
+        all.forEach { (string, locale) ->
+            assertEquals(expected = locale, actual = Json.decodeFromString("\"$string\""))
+        }
+    }
+
+    @Test
+    fun `all documented Locales can be serialized`() {
+        all.forEach { (string, locale) ->
+            assertEquals(expected = "\"$string\"", actual = Json.encodeToString(locale))
+        }
+    }
+}


### PR DESCRIPTION
See https://github.com/kordlib/kord/pull/594#issuecomment-1099719976 (only allow `-` as separator between language and country)

Additional changes:
- only allow `[a-z]` for language and `[A-Z]` for country (is this actually desirable?)
- throw `IllegalArgumentException` instead of `IllegalStateException`
- coerce empty country to `null` for unknown Locales and `JLocale` to `Locale` conversion