### PR TITLE
Use Ktor's Base64 functions

### DIFF
--- a/core/src/main/kotlin/builder/kord/KordBuilderUtil.kt
+++ b/core/src/main/kotlin/builder/kord/KordBuilderUtil.kt
@@ -6,8 +6,8 @@ import io.ktor.client.engine.cio.*
 import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.client.plugins.websocket.*
 import io.ktor.serialization.kotlinx.json.*
+import io.ktor.util.*
 import kotlinx.serialization.json.Json
-import java.util.*
 
 internal fun HttpClientConfig<*>.defaultConfig() {
     expectSuccess = false
@@ -39,12 +39,8 @@ internal fun HttpClient?.configure(): HttpClient {
 }
 
 
-internal fun getBotIdFromToken(token: String): Snowflake {
-    try {
-        val bytes = Base64.getDecoder().decode(token.split(""".""").first())
-        return Snowflake(String(bytes))
-    } catch (exception: IllegalArgumentException) {
-        throw IllegalArgumentException("Malformed bot token: '$token'. Make sure that your token is correct.")
-    }
+internal fun getBotIdFromToken(token: String) = try {
+    Snowflake(token.substringBefore('.').decodeBase64String())
+} catch (exception: IllegalArgumentException) {
+    throw IllegalArgumentException("Malformed bot token: '$token'. Make sure that your token is correct.")
 }
-

--- a/rest/src/main/kotlin/Image.kt
+++ b/rest/src/main/kotlin/Image.kt
@@ -3,16 +3,12 @@ package dev.kord.rest
 import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.request.*
+import io.ktor.util.*
 import kotlinx.coroutines.Dispatchers
-import java.util.*
 
 public class Image private constructor(public val data: ByteArray, public val format: Format) {
 
-    public val dataUri: String
-        get() {
-            val hash = Base64.getEncoder().encodeToString(data)
-            return "data:image/${format.extensions.first()};base64,$hash"
-        }
+    public val dataUri: String get() = "data:image/${format.extensions.first()};base64,${data.encodeBase64()}"
 
     public companion object {
         public fun raw(data: ByteArray, format: Format): Image {


### PR DESCRIPTION
Since Ktor 2.0.0, the base64 functions of Ktor are no longer marked with `@InternalAPI` (https://github.com/ktorio/ktor/commit/99d172d9f8df1e95c58d4335d599ff20ac0d29e6#diff-b76509854a5451678a47f5b3b58101b66a07eeaa24a6942ba162caddd58d255d)

This PR replaces the usage of the java base64 api with the base64 functions from ktor (small step for https://github.com/kordlib/kord/issues/69).