### PR TITLE
Refactor Choice serializer

### DIFF
--- a/common/src/main/kotlin/entity/Interactions.kt
+++ b/common/src/main/kotlin/entity/Interactions.kt
@@ -206,17 +206,18 @@ public sealed class Choice<out T> {
             }
         }
 
-        override fun serialize(encoder: Encoder, value: Choice<*>) {
-            encoder.encodeStructure(descriptor) {
-                encodeStringElement(descriptor, 0, value.name)
-                when (value) {
-                    is IntChoice -> encodeLongElement(descriptor, 1, value.value)
-                    is NumberChoice -> encodeDoubleElement(descriptor, 1, value.value)
-                    else -> encodeStringElement(descriptor, 1, value.value.toString())
-                }
-                if (value.nameLocalizations !is Optional.Missing) {
-                    encodeSerializableElement(descriptor, 2, LocalizationSerializer, value.nameLocalizations)
-                }
+        override fun serialize(encoder: Encoder, value: Choice<*>) = encoder.encodeStructure(descriptor) {
+
+            encodeStringElement(descriptor, 0, value.name)
+
+            when (value) {
+                is IntChoice -> encodeLongElement(descriptor, 1, value.value)
+                is NumberChoice -> encodeDoubleElement(descriptor, 1, value.value)
+                is StringChoice -> encodeStringElement(descriptor, 1, value.value)
+            }
+
+            if (value.nameLocalizations !is Optional.Missing) {
+                encodeSerializableElement(descriptor, 2, LocalizationSerializer, value.nameLocalizations)
             }
         }
     }

--- a/common/src/main/kotlin/entity/Interactions.kt
+++ b/common/src/main/kotlin/entity/Interactions.kt
@@ -173,7 +173,8 @@ public sealed class Choice<out T> {
         override val value: String
     ) : Choice<String>()
 
-    internal class Serializer<T>(serializer: KSerializer<T>) : KSerializer<Choice<*>> {
+    internal object Serializer : KSerializer<Choice<*>> {
+
         override val descriptor: SerialDescriptor = buildClassSerialDescriptor("Choice") {
             element<String>("name")
             element<JsonPrimitive>("value")


### PR DESCRIPTION
- replace class with object, serializer argument was unused
- `deserialize()`: check for string using `JsonPrimitive.isString` and replace `JsonPrimitive.toString()` with `JsonPrimitive.content` to remove extra quotes (e.g. `JsonPrimitive("string").toString() == "\"string\""` is `true`)
- `serialize()`: use sealed `when` instead of `else`