### PR TITLE
Nullable user_limit

### DIFF
--- a/common/src/main/kotlin/entity/DiscordChannel.kt
+++ b/common/src/main/kotlin/entity/DiscordChannel.kt
@@ -59,7 +59,7 @@ public data class DiscordChannel(
     val lastMessageId: OptionalSnowflake? = OptionalSnowflake.Missing,
     val bitrate: OptionalInt = OptionalInt.Missing,
     @SerialName("user_limit")
-    val userLimit: OptionalInt = OptionalInt.Missing,
+    val userLimit: OptionalInt? = OptionalInt.Missing,
     @SerialName("rate_limit_per_user")
     val rateLimitPerUser: Optional<DurationInSeconds> = Optional.Missing(),
     val recipients: Optional<List<DiscordUser>> = Optional.Missing(),

--- a/core/src/main/kotlin/cache/data/ChannelData.kt
+++ b/core/src/main/kotlin/cache/data/ChannelData.kt
@@ -20,7 +20,7 @@ public data class ChannelData(
     val nsfw: OptionalBoolean = OptionalBoolean.Missing,
     val lastMessageId: OptionalSnowflake? = OptionalSnowflake.Missing,
     val bitrate: OptionalInt = OptionalInt.Missing,
-    val userLimit: OptionalInt = OptionalInt.Missing,
+    val userLimit: OptionalInt? = OptionalInt.Missing,
     val rateLimitPerUser: Optional<DurationInSeconds> = Optional.Missing(),
     val recipients: Optional<List<Snowflake>> = Optional.Missing(),
     val icon: Optional<String?> = Optional.Missing(),


### PR DESCRIPTION
The `user_limit` field of a channel object can be `null`, even though it is [only documented as optional](https://discord.com/developers/docs/resources/channel#channel-object-channel-structure).
This PR fixes this.