### PR TITLE
feature/slash commands permissions v2

### DIFF
--- a/common/src/main/kotlin/entity/AuditLog.kt
+++ b/common/src/main/kotlin/entity/AuditLog.kt
@@ -10,7 +10,10 @@ import kotlinx.serialization.*
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*
-import kotlinx.serialization.json.*
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.int
 import kotlin.time.Duration
 import dev.kord.common.Color as CommonColor
 import dev.kord.common.entity.DefaultMessageNotificationLevel as CommonDefaultMessageNotificationLevel
@@ -427,6 +430,7 @@ public sealed class AuditLogChangeKey<T>(public val name: String, public val ser
                 "rate_limit_per_user" -> RateLimitPerUser
                 "permissions" -> Permissions
                 "color" -> Color
+                "command_id" -> CommandId
                 "communication_disabled_until" -> CommunicationDisabledUntil
                 "hoist" -> Hoist
                 "mentionable" -> Mentionable
@@ -572,6 +576,7 @@ public sealed class AuditLogEvent(public val value: Int) {
             110 -> ThreadCreate
             111 -> ThreadUpdate
             112 -> ThreadDelete
+            121 -> ApplicationCommandPermissionUpdate
             else -> Unknown(value)
         }
     }

--- a/common/src/main/kotlin/entity/AuditLog.kt
+++ b/common/src/main/kotlin/entity/AuditLog.kt
@@ -8,7 +8,10 @@ import kotlinx.serialization.*
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*
-import kotlinx.serialization.json.*
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.int
 import dev.kord.common.Color as CommonColor
 import dev.kord.common.entity.DefaultMessageNotificationLevel as CommonDefaultMessageNotificationLevel
 import dev.kord.common.entity.ExplicitContentFilter as CommonExplicitContentFilter
