### PR TITLE
Add API version configuration

### DIFF
--- a/common/src/main/kotlin/KordConfiguration.kt
+++ b/common/src/main/kotlin/KordConfiguration.kt
@@ -10,8 +10,10 @@ public object KordConfiguration {
     // https://github.com/Kotlin/kotlinx.atomicfu/issues/186
     // TODO use delegation when AtomicFU fixes this
 
+    private const val REST_GATEWAY_DEFAULT = 10
 
-    private val REST = atomic(10)
+
+    private val REST = atomic(REST_GATEWAY_DEFAULT)
 
     /**
      * The [version of Discord's REST API](https://discord.com/developers/docs/reference#api-versioning) Kord uses.
@@ -27,7 +29,7 @@ public object KordConfiguration {
         }
 
 
-    private val GATEWAY = atomic(10)
+    private val GATEWAY = atomic(REST_GATEWAY_DEFAULT)
 
     /**
      * The [version of Discord's Gateway](https://discord.com/developers/docs/topics/gateway#gateways-gateway-versions)

--- a/common/src/main/kotlin/KordConfiguration.kt
+++ b/common/src/main/kotlin/KordConfiguration.kt
@@ -1,6 +1,7 @@
 package dev.kord.common
 
 import dev.kord.common.annotation.KordExperimental
+import dev.kord.common.annotation.KordUnsafe
 import kotlinx.atomicfu.atomic
 
 @KordExperimental
@@ -18,6 +19,7 @@ public object KordConfiguration {
      * Changing this version might lead to errors since Kord is designed to work with the initially set version.
      */
     @KordExperimental
+    @set:KordUnsafe
     public var REST_VERSION: Int
         get() = REST.value
         set(value) {
@@ -34,6 +36,7 @@ public object KordConfiguration {
      * Changing this version might lead to errors since Kord is designed to work with the initially set version.
      */
     @KordExperimental
+    @set:KordUnsafe
     public var GATEWAY_VERSION: Int
         get() = GATEWAY.value
         set(value) {
@@ -51,6 +54,7 @@ public object KordConfiguration {
      * Changing this version might lead to errors since Kord is designed to work with the initially set version.
      */
     @KordExperimental
+    @set:KordUnsafe
     public var VOICE_GATEWAY_VERSION: Int
         get() = VOICE.value
         set(value) {

--- a/common/src/main/kotlin/KordConfiguration.kt
+++ b/common/src/main/kotlin/KordConfiguration.kt
@@ -1,0 +1,59 @@
+package dev.kord.common
+
+import dev.kord.common.annotation.KordExperimental
+import kotlinx.atomicfu.atomic
+
+@KordExperimental
+public object KordConfiguration {
+    // not able to write it like `public var REST_VERSION: Int by atomic(10)` because of
+    // https://github.com/Kotlin/kotlinx.atomicfu/issues/186
+    // TODO use delegation when AtomicFU fixes this
+
+
+    private val REST = atomic(10)
+
+    /**
+     * The [version of Discord's REST API](https://discord.com/developers/docs/reference#api-versioning) Kord uses.
+     *
+     * Changing this version might lead to errors since Kord is designed to work with the initially set version.
+     */
+    @KordExperimental
+    public var REST_VERSION: Int
+        get() = REST.value
+        set(value) {
+            REST.value = value
+        }
+
+
+    private val GATEWAY = atomic(10)
+
+    /**
+     * The [version of Discord's Gateway](https://discord.com/developers/docs/topics/gateway#gateways-gateway-versions)
+     * Kord uses.
+     *
+     * Changing this version might lead to errors since Kord is designed to work with the initially set version.
+     */
+    @KordExperimental
+    public var GATEWAY_VERSION: Int
+        get() = GATEWAY.value
+        set(value) {
+            GATEWAY.value = value
+        }
+
+
+    private val VOICE = atomic(4)
+
+    /**
+     * The
+     * [version of Discord's Voice Gateway](https://discord.com/developers/docs/topics/voice-connections#voice-gateway-versioning)
+     * Kord uses.
+     *
+     * Changing this version might lead to errors since Kord is designed to work with the initially set version.
+     */
+    @KordExperimental
+    public var VOICE_GATEWAY_VERSION: Int
+        get() = VOICE.value
+        set(value) {
+            VOICE.value = value
+        }
+}

--- a/common/src/main/kotlin/annotation/Annotations.kt
+++ b/common/src/main/kotlin/annotation/Annotations.kt
@@ -1,10 +1,12 @@
 package dev.kord.common.annotation
 
+import kotlin.annotation.AnnotationTarget.*
+
 /**
  * Dsl marker for Kord dsls.
  */
 @DslMarker
-@Target(AnnotationTarget.CLASS)
+@Target(CLASS)
 public annotation class KordDsl
 
 /**
@@ -18,7 +20,7 @@ public annotation class KordDsl
 @MustBeDocumented
 @Retention(value = AnnotationRetention.BINARY)
 @RequiresOptIn(level = RequiresOptIn.Level.WARNING)
-@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.TYPEALIAS, AnnotationTarget.PROPERTY)
+@Target(CLASS, PROPERTY, FUNCTION, TYPEALIAS)
 public annotation class KordPreview
 
 /**
@@ -33,7 +35,7 @@ public annotation class KordPreview
 @MustBeDocumented
 @Retention(value = AnnotationRetention.BINARY)
 @RequiresOptIn(level = RequiresOptIn.Level.WARNING)
-@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.TYPEALIAS, AnnotationTarget.PROPERTY)
+@Target(CLASS, PROPERTY, FUNCTION, TYPEALIAS)
 public annotation class KordExperimental
 
 /**
@@ -47,7 +49,7 @@ public annotation class KordExperimental
 @MustBeDocumented
 @Retention(value = AnnotationRetention.BINARY)
 @RequiresOptIn(level = RequiresOptIn.Level.WARNING)
-@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.TYPEALIAS, AnnotationTarget.PROPERTY)
+@Target(CLASS, PROPERTY, FUNCTION, TYPEALIAS)
 public annotation class KordVoice
 
 /**
@@ -63,21 +65,12 @@ public annotation class KordVoice
 @MustBeDocumented
 @Retention(value = AnnotationRetention.BINARY)
 @RequiresOptIn(level = RequiresOptIn.Level.WARNING)
-@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.TYPEALIAS, AnnotationTarget.PROPERTY)
+@Target(CLASS, PROPERTY, FUNCTION, PROPERTY_SETTER, TYPEALIAS)
 public annotation class KordUnsafe
 
 /**
  * Marks the annotated declaration as deprecated since [version].
  */
 @MustBeDocumented
-@Target(
-    AnnotationTarget.CLASS,
-    AnnotationTarget.FUNCTION,
-    AnnotationTarget.PROPERTY,
-    AnnotationTarget.ANNOTATION_CLASS,
-    AnnotationTarget.CONSTRUCTOR,
-    AnnotationTarget.PROPERTY_SETTER,
-    AnnotationTarget.PROPERTY_GETTER,
-    AnnotationTarget.TYPEALIAS
-)
+@Target(CLASS, ANNOTATION_CLASS, PROPERTY, CONSTRUCTOR, FUNCTION, PROPERTY_GETTER, PROPERTY_SETTER, TYPEALIAS)
 public annotation class DeprecatedSinceKord(val version: String)

--- a/core/src/main/kotlin/builder/kord/KordBuilder.kt
+++ b/core/src/main/kotlin/builder/kord/KordBuilder.kt
@@ -47,7 +47,6 @@ public operator fun DefaultGateway.Companion.invoke(
     retry: Retry = LinearRetry(2.seconds, 60.seconds, 10)
 ): DefaultGateway {
     return DefaultGateway {
-        url = "wss://gateway.discord.gg/"
         client = resources.httpClient
         reconnectRetry = retry
         sendRateLimiter = IntervalRateLimiter(limit = 120, interval = 60.seconds)

--- a/gateway/src/main/kotlin/DefaultGatewayBuilder.kt
+++ b/gateway/src/main/kotlin/DefaultGatewayBuilder.kt
@@ -1,5 +1,7 @@
 package dev.kord.gateway
 
+import dev.kord.common.KordConfiguration
+import dev.kord.common.annotation.KordExperimental
 import dev.kord.common.ratelimit.IntervalRateLimiter
 import dev.kord.common.ratelimit.RateLimiter
 import dev.kord.gateway.retry.LinearRetry
@@ -17,7 +19,9 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlin.time.Duration.Companion.seconds
 
 public class DefaultGatewayBuilder {
-    public var url: String = "wss://gateway.discord.gg/?v=10&encoding=json&compress=zlib-stream"
+    @OptIn(KordExperimental::class)
+    public var url: String =
+        "wss://gateway.discord.gg/?v=${KordConfiguration.GATEWAY_VERSION}&encoding=json&compress=zlib-stream"
     public var client: HttpClient? = null
     public var reconnectRetry: Retry? = null
     public var sendRateLimiter: RateLimiter? = null

--- a/rest/src/main/kotlin/route/Route.kt
+++ b/rest/src/main/kotlin/route/Route.kt
@@ -1,5 +1,6 @@
 package dev.kord.rest.route
 
+import dev.kord.common.KordConfiguration
 import dev.kord.common.annotation.DeprecatedSinceKord
 import dev.kord.common.annotation.KordExperimental
 import dev.kord.common.entity.*
@@ -15,9 +16,6 @@ import kotlinx.serialization.descriptors.StructureKind
 import kotlinx.serialization.descriptors.buildSerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.json.Json
-
-internal const val REST_VERSION_PROPERTY_NAME = "dev.kord.rest.version"
-internal val restVersion get() = System.getenv(REST_VERSION_PROPERTY_NAME) ?: "v10"
 
 public sealed interface ResponseMapper<T> {
     public fun deserialize(json: Json, body: String): T
@@ -56,7 +54,8 @@ public sealed class Route<T>(
 ) {
 
     public companion object {
-        public val baseUrl: String = "https://discord.com/api/$restVersion"
+        @OptIn(KordExperimental::class)
+        public val baseUrl: String get() = "https://discord.com/api/v${KordConfiguration.REST_VERSION}"
     }
 
 

--- a/voice/src/main/kotlin/VoiceConnectionBuilder.kt
+++ b/voice/src/main/kotlin/VoiceConnectionBuilder.kt
@@ -1,5 +1,7 @@
 package dev.kord.voice
 
+import dev.kord.common.KordConfiguration
+import dev.kord.common.annotation.KordExperimental
 import dev.kord.common.annotation.KordVoice
 import dev.kord.common.entity.Snowflake
 import dev.kord.gateway.Gateway
@@ -142,7 +144,8 @@ public class VoiceConnectionBuilder(
             voiceState.sessionId
         ) to VoiceGatewayConfiguration(
             voiceServer.token,
-            "wss://${voiceServer.endpoint}?v=4"
+            @OptIn(KordExperimental::class)
+            "wss://${voiceServer.endpoint}?v=${KordConfiguration.VOICE_GATEWAY_VERSION}",
         )
     }
 

--- a/voice/src/main/kotlin/handlers/VoiceUpdateEventHandler.kt
+++ b/voice/src/main/kotlin/handlers/VoiceUpdateEventHandler.kt
@@ -1,5 +1,7 @@
 package dev.kord.voice.handlers
 
+import dev.kord.common.KordConfiguration
+import dev.kord.common.annotation.KordExperimental
 import dev.kord.common.annotation.KordVoice
 import dev.kord.gateway.VoiceServerUpdate
 import dev.kord.gateway.VoiceStateUpdate
@@ -61,10 +63,11 @@ internal class VoiceUpdateEventHandler(
 
             voiceUpdateLogger.trace { "changing voice servers for session ${connection.data.sessionId}" }
 
+            @OptIn(KordExperimental::class)
             // update the gateway configuration accordingly
             connection.voiceGatewayConfiguration = connection.voiceGatewayConfiguration.copy(
                 token = voiceServerUpdate.voiceServerUpdateData.token,
-                endpoint = "wss://${voiceServerUpdate.voiceServerUpdateData.endpoint}?v=4"
+                endpoint = "wss://${voiceServerUpdate.voiceServerUpdateData.endpoint}?v=${KordConfiguration.VOICE_GATEWAY_VERSION}"
             )
 
             // reconnect...


### PR DESCRIPTION
This PR allows to configure which versions of Discord's APIs Kord uses.
This is achieved by changing the properties `REST_VERSION`, `GATEWAY_VERSION` or `VOICE_GATEWAY_VERSION` of the `KordConfiguration` object:
```kotlin
object KordConfiguration {
    var REST_VERSION: Int
    var GATEWAY_VERSION: Int
    var VOICE_GATEWAY_VERSION: Int
}
```

Reading the REST version from the environment variable `dev.kord.rest.version` is removed.

`DefaultGateway.Companion.invoke` now no longer uses an unversioned gateway url.