@@ -244,6 +247,9 @@ public sealed class AuditLogChangeKey<T>(public val name: String, public val ser
 
     @SerialName("color")
     public object Color : AuditLogChangeKey<CommonColor>("color", serializer())
+
+    @SerialName("command_id")
+    public object CommandId : AuditLogChangeKey<Snowflake>("command_id", serializer())
 
     @SerialName("communication_disabled_until")
     public object CommunicationDisabledUntil : AuditLogChangeKey<Instant>("communication_disabled_until", serializer())
@@ -507,6 +513,7 @@ public sealed class AuditLogEvent(public val value: Int) {
     public object ThreadCreate : AuditLogEvent(110)
     public object ThreadUpdate : AuditLogEvent(111)
     public object ThreadDelete : AuditLogEvent(112)
+    public object ApplicationCommandPermissionUpdate : AuditLogEvent(121)
 
 
     internal object Serializer : KSerializer<AuditLogEvent> {

--- a/common/src/main/kotlin/entity/Interactions.kt
+++ b/common/src/main/kotlin/entity/Interactions.kt
@@ -34,12 +34,12 @@ public data class DiscordApplicationCommand(
     val guildId: OptionalSnowflake = OptionalSnowflake.Missing,
     val options: Optional<List<ApplicationCommandOption>> = Optional.Missing(),
     @SerialName("default_member_permissions")
-    val defaultMemberPermissions: Optional<Permissions> = Optional.Missing(),
-    @SerialName("dm_permissions")
-    val dmPermissions: OptionalBoolean = OptionalBoolean.Missing,
+    val defaultMemberPermissions: Optional<Permissions?> = Optional.Missing(),
+    @SerialName("dm_permission")
+    val dmPermission: OptionalBoolean? = OptionalBoolean.Missing,
     @SerialName("default_permission")
     @Deprecated("'defaultPermission' is deprecated in favor of 'defaultMemberPermissions' and 'dmPermission'.")
-    val defaultPermission: OptionalBoolean = OptionalBoolean.Missing,
+    val defaultPermission: OptionalBoolean? = OptionalBoolean.Missing,
     val version: Snowflake
 )
 

--- a/common/src/main/kotlin/entity/Interactions.kt
+++ b/common/src/main/kotlin/entity/Interactions.kt
@@ -785,14 +785,6 @@ public data class DiscordGuildApplicationCommandPermissions(
     val permissions: List<DiscordGuildApplicationCommandPermission>
 )
 
-
-@Serializable
-public data class PartialDiscordGuildApplicationCommandPermissions(
-    val id: Snowflake,
-    val permissions: List<DiscordGuildApplicationCommandPermission>
-)
-
-
 @Serializable
 public data class DiscordGuildApplicationCommandPermission(
     val id: Snowflake,

--- a/common/src/main/kotlin/entity/Interactions.kt
+++ b/common/src/main/kotlin/entity/Interactions.kt
@@ -27,7 +27,12 @@ public data class DiscordApplicationCommand(
     @SerialName("guild_id")
     val guildId: OptionalSnowflake = OptionalSnowflake.Missing,
     val options: Optional<List<ApplicationCommandOption>> = Optional.Missing(),
+    @SerialName("default_member_permissions")
+    val defaultMemberPermissions: Optional<Permissions> = Optional.Missing(),
+    @SerialName("dm_permissions")
+    val dmPermissions: OptionalBoolean = OptionalBoolean.Missing,
     @SerialName("default_permission")
+    @Deprecated("danger default_permission will soon be deprecated. You can instead set default_member_permissions to \"0\" to disable the command by default and/or set dm_permission to false to disable globally-scoped commands inside of DMs with your app")
     val defaultPermission: OptionalBoolean = OptionalBoolean.Missing,
     val version: Snowflake
 )
@@ -759,6 +764,7 @@ public data class DiscordGuildApplicationCommandPermission(
     public sealed class Type(public val value: Int) {
         public object Role : Type(1)
         public object User : Type(2)
+        public object Channel : Type(3)
         public class Unknown(value: Int) : Type(value)
 
         public object Serializer : KSerializer<Type> {

--- a/common/src/main/kotlin/entity/Interactions.kt
+++ b/common/src/main/kotlin/entity/Interactions.kt
@@ -38,7 +38,7 @@ public data class DiscordApplicationCommand(
     @SerialName("dm_permissions")
     val dmPermissions: OptionalBoolean = OptionalBoolean.Missing,
     @SerialName("default_permission")
-    @Deprecated("danger default_permission will soon be deprecated. You can instead set default_member_permissions to \"0\" to disable the command by default and/or set dm_permission to false to disable globally-scoped commands inside of DMs with your app")
+    @Deprecated("'defaultPermission' is deprecated in favor of 'defaultMemberPermissions' and 'dmPermission'.")
     val defaultPermission: OptionalBoolean = OptionalBoolean.Missing,
     val version: Snowflake
 )

--- a/common/src/main/kotlin/entity/Interactions.kt
+++ b/common/src/main/kotlin/entity/Interactions.kt
@@ -814,6 +814,7 @@ public data class DiscordGuildApplicationCommandPermission(
                 when (val value = decoder.decodeInt()) {
                     1 -> Role
                     2 -> User
+                    3 -> Channel
                     else -> Unknown(value)
                 }
 

--- a/common/src/main/kotlin/entity/optional/Optional.kt
+++ b/common/src/main/kotlin/entity/optional/Optional.kt
@@ -10,10 +10,6 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
-@PublishedApi
-internal fun Optional<*>.unsupportedOptional(): Nothing =
-    throw UnsupportedOperationException("Got unexpected Optional type: ${this::class.qualifiedName}")
-
 /**
  * Represents a value that encapsulates all [three possible states of a value in the Discord API](https://discord.com/developers/docs/reference#nullable-and-optional-resource-fields).
  * Specifically:
@@ -42,10 +38,8 @@ internal fun Optional<*>.unsupportedOptional(): Nothing =
  * )
  * ```
  */
-// Why this class is open and not sealed:
-// https://github.com/Kotlin/kotlinx.serialization/issues/1705#issuecomment-1001786343
 @Serializable(with = OptionalSerializer::class)
-public open class Optional<out T> private constructor() {
+public sealed class Optional<out T> private constructor() {
 
     /**
      * The value this optional wraps.
@@ -189,7 +183,6 @@ public open class Optional<out T> private constructor() {
             is Missing<*> -> throw SerializationException("missing values cannot be serialized")
             is Null<*> -> encoder.encodeNull()
             is Value -> encoder.encodeSerializableValue(contentSerializer, value.value)
-            else -> value.unsupportedOptional()
         }
     }
 }
@@ -197,32 +190,27 @@ public open class Optional<out T> private constructor() {
 public fun <T : Any> Optional<T>.switchOnMissing(value: T): Optional<T> = when (this) {
     is Missing -> Value(value)
     is Null<*>, is Value -> this
-    else -> unsupportedOptional()
 }
 
 public fun <T : Any> Optional<T>.switchOnMissing(value: Optional<T>): Optional<T> = when (this) {
     is Missing -> value
     is Null<*>, is Value -> this
-    else -> unsupportedOptional()
 }
 
 public fun <E> Optional<List<E>>.orEmpty(): List<E> = when (this) {
     is Missing, is Null<*> -> emptyList()
     is Value -> value
-    else -> unsupportedOptional()
 }
 
 public fun <E> Optional<Set<E>>.orEmpty(): Set<E> = when (this) {
     is Missing, is Null<*> -> emptySet()
     is Value -> value
-    else -> unsupportedOptional()
 }
 
 @Suppress("UNCHECKED_CAST")
 public inline fun <E, T> Optional<List<E>>.mapList(mapper: (E) -> T): Optional<List<T>> = when (this) {
     is Missing, is Null<*> -> this as Optional<List<T>>
     is Value -> Value(value.map(mapper))
-    else -> unsupportedOptional()
 }
 
 
@@ -230,7 +218,6 @@ public inline fun <E, T> Optional<List<E>>.mapList(mapper: (E) -> T): Optional<L
 public inline fun <K, V, R> Optional<Map<K, V>>.mapValues(mapper: (Map.Entry<K, V>) -> R): Optional<Map<K, R>> = when (this) {
     is Missing, is Null<*> -> this as Optional<Map<K, R>>
     is Value -> Value(value.mapValues(mapper))
-    else -> unsupportedOptional()
 }
 
 
@@ -238,14 +225,12 @@ public inline fun <K, V, R> Optional<Map<K, V>>.mapValues(mapper: (Map.Entry<K, 
 public inline fun <E> Optional<List<E>>.filterList(mapper: (E) -> Boolean): Optional<List<E>> = when (this) {
     is Missing, is Null<*> -> this
     is Value -> Value(value.filter(mapper))
-    else -> unsupportedOptional()
 }
 
 @Suppress("UNCHECKED_CAST")
 public inline fun <reified R> Optional<List<*>>.filterInstanceOfList(): Optional<List<R>> = when (this) {
     is Missing, is Null<*> -> this as Optional<List<R>>
     is Value -> Value(value.filterIsInstance<R>())
-    else -> unsupportedOptional()
 }
 
 
@@ -253,7 +238,6 @@ public inline fun <reified R> Optional<List<*>>.filterInstanceOfList(): Optional
 public inline fun <E : Any, T : Any> Optional<E>.map(mapper: (E) -> T): Optional<T> = when (this) {
     is Missing, is Null<*> -> this as Optional<T>
     is Value -> Value(mapper(value))
-    else -> unsupportedOptional()
 }
 
 /**
@@ -263,7 +247,6 @@ public inline fun <E : Any, T : Any> Optional<E>.map(mapper: (E) -> T): Optional
 public inline fun <E : Any, T : Any> Optional<E>.flatMap(mapper: (E) -> Optional<T>): Optional<T> = when (this) {
     is Missing, is Null<*> -> this as Optional<T>
     is Value -> mapper(value)
-    else -> unsupportedOptional()
 }
 
 @Suppress("UNCHECKED_CAST")
@@ -271,14 +254,12 @@ public inline fun <E : Any, T : Any> Optional<E>.flatMap(mapper: (E) -> Optional
 public inline fun <E : Any, T : Any> Optional<E?>.map(mapper: (E) -> T): Optional<T?> = when (this) {
     is Missing, is Null<*> -> this as Optional<T>
     is Value -> Value(mapper(value!!))
-    else -> unsupportedOptional()
 }
 
 @Suppress("UNCHECKED_CAST")
 public inline fun <E, T> Optional<E>.mapNullable(mapper: (E) -> T): Optional<T?> = when (this) {
     is Missing, is Null<*> -> this as Optional<T>
     is Value -> Optional(mapper(value))
-    else -> unsupportedOptional()
 }
 
 @Suppress("UNCHECKED_CAST")
@@ -286,13 +267,11 @@ public inline fun <E : Any, T> Optional<E?>.mapNotNull(mapper: (E) -> T): Option
     is Missing -> this as Optional<T?>
     is Null<*> -> this as Optional<T?>
     is Value -> Optional(mapper(value!!))
-    else -> unsupportedOptional()
 }
 
 public inline fun <E> Optional<List<E>>.firstOrNull(predicate: (E) -> Boolean): E? = when (this) {
     is Missing, is Null<*> -> null
     is Value -> value.firstOrNull(predicate)
-    else -> unsupportedOptional()
 }
 
 
@@ -302,27 +281,23 @@ public inline fun <E> Optional<List<E>>.first(predicate: (E) -> Boolean): E = fi
 public inline fun <E : Any> Optional<E>.mapSnowflake(mapper: (E) -> Snowflake): OptionalSnowflake = when (this) {
     is Missing, is Null<*> -> OptionalSnowflake.Missing
     is Value -> OptionalSnowflake.Value(mapper(value))
-    else -> unsupportedOptional()
 }
 
 @JvmName("mapNullableSnowflake")
 public inline fun <E : Any> Optional<E?>.mapSnowflake(mapper: (E) -> Snowflake): OptionalSnowflake = when (this) {
     is Missing, is Null<*> -> OptionalSnowflake.Missing
     is Value -> OptionalSnowflake.Value(mapper(value!!))
-    else -> unsupportedOptional()
 }
 
 public inline fun <T, R : Any> Optional<T>.unwrap(mapper: (T) -> R): R? = when (this) {
     is Missing, is Null<*> -> null
     is Value -> mapper(value)
-    else -> unsupportedOptional()
 }
 
 @Suppress("UNCHECKED_CAST")
 public fun <T : Any> Optional<T?>.coerceToMissing(): Optional<T> = when (this) {
     is Missing, is Null -> Missing()
     is Value -> this as Value<T>
-    else -> unsupportedOptional()
 }
 
 @Suppress("RemoveRedundantQualifierName")

--- a/common/src/main/kotlin/entity/optional/Optional.kt
+++ b/common/src/main/kotlin/entity/optional/Optional.kt
@@ -39,7 +39,7 @@ import kotlinx.serialization.encoding.Encoder
  * ```
  */
 @Serializable(with = OptionalSerializer::class)
-public sealed class Optional<out T> private constructor() {
+public sealed class Optional<out T> {
 
     /**
      * The value this optional wraps.

--- a/core/src/main/kotlin/Kord.kt
+++ b/core/src/main/kotlin/Kord.kt
@@ -27,7 +27,10 @@ import dev.kord.gateway.Gateway
 import dev.kord.gateway.builder.LoginBuilder
 import dev.kord.gateway.builder.PresenceBuilder
 import dev.kord.rest.builder.guild.GuildCreateBuilder
-import dev.kord.rest.builder.interaction.*
+import dev.kord.rest.builder.interaction.ChatInputCreateBuilder
+import dev.kord.rest.builder.interaction.MessageCommandCreateBuilder
+import dev.kord.rest.builder.interaction.MultiApplicationCommandBuilder
+import dev.kord.rest.builder.interaction.UserCommandCreateBuilder
 import dev.kord.rest.builder.user.CurrentUserModifyBuilder
 import dev.kord.rest.request.RestRequestException
 import dev.kord.rest.service.RestClient
@@ -580,27 +583,6 @@ public class Kord(
                 emit(GuildApplicationCommand(data, rest.interaction))
             }
         }
-    }
-
-    public suspend inline fun editApplicationCommandPermissions(
-        guildId: Snowflake,
-        commandId: Snowflake,
-        token: String,
-        builder: ApplicationCommandPermissionsModifyBuilder.() -> Unit,
-    ) {
-        contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
-        rest.interaction.editApplicationCommandPermissions(resources.applicationId, guildId, commandId, token, builder)
-    }
-
-
-    @KordUnsafe
-    public suspend inline fun bulkEditApplicationCommandPermissions(
-        guildId: Snowflake,
-        token: String,
-        builder: ApplicationCommandPermissionsBulkModifyBuilder.() -> Unit,
-    ) {
-        contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
-        rest.interaction.bulkEditApplicationCommandPermissions(resources.applicationId, guildId, token, builder)
     }
 }
 

--- a/core/src/main/kotlin/Kord.kt
+++ b/core/src/main/kotlin/Kord.kt
@@ -27,10 +27,7 @@ import dev.kord.gateway.Gateway
 import dev.kord.gateway.builder.LoginBuilder
 import dev.kord.gateway.builder.PresenceBuilder
 import dev.kord.rest.builder.guild.GuildCreateBuilder
-import dev.kord.rest.builder.interaction.ChatInputCreateBuilder
-import dev.kord.rest.builder.interaction.MessageCommandCreateBuilder
-import dev.kord.rest.builder.interaction.MultiApplicationCommandBuilder
-import dev.kord.rest.builder.interaction.UserCommandCreateBuilder
+import dev.kord.rest.builder.interaction.*
 import dev.kord.rest.builder.user.CurrentUserModifyBuilder
 import dev.kord.rest.request.RestRequestException
 import dev.kord.rest.service.RestClient
@@ -465,7 +462,7 @@ public class Kord(
     public suspend inline fun createGlobalChatInputCommand(
         name: String,
         description: String,
-        builder: ChatInputCreateBuilder.() -> Unit = {},
+        builder: GlobalChatInputCreateBuilder.() -> Unit = {},
     ): GlobalChatInputCommand {
         contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
         val response = rest.interaction.createGlobalChatInputApplicationCommand(
@@ -480,7 +477,7 @@ public class Kord(
 
     public suspend inline fun createGlobalMessageCommand(
         name: String,
-        builder: MessageCommandCreateBuilder.() -> Unit = {},
+        builder: GlobalMessageCommandCreateBuilder.() -> Unit = {},
     ): GlobalMessageCommand {
         contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
         val response =
@@ -491,7 +488,7 @@ public class Kord(
 
     public suspend inline fun createGlobalUserCommand(
         name: String,
-        builder: UserCommandCreateBuilder.() -> Unit = {},
+        builder: GlobalUserCommandCreateBuilder.() -> Unit = {},
     ): GlobalUserCommand {
         contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
         val response =

--- a/core/src/main/kotlin/Kord.kt
+++ b/core/src/main/kotlin/Kord.kt
@@ -13,14 +13,7 @@ import dev.kord.core.cache.data.ApplicationCommandData
 import dev.kord.core.cache.data.GuildData
 import dev.kord.core.cache.data.UserData
 import dev.kord.core.entity.*
-import dev.kord.core.entity.application.GlobalApplicationCommand
-import dev.kord.core.entity.application.GlobalChatInputCommand
-import dev.kord.core.entity.application.GlobalMessageCommand
-import dev.kord.core.entity.application.GlobalUserCommand
-import dev.kord.core.entity.application.GuildApplicationCommand
-import dev.kord.core.entity.application.GuildChatInputCommand
-import dev.kord.core.entity.application.GuildMessageCommand
-import dev.kord.core.entity.application.GuildUserCommand
+import dev.kord.core.entity.application.*
 import dev.kord.core.entity.channel.Channel
 import dev.kord.core.event.Event
 import dev.kord.core.exception.EntityNotFoundException
@@ -29,40 +22,17 @@ import dev.kord.core.gateway.MasterGateway
 import dev.kord.core.gateway.handler.DefaultGatewayEventInterceptor
 import dev.kord.core.gateway.handler.GatewayEventInterceptor
 import dev.kord.core.gateway.start
-import dev.kord.core.supplier.EntitySupplier
-import dev.kord.core.supplier.EntitySupplyStrategy
-import dev.kord.core.supplier.getChannelOfOrNull
-import dev.kord.core.supplier.getGlobalApplicationCommandOf
-import dev.kord.core.supplier.getGlobalApplicationCommandOfOrNull
-import dev.kord.core.supplier.getGuildApplicationCommandOf
-import dev.kord.core.supplier.getGuildApplicationCommandOfOrNull
+import dev.kord.core.supplier.*
 import dev.kord.gateway.Gateway
 import dev.kord.gateway.builder.LoginBuilder
 import dev.kord.gateway.builder.PresenceBuilder
 import dev.kord.rest.builder.guild.GuildCreateBuilder
-import dev.kord.rest.builder.interaction.ApplicationCommandPermissionsBulkModifyBuilder
-import dev.kord.rest.builder.interaction.ApplicationCommandPermissionsModifyBuilder
-import dev.kord.rest.builder.interaction.ChatInputCreateBuilder
-import dev.kord.rest.builder.interaction.MessageCommandCreateBuilder
-import dev.kord.rest.builder.interaction.MultiApplicationCommandBuilder
-import dev.kord.rest.builder.interaction.UserCommandCreateBuilder
+import dev.kord.rest.builder.interaction.*
 import dev.kord.rest.builder.user.CurrentUserModifyBuilder
 import dev.kord.rest.request.RestRequestException
 import dev.kord.rest.service.RestClient
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.buffer
-import kotlinx.coroutines.flow.filterIsInstance
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.*
 import mu.KLogger
 import mu.KotlinLogging
 import kotlin.contracts.InvocationKind
@@ -613,19 +583,22 @@ public class Kord(
     public suspend inline fun editApplicationCommandPermissions(
         guildId: Snowflake,
         commandId: Snowflake,
+        token: String,
         builder: ApplicationCommandPermissionsModifyBuilder.() -> Unit,
     ) {
         contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
-        rest.interaction.editApplicationCommandPermissions(resources.applicationId, guildId, commandId, builder)
+        rest.interaction.editApplicationCommandPermissions(resources.applicationId, guildId, commandId, token, builder)
     }
 
 
+    @KordUnsafe
     public suspend inline fun bulkEditApplicationCommandPermissions(
         guildId: Snowflake,
+        token: String,
         builder: ApplicationCommandPermissionsBulkModifyBuilder.() -> Unit,
     ) {
         contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
-        rest.interaction.bulkEditApplicationCommandPermissions(resources.applicationId, guildId, builder)
+        rest.interaction.bulkEditApplicationCommandPermissions(resources.applicationId, guildId, token, builder)
     }
 }
 

--- a/core/src/main/kotlin/Kord.kt
+++ b/core/src/main/kotlin/Kord.kt
@@ -499,7 +499,7 @@ public class Kord(
 
 
     public suspend inline fun createGlobalApplicationCommands(
-        builder: MultiApplicationCommandBuilder.() -> Unit,
+        builder: GlobalMultiApplicationCommandBuilder.() -> Unit,
     ): Flow<GlobalApplicationCommand> {
 
         contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }

--- a/core/src/main/kotlin/behavior/ChatInputCommandBehavior.kt
+++ b/core/src/main/kotlin/behavior/ChatInputCommandBehavior.kt
@@ -1,39 +1,37 @@
 package dev.kord.core.behavior
 
-import dev.kord.common.annotation.KordUnsafe
 import dev.kord.core.cache.data.ApplicationCommandData
 import dev.kord.core.entity.application.ChatInputCommandCommand
 import dev.kord.core.entity.application.GlobalChatInputCommand
 import dev.kord.core.entity.application.GuildChatInputCommand
 import dev.kord.rest.builder.interaction.ChatInputModifyBuilder
-import dev.kord.rest.builder.interaction.ChatInputModifyBuilderImpl
 
 
 public interface ChatInputCommandBehavior : ApplicationCommandBehavior {
 
-     public suspend fun edit(builder: suspend ChatInputModifyBuilder.() -> Unit): ChatInputCommandCommand
+    public suspend fun edit(builder: suspend ChatInputModifyBuilder.() -> Unit): ChatInputCommandCommand
 
 }
 
 
 public interface GuildChatInputCommandBehavior : ChatInputCommandBehavior, GuildApplicationCommandBehavior {
 
-     override suspend fun edit(builder: suspend ChatInputModifyBuilder.() -> Unit): GuildChatInputCommand {
-          val request = ChatInputModifyBuilderImpl().apply { builder() }.toRequest()
-          val response = service.modifyGuildApplicationCommand(applicationId, guildId, id, request)
-          val data = ApplicationCommandData.from(response)
-          return GuildChatInputCommand(data, service)
-     }
+    override suspend fun edit(builder: suspend ChatInputModifyBuilder.() -> Unit): GuildChatInputCommand {
+        val response = service.modifyGuildChatInputApplicationCommand(applicationId, guildId, id) {
+            builder()
+        }
+        val data = ApplicationCommandData.from(response)
+        return GuildChatInputCommand(data, service)
+    }
 }
 
 
-
-public interface GlobalChatInputCommandBehavior : ChatInputCommandBehavior,GlobalApplicationCommandBehavior {
-     @OptIn(KordUnsafe::class)
-     override suspend fun edit(builder: suspend ChatInputModifyBuilder.() -> Unit): GlobalChatInputCommand {
-          val request = ChatInputModifyBuilderImpl().apply { builder() }.toRequest()
-          val response = service.modifyGlobalApplicationCommand(applicationId,id, request)
-          val data = ApplicationCommandData.from(response)
-          return GlobalChatInputCommand(data, service)
-     }
+public interface GlobalChatInputCommandBehavior : ChatInputCommandBehavior, GlobalApplicationCommandBehavior {
+    override suspend fun edit(builder: suspend ChatInputModifyBuilder.() -> Unit): GlobalChatInputCommand {
+        val response = service.modifyGlobalChatInputApplicationCommand(applicationId, id) {
+            builder()
+        }
+        val data = ApplicationCommandData.from(response)
+        return GlobalChatInputCommand(data, service)
+    }
 }

--- a/core/src/main/kotlin/behavior/ChatInputCommandBehavior.kt
+++ b/core/src/main/kotlin/behavior/ChatInputCommandBehavior.kt
@@ -1,10 +1,12 @@
 package dev.kord.core.behavior
 
+import dev.kord.common.annotation.KordUnsafe
 import dev.kord.core.cache.data.ApplicationCommandData
 import dev.kord.core.entity.application.ChatInputCommandCommand
 import dev.kord.core.entity.application.GlobalChatInputCommand
 import dev.kord.core.entity.application.GuildChatInputCommand
 import dev.kord.rest.builder.interaction.ChatInputModifyBuilder
+import dev.kord.rest.builder.interaction.ChatInputModifyBuilderImpl
 
 
 public interface ChatInputCommandBehavior : ApplicationCommandBehavior {
@@ -16,8 +18,9 @@ public interface ChatInputCommandBehavior : ApplicationCommandBehavior {
 
 public interface GuildChatInputCommandBehavior : ChatInputCommandBehavior, GuildApplicationCommandBehavior {
 
+     @OptIn(KordUnsafe::class)
      override suspend fun edit(builder: suspend ChatInputModifyBuilder.() -> Unit): GuildChatInputCommand {
-          val request = ChatInputModifyBuilder().apply { builder() }.toRequest()
+          val request = ChatInputModifyBuilderImpl().apply { builder() }.toRequest()
           val response = service.modifyGuildApplicationCommand(applicationId, guildId, id, request)
           val data = ApplicationCommandData.from(response)
           return GuildChatInputCommand(data, service)
@@ -27,9 +30,9 @@ public interface GuildChatInputCommandBehavior : ChatInputCommandBehavior, Guild
 
 
 public interface GlobalChatInputCommandBehavior : ChatInputCommandBehavior,GlobalApplicationCommandBehavior {
-
+     @OptIn(KordUnsafe::class)
      override suspend fun edit(builder: suspend ChatInputModifyBuilder.() -> Unit): GlobalChatInputCommand {
-          val request = ChatInputModifyBuilder().apply { builder() }.toRequest()
+          val request = ChatInputModifyBuilderImpl().apply { builder() }.toRequest()
           val response = service.modifyGlobalApplicationCommand(applicationId,id, request)
           val data = ApplicationCommandData.from(response)
           return GlobalChatInputCommand(data, service)

--- a/core/src/main/kotlin/behavior/ChatInputCommandBehavior.kt
+++ b/core/src/main/kotlin/behavior/ChatInputCommandBehavior.kt
@@ -18,7 +18,6 @@ public interface ChatInputCommandBehavior : ApplicationCommandBehavior {
 
 public interface GuildChatInputCommandBehavior : ChatInputCommandBehavior, GuildApplicationCommandBehavior {
 
-     @OptIn(KordUnsafe::class)
      override suspend fun edit(builder: suspend ChatInputModifyBuilder.() -> Unit): GuildChatInputCommand {
           val request = ChatInputModifyBuilderImpl().apply { builder() }.toRequest()
           val response = service.modifyGuildApplicationCommand(applicationId, guildId, id, request)

--- a/core/src/main/kotlin/behavior/GlobalApplicationCommandBehavior.kt
+++ b/core/src/main/kotlin/behavior/GlobalApplicationCommandBehavior.kt
@@ -2,7 +2,6 @@ package dev.kord.core.behavior
 
 import dev.kord.common.entity.Snowflake
 import dev.kord.core.entity.Entity
-import dev.kord.rest.builder.interaction.ApplicationCommandPermissionsModifyBuilder
 import dev.kord.rest.request.RestRequestException
 import dev.kord.rest.service.InteractionService
 
@@ -31,21 +30,6 @@ public interface GlobalApplicationCommandBehavior : ApplicationCommandBehavior {
     override suspend fun delete() {
         service.deleteGlobalApplicationCommand(applicationId, id)
     }
-
-    /**
-     * Updates the permissions for this command on the guild corresponding to [guildId].
-     *
-     * @param token a Bearer token with the `applications.commands.permissions.update` scope
-     * @throws [RestRequestException] when something goes wrong during the request.
-     */
-    public suspend fun editPermissions(
-        guildId: Snowflake,
-        token: String,
-        builder: ApplicationCommandPermissionsModifyBuilder.() -> Unit
-    ) {
-        val request = ApplicationCommandPermissionsModifyBuilder(guildId).apply(builder).toRequest()
-        service.editApplicationCommandPermissions(applicationId, guildId, id, token, request)
-    }
 }
 
 
@@ -54,19 +38,6 @@ public interface GlobalApplicationCommandBehavior : ApplicationCommandBehavior {
  */
 public interface GuildApplicationCommandBehavior : ApplicationCommandBehavior {
     public val guildId: Snowflake
-
-    /**
-     * Updates the permissions for this command on the guild.
-     *
-     * @throws [RestRequestException] when something goes wrong during the request.
-     */
-    public suspend fun editPermissions(
-        token: String,
-        builder: ApplicationCommandPermissionsModifyBuilder.() -> Unit
-    ) {
-        val request = ApplicationCommandPermissionsModifyBuilder(guildId).apply(builder).toRequest()
-        service.editApplicationCommandPermissions(applicationId, guildId, id, token, request)
-    }
 
     override suspend fun delete() {
         service.deleteGuildApplicationCommand(applicationId, guildId, id)

--- a/core/src/main/kotlin/behavior/GlobalApplicationCommandBehavior.kt
+++ b/core/src/main/kotlin/behavior/GlobalApplicationCommandBehavior.kt
@@ -1,6 +1,5 @@
 package dev.kord.core.behavior
 
-import dev.kord.common.annotation.KordPreview
 import dev.kord.common.entity.Snowflake
 import dev.kord.core.entity.Entity
 import dev.kord.rest.builder.interaction.ApplicationCommandPermissionsModifyBuilder
@@ -36,14 +35,16 @@ public interface GlobalApplicationCommandBehavior : ApplicationCommandBehavior {
     /**
      * Updates the permissions for this command on the guild corresponding to [guildId].
      *
+     * @param token a Bearer token with the `applications.commands.permissions.update` scope
      * @throws [RestRequestException] when something goes wrong during the request.
      */
     public suspend fun editPermissions(
         guildId: Snowflake,
+        token: String,
         builder: ApplicationCommandPermissionsModifyBuilder.() -> Unit
     ) {
-        val request = ApplicationCommandPermissionsModifyBuilder().apply(builder).toRequest()
-        service.editApplicationCommandPermissions(applicationId, guildId, id, request)
+        val request = ApplicationCommandPermissionsModifyBuilder(guildId).apply(builder).toRequest()
+        service.editApplicationCommandPermissions(applicationId, guildId, id, token, request)
     }
 }
 
@@ -60,10 +61,11 @@ public interface GuildApplicationCommandBehavior : ApplicationCommandBehavior {
      * @throws [RestRequestException] when something goes wrong during the request.
      */
     public suspend fun editPermissions(
+        token: String,
         builder: ApplicationCommandPermissionsModifyBuilder.() -> Unit
     ) {
-        val request = ApplicationCommandPermissionsModifyBuilder().apply(builder).toRequest()
-        service.editApplicationCommandPermissions(applicationId, guildId, id, request)
+        val request = ApplicationCommandPermissionsModifyBuilder(guildId).apply(builder).toRequest()
+        service.editApplicationCommandPermissions(applicationId, guildId, id, token, request)
     }
 
     override suspend fun delete() {

--- a/core/src/main/kotlin/behavior/GuildBehavior.kt
+++ b/core/src/main/kotlin/behavior/GuildBehavior.kt
@@ -3,7 +3,6 @@ package dev.kord.core.behavior
 import dev.kord.cache.api.query
 import dev.kord.common.annotation.DeprecatedSinceKord
 import dev.kord.common.annotation.KordExperimental
-import dev.kord.common.annotation.KordUnsafe
 import dev.kord.common.entity.DiscordUser
 import dev.kord.common.entity.GuildScheduledEventPrivacyLevel
 import dev.kord.common.entity.ScheduledEntityType
@@ -37,7 +36,10 @@ import dev.kord.rest.builder.auditlog.AuditLogGetRequestBuilder
 import dev.kord.rest.builder.ban.BanCreateBuilder
 import dev.kord.rest.builder.channel.*
 import dev.kord.rest.builder.guild.*
-import dev.kord.rest.builder.interaction.*
+import dev.kord.rest.builder.interaction.ChatInputCreateBuilder
+import dev.kord.rest.builder.interaction.MessageCommandCreateBuilder
+import dev.kord.rest.builder.interaction.MultiApplicationCommandBuilder
+import dev.kord.rest.builder.interaction.UserCommandCreateBuilder
 import dev.kord.rest.builder.role.RoleCreateBuilder
 import dev.kord.rest.builder.role.RolePositionsModifyBuilder
 import dev.kord.rest.json.JsonErrorCode
@@ -1009,17 +1011,6 @@ public inline fun GuildBehavior.requestMembers(builder: RequestGuildMembersBuild
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
     val request = RequestGuildMembersBuilder(id).apply(builder).toRequest()
     return requestMembers(request)
-}
-
-@KordUnsafe
-public suspend inline fun GuildBehavior.bulkEditSlashCommandPermissions(
-    token: String,
-    noinline builder: ApplicationCommandPermissionsBulkModifyBuilder.() -> Unit
-) {
-
-    contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
-
-    kord.bulkEditApplicationCommandPermissions(id, token, builder)
 }
 
 /**

--- a/core/src/main/kotlin/behavior/GuildBehavior.kt
+++ b/core/src/main/kotlin/behavior/GuildBehavior.kt
@@ -3,6 +3,7 @@ package dev.kord.core.behavior
 import dev.kord.cache.api.query
 import dev.kord.common.annotation.DeprecatedSinceKord
 import dev.kord.common.annotation.KordExperimental
+import dev.kord.common.annotation.KordUnsafe
 import dev.kord.common.entity.DiscordUser
 import dev.kord.common.entity.GuildScheduledEventPrivacyLevel
 import dev.kord.common.entity.ScheduledEntityType
@@ -31,7 +32,6 @@ import dev.kord.gateway.RequestGuildMembers
 import dev.kord.gateway.builder.RequestGuildMembersBuilder
 import dev.kord.gateway.start
 import dev.kord.rest.Image
-import kotlinx.coroutines.flow.toList
 import dev.kord.rest.NamedFile
 import dev.kord.rest.builder.auditlog.AuditLogGetRequestBuilder
 import dev.kord.rest.builder.ban.BanCreateBuilder
@@ -48,7 +48,7 @@ import dev.kord.rest.request.RestRequestException
 import dev.kord.rest.service.*
 import kotlinx.coroutines.flow.*
 import kotlinx.datetime.Instant
-import java.util.Objects
+import java.util.*
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -575,7 +575,8 @@ public interface GuildBehavior : KordEntity, Strategizable {
 
     public suspend fun getSticker(stickerId: Snowflake): GuildSticker = supplier.getGuildSticker(id, stickerId)
 
-    public suspend fun getStickerOrNull(stickerId: Snowflake): GuildSticker? = supplier.getGuildStickerOrNull(id, stickerId)
+    public suspend fun getStickerOrNull(stickerId: Snowflake): GuildSticker? =
+        supplier.getGuildStickerOrNull(id, stickerId)
 
     public suspend fun createSticker(name: String, description: String, tags: String, file: NamedFile): GuildSticker {
         val request = MultipartGuildStickerCreateRequest(GuildStickerCreateRequest(name, description, tags), file)
@@ -622,7 +623,6 @@ public fun GuildBehavior(
 }
 
 
-
 public suspend inline fun GuildBehavior.createChatInputCommand(
     name: String,
     description: String,
@@ -631,7 +631,6 @@ public suspend inline fun GuildBehavior.createChatInputCommand(
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
     return kord.createGuildChatInputCommand(id, name, description, builder)
 }
-
 
 
 public suspend inline fun GuildBehavior.createMessageCommand(
@@ -650,7 +649,6 @@ public suspend inline fun GuildBehavior.createUserCommand(
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
     return kord.createGuildUserCommand(id, name, builder)
 }
-
 
 
 public suspend inline fun GuildBehavior.createApplicationCommands(
@@ -1011,11 +1009,15 @@ public inline fun GuildBehavior.requestMembers(builder: RequestGuildMembersBuild
     return requestMembers(request)
 }
 
-public suspend inline fun GuildBehavior.bulkEditSlashCommandPermissions(noinline builder: ApplicationCommandPermissionsBulkModifyBuilder.() -> Unit) {
+@KordUnsafe
+public suspend inline fun GuildBehavior.bulkEditSlashCommandPermissions(
+    token: String,
+    noinline builder: ApplicationCommandPermissionsBulkModifyBuilder.() -> Unit
+) {
 
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
 
-    kord.bulkEditApplicationCommandPermissions(id, builder)
+    kord.bulkEditApplicationCommandPermissions(id, token, builder)
 }
 
 /**

--- a/core/src/main/kotlin/behavior/MessageCommandBehavior.kt
+++ b/core/src/main/kotlin/behavior/MessageCommandBehavior.kt
@@ -1,7 +1,9 @@
 package dev.kord.core.behavior
 
 import dev.kord.core.cache.data.ApplicationCommandData
-import dev.kord.core.entity.application.*
+import dev.kord.core.entity.application.GlobalMessageCommand
+import dev.kord.core.entity.application.GuildMessageCommand
+import dev.kord.core.entity.application.MessageCommand
 import dev.kord.rest.builder.interaction.MessageCommandModifyBuilder
 
 
@@ -11,22 +13,20 @@ public interface MessageCommandBehavior : ApplicationCommandBehavior {
 }
 
 
-
 public interface GuildMessageCommandBehavior : MessageCommandBehavior, GuildApplicationCommandBehavior {
     override suspend fun edit(builder: suspend MessageCommandModifyBuilder.() -> Unit): GuildMessageCommand {
-        val request = MessageCommandModifyBuilder().apply { builder() }.toRequest()
-        val response = service.modifyGuildApplicationCommand(applicationId, guildId, id, request)
+        val response = service.modifyGuildMessageApplicationCommand(applicationId, guildId, id) { builder() }
         val data = ApplicationCommandData.from(response)
         return GuildMessageCommand(data, service)
     }
 }
 
 
-
-public interface GlobalMessageCommandBehavior : MessageCommandBehavior,GlobalApplicationCommandBehavior {
+public interface GlobalMessageCommandBehavior : MessageCommandBehavior, GlobalApplicationCommandBehavior {
     override suspend fun edit(builder: suspend MessageCommandModifyBuilder.() -> Unit): GlobalMessageCommand {
-        val request = MessageCommandModifyBuilder().apply { builder() }.toRequest()
-        val response = service.modifyGlobalApplicationCommand(applicationId,id, request)
+        val response = service.modifyGlobalMessageApplicationCommand(applicationId, id) {
+            builder()
+        }
         val data = ApplicationCommandData.from(response)
         return GlobalMessageCommand(data, service)
     }

--- a/core/src/main/kotlin/behavior/UserCommandBehavior.kt
+++ b/core/src/main/kotlin/behavior/UserCommandBehavior.kt
@@ -1,7 +1,9 @@
 package dev.kord.core.behavior
 
 import dev.kord.core.cache.data.ApplicationCommandData
-import dev.kord.core.entity.application.*
+import dev.kord.core.entity.application.GlobalUserCommand
+import dev.kord.core.entity.application.GuildUserCommand
+import dev.kord.core.entity.application.UserCommand
 import dev.kord.rest.builder.interaction.UserCommandModifyBuilder
 
 
@@ -13,19 +15,18 @@ public interface UserCommandBehavior : ApplicationCommandBehavior {
 
 public interface GlobalUserCommandBehavior : UserCommandBehavior, GlobalApplicationCommandBehavior {
     override suspend fun edit(builder: suspend UserCommandModifyBuilder.() -> Unit): GlobalUserCommand {
-        val request = UserCommandModifyBuilder().apply { builder() }.toRequest()
-        val response = service.modifyGlobalApplicationCommand(applicationId,id, request)
+        val response = service.modifyGlobalUserApplicationCommand(applicationId, id) { builder() }
         val data = ApplicationCommandData.from(response)
         return GlobalUserCommand(data, service)
     }
 }
 
 
-
 public interface GuildUserCommandBehavior : UserCommandBehavior, GuildApplicationCommandBehavior {
     override suspend fun edit(builder: suspend UserCommandModifyBuilder.() -> Unit): GuildUserCommand {
-        val request = UserCommandModifyBuilder().apply { builder() }.toRequest()
-        val response = service.modifyGuildApplicationCommand(applicationId, guildId, id, request)
+        val response = service.modifyGuildUserApplicationCommand(applicationId, guildId, id) {
+            builder()
+        }
         val data = ApplicationCommandData.from(response)
         return GuildUserCommand(data, service)
     }

--- a/core/src/main/kotlin/cache/data/ApplicationCommandData.kt
+++ b/core/src/main/kotlin/cache/data/ApplicationCommandData.kt
@@ -41,7 +41,7 @@ public data class ApplicationCommandData(
                     guildId,
                     options.mapList { ApplicationCommandOptionData.from(it) },
                     defaultMemberPermissions,
-                    dmPermissions,
+                    dmPermission,
                     defaultPermission,
                     version
                 )

--- a/core/src/main/kotlin/cache/data/ApplicationCommandData.kt
+++ b/core/src/main/kotlin/cache/data/ApplicationCommandData.kt
@@ -19,9 +19,9 @@ public data class ApplicationCommandData(
     val guildId: OptionalSnowflake = OptionalSnowflake.Missing,
     val options: Optional<List<ApplicationCommandOptionData>> = Optional.Missing(),
     val defaultMemberPermissions: Optional<Permissions?> = Optional.Missing(),
-    val dmPermission: OptionalBoolean = OptionalBoolean.Missing,
+    val dmPermission: OptionalBoolean? = OptionalBoolean.Missing,
     @Deprecated("'defaultPermission' is deprecated in favor of 'defaultMemberPermissions' and 'dmPermission'.")
-    val defaultPermission: OptionalBoolean = OptionalBoolean.Missing,
+    val defaultPermission: OptionalBoolean? = OptionalBoolean.Missing,
     val version: Snowflake
 ) {
     public companion object {

--- a/core/src/main/kotlin/cache/data/ApplicationCommandData.kt
+++ b/core/src/main/kotlin/cache/data/ApplicationCommandData.kt
@@ -3,11 +3,7 @@ package dev.kord.core.cache.data
 import dev.kord.cache.api.data.DataDescription
 import dev.kord.cache.api.data.description
 import dev.kord.common.entity.*
-import dev.kord.common.entity.optional.Optional
-import dev.kord.common.entity.optional.OptionalBoolean
-import dev.kord.common.entity.optional.OptionalSnowflake
-import dev.kord.common.entity.optional.mapList
-import dev.kord.common.entity.optional.orEmpty
+import dev.kord.common.entity.optional.*
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -19,6 +15,8 @@ public data class ApplicationCommandData(
     val description: String?,
     val guildId: OptionalSnowflake,
     val options: Optional<List<ApplicationCommandOptionData>>,
+    val defaultMemberPermissions: Optional<Permissions?> = Optional.Missing(),
+    val dmPermission: OptionalBoolean = OptionalBoolean.Missing,
     val defaultPermission: OptionalBoolean = OptionalBoolean.Missing,
     val version: Snowflake
 ) {
@@ -36,6 +34,8 @@ public data class ApplicationCommandData(
                     description,
                     guildId,
                     options.mapList { ApplicationCommandOptionData.from(it) },
+                    defaultMemberPermissions,
+                    dmPermissions,
                     defaultPermission,
                     version
                 )

--- a/core/src/main/kotlin/cache/data/ApplicationCommandData.kt
+++ b/core/src/main/kotlin/cache/data/ApplicationCommandData.kt
@@ -20,6 +20,7 @@ public data class ApplicationCommandData(
     val options: Optional<List<ApplicationCommandOptionData>> = Optional.Missing(),
     val defaultMemberPermissions: Optional<Permissions?> = Optional.Missing(),
     val dmPermission: OptionalBoolean = OptionalBoolean.Missing,
+    @Deprecated("'defaultPermission' is deprecated in favor of 'defaultMemberPermissions' and 'dmPermission'.")
     val defaultPermission: OptionalBoolean = OptionalBoolean.Missing,
     val version: Snowflake
 ) {

--- a/core/src/main/kotlin/entity/application/ApplicationCommand.kt
+++ b/core/src/main/kotlin/entity/application/ApplicationCommand.kt
@@ -56,7 +56,7 @@ public sealed interface ApplicationCommand : ApplicationCommandBehavior {
      * whether the command is enabled by default when the app is added to a guild.
      */
     @Deprecated("'defaultPermission' is deprecated in favor of 'defaultMemberPermissions' and 'dmPermission'.")
-    public val defaultPermission: Boolean? get() = data.defaultPermission?.discordBoolean
+    public val defaultPermission: Boolean? get() = data.defaultPermission.value
 
 
 }

--- a/core/src/main/kotlin/entity/application/ApplicationCommand.kt
+++ b/core/src/main/kotlin/entity/application/ApplicationCommand.kt
@@ -64,9 +64,9 @@ public sealed interface ApplicationCommand : ApplicationCommandBehavior {
 
 public interface GlobalApplicationCommand : ApplicationCommand, GlobalApplicationCommandBehavior {
     /**
-     * Whether this command can be executed in dms or not
+     * Whether this command is available in DMs with the application.
      */
-    public val dmPermission: Boolean? get() = data.dmPermission.value
+    public val dmPermission: Boolean get() = data.dmPermission.orElse(true)
 }
 public class UnknownGlobalApplicationCommand(
     override val data: ApplicationCommandData,

--- a/core/src/main/kotlin/entity/application/ApplicationCommand.kt
+++ b/core/src/main/kotlin/entity/application/ApplicationCommand.kt
@@ -55,6 +55,7 @@ public sealed interface ApplicationCommand : ApplicationCommandBehavior {
     /**
      * whether the command is enabled by default when the app is added to a guild.
      */
+    @Deprecated("'defaultPermission' is deprecated in favor of 'defaultMemberPermissions' and 'dmPermission'.")
     public val defaultPermission: Boolean? get() = data.defaultPermission.discordBoolean
 
 

--- a/core/src/main/kotlin/entity/application/ApplicationCommand.kt
+++ b/core/src/main/kotlin/entity/application/ApplicationCommand.kt
@@ -56,7 +56,7 @@ public sealed interface ApplicationCommand : ApplicationCommandBehavior {
      * whether the command is enabled by default when the app is added to a guild.
      */
     @Deprecated("'defaultPermission' is deprecated in favor of 'defaultMemberPermissions' and 'dmPermission'.")
-    public val defaultPermission: Boolean? get() = data.defaultPermission.discordBoolean
+    public val defaultPermission: Boolean? get() = data.defaultPermission?.discordBoolean
 
 
 }

--- a/core/src/main/kotlin/entity/application/ApplicationCommand.kt
+++ b/core/src/main/kotlin/entity/application/ApplicationCommand.kt
@@ -2,12 +2,15 @@ package dev.kord.core.entity.application
 
 import dev.kord.common.entity.ApplicationCommandType
 import dev.kord.common.entity.ChannelType
+import dev.kord.common.entity.Permissions
 import dev.kord.common.entity.Snowflake
 import dev.kord.common.entity.optional.orEmpty
+import dev.kord.common.entity.optional.value
 import dev.kord.core.behavior.ApplicationCommandBehavior
 import dev.kord.core.behavior.GlobalApplicationCommandBehavior
 import dev.kord.core.behavior.GuildApplicationCommandBehavior
-import dev.kord.core.cache.data.*
+import dev.kord.core.cache.data.ApplicationCommandData
+import dev.kord.core.cache.data.ApplicationCommandParameterData
 import dev.kord.rest.service.InteractionService
 
 /**
@@ -35,6 +38,11 @@ public sealed interface ApplicationCommand : ApplicationCommandBehavior {
     public val version: Snowflake get() = data.version
 
     /**
+     * Set of [Permissions] required to execute this command unless a server admin changed them.
+     */
+    public val defaultMemberPermissions: Permissions? get() = data.defaultMemberPermissions.value
+
+    /**
      * whether the command is enabled by default when the app is added to a guild.
      */
     public val defaultPermission: Boolean? get() = data.defaultPermission.discordBoolean
@@ -43,7 +51,12 @@ public sealed interface ApplicationCommand : ApplicationCommandBehavior {
 }
 
 
-public interface GlobalApplicationCommand : ApplicationCommand, GlobalApplicationCommandBehavior
+public interface GlobalApplicationCommand : ApplicationCommand, GlobalApplicationCommandBehavior {
+    /**
+     * Whether this command can be executed in dms or not
+     */
+    public val dmPermission: Boolean? get() = data.dmPermission.value
+}
 public class UnknownGlobalApplicationCommand(
     override val data: ApplicationCommandData,
     override val service: InteractionService,

--- a/core/src/main/kotlin/entity/application/ApplicationCommand.kt
+++ b/core/src/main/kotlin/entity/application/ApplicationCommand.kt
@@ -66,7 +66,7 @@ public interface GlobalApplicationCommand : ApplicationCommand, GlobalApplicatio
     /**
      * Whether this command is available in DMs with the application.
      */
-    public val dmPermission: Boolean get() = data.dmPermission.orElse(true)
+    public val dmPermission: Boolean get() = data.dmPermission?.value ?: true
 }
 public class UnknownGlobalApplicationCommand(
     override val data: ApplicationCommandData,

--- a/core/src/main/kotlin/event/interaction/ApplicationCommandPermissionsUpdateEvent.kt
+++ b/core/src/main/kotlin/event/interaction/ApplicationCommandPermissionsUpdateEvent.kt
@@ -1,0 +1,15 @@
+package dev.kord.core.event.interaction
+
+import dev.kord.core.Kord
+import dev.kord.core.entity.application.ApplicationCommandPermissions
+import dev.kord.core.event.Event
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.job
+
+public class ApplicationCommandPermissionsUpdateEvent(
+    public val permissions: ApplicationCommandPermissions,
+    override val kord: Kord,
+    override val shard: Int,
+    public val coroutineScope: CoroutineScope = CoroutineScope(kord.coroutineContext + SupervisorJob(kord.coroutineContext.job)),
+) : Event, CoroutineScope by coroutineScope

--- a/core/src/main/kotlin/event/interaction/ApplicationCommandPermissionsUpdateEvent.kt
+++ b/core/src/main/kotlin/event/interaction/ApplicationCommandPermissionsUpdateEvent.kt
@@ -3,9 +3,8 @@ package dev.kord.core.event.interaction
 import dev.kord.core.Kord
 import dev.kord.core.entity.application.ApplicationCommandPermissions
 import dev.kord.core.event.Event
+import dev.kord.core.event.kordCoroutineScope
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.job
 
 public class ApplicationCommandPermissionsUpdateEvent(
     public val permissions: ApplicationCommandPermissions,

--- a/core/src/main/kotlin/event/interaction/ApplicationCommandPermissionsUpdateEvent.kt
+++ b/core/src/main/kotlin/event/interaction/ApplicationCommandPermissionsUpdateEvent.kt
@@ -11,5 +11,5 @@ public class ApplicationCommandPermissionsUpdateEvent(
     public val permissions: ApplicationCommandPermissions,
     override val kord: Kord,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = CoroutineScope(kord.coroutineContext + SupervisorJob(kord.coroutineContext.job)),
+    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord),
 ) : Event, CoroutineScope by coroutineScope

--- a/core/src/main/kotlin/gateway/handler/InteractionEventHandler.kt
+++ b/core/src/main/kotlin/gateway/handler/InteractionEventHandler.kt
@@ -28,14 +28,7 @@ public class InteractionEventHandler(
             is ApplicationCommandUpdate -> handle(event, shard, kord, coroutineScope)
             is ApplicationCommandDelete -> handle(event, shard, kord, coroutineScope)
             is ApplicationCommandPermissionsUpdate -> {
-                val data = GuildApplicationCommandPermissionsData(
-                    event.permissions.id,
-                    event.permissions.applicationId,
-                    event.permissions.guildId,
-                    event.permissions.permissions.map {
-                        GuildApplicationCommandPermissionData.from(it)
-                    }
-                )
+                val data = GuildApplicationCommandPermissionsData.from(event.permissions)
                 ApplicationCommandPermissionsUpdateEvent(
                     ApplicationCommandPermissions(data),
                     kord, shard, coroutineScope

--- a/core/src/main/kotlin/gateway/handler/InteractionEventHandler.kt
+++ b/core/src/main/kotlin/gateway/handler/InteractionEventHandler.kt
@@ -5,6 +5,8 @@ import dev.kord.cache.api.put
 import dev.kord.cache.api.remove
 import dev.kord.core.Kord
 import dev.kord.core.cache.data.ApplicationCommandData
+import dev.kord.core.cache.data.GuildApplicationCommandPermissionData
+import dev.kord.core.cache.data.GuildApplicationCommandPermissionsData
 import dev.kord.core.cache.data.InteractionData
 import dev.kord.core.cache.idEq
 import dev.kord.core.entity.application.*
@@ -25,6 +27,20 @@ public class InteractionEventHandler(
             is ApplicationCommandCreate -> handle(event, shard, kord, coroutineScope)
             is ApplicationCommandUpdate -> handle(event, shard, kord, coroutineScope)
             is ApplicationCommandDelete -> handle(event, shard, kord, coroutineScope)
+            is ApplicationCommandPermissionsUpdate -> {
+                val data = GuildApplicationCommandPermissionsData(
+                    event.permissions.id,
+                    event.permissions.applicationId,
+                    event.permissions.guildId,
+                    event.permissions.permissions.map {
+                        GuildApplicationCommandPermissionData.from(it)
+                    }
+                )
+                ApplicationCommandPermissionsUpdateEvent(
+                    ApplicationCommandPermissions(data),
+                    kord, shard, coroutineScope
+                )
+            }
             else -> null
         }
 

--- a/gateway/src/main/kotlin/Event.kt
+++ b/gateway/src/main/kotlin/Event.kt
@@ -4,7 +4,10 @@ import dev.kord.common.entity.*
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
 import dev.kord.common.entity.optional.OptionalSnowflake
-import kotlinx.serialization.*
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.nullable
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.descriptors.PrimitiveKind
@@ -118,6 +121,11 @@ public sealed class Event {
                     Resumed(sequence)
                 }
                 "READY" -> Ready(decoder.decodeSerializableElement(descriptor, index, ReadyData.serializer()), sequence)
+                "APPLICATION_COMMAND_PERMISSIONS_UPDATE" -> ApplicationCommandPermissionsUpdate(
+                    decoder.decodeSerializableElement(
+                        descriptor, index, DiscordGuildApplicationCommandPermissions.serializer()
+                    ), sequence
+                )
                 "CHANNEL_CREATE" -> ChannelCreate(
                     decoder.decodeSerializableElement(
                         descriptor,
@@ -568,6 +576,11 @@ public data class InvalidSession(val resumable: Boolean) : Event() {
         }
     }
 }
+
+public data class ApplicationCommandPermissionsUpdate(
+    val permissions: DiscordGuildApplicationCommandPermissions,
+    override val sequence: Int?
+) : DispatchEvent()
 
 public data class ChannelCreate(val channel: DiscordChannel, override val sequence: Int?) : DispatchEvent()
 public data class ChannelUpdate(val channel: DiscordChannel, override val sequence: Int?) : DispatchEvent()

--- a/rest/src/main/kotlin/builder/interaction/ApplicationCommandBuilders.kt
+++ b/rest/src/main/kotlin/builder/interaction/ApplicationCommandBuilders.kt
@@ -53,6 +53,8 @@ public interface GlobalApplicationCommandModifyBuilder : ApplicationCommandModif
 public interface ApplicationCommandModifyBuilder : LocalizedNameModifyBuilder,
     RequestBuilder<ApplicationCommandModifyRequest> {
 
+    public var defaultMemberPermissions: Permissions?
+
     @Deprecated("'defaultPermission' is deprecated in favor of 'defaultMemberPermissions' and 'dmPermission'. Setting 'defaultPermission' to false can be replaced by setting 'defaultMemberPermissions' to empty Permissions and 'dmPermission' to false ('dmPermission' is only available for global commands).")
     public var defaultPermission: Boolean?
 }

--- a/rest/src/main/kotlin/builder/interaction/ApplicationCommandBuilders.kt
+++ b/rest/src/main/kotlin/builder/interaction/ApplicationCommandBuilders.kt
@@ -16,12 +16,31 @@ public interface ApplicationCommandCreateBuilder : LocalizedNameCreateBuilder,
     @Deprecated("'defaultPermission' is deprecated in favor of 'defaultMemberPermissions' and 'dmPermission'. Setting 'defaultPermission' to false can be replaced by setting 'defaultMemberPermissions' to empty Permissions and 'dmPermission' to false ('dmPermission' is only available for global commands).")
     public var defaultPermission: Boolean?
     public val type: ApplicationCommandType
+
+    /**
+     * Disables the command for everyone by default.
+     *
+     * **This does not ensure normal users cannot execute the command, any server owner can change this setting**
+     */
+    public fun disableCommand() {
+        defaultMemberPermissions = Permissions()
+    }
 }
 
 @KordDsl
 public interface GlobalApplicationCommandCreateBuilder : ApplicationCommandCreateBuilder,
     RequestBuilder<ApplicationCommandCreateRequest> {
     public var dmPermission: Boolean?
+
+    /**
+     * Disables the command for everyone by default.
+     *
+     * **This only ensures that DM users cannot execute the command, any server owner can change this setting**
+     */
+    override fun disableCommand() {
+        super.disableCommand()
+        dmPermission = false
+    }
 }
 
 @KordDsl

--- a/rest/src/main/kotlin/builder/interaction/ApplicationCommandBuilders.kt
+++ b/rest/src/main/kotlin/builder/interaction/ApplicationCommandBuilders.kt
@@ -15,7 +15,7 @@ public interface ApplicationCommandCreateBuilder : LocalizedNameCreateBuilder,
 
     public var defaultMemberPermissions: Permissions?
 
-    @Deprecated("danger default_permission will soon be deprecated. You can instead set default_member_permissions to \"0\" to disable the command by default and/or set dm_permission to false to disable globally-scoped commands inside of DMs with your app")
+    @Deprecated("'defaultPermission' is deprecated in favor of 'defaultMemberPermissions' and 'dmPermission'. Setting 'defaultPermission' to false can be replaced by setting 'defaultMemberPermissions' to empty Permissions and 'dmPermission' to false ('dmPermission' is only available for global commands).")
     public var defaultPermission: Boolean?
     public val type: ApplicationCommandType
 }
@@ -36,7 +36,7 @@ public interface GlobalApplicationCommandModifyBuilder : ApplicationCommandModif
 public interface ApplicationCommandModifyBuilder : LocalizedNameModifyBuilder,
     RequestBuilder<ApplicationCommandModifyRequest> {
 
-    @Deprecated("danger default_permission will soon be deprecated. You can instead set default_member_permissions to \"0\" to disable the command by default and/or set dm_permission to false to disable globally-scoped commands inside of DMs with your app")
+    @Deprecated("'defaultPermission' is deprecated in favor of 'defaultMemberPermissions' and 'dmPermission'. Setting 'defaultPermission' to false can be replaced by setting 'defaultMemberPermissions' to empty Permissions and 'dmPermission' to false ('dmPermission' is only available for global commands).")
     public var defaultPermission: Boolean?
     public var defaultMemberPermissions: Permissions?
 }

--- a/rest/src/main/kotlin/builder/interaction/ApplicationCommandBuilders.kt
+++ b/rest/src/main/kotlin/builder/interaction/ApplicationCommandBuilders.kt
@@ -1,13 +1,11 @@
 package dev.kord.rest.builder.interaction
 
 import dev.kord.common.annotation.KordDsl
-import dev.kord.common.entity.*
+import dev.kord.common.entity.ApplicationCommandType
+import dev.kord.common.entity.Permissions
 import dev.kord.rest.builder.RequestBuilder
 import dev.kord.rest.json.request.ApplicationCommandCreateRequest
 import dev.kord.rest.json.request.ApplicationCommandModifyRequest
-import dev.kord.rest.json.request.ApplicationCommandPermissionsEditRequest
-import kotlin.contracts.InvocationKind
-import kotlin.contracts.contract
 
 @KordDsl
 public interface ApplicationCommandCreateBuilder : LocalizedNameCreateBuilder,
@@ -39,75 +37,4 @@ public interface ApplicationCommandModifyBuilder : LocalizedNameModifyBuilder,
     @Deprecated("'defaultPermission' is deprecated in favor of 'defaultMemberPermissions' and 'dmPermission'. Setting 'defaultPermission' to false can be replaced by setting 'defaultMemberPermissions' to empty Permissions and 'dmPermission' to false ('dmPermission' is only available for global commands).")
     public var defaultPermission: Boolean?
     public var defaultMemberPermissions: Permissions?
-}
-
-@KordDsl
-public class ApplicationCommandPermissionsBulkModifyBuilder(@PublishedApi internal val guildId: Snowflake) :
-    RequestBuilder<List<PartialDiscordGuildApplicationCommandPermissions>> {
-
-    @PublishedApi
-    internal val permissions: MutableMap<Snowflake, ApplicationCommandPermissionsModifyBuilder> = mutableMapOf()
-
-    public inline fun command(
-        commandId: Snowflake,
-        builder: ApplicationCommandPermissionsModifyBuilder.() -> Unit,
-    ) {
-        contract {
-            callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
-        }
-
-        permissions[commandId] = ApplicationCommandPermissionsModifyBuilder(guildId).apply(builder)
-    }
-
-    override fun toRequest(): List<PartialDiscordGuildApplicationCommandPermissions> {
-        return permissions.map { (id, builder) ->
-            PartialDiscordGuildApplicationCommandPermissions(
-                id, builder.permissions.toList()
-            )
-        }
-    }
-}
-
-@KordDsl
-public class ApplicationCommandPermissionsModifyBuilder(private val guildId: Snowflake) :
-    RequestBuilder<ApplicationCommandPermissionsEditRequest> {
-
-    public var permissions: MutableList<DiscordGuildApplicationCommandPermission> = mutableListOf()
-
-    public fun role(id: Snowflake, allow: Boolean = true) {
-        permissions.add(
-            DiscordGuildApplicationCommandPermission(
-                id,
-                DiscordGuildApplicationCommandPermission.Type.Role,
-                allow
-            )
-        )
-    }
-
-    public fun user(id: Snowflake, allow: Boolean = true) {
-        permissions.add(
-            DiscordGuildApplicationCommandPermission(
-                id,
-                DiscordGuildApplicationCommandPermission.Type.User,
-                allow
-            )
-        )
-    }
-
-    public fun channel(id: Snowflake, allow: Boolean = true) {
-        permissions.add(
-            DiscordGuildApplicationCommandPermission(
-                id,
-                DiscordGuildApplicationCommandPermission.Type.Channel,
-                allow
-            )
-        )
-    }
-
-    public fun everyone(allow: Boolean = true): Unit = role(guildId, allow)
-    public fun allChannels(allow: Boolean = true): Unit = channel(Snowflake(guildId.value - 1UL), allow)
-
-    override fun toRequest(): ApplicationCommandPermissionsEditRequest =
-        ApplicationCommandPermissionsEditRequest(permissions)
-
 }

--- a/rest/src/main/kotlin/builder/interaction/ApplicationCommandBuilders.kt
+++ b/rest/src/main/kotlin/builder/interaction/ApplicationCommandBuilders.kt
@@ -22,7 +22,7 @@ public interface ApplicationCommandCreateBuilder : LocalizedNameCreateBuilder,
      *
      * **This does not ensure normal users cannot execute the command, any server owner can change this setting**
      */
-    public fun disableCommand() {
+    public fun disableCommandInGuilds() {
         defaultMemberPermissions = Permissions()
     }
 }
@@ -31,16 +31,6 @@ public interface ApplicationCommandCreateBuilder : LocalizedNameCreateBuilder,
 public interface GlobalApplicationCommandCreateBuilder : ApplicationCommandCreateBuilder,
     RequestBuilder<ApplicationCommandCreateRequest> {
     public var dmPermission: Boolean?
-
-    /**
-     * Disables the command for everyone by default.
-     *
-     * **This only ensures that DM users cannot execute the command, any server owner can change this setting**
-     */
-    override fun disableCommand() {
-        super.disableCommand()
-        dmPermission = false
-    }
 }
 
 @KordDsl

--- a/rest/src/main/kotlin/builder/interaction/ApplicationCommandBuilders.kt
+++ b/rest/src/main/kotlin/builder/interaction/ApplicationCommandBuilders.kt
@@ -36,5 +36,4 @@ public interface ApplicationCommandModifyBuilder : LocalizedNameModifyBuilder,
 
     @Deprecated("'defaultPermission' is deprecated in favor of 'defaultMemberPermissions' and 'dmPermission'. Setting 'defaultPermission' to false can be replaced by setting 'defaultMemberPermissions' to empty Permissions and 'dmPermission' to false ('dmPermission' is only available for global commands).")
     public var defaultPermission: Boolean?
-    public var defaultMemberPermissions: Permissions?
 }

--- a/rest/src/main/kotlin/builder/interaction/ApplicationCommandStateHolder.kt
+++ b/rest/src/main/kotlin/builder/interaction/ApplicationCommandStateHolder.kt
@@ -25,7 +25,7 @@ internal class ApplicationCommandModifyStateHolder {
     var dmPermission: OptionalBoolean? = OptionalBoolean.Missing
 
 
-    @Deprecated("danger default_permission will soon be deprecated. You can instead set default_member_permissions to \"0\" to disable the command by default and/or set dm_permission to false to disable globally-scoped commands inside of DMs with your app")
+    @Deprecated("'defaultPermission' is deprecated in favor of 'defaultMemberPermissions' and 'dmPermission'. Setting 'defaultPermission' to false can be replaced by setting 'defaultMemberPermissions' to empty Permissions and 'dmPermission' to false ('dmPermission' is only available for global commands).")
     @SerialName("default_permission")
     var defaultPermission: OptionalBoolean = OptionalBoolean.Missing
 

--- a/rest/src/main/kotlin/builder/interaction/ApplicationCommandStateHolder.kt
+++ b/rest/src/main/kotlin/builder/interaction/ApplicationCommandStateHolder.kt
@@ -1,5 +1,6 @@
 package dev.kord.rest.builder.interaction
 
+import dev.kord.common.entity.Permissions
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
 import kotlinx.serialization.SerialName
@@ -17,6 +18,11 @@ internal class ApplicationCommandModifyStateHolder {
 
     var options: Optional<MutableList<OptionsBuilder>> = Optional.Missing()
 
+    var defaultMemberPermissions: Optional<Permissions?> = Optional.Missing()
+    var dmPermission: OptionalBoolean? = OptionalBoolean.Missing
+
+
+    @Deprecated("danger default_permission will soon be deprecated. You can instead set default_member_permissions to \"0\" to disable the command by default and/or set dm_permission to false to disable globally-scoped commands inside of DMs with your app")
     @SerialName("default_permission")
     var defaultPermission: OptionalBoolean = OptionalBoolean.Missing
 

--- a/rest/src/main/kotlin/builder/interaction/InputChatBuilders.kt
+++ b/rest/src/main/kotlin/builder/interaction/InputChatBuilders.kt
@@ -2,7 +2,6 @@ package dev.kord.rest.builder.interaction
 
 import dev.kord.common.Locale
 import dev.kord.common.annotation.KordDsl
-import dev.kord.common.annotation.KordUnsafe
 import dev.kord.common.entity.ApplicationCommandType
 import dev.kord.common.entity.Permissions
 import dev.kord.common.entity.optional.Optional
@@ -178,8 +177,8 @@ public interface ChatInputModifyBuilder : LocalizedDescriptionModifyBuilder, App
 @KordDsl
 public interface GlobalChatInputModifyBuilder : ChatInputModifyBuilder, GlobalApplicationCommandModifyBuilder
 
-@KordUnsafe
-public class ChatInputModifyBuilderImpl : GlobalChatInputModifyBuilder {
+@PublishedApi
+internal class ChatInputModifyBuilderImpl : GlobalChatInputModifyBuilder {
 
     private val state = ApplicationCommandModifyStateHolder()
     override var name: String? by state::name.delegate()

--- a/rest/src/main/kotlin/builder/interaction/InputChatBuilders.kt
+++ b/rest/src/main/kotlin/builder/interaction/InputChatBuilders.kt
@@ -150,7 +150,7 @@ internal class ChatInputCreateBuilderImpl(
     override var defaultMemberPermissions: Permissions? by state::defaultMemberPermissions.delegate()
     override var dmPermission: Boolean? by state::dmPermission.delegate()
 
-    @Deprecated("danger default_permission will soon be deprecated. You can instead set default_member_permissions to \"0\" to disable the command by default and/or set dm_permission to false to disable globally-scoped commands inside of DMs with your app")
+    @Deprecated("'defaultPermission' is deprecated in favor of 'defaultMemberPermissions' and 'dmPermission'. Setting 'defaultPermission' to false can be replaced by setting 'defaultMemberPermissions' to empty Permissions and 'dmPermission' to false ('dmPermission' is only available for global commands).")
     override var defaultPermission: Boolean? by state::defaultPermission.delegate()
 
 
@@ -193,6 +193,7 @@ public class ChatInputModifyBuilderImpl : GlobalChatInputModifyBuilder {
     override var defaultMemberPermissions: Permissions? by state::defaultMemberPermissions.delegate()
     override var dmPermission: Boolean? by state::dmPermission.delegate()
 
+    @Deprecated("'defaultPermission' is deprecated in favor of 'defaultMemberPermissions' and 'dmPermission'. Setting 'defaultPermission' to false can be replaced by setting 'defaultMemberPermissions' to empty Permissions and 'dmPermission' to false ('dmPermission' is only available for global commands).")
     override var defaultPermission: Boolean? by state::defaultPermission.delegate()
 
     override fun toRequest(): ApplicationCommandModifyRequest {

--- a/rest/src/main/kotlin/builder/interaction/MessageCommandBuilders.kt
+++ b/rest/src/main/kotlin/builder/interaction/MessageCommandBuilders.kt
@@ -2,6 +2,7 @@ package dev.kord.rest.builder.interaction
 
 import dev.kord.common.annotation.KordDsl
 import dev.kord.common.entity.ApplicationCommandType
+import dev.kord.common.entity.Permissions
 import dev.kord.common.entity.optional.delegate.delegate
 import dev.kord.rest.json.request.ApplicationCommandCreateRequest
 import dev.kord.rest.json.request.ApplicationCommandModifyRequest
@@ -14,11 +15,13 @@ public class MessageCommandModifyBuilder : ApplicationCommandModifyBuilder {
 
     override var name: String? by state::name.delegate()
 
+    override var defaultMemberPermissions: Permissions? by state::defaultMemberPermissions.delegate()
     override var defaultPermission: Boolean? by state::defaultPermission.delegate()
 
     override fun toRequest(): ApplicationCommandModifyRequest {
         return ApplicationCommandModifyRequest(
             name = state.name,
+            defaultMemberPermissions = state.defaultMemberPermissions,
             defaultPermission = state.defaultPermission
         )
 
@@ -34,12 +37,14 @@ public class MessageCommandCreateBuilder(override var name: String) : Applicatio
 
     private val state = ApplicationCommandModifyStateHolder()
 
+    override var defaultMemberPermissions: Permissions? by state::defaultMemberPermissions.delegate()
     override var defaultPermission: Boolean? by state::defaultPermission.delegate()
 
     override fun toRequest(): ApplicationCommandCreateRequest {
         return ApplicationCommandCreateRequest(
             name = name,
             type = type,
+            defaultMemberPermissions = state.defaultMemberPermissions,
             defaultPermission = state.defaultPermission
         )
     }

--- a/rest/src/main/kotlin/builder/interaction/MessageCommandBuilders.kt
+++ b/rest/src/main/kotlin/builder/interaction/MessageCommandBuilders.kt
@@ -18,6 +18,8 @@ public class MessageCommandModifyBuilder : ApplicationCommandModifyBuilder {
     override var nameLocalizations: MutableMap<Locale, String>? by state::nameLocalizations.delegate()
 
     override var defaultMemberPermissions: Permissions? by state::defaultMemberPermissions.delegate()
+
+    @Deprecated("'defaultPermission' is deprecated in favor of 'defaultMemberPermissions' and 'dmPermission'. Setting 'defaultPermission' to false can be replaced by setting 'defaultMemberPermissions' to empty Permissions and 'dmPermission' to false ('dmPermission' is only available for global commands).")
     override var defaultPermission: Boolean? by state::defaultPermission.delegate()
 
     override fun toRequest(): ApplicationCommandModifyRequest {
@@ -43,6 +45,8 @@ public class MessageCommandCreateBuilder(override var name: String) : Applicatio
     override var nameLocalizations: MutableMap<Locale, String>? by state::nameLocalizations.delegate()
 
     override var defaultMemberPermissions: Permissions? by state::defaultMemberPermissions.delegate()
+
+    @Deprecated("'defaultPermission' is deprecated in favor of 'defaultMemberPermissions' and 'dmPermission'. Setting 'defaultPermission' to false can be replaced by setting 'defaultMemberPermissions' to empty Permissions and 'dmPermission' to false ('dmPermission' is only available for global commands).")
     override var defaultPermission: Boolean? by state::defaultPermission.delegate()
 
     override fun toRequest(): ApplicationCommandCreateRequest {

--- a/rest/src/main/kotlin/builder/interaction/MessageCommandBuilders.kt
+++ b/rest/src/main/kotlin/builder/interaction/MessageCommandBuilders.kt
@@ -10,7 +10,13 @@ import dev.kord.rest.json.request.ApplicationCommandModifyRequest
 
 
 @KordDsl
-public class MessageCommandModifyBuilder : ApplicationCommandModifyBuilder {
+public interface MessageCommandModifyBuilder : ApplicationCommandModifyBuilder
+
+@KordDsl
+public interface GlobalMessageCommandModifyBuilder : MessageCommandModifyBuilder, GlobalApplicationCommandModifyBuilder
+
+@PublishedApi
+internal class MessageCommandModifyBuilderImpl : GlobalMessageCommandModifyBuilder {
 
     private val state = ApplicationCommandModifyStateHolder()
 
@@ -18,6 +24,7 @@ public class MessageCommandModifyBuilder : ApplicationCommandModifyBuilder {
     override var nameLocalizations: MutableMap<Locale, String>? by state::nameLocalizations.delegate()
 
     override var defaultMemberPermissions: Permissions? by state::defaultMemberPermissions.delegate()
+    override var dmPermission: Boolean? by state::dmPermission.delegate()
 
     @Deprecated("'defaultPermission' is deprecated in favor of 'defaultMemberPermissions' and 'dmPermission'. Setting 'defaultPermission' to false can be replaced by setting 'defaultMemberPermissions' to empty Permissions and 'dmPermission' to false ('dmPermission' is only available for global commands).")
     override var defaultPermission: Boolean? by state::defaultPermission.delegate()
@@ -26,6 +33,7 @@ public class MessageCommandModifyBuilder : ApplicationCommandModifyBuilder {
         return ApplicationCommandModifyRequest(
             name = state.name,
             nameLocalizations = state.nameLocalizations,
+            dmPermission = state.dmPermission,
             defaultMemberPermissions = state.defaultMemberPermissions,
             defaultPermission = state.defaultPermission
         )
@@ -35,7 +43,13 @@ public class MessageCommandModifyBuilder : ApplicationCommandModifyBuilder {
 }
 
 @KordDsl
-public class MessageCommandCreateBuilder(override var name: String) : ApplicationCommandCreateBuilder {
+public interface MessageCommandCreateBuilder : ApplicationCommandCreateBuilder
+
+@KordDsl
+public interface GlobalMessageCommandCreateBuilder : MessageCommandCreateBuilder, GlobalApplicationCommandCreateBuilder
+
+@PublishedApi
+internal class MessageCommandCreateBuilderImpl(override var name: String) : GlobalMessageCommandCreateBuilder {
     override val type: ApplicationCommandType
         get() = ApplicationCommandType.Message
 
@@ -45,6 +59,7 @@ public class MessageCommandCreateBuilder(override var name: String) : Applicatio
     override var nameLocalizations: MutableMap<Locale, String>? by state::nameLocalizations.delegate()
 
     override var defaultMemberPermissions: Permissions? by state::defaultMemberPermissions.delegate()
+    override var dmPermission: Boolean? by state::dmPermission.delegate()
 
     @Deprecated("'defaultPermission' is deprecated in favor of 'defaultMemberPermissions' and 'dmPermission'. Setting 'defaultPermission' to false can be replaced by setting 'defaultMemberPermissions' to empty Permissions and 'dmPermission' to false ('dmPermission' is only available for global commands).")
     override var defaultPermission: Boolean? by state::defaultPermission.delegate()
@@ -54,6 +69,7 @@ public class MessageCommandCreateBuilder(override var name: String) : Applicatio
             name = name,
             nameLocalizations = state.nameLocalizations,
             type = type,
+            dmPermission = state.dmPermission,
             defaultMemberPermissions = state.defaultMemberPermissions,
             defaultPermission = state.defaultPermission
         )

--- a/rest/src/main/kotlin/builder/interaction/MultiApplicationCommandBuilder.kt
+++ b/rest/src/main/kotlin/builder/interaction/MultiApplicationCommandBuilder.kt
@@ -9,16 +9,6 @@ import kotlin.contracts.contract
 public sealed class MultiApplicationCommandBuilder {
     public val commands: MutableList<ApplicationCommandCreateBuilder> = mutableListOf()
 
-    public inline fun message(name: String, builder: MessageCommandCreateBuilder.() -> Unit = {}) {
-        contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
-        commands += MessageCommandCreateBuilder(name).apply(builder)
-    }
-
-    public inline fun user(name: String, builder: UserCommandCreateBuilder.() -> Unit = {}) {
-        contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
-        commands += UserCommandCreateBuilder(name).apply(builder)
-    }
-
     public fun build(): List<ApplicationCommandCreateRequest> {
         return commands.map { it.toRequest() }
     }
@@ -29,11 +19,33 @@ public class GlobalMultiApplicationCommandBuilder : MultiApplicationCommandBuild
         contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
         commands += ChatInputCreateBuilderImpl(name, description).apply(builder)
     }
+
+    public inline fun message(name: String, builder: GlobalMessageCommandCreateBuilder.() -> Unit = {}) {
+        contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
+        commands += MessageCommandCreateBuilderImpl(name).apply(builder)
+    }
+
+
+    public inline fun user(name: String, builder: GlobalUserCommandCreateBuilder.() -> Unit = {}) {
+        contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
+        commands += UserCommandCreateBuilderImpl(name).apply(builder)
+    }
 }
 
 public class GuildMultiApplicationCommandBuilder : MultiApplicationCommandBuilder() {
     public inline fun input(name: String, description: String, builder: ChatInputCreateBuilder.() -> Unit = {}) {
         contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
         commands += ChatInputCreateBuilderImpl(name, description).apply(builder)
+    }
+
+    public inline fun message(name: String, builder: MessageCommandCreateBuilder.() -> Unit = {}) {
+        contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
+        commands += MessageCommandCreateBuilderImpl(name).apply(builder)
+    }
+
+
+    public inline fun user(name: String, builder: UserCommandCreateBuilder.() -> Unit = {}) {
+        contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
+        commands += UserCommandCreateBuilderImpl(name).apply(builder)
     }
 }

--- a/rest/src/main/kotlin/builder/interaction/MultiApplicationCommandBuilder.kt
+++ b/rest/src/main/kotlin/builder/interaction/MultiApplicationCommandBuilder.kt
@@ -13,7 +13,30 @@ public sealed class MultiApplicationCommandBuilder {
         return commands.map { it.toRequest() }
     }
 }
+public inline fun MultiApplicationCommandBuilder.input(
+    name: String,
+    description: String,
+    builder: ChatInputCreateBuilder.() -> Unit = {},
+) {
+    contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
+    commands += ChatInputCreateBuilderImpl(name, description).apply(builder)
+}
 
+public inline fun MultiApplicationCommandBuilder.message(
+    name: String,
+    builder: MessageCommandCreateBuilder.() -> Unit = {},
+) {
+    contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
+    commands += MessageCommandCreateBuilderImpl(name).apply(builder)
+}
+
+
+public inline fun MultiApplicationCommandBuilder.user(name: String, builder: UserCommandCreateBuilder.() -> Unit = {}) {
+    contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
+    commands += UserCommandCreateBuilderImpl(name).apply(builder)
+}
+
+@KordDsl
 public class GlobalMultiApplicationCommandBuilder : MultiApplicationCommandBuilder() {
     public inline fun input(name: String, description: String, builder: GlobalChatInputCreateBuilder.() -> Unit = {}) {
         contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
@@ -32,6 +55,7 @@ public class GlobalMultiApplicationCommandBuilder : MultiApplicationCommandBuild
     }
 }
 
+@KordDsl
 public class GuildMultiApplicationCommandBuilder : MultiApplicationCommandBuilder() {
     public inline fun input(name: String, description: String, builder: ChatInputCreateBuilder.() -> Unit = {}) {
         contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }

--- a/rest/src/main/kotlin/builder/interaction/MultiApplicationCommandBuilder.kt
+++ b/rest/src/main/kotlin/builder/interaction/MultiApplicationCommandBuilder.kt
@@ -6,7 +6,7 @@ import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
 @KordDsl
-public class MultiApplicationCommandBuilder {
+public sealed class MultiApplicationCommandBuilder {
     public val commands: MutableList<ApplicationCommandCreateBuilder> = mutableListOf()
 
     public inline fun message(name: String, builder: MessageCommandCreateBuilder.() -> Unit = {}) {
@@ -19,12 +19,21 @@ public class MultiApplicationCommandBuilder {
         commands += UserCommandCreateBuilder(name).apply(builder)
     }
 
-    public inline fun input(name: String, description: String, builder: ChatInputCreateBuilder.() -> Unit = {}) {
-        contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
-        commands += ChatInputCreateBuilder(name, description).apply(builder)
-    }
-
     public fun build(): List<ApplicationCommandCreateRequest> {
         return commands.map { it.toRequest() }
+    }
+}
+
+public class GlobalMultiApplicationCommandBuilder : MultiApplicationCommandBuilder() {
+    public inline fun input(name: String, description: String, builder: GlobalChatInputCreateBuilder.() -> Unit = {}) {
+        contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
+        commands += ChatInputCreateBuilderImpl(name, description).apply(builder)
+    }
+}
+
+public class GuildMultiApplicationCommandBuilder : MultiApplicationCommandBuilder() {
+    public inline fun input(name: String, description: String, builder: ChatInputCreateBuilder.() -> Unit = {}) {
+        contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
+        commands += ChatInputCreateBuilderImpl(name, description).apply(builder)
     }
 }

--- a/rest/src/main/kotlin/builder/interaction/UserCommandBuilders.kt
+++ b/rest/src/main/kotlin/builder/interaction/UserCommandBuilders.kt
@@ -2,6 +2,7 @@ package dev.kord.rest.builder.interaction
 
 import dev.kord.common.annotation.KordDsl
 import dev.kord.common.entity.ApplicationCommandType
+import dev.kord.common.entity.Permissions
 import dev.kord.common.entity.optional.delegate.delegate
 import dev.kord.rest.json.request.ApplicationCommandCreateRequest
 import dev.kord.rest.json.request.ApplicationCommandModifyRequest
@@ -13,11 +14,13 @@ public class UserCommandModifyBuilder : ApplicationCommandModifyBuilder {
 
     override var name: String? by state::name.delegate()
 
+    override var defaultMemberPermissions: Permissions? by state::defaultMemberPermissions.delegate()
     override var defaultPermission: Boolean? by state::defaultPermission.delegate()
 
     override fun toRequest(): ApplicationCommandModifyRequest {
         return ApplicationCommandModifyRequest(
             name = state.name,
+            defaultMemberPermissions = state.defaultMemberPermissions,
             defaultPermission = state.defaultPermission
         )
     }
@@ -31,12 +34,15 @@ public class UserCommandCreateBuilder(override var name: String) : ApplicationCo
 
     private val state = ApplicationCommandModifyStateHolder()
 
+    override var defaultMemberPermissions: Permissions? by state::defaultMemberPermissions.delegate()
     override var defaultPermission: Boolean? by state::defaultPermission.delegate()
 
     override fun toRequest(): ApplicationCommandCreateRequest {
         return ApplicationCommandCreateRequest(
             name = name,
             type = type,
+            defaultMemberPermissions = state.defaultMemberPermissions,
+            dmPermission = state.dmPermission,
             defaultPermission = state.defaultPermission
         )
     }

--- a/rest/src/main/kotlin/builder/interaction/UserCommandBuilders.kt
+++ b/rest/src/main/kotlin/builder/interaction/UserCommandBuilders.kt
@@ -42,6 +42,7 @@ internal class UserCommandModifyBuilderImpl : GlobalUserCommandModifyBuilder {
 @KordDsl
 public interface UserCommandCreateBuilder : ApplicationCommandCreateBuilder
 
+@KordDsl
 public interface GlobalUserCommandCreateBuilder : UserCommandCreateBuilder, GlobalApplicationCommandCreateBuilder
 
 @PublishedApi

--- a/rest/src/main/kotlin/builder/interaction/UserCommandBuilders.kt
+++ b/rest/src/main/kotlin/builder/interaction/UserCommandBuilders.kt
@@ -9,7 +9,13 @@ import dev.kord.rest.json.request.ApplicationCommandCreateRequest
 import dev.kord.rest.json.request.ApplicationCommandModifyRequest
 
 @KordDsl
-public class UserCommandModifyBuilder : ApplicationCommandModifyBuilder {
+public interface UserCommandModifyBuilder : ApplicationCommandModifyBuilder
+
+@KordDsl
+public interface GlobalUserCommandModifyBuilder : UserCommandModifyBuilder, GlobalApplicationCommandModifyBuilder
+
+@PublishedApi
+internal class UserCommandModifyBuilderImpl : GlobalUserCommandModifyBuilder {
 
     private val state = ApplicationCommandModifyStateHolder()
 
@@ -17,6 +23,7 @@ public class UserCommandModifyBuilder : ApplicationCommandModifyBuilder {
     override var nameLocalizations: MutableMap<Locale, String>? by state::nameLocalizations.delegate()
 
     override var defaultMemberPermissions: Permissions? by state::defaultMemberPermissions.delegate()
+    override var dmPermission: Boolean? by state::dmPermission.delegate()
 
     @Deprecated("'defaultPermission' is deprecated in favor of 'defaultMemberPermissions' and 'dmPermission'. Setting 'defaultPermission' to false can be replaced by setting 'defaultMemberPermissions' to empty Permissions and 'dmPermission' to false ('dmPermission' is only available for global commands).")
     override var defaultPermission: Boolean? by state::defaultPermission.delegate()
@@ -25,6 +32,7 @@ public class UserCommandModifyBuilder : ApplicationCommandModifyBuilder {
         return ApplicationCommandModifyRequest(
             name = state.name,
             nameLocalizations = state.nameLocalizations,
+            dmPermission = state.dmPermission,
             defaultMemberPermissions = state.defaultMemberPermissions,
             defaultPermission = state.defaultPermission
         )
@@ -32,7 +40,12 @@ public class UserCommandModifyBuilder : ApplicationCommandModifyBuilder {
 }
 
 @KordDsl
-public class UserCommandCreateBuilder(override var name: String) : ApplicationCommandCreateBuilder {
+public interface UserCommandCreateBuilder : ApplicationCommandCreateBuilder
+
+public interface GlobalUserCommandCreateBuilder : UserCommandCreateBuilder, GlobalApplicationCommandCreateBuilder
+
+@PublishedApi
+internal class UserCommandCreateBuilderImpl(override var name: String) : GlobalUserCommandCreateBuilder {
     override val type: ApplicationCommandType
         get() = ApplicationCommandType.User
     private val state = ApplicationCommandModifyStateHolder()
@@ -40,6 +53,7 @@ public class UserCommandCreateBuilder(override var name: String) : ApplicationCo
     override var nameLocalizations: MutableMap<Locale, String>? by state::nameLocalizations.delegate()
 
     override var defaultMemberPermissions: Permissions? by state::defaultMemberPermissions.delegate()
+    override var dmPermission: Boolean? by state::dmPermission.delegate()
 
     @Deprecated("'defaultPermission' is deprecated in favor of 'defaultMemberPermissions' and 'dmPermission'. Setting 'defaultPermission' to false can be replaced by setting 'defaultMemberPermissions' to empty Permissions and 'dmPermission' to false ('dmPermission' is only available for global commands).")
     override var defaultPermission: Boolean? by state::defaultPermission.delegate()

--- a/rest/src/main/kotlin/builder/interaction/UserCommandBuilders.kt
+++ b/rest/src/main/kotlin/builder/interaction/UserCommandBuilders.kt
@@ -17,6 +17,8 @@ public class UserCommandModifyBuilder : ApplicationCommandModifyBuilder {
     override var nameLocalizations: MutableMap<Locale, String>? by state::nameLocalizations.delegate()
 
     override var defaultMemberPermissions: Permissions? by state::defaultMemberPermissions.delegate()
+
+    @Deprecated("'defaultPermission' is deprecated in favor of 'defaultMemberPermissions' and 'dmPermission'. Setting 'defaultPermission' to false can be replaced by setting 'defaultMemberPermissions' to empty Permissions and 'dmPermission' to false ('dmPermission' is only available for global commands).")
     override var defaultPermission: Boolean? by state::defaultPermission.delegate()
 
     override fun toRequest(): ApplicationCommandModifyRequest {
@@ -38,6 +40,8 @@ public class UserCommandCreateBuilder(override var name: String) : ApplicationCo
     override var nameLocalizations: MutableMap<Locale, String>? by state::nameLocalizations.delegate()
 
     override var defaultMemberPermissions: Permissions? by state::defaultMemberPermissions.delegate()
+
+    @Deprecated("'defaultPermission' is deprecated in favor of 'defaultMemberPermissions' and 'dmPermission'. Setting 'defaultPermission' to false can be replaced by setting 'defaultMemberPermissions' to empty Permissions and 'dmPermission' to false ('dmPermission' is only available for global commands).")
     override var defaultPermission: Boolean? by state::defaultPermission.delegate()
 
     override fun toRequest(): ApplicationCommandCreateRequest {

--- a/rest/src/main/kotlin/json/request/InteractionsRequests.kt
+++ b/rest/src/main/kotlin/json/request/InteractionsRequests.kt
@@ -128,8 +128,3 @@ public data class MultipartFollowupMessageModifyRequest(
     val request: FollowupMessageModifyRequest,
     val files: Optional<List<NamedFile>> = Optional.Missing()
 )
-
-@Serializable
-public data class ApplicationCommandPermissionsEditRequest(
-    val permissions: List<DiscordGuildApplicationCommandPermission>
-)

--- a/rest/src/main/kotlin/json/request/InteractionsRequests.kt
+++ b/rest/src/main/kotlin/json/request/InteractionsRequests.kt
@@ -13,6 +13,10 @@ public data class ApplicationCommandCreateRequest(
     val type: ApplicationCommandType,
     val description: Optional<String> = Optional.Missing(),
     val options: Optional<List<ApplicationCommandOption>> = Optional.Missing(),
+    @SerialName("default_member_permissions")
+    public var defaultMemberPermissions: Optional<Permissions?> = Optional.Missing(),
+    @SerialName("dm_permission")
+    public var dmPermission: OptionalBoolean? = OptionalBoolean.Missing,
     @SerialName("default_permission")
     val defaultPermission: OptionalBoolean = OptionalBoolean.Missing
 )
@@ -22,6 +26,10 @@ public data class ApplicationCommandModifyRequest(
     val name: Optional<String> = Optional.Missing(),
     val description: Optional<String> = Optional.Missing(),
     val options: Optional<List<ApplicationCommandOption>> = Optional.Missing(),
+    @SerialName("default_member_permissions")
+    public var defaultMemberPermissions: Optional<Permissions?> = Optional.Missing(),
+    @SerialName("dm_permission")
+    public var dmPermission: OptionalBoolean? = OptionalBoolean.Missing,
     @SerialName("default_permission")
     val defaultPermission: OptionalBoolean = OptionalBoolean.Missing
 )

--- a/rest/src/main/kotlin/json/request/InteractionsRequests.kt
+++ b/rest/src/main/kotlin/json/request/InteractionsRequests.kt
@@ -22,6 +22,7 @@ public data class ApplicationCommandCreateRequest(
     public var defaultMemberPermissions: Optional<Permissions?> = Optional.Missing(),
     @SerialName("dm_permission")
     public var dmPermission: OptionalBoolean? = OptionalBoolean.Missing,
+    @Deprecated("'defaultPermission' is deprecated in favor of 'defaultMemberPermissions' and 'dmPermission'. Setting 'defaultPermission' to false can be replaced by setting 'defaultMemberPermissions' to empty Permissions and 'dmPermission' to false ('dmPermission' is only available for global commands).")
     @SerialName("default_permission")
     val defaultPermission: OptionalBoolean = OptionalBoolean.Missing
 )
@@ -39,6 +40,7 @@ public data class ApplicationCommandModifyRequest(
     public var defaultMemberPermissions: Optional<Permissions?> = Optional.Missing(),
     @SerialName("dm_permission")
     public var dmPermission: OptionalBoolean? = OptionalBoolean.Missing,
+    @Deprecated("'defaultPermission' is deprecated in favor of 'defaultMemberPermissions' and 'dmPermission'. Setting 'defaultPermission' to false can be replaced by setting 'defaultMemberPermissions' to empty Permissions and 'dmPermission' to false ('dmPermission' is only available for global commands).")
     @SerialName("default_permission")
     val defaultPermission: OptionalBoolean = OptionalBoolean.Missing
 )

--- a/rest/src/main/kotlin/json/request/InteractionsRequests.kt
+++ b/rest/src/main/kotlin/json/request/InteractionsRequests.kt
@@ -19,9 +19,9 @@ public data class ApplicationCommandCreateRequest(
     val descriptionLocalizations: Optional<Map<Locale, String>?> = Optional.Missing(),
     val options: Optional<List<ApplicationCommandOption>> = Optional.Missing(),
     @SerialName("default_member_permissions")
-    public var defaultMemberPermissions: Optional<Permissions?> = Optional.Missing(),
+    public val defaultMemberPermissions: Optional<Permissions?> = Optional.Missing(),
     @SerialName("dm_permission")
-    public var dmPermission: OptionalBoolean? = OptionalBoolean.Missing,
+    public val dmPermission: OptionalBoolean? = OptionalBoolean.Missing,
     @Deprecated("'defaultPermission' is deprecated in favor of 'defaultMemberPermissions' and 'dmPermission'. Setting 'defaultPermission' to false can be replaced by setting 'defaultMemberPermissions' to empty Permissions and 'dmPermission' to false ('dmPermission' is only available for global commands).")
     @SerialName("default_permission")
     val defaultPermission: OptionalBoolean = OptionalBoolean.Missing
@@ -37,9 +37,9 @@ public data class ApplicationCommandModifyRequest(
     val descriptionLocalizations: Optional<Map<Locale, String>?> = Optional.Missing(),
     val options: Optional<List<ApplicationCommandOption>> = Optional.Missing(),
     @SerialName("default_member_permissions")
-    public var defaultMemberPermissions: Optional<Permissions?> = Optional.Missing(),
+    public val defaultMemberPermissions: Optional<Permissions?> = Optional.Missing(),
     @SerialName("dm_permission")
-    public var dmPermission: OptionalBoolean? = OptionalBoolean.Missing,
+    public val dmPermission: OptionalBoolean? = OptionalBoolean.Missing,
     @Deprecated("'defaultPermission' is deprecated in favor of 'defaultMemberPermissions' and 'dmPermission'. Setting 'defaultPermission' to false can be replaced by setting 'defaultMemberPermissions' to empty Permissions and 'dmPermission' to false ('dmPermission' is only available for global commands).")
     @SerialName("default_permission")
     val defaultPermission: OptionalBoolean = OptionalBoolean.Missing

--- a/rest/src/main/kotlin/route/Route.kt
+++ b/rest/src/main/kotlin/route/Route.kt
@@ -806,22 +806,6 @@ public sealed class Route<T>(
             DiscordGuildApplicationCommandPermissions.serializer()
         )
 
-    public object ApplicationCommandPermissionsPut :
-        Route<DiscordGuildApplicationCommandPermissions>(
-            HttpMethod.Put,
-            "/applications/$ApplicationId/guilds/$GuildId/commands/$CommandId/permissions",
-            DiscordGuildApplicationCommandPermissions.serializer(),
-            false
-        )
-
-    public object ApplicationCommandPermissionsBatchPut :
-        Route<List<DiscordGuildApplicationCommandPermissions>>(
-            HttpMethod.Put,
-            "/applications/$ApplicationId/guilds/$GuildId/commands/permissions",
-            ListSerializer(DiscordGuildApplicationCommandPermissions.serializer())
-        )
-
-
     /*
      * Guild Scheduled Event:
      * https://discord.com/developers/docs/resources/guild-scheduled-event

--- a/rest/src/main/kotlin/route/Route.kt
+++ b/rest/src/main/kotlin/route/Route.kt
@@ -810,7 +810,8 @@ public sealed class Route<T>(
         Route<DiscordGuildApplicationCommandPermissions>(
             HttpMethod.Put,
             "/applications/$ApplicationId/guilds/$GuildId/commands/$CommandId/permissions",
-            DiscordGuildApplicationCommandPermissions.serializer()
+            DiscordGuildApplicationCommandPermissions.serializer(),
+            false
         )
 
     public object ApplicationCommandPermissionsBatchPut :

--- a/rest/src/main/kotlin/service/InteractionService.kt
+++ b/rest/src/main/kotlin/service/InteractionService.kt
@@ -383,28 +383,28 @@ public class InteractionService(requestHandler: RequestHandler) : RestService(re
     public suspend inline fun createGlobalMessageCommandApplicationCommand(
         applicationId: Snowflake,
         name: String,
-        builder: MessageCommandCreateBuilder.() -> Unit = {}
+        builder: GlobalMessageCommandCreateBuilder.() -> Unit = {}
     ): DiscordApplicationCommand {
 
         contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
 
         return createGlobalApplicationCommand(
             applicationId,
-            MessageCommandCreateBuilder(name).apply(builder).toRequest()
+            MessageCommandCreateBuilderImpl(name).apply(builder).toRequest()
         )
     }
 
     public suspend inline fun createGlobalUserCommandApplicationCommand(
         applicationId: Snowflake,
         name: String,
-        builder: UserCommandCreateBuilder.() -> Unit = {}
+        builder: GlobalUserCommandCreateBuilder.() -> Unit = {}
     ): DiscordApplicationCommand {
 
         contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
 
         return createGlobalApplicationCommand(
             applicationId,
-            UserCommandCreateBuilder(name).apply(builder).toRequest()
+            UserCommandCreateBuilderImpl(name).apply(builder).toRequest()
         )
     }
 
@@ -438,27 +438,27 @@ public class InteractionService(requestHandler: RequestHandler) : RestService(re
     public suspend inline fun modifyGlobalMessageApplicationCommand(
         applicationId: Snowflake,
         commandId: Snowflake,
-        builder: MessageCommandModifyBuilder.() -> Unit
+        builder: GlobalMessageCommandModifyBuilder.() -> Unit
     ): DiscordApplicationCommand {
         contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
 
         return modifyGlobalApplicationCommand(
             applicationId,
             commandId,
-            MessageCommandModifyBuilder().apply(builder).toRequest()
+            MessageCommandModifyBuilderImpl().apply(builder).toRequest()
         )
     }
 
     public suspend inline fun modifyGlobalUserApplicationCommand(
         applicationId: Snowflake,
         commandId: Snowflake,
-        builder: UserCommandModifyBuilder.() -> Unit
+        builder: GlobalUserCommandModifyBuilder.() -> Unit
     ): DiscordApplicationCommand {
         contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
         return modifyGlobalApplicationCommand(
             applicationId,
             commandId,
-            UserCommandModifyBuilder().apply(builder).toRequest()
+            UserCommandModifyBuilderImpl().apply(builder).toRequest()
         )
     }
 
@@ -489,7 +489,7 @@ public class InteractionService(requestHandler: RequestHandler) : RestService(re
         return createGuildApplicationCommand(
             applicationId,
             guildId,
-            MessageCommandCreateBuilder(name).apply(builder).toRequest()
+            MessageCommandCreateBuilderImpl(name).apply(builder).toRequest()
         )
     }
 
@@ -505,7 +505,7 @@ public class InteractionService(requestHandler: RequestHandler) : RestService(re
         return createGuildApplicationCommand(
             applicationId,
             guildId,
-            UserCommandCreateBuilder(name).apply(builder).toRequest()
+            UserCommandCreateBuilderImpl(name).apply(builder).toRequest()
         )
     }
 
@@ -552,7 +552,7 @@ public class InteractionService(requestHandler: RequestHandler) : RestService(re
             applicationId,
             guildId,
             commandId,
-            MessageCommandModifyBuilder().apply(builder).toRequest()
+            MessageCommandModifyBuilderImpl().apply(builder).toRequest()
         )
     }
 
@@ -567,7 +567,7 @@ public class InteractionService(requestHandler: RequestHandler) : RestService(re
             applicationId,
             guildId,
             commandId,
-            UserCommandModifyBuilder().apply(builder).toRequest()
+            UserCommandModifyBuilderImpl().apply(builder).toRequest()
         )
     }
 

--- a/rest/src/main/kotlin/service/InteractionService.kt
+++ b/rest/src/main/kotlin/service/InteractionService.kt
@@ -371,7 +371,7 @@ public class InteractionService(requestHandler: RequestHandler) : RestService(re
         applicationId: Snowflake,
         name: String,
         description: String,
-        builder: ChatInputCreateBuilder.() -> Unit = {}
+        builder: GlobalChatInputCreateBuilder.() -> Unit = {}
     ): DiscordApplicationCommand {
         contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
         return createGlobalApplicationCommand(
@@ -424,7 +424,7 @@ public class InteractionService(requestHandler: RequestHandler) : RestService(re
     public suspend inline fun modifyGlobalChatInputApplicationCommand(
         applicationId: Snowflake,
         commandId: Snowflake,
-        builder: ChatInputModifyBuilder.() -> Unit
+        builder: GlobalChatInputModifyBuilder.() -> Unit
     ): DiscordApplicationCommand {
         contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
 

--- a/rest/src/main/kotlin/service/InteractionService.kt
+++ b/rest/src/main/kotlin/service/InteractionService.kt
@@ -1,6 +1,5 @@
 package dev.kord.rest.service
 
-import dev.kord.common.annotation.KordUnsafe
 import dev.kord.common.entity.*
 import dev.kord.common.entity.MessageFlag.Ephemeral
 import dev.kord.common.entity.optional.Optional
@@ -15,10 +14,10 @@ import dev.kord.rest.json.request.*
 import dev.kord.rest.request.RequestBuilder
 import dev.kord.rest.request.RequestHandler
 import dev.kord.rest.route.Route
-import io.ktor.http.*
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.serializer
+import kotlin.collections.set
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -343,30 +342,6 @@ public class InteractionService(requestHandler: RequestHandler) : RestService(re
         applicationIdGuildIdCommandId(applicationId, guildId, commandId)
     }
 
-    public suspend fun editApplicationCommandPermissions(
-        applicationId: Snowflake,
-        guildId: Snowflake,
-        commandId: Snowflake,
-        token: String,
-        request: ApplicationCommandPermissionsEditRequest
-    ): DiscordGuildApplicationCommandPermissions = call(Route.ApplicationCommandPermissionsPut) {
-        applicationIdGuildIdCommandId(applicationId, guildId, commandId)
-        urlEncodedHeader(HttpHeaders.Authorization, "Bearer $token")
-        body(ApplicationCommandPermissionsEditRequest.serializer(), request)
-    }
-
-    @KordUnsafe
-    public suspend fun bulkEditApplicationCommandPermissions(
-        applicationId: Snowflake,
-        guildId: Snowflake,
-        token: String,
-        request: List<PartialDiscordGuildApplicationCommandPermissions>,
-    ): List<DiscordGuildApplicationCommandPermissions> = call(Route.ApplicationCommandPermissionsBatchPut) {
-        applicationIdGuildId(applicationId, guildId)
-        urlEncodedHeader(HttpHeaders.Authorization, "Bearer $token")
-        body(ListSerializer(PartialDiscordGuildApplicationCommandPermissions.serializer()), request)
-    }
-
     public suspend inline fun createGlobalChatInputApplicationCommand(
         applicationId: Snowflake,
         name: String,
@@ -640,39 +615,6 @@ public class InteractionService(requestHandler: RequestHandler) : RestService(re
             interactionToken,
             messageId,
             FollowupMessageModifyBuilder().apply(builder).toRequest()
-        )
-    }
-
-    @KordUnsafe
-    public suspend inline fun bulkEditApplicationCommandPermissions(
-        applicationId: Snowflake,
-        guildId: Snowflake,
-        token: String,
-        builder: ApplicationCommandPermissionsBulkModifyBuilder.() -> Unit = {}
-    ): List<DiscordGuildApplicationCommandPermissions> {
-        contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
-        return bulkEditApplicationCommandPermissions(
-            applicationId,
-            guildId,
-            token,
-            ApplicationCommandPermissionsBulkModifyBuilder(guildId).apply(builder).toRequest()
-        )
-    }
-
-    public suspend inline fun editApplicationCommandPermissions(
-        applicationId: Snowflake,
-        guildId: Snowflake,
-        commandId: Snowflake,
-        token: String,
-        builder: ApplicationCommandPermissionsModifyBuilder.() -> Unit
-    ): DiscordGuildApplicationCommandPermissions {
-        contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
-        return editApplicationCommandPermissions(
-            applicationId,
-            guildId,
-            commandId,
-            token,
-            ApplicationCommandPermissionsModifyBuilder(guildId).apply(builder).toRequest()
         )
     }
 


### PR DESCRIPTION
Update to slash command permissions v2 - Deprecate defaultPermission in builders - Add new types - Add new events - Add builders for @everyone and all channels - Mark bulk update endpoints as @KordUnsafe (as it is currently disabled)

Superseeds #483
