### PR TITLE
Deserialize timestamps as `Instant`

### DIFF
--- a/common/src/main/kotlin/entity/Data.kt
+++ b/common/src/main/kotlin/entity/Data.kt
@@ -14,12 +14,7 @@ public data class DiscordPinsUpdateData(
     @SerialName("channel_id")
     val channelId: Snowflake,
     @SerialName("last_pin_timestamp")
-    /*
-    Do not trust the docs:
-    2020-11-06 Docs mention this being optional only, but unpinning a channel results
-    in this field being null.
-    */
-    val lastPinTimestamp: Optional<String?> = Optional.Missing()
+    val lastPinTimestamp: Optional<Instant?> = Optional.Missing(),
 )
 
 @Serializable

--- a/common/src/main/kotlin/entity/Data.kt
+++ b/common/src/main/kotlin/entity/Data.kt
@@ -2,6 +2,8 @@ package dev.kord.common.entity
 
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalSnowflake
+import dev.kord.common.serialization.InstantInEpochSecondsSerializer
+import kotlinx.datetime.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -28,6 +30,7 @@ public data class DiscordTyping(
     val guildId: OptionalSnowflake = OptionalSnowflake.Missing,
     @SerialName("user_id")
     val userId: Snowflake,
-    val timestamp: Long,
+    @Serializable(with = InstantInEpochSecondsSerializer::class)
+    val timestamp: Instant,
     val member: Optional<DiscordGuildMember> = Optional.Missing()
 )

--- a/common/src/main/kotlin/entity/Data.kt
+++ b/common/src/main/kotlin/entity/Data.kt
@@ -2,7 +2,7 @@ package dev.kord.common.entity
 
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalSnowflake
-import dev.kord.common.serialization.InstantInEpochSeconds
+import dev.kord.common.serialization.InstantInEpochSecondsSerializer
 import kotlinx.datetime.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -25,6 +25,7 @@ public data class DiscordTyping(
     val guildId: OptionalSnowflake = OptionalSnowflake.Missing,
     @SerialName("user_id")
     val userId: Snowflake,
-    val timestamp: InstantInEpochSeconds,
+    @Serializable(with = InstantInEpochSecondsSerializer::class)
+    val timestamp: Instant,
     val member: Optional<DiscordGuildMember> = Optional.Missing()
 )

--- a/common/src/main/kotlin/entity/Data.kt
+++ b/common/src/main/kotlin/entity/Data.kt
@@ -2,7 +2,7 @@ package dev.kord.common.entity
 
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalSnowflake
-import dev.kord.common.serialization.InstantInEpochSecondsSerializer
+import dev.kord.common.serialization.InstantInEpochSeconds
 import kotlinx.datetime.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -25,7 +25,6 @@ public data class DiscordTyping(
     val guildId: OptionalSnowflake = OptionalSnowflake.Missing,
     @SerialName("user_id")
     val userId: Snowflake,
-    @Serializable(with = InstantInEpochSecondsSerializer::class)
-    val timestamp: Instant,
+    val timestamp: InstantInEpochSeconds,
     val member: Optional<DiscordGuildMember> = Optional.Missing()
 )

--- a/common/src/main/kotlin/entity/DiscordActivity.kt
+++ b/common/src/main/kotlin/entity/DiscordActivity.kt
@@ -2,14 +2,16 @@ package dev.kord.common.entity
 
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
-import dev.kord.common.entity.optional.OptionalLong
 import dev.kord.common.entity.optional.OptionalSnowflake
+import dev.kord.common.serialization.InstantInEpochMillisecondsSerializer
+import kotlinx.datetime.Instant
 import kotlinx.serialization.*
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
+import dev.kord.common.serialization.InstantInEpochMillisecondsSerializer as InEpochMilliseconds
 
 @Serializable
 public data class DiscordBotActivity(
@@ -24,7 +26,8 @@ public data class DiscordActivity(
     val type: ActivityType,
     val url: Optional<String?> = Optional.Missing(),
     @SerialName("created_at")
-    val createdAt: Long,
+    @Serializable(with = InstantInEpochMillisecondsSerializer::class)
+    val createdAt: Instant,
     val timestamps: Optional<DiscordActivityTimestamps> = Optional.Missing(),
     @SerialName("application_id")
     val applicationId: OptionalSnowflake = OptionalSnowflake.Missing,
@@ -77,8 +80,8 @@ public typealias DiscordActivityTimeStamps = DiscordActivityTimestamps
 
 @Serializable
 public data class DiscordActivityTimestamps(
-    val start: OptionalLong = OptionalLong.Missing,
-    val end: OptionalLong = OptionalLong.Missing
+    val start: Optional<@Serializable(InEpochMilliseconds::class) Instant> = Optional.Missing(),
+    val end: Optional<@Serializable(InEpochMilliseconds::class) Instant> = Optional.Missing(),
 )
 
 @Serializable

--- a/common/src/main/kotlin/entity/DiscordActivity.kt
+++ b/common/src/main/kotlin/entity/DiscordActivity.kt
@@ -3,15 +3,13 @@ package dev.kord.common.entity
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
 import dev.kord.common.entity.optional.OptionalSnowflake
-import dev.kord.common.serialization.InstantInEpochMillisecondsSerializer
-import kotlinx.datetime.Instant
+import dev.kord.common.serialization.InstantInEpochMilliseconds
 import kotlinx.serialization.*
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
-import dev.kord.common.serialization.InstantInEpochMillisecondsSerializer as InEpochMilliseconds
 
 @Serializable
 public data class DiscordBotActivity(
@@ -26,8 +24,7 @@ public data class DiscordActivity(
     val type: ActivityType,
     val url: Optional<String?> = Optional.Missing(),
     @SerialName("created_at")
-    @Serializable(with = InstantInEpochMillisecondsSerializer::class)
-    val createdAt: Instant,
+    val createdAt: InstantInEpochMilliseconds,
     val timestamps: Optional<DiscordActivityTimestamps> = Optional.Missing(),
     @SerialName("application_id")
     val applicationId: OptionalSnowflake = OptionalSnowflake.Missing,
@@ -80,8 +77,8 @@ public typealias DiscordActivityTimeStamps = DiscordActivityTimestamps
 
 @Serializable
 public data class DiscordActivityTimestamps(
-    val start: Optional<@Serializable(InEpochMilliseconds::class) Instant> = Optional.Missing(),
-    val end: Optional<@Serializable(InEpochMilliseconds::class) Instant> = Optional.Missing(),
+    val start: Optional<InstantInEpochMilliseconds> = Optional.Missing(),
+    val end: Optional<InstantInEpochMilliseconds> = Optional.Missing(),
 )
 
 @Serializable

--- a/common/src/main/kotlin/entity/DiscordActivity.kt
+++ b/common/src/main/kotlin/entity/DiscordActivity.kt
@@ -3,7 +3,8 @@ package dev.kord.common.entity
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
 import dev.kord.common.entity.optional.OptionalSnowflake
-import dev.kord.common.serialization.InstantInEpochMilliseconds
+import dev.kord.common.serialization.InstantInEpochMillisecondsSerializer
+import kotlinx.datetime.Instant
 import kotlinx.serialization.*
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.serializer
@@ -24,7 +25,8 @@ public data class DiscordActivity(
     val type: ActivityType,
     val url: Optional<String?> = Optional.Missing(),
     @SerialName("created_at")
-    val createdAt: InstantInEpochMilliseconds,
+    @Serializable(with = InstantInEpochMillisecondsSerializer::class)
+    val createdAt: Instant,
     val timestamps: Optional<DiscordActivityTimestamps> = Optional.Missing(),
     @SerialName("application_id")
     val applicationId: OptionalSnowflake = OptionalSnowflake.Missing,
@@ -77,8 +79,8 @@ public typealias DiscordActivityTimeStamps = DiscordActivityTimestamps
 
 @Serializable
 public data class DiscordActivityTimestamps(
-    val start: Optional<InstantInEpochMilliseconds> = Optional.Missing(),
-    val end: Optional<InstantInEpochMilliseconds> = Optional.Missing(),
+    val start: Optional<@Serializable(with = InstantInEpochMillisecondsSerializer::class) Instant> = Optional.Missing(),
+    val end: Optional<@Serializable(with = InstantInEpochMillisecondsSerializer::class) Instant> = Optional.Missing(),
 )
 
 @Serializable

--- a/common/src/main/kotlin/entity/DiscordChannel.kt
+++ b/common/src/main/kotlin/entity/DiscordChannel.kt
@@ -71,7 +71,7 @@ public data class DiscordChannel(
     @SerialName("parent_id")
     val parentId: OptionalSnowflake? = OptionalSnowflake.Missing,
     @SerialName("last_pin_timestamp")
-    val lastPinTimestamp: Optional<String?> = Optional.Missing(),
+    val lastPinTimestamp: Optional<Instant?> = Optional.Missing(),
     @SerialName("rtc_region")
     val rtcRegion: Optional<String?> = Optional.Missing(),
     val permissions: Optional<Permissions> = Optional.Missing(),

--- a/common/src/main/kotlin/entity/DiscordChannel.kt
+++ b/common/src/main/kotlin/entity/DiscordChannel.kt
@@ -213,7 +213,7 @@ public sealed class OverwriteType(public val value: Int) {
 public data class DiscordThreadMetadata(
     val archived: Boolean,
     @SerialName("archive_timestamp")
-    val archiveTimestamp: String,
+    val archiveTimestamp: Instant,
     @SerialName("auto_archive_duration")
     val autoArchiveDuration: ArchiveDuration,
     val locked: OptionalBoolean = OptionalBoolean.Missing,

--- a/common/src/main/kotlin/entity/DiscordGuild.kt
+++ b/common/src/main/kotlin/entity/DiscordGuild.kt
@@ -108,7 +108,7 @@ public data class DiscordGuild(
     @SerialName("system_channel_id") val systemChannelId: Snowflake?,
     @SerialName("system_channel_flags") val systemChannelFlags: SystemChannelFlags,
     @SerialName("rules_channel_id") val rulesChannelId: Snowflake?,
-    @SerialName("joined_at") val joinedAt: Optional<String> = Optional.Missing(),
+    @SerialName("joined_at") val joinedAt: Optional<Instant> = Optional.Missing(),
     val large: OptionalBoolean = OptionalBoolean.Missing,
     val unavailable: OptionalBoolean = OptionalBoolean.Missing,
     @SerialName("member_count") val memberCount: OptionalInt = OptionalInt.Missing,

--- a/common/src/main/kotlin/entity/DiscordIntegration.kt
+++ b/common/src/main/kotlin/entity/DiscordIntegration.kt
@@ -3,6 +3,7 @@ package dev.kord.common.entity
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
 import dev.kord.common.serialization.DurationInDays
+import kotlinx.datetime.Instant
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -30,7 +31,7 @@ public data class DiscordIntegration(
     val user: DiscordUser,
     val account: DiscordIntegrationsAccount,
     @SerialName("synced_at")
-    val syncedAt: String,
+    val syncedAt: Instant,
     val subscriberCount: Int,
     val revoked: Boolean,
     val application: IntegrationApplication

--- a/common/src/main/kotlin/entity/DiscordMessage.kt
+++ b/common/src/main/kotlin/entity/DiscordMessage.kt
@@ -489,7 +489,7 @@ public data class DiscordEmbed(
     val type: Optional<EmbedType> = Optional.Missing(),
     val description: Optional<String> = Optional.Missing(),
     val url: Optional<String> = Optional.Missing(),
-    val timestamp: Optional<String> = Optional.Missing(),
+    val timestamp: Optional<Instant> = Optional.Missing(),
     val color: OptionalInt = OptionalInt.Missing,
     val footer: Optional<Footer> = Optional.Missing(),
     val image: Optional<Image> = Optional.Missing(),

--- a/common/src/main/kotlin/entity/DiscordMessage.kt
+++ b/common/src/main/kotlin/entity/DiscordMessage.kt
@@ -4,6 +4,7 @@ import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
 import dev.kord.common.entity.optional.OptionalInt
 import dev.kord.common.entity.optional.OptionalSnowflake
+import kotlinx.datetime.Instant
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -74,9 +75,9 @@ public data class DiscordMessage(
     val author: DiscordUser,
     val member: Optional<DiscordGuildMember> = Optional.Missing(),
     val content: String,
-    val timestamp: String,
+    val timestamp: Instant,
     @SerialName("edited_timestamp")
-    val editedTimestamp: String?,
+    val editedTimestamp: Instant?,
     val tts: Boolean,
     @SerialName("mention_everyone")
     val mentionEveryone: Boolean,
@@ -248,9 +249,9 @@ public data class DiscordPartialMessage(
     val author: Optional<DiscordUser> = Optional.Missing(),
     val member: Optional<DiscordGuildMember> = Optional.Missing(),
     val content: Optional<String> = Optional.Missing(),
-    val timestamp: Optional<String> = Optional.Missing(),
+    val timestamp: Optional<Instant> = Optional.Missing(),
     @SerialName("edited_timestamp")
-    val editedTimestamp: Optional<String?> = Optional.Missing(),
+    val editedTimestamp: Optional<Instant?> = Optional.Missing(),
     val tts: OptionalBoolean = OptionalBoolean.Missing,
     @SerialName("mention_everyone")
     val mentionEveryone: OptionalBoolean = OptionalBoolean.Missing,

--- a/common/src/main/kotlin/entity/DiscordTemplate.kt
+++ b/common/src/main/kotlin/entity/DiscordTemplate.kt
@@ -1,5 +1,6 @@
 package dev.kord.common.entity
 
+import kotlinx.datetime.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -14,9 +15,9 @@ public data class DiscordTemplate(
     val creatorId: Snowflake,
     val creator: DiscordUser,
     @SerialName("created_at")
-    val createdAt: String,
+    val createdAt: Instant,
     @SerialName("updated_at")
-    val updatedAt: String,
+    val updatedAt: Instant,
     @SerialName("source_guild_id")
     val sourceGuildId: Snowflake,
     @SerialName("serialized_source_guild")

--- a/common/src/main/kotlin/entity/Member.kt
+++ b/common/src/main/kotlin/entity/Member.kt
@@ -103,6 +103,6 @@ public data class DiscordThreadMember(
     @SerialName("user_id")
     val userId: OptionalSnowflake = OptionalSnowflake.Missing,
     @SerialName("join_timestamp")
-    val joinTimestamp: String,
+    val joinTimestamp: Instant,
     val flags: Int
 )

--- a/common/src/main/kotlin/entity/Member.kt
+++ b/common/src/main/kotlin/entity/Member.kt
@@ -17,7 +17,7 @@ public data class DiscordGuildMember(
     val nick: Optional<String?> = Optional.Missing(),
     val roles: List<Snowflake>,
     @SerialName("joined_at")
-    val joinedAt: String,
+    val joinedAt: Instant,
     @SerialName("premium_since")
     val premiumSince: Optional<String?> = Optional.Missing(),
     val deaf: OptionalBoolean = OptionalBoolean.Missing,
@@ -39,7 +39,7 @@ public data class DiscordInteractionGuildMember(
     val nick: Optional<String?> = Optional.Missing(),
     val roles: List<Snowflake>,
     @SerialName("joined_at")
-    val joinedAt: String,
+    val joinedAt: Instant,
     @SerialName("premium_since")
     val premiumSince: Optional<String?> = Optional.Missing(),
     val permissions: Permissions,
@@ -60,7 +60,7 @@ public data class DiscordAddedGuildMember(
     val nick: Optional<String?> = Optional.Missing(),
     val roles: List<Snowflake>,
     @SerialName("joined_at")
-    val joinedAt: String,
+    val joinedAt: Instant,
     @SerialName("premium_since")
     val premiumSince: Optional<String?> = Optional.Missing(),
     val deaf: Boolean,
@@ -88,7 +88,7 @@ public data class DiscordUpdatedGuildMember(
     val user: DiscordUser,
     val nick: Optional<String?> = Optional.Missing(),
     @SerialName("joined_at")
-    val joinedAt: String,
+    val joinedAt: Instant,
     @SerialName("premium_since")
     val premiumSince: Optional<String?> = Optional.Missing(),
     val pending: OptionalBoolean = OptionalBoolean.Missing,

--- a/common/src/main/kotlin/entity/Member.kt
+++ b/common/src/main/kotlin/entity/Member.kt
@@ -19,7 +19,7 @@ public data class DiscordGuildMember(
     @SerialName("joined_at")
     val joinedAt: Instant,
     @SerialName("premium_since")
-    val premiumSince: Optional<String?> = Optional.Missing(),
+    val premiumSince: Optional<Instant?> = Optional.Missing(),
     val deaf: OptionalBoolean = OptionalBoolean.Missing,
     val mute: OptionalBoolean = OptionalBoolean.Missing,
     val pending: OptionalBoolean = OptionalBoolean.Missing,
@@ -41,7 +41,7 @@ public data class DiscordInteractionGuildMember(
     @SerialName("joined_at")
     val joinedAt: Instant,
     @SerialName("premium_since")
-    val premiumSince: Optional<String?> = Optional.Missing(),
+    val premiumSince: Optional<Instant?> = Optional.Missing(),
     val permissions: Permissions,
     val pending: OptionalBoolean = OptionalBoolean.Missing,
     val avatar: Optional<String?> = Optional.Missing(),
@@ -62,7 +62,7 @@ public data class DiscordAddedGuildMember(
     @SerialName("joined_at")
     val joinedAt: Instant,
     @SerialName("premium_since")
-    val premiumSince: Optional<String?> = Optional.Missing(),
+    val premiumSince: Optional<Instant?> = Optional.Missing(),
     val deaf: Boolean,
     val mute: Boolean,
     @SerialName("guild_id")
@@ -90,7 +90,7 @@ public data class DiscordUpdatedGuildMember(
     @SerialName("joined_at")
     val joinedAt: Instant,
     @SerialName("premium_since")
-    val premiumSince: Optional<String?> = Optional.Missing(),
+    val premiumSince: Optional<Instant?> = Optional.Missing(),
     val pending: OptionalBoolean = OptionalBoolean.Missing,
     val avatar: Optional<String?> = Optional.Missing(),
     @SerialName("communication_disabled_until")

--- a/common/src/main/kotlin/serialization/InstantSerializers.kt
+++ b/common/src/main/kotlin/serialization/InstantSerializers.kt
@@ -3,6 +3,7 @@ package dev.kord.common.serialization
 import kotlinx.datetime.Instant
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
@@ -19,7 +20,23 @@ public object InstantInEpochMillisecondsSerializer : KSerializer<Instant> {
         PrimitiveSerialDescriptor("dev.kord.common.serialization.InstantInEpochMilliseconds", PrimitiveKind.LONG)
 
     override fun serialize(encoder: Encoder, value: Instant) {
-        encoder.encodeLong(value.toEpochMilliseconds())
+
+        // if the result of toEpochMilliseconds() doesn't fit in the range of Long type, it is coerced into that range
+        val valueInMillis = value.toEpochMilliseconds()
+
+        val atLimit = when (valueInMillis) {
+            Long.MIN_VALUE, Long.MAX_VALUE -> true
+            else -> false
+        }
+
+        // construct Instant from valueInMillis and compare with original Instant to check
+        // whether valueInMillis was exactly at limit or coerced into the range of Long type
+        if (atLimit && (Instant.fromEpochMilliseconds(valueInMillis) != value)) throw SerializationException(
+            "The Instant $value expressed as a number of milliseconds from the epoch Instant does not fit in the " +
+                    "range of Long type and therefore cannot be serialized with InstantInEpochMillisecondsSerializer"
+        )
+
+        encoder.encodeLong(valueInMillis)
     }
 
     override fun deserialize(decoder: Decoder): Instant {
@@ -40,6 +57,7 @@ public object InstantInEpochSecondsSerializer : KSerializer<Instant> {
         PrimitiveSerialDescriptor("dev.kord.common.serialization.InstantInEpochSeconds", PrimitiveKind.LONG)
 
     override fun serialize(encoder: Encoder, value: Instant) {
+        // epochSeconds always fits in the range of Long type and never coerces -> no need to check for overflow
         encoder.encodeLong(value.epochSeconds)
     }
 

--- a/common/src/main/kotlin/serialization/InstantSerializers.kt
+++ b/common/src/main/kotlin/serialization/InstantSerializers.kt
@@ -37,8 +37,11 @@ public object InstantInEpochMillisecondsSerializer : KSerializer<Instant> {
     }
 }
 
-/** An [Instant] that is [serializable][Serializable] with [InstantInEpochMillisecondsSerializer]. */
-public typealias InstantInEpochMilliseconds = @Serializable(with = InstantInEpochMillisecondsSerializer::class) Instant
+// TODO use this typealias instead of annotating types/properties with
+//  @Serializable(with = InstantInEpochMillisecondsSerializer::class) once
+//  https://github.com/Kotlin/kotlinx.serialization/issues/1895 is fixed
+// /** An [Instant] that is [serializable][Serializable] with [InstantInEpochMillisecondsSerializer]. */
+// public typealias InstantInEpochMilliseconds = @Serializable(with = InstantInEpochMillisecondsSerializer::class) Instant
 
 
 // epoch seconds
@@ -59,5 +62,8 @@ public object InstantInEpochSecondsSerializer : KSerializer<Instant> {
     }
 }
 
-/** An [Instant] that is [serializable][Serializable] with [InstantInEpochSecondsSerializer]. */
-public typealias InstantInEpochSeconds = @Serializable(with = InstantInEpochSecondsSerializer::class) Instant
+// TODO use this typealias instead of annotating types/properties with
+//  @Serializable(with = InstantInEpochSecondsSerializer::class) once
+//  https://github.com/Kotlin/kotlinx.serialization/issues/1895 is fixed
+// /** An [Instant] that is [serializable][Serializable] with [InstantInEpochSecondsSerializer]. */
+// public typealias InstantInEpochSeconds = @Serializable(with = InstantInEpochSecondsSerializer::class) Instant

--- a/common/src/main/kotlin/serialization/InstantSerializers.kt
+++ b/common/src/main/kotlin/serialization/InstantSerializers.kt
@@ -2,12 +2,15 @@ package dev.kord.common.serialization
 
 import kotlinx.datetime.Instant
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
+
+// epoch milliseconds
 
 /** Serializer that encodes and decodes [Instant]s in [epoch milliseconds][Instant.toEpochMilliseconds]. */
 public object InstantInEpochMillisecondsSerializer : KSerializer<Instant> {
@@ -24,6 +27,11 @@ public object InstantInEpochMillisecondsSerializer : KSerializer<Instant> {
     }
 }
 
+/** An [Instant] that is [serializable][Serializable] with [InstantInEpochMillisecondsSerializer]. */
+public typealias InstantInEpochMilliseconds = @Serializable(with = InstantInEpochMillisecondsSerializer::class) Instant
+
+
+// epoch seconds
 
 /** Serializer that encodes and decodes [Instant]s in [epoch seconds][Instant.epochSeconds]. */
 public object InstantInEpochSecondsSerializer : KSerializer<Instant> {
@@ -39,3 +47,6 @@ public object InstantInEpochSecondsSerializer : KSerializer<Instant> {
         return Instant.fromEpochSeconds(decoder.decodeLong())
     }
 }
+
+/** An [Instant] that is [serializable][Serializable] with [InstantInEpochSecondsSerializer]. */
+public typealias InstantInEpochSeconds = @Serializable(with = InstantInEpochSecondsSerializer::class) Instant

--- a/common/src/main/kotlin/serialization/InstantSerializers.kt
+++ b/common/src/main/kotlin/serialization/InstantSerializers.kt
@@ -1,0 +1,41 @@
+package dev.kord.common.serialization
+
+import kotlinx.datetime.Instant
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+
+/** Serializer that encodes and decodes [Instant]s in [epoch milliseconds][Instant.toEpochMilliseconds]. */
+public object InstantInEpochMillisecondsSerializer : KSerializer<Instant> {
+
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("dev.kord.common.serialization.InstantInEpochMilliseconds", PrimitiveKind.LONG)
+
+    override fun serialize(encoder: Encoder, value: Instant) {
+        encoder.encodeLong(value.toEpochMilliseconds())
+    }
+
+    override fun deserialize(decoder: Decoder): Instant {
+        return Instant.fromEpochMilliseconds(decoder.decodeLong())
+    }
+}
+
+
+/** Serializer that encodes and decodes [Instant]s in [epoch seconds][Instant.epochSeconds]. */
+public object InstantInEpochSecondsSerializer : KSerializer<Instant> {
+
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("dev.kord.common.serialization.InstantInEpochSeconds", PrimitiveKind.LONG)
+
+    override fun serialize(encoder: Encoder, value: Instant) {
+        encoder.encodeLong(value.epochSeconds)
+    }
+
+    override fun deserialize(decoder: Decoder): Instant {
+        return Instant.fromEpochSeconds(decoder.decodeLong())
+    }
+}

--- a/common/src/test/kotlin/json/GuildTest.kt
+++ b/common/src/test/kotlin/json/GuildTest.kt
@@ -1,6 +1,7 @@
 package json
 
 import dev.kord.common.entity.*
+import kotlinx.datetime.Instant
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Test
 import kotlin.time.Duration.Companion.seconds
@@ -81,7 +82,7 @@ class GuildTest {
         with(member) {
             nick shouldBe "NOT API SUPPORT"
             roles shouldBe emptyList()
-            joinedAt shouldBe "2015-04-26T06:26:56.936000+00:00"
+            joinedAt shouldBe Instant.parse("2015-04-26T06:26:56.936000+00:00")
             deaf shouldBe false
             mute shouldBe false
         }

--- a/common/src/test/kotlin/json/MessageTest.kt
+++ b/common/src/test/kotlin/json/MessageTest.kt
@@ -1,13 +1,14 @@
 package json
 
 import dev.kord.common.entity.*
+import kotlinx.datetime.Instant
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Test
 
 
 private fun file(name: String): String {
     val loader = ChannelTest::class.java.classLoader
-    return loader.getResource("json/message/$name.json").readText()
+    return loader.getResource("json/message/$name.json")!!.readText()
 }
 
 class MessageTest {
@@ -29,7 +30,7 @@ class MessageTest {
             attachments shouldBe emptyList()
             tts shouldBe false
             embeds shouldBe emptyList()
-            timestamp shouldBe "2017-07-11T17:27:07.299000+00:00"
+            timestamp shouldBe Instant.parse("2017-07-11T17:27:07.299000+00:00")
             mentionEveryone shouldBe false
             id.toString() shouldBe "334385199974967042"
             pinned shouldBe false
@@ -65,7 +66,7 @@ class MessageTest {
             attachments shouldBe emptyList()
             tts shouldBe false
             embeds shouldBe emptyList()
-            timestamp shouldBe "2017-07-11T17:27:07.299000+00:00"
+            timestamp shouldBe Instant.parse("2017-07-11T17:27:07.299000+00:00")
             mentionEveryone shouldBe false
             id.toString() shouldBe "334385199974967042"
             pinned shouldBe false

--- a/common/src/test/kotlin/serialization/InstantSerializersTests.kt
+++ b/common/src/test/kotlin/serialization/InstantSerializersTests.kt
@@ -1,0 +1,56 @@
+package serialization
+
+import dev.kord.common.serialization.InstantInEpochMillisecondsSerializer
+import dev.kord.common.serialization.InstantInEpochSecondsSerializer
+import kotlinx.datetime.Instant
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private val EPOCH = Instant.fromEpochSeconds(0)
+
+abstract class InstantSerializerTest(
+    private val json: String,
+    private val instant: Instant,
+    private val serializer: KSerializer<Instant>,
+) {
+
+    @Test
+    fun `epoch Instant can be serialized`() {
+        val serialized = Json.encodeToString(serializer, EPOCH)
+        assertEquals(expected = "0", actual = serialized)
+    }
+
+    @Test
+    fun `epoch Instant can be deserialized`() {
+        val deserialized = Json.decodeFromString(serializer, "0")
+        assertEquals(expected = EPOCH, actual = deserialized)
+    }
+
+
+    @Test
+    fun `Instant can be serialized`() {
+        val serialized = Json.encodeToString(serializer, instant)
+        assertEquals(expected = json, actual = serialized)
+    }
+
+    @Test
+    fun `Instant can be deserialized`() {
+        val deserialized = Json.decodeFromString(serializer, json)
+        assertEquals(expected = instant, actual = deserialized)
+    }
+}
+
+
+class InstantInEpochMillisecondsSerializerTest : InstantSerializerTest(
+    json = "796514689159",
+    instant = Instant.fromEpochMilliseconds(796514689159),
+    serializer = InstantInEpochMillisecondsSerializer,
+)
+
+class InstantInEpochSecondsSerializerTest : InstantSerializerTest(
+    json = "3992794563",
+    instant = Instant.fromEpochSeconds(3992794563),
+    serializer = InstantInEpochSecondsSerializer,
+)

--- a/common/src/test/kotlin/serialization/InstantSerializersTests.kt
+++ b/common/src/test/kotlin/serialization/InstantSerializersTests.kt
@@ -71,6 +71,23 @@ class InstantInEpochMillisecondsSerializerTest : InstantSerializerTest(
     private val pastInstantExactlyAtLimit = Instant.fromEpochMilliseconds(Long.MIN_VALUE)
 
     @Test
+    fun `future Instant under limit can be serialized`() {
+        assertEquals(
+            expected = (Long.MAX_VALUE - 1).toString(),
+            actual = serialize(futureInstantExactlyAtLimit - 1.nanoseconds),
+        )
+    }
+
+    @Test
+    fun `past Instant under limit can be serialized`() {
+        assertEquals(
+            expected = Long.MIN_VALUE.toString(),
+            actual = serialize(pastInstantExactlyAtLimit + 1.nanoseconds),
+        )
+    }
+
+
+    @Test
     fun `future Instant exactly at limit can be serialized`() {
         assertEquals(expected = Long.MAX_VALUE.toString(), actual = serialize(futureInstantExactlyAtLimit))
     }

--- a/common/src/test/kotlin/serialization/InstantSerializersTests.kt
+++ b/common/src/test/kotlin/serialization/InstantSerializersTests.kt
@@ -15,30 +15,46 @@ abstract class InstantSerializerTest(
     private val instant: Instant,
     private val serializer: KSerializer<Instant>,
 ) {
+    init {
+        require(instant > EPOCH)
+    }
+
+    private val mirroredInstant = EPOCH - (instant - EPOCH)
+
+    private fun serialize(instant: Instant) = Json.encodeToString(serializer, instant)
+    private fun deserialize(json: String) = Json.decodeFromString(serializer, json)
+
 
     @Test
     fun `epoch Instant can be serialized`() {
-        val serialized = Json.encodeToString(serializer, EPOCH)
-        assertEquals(expected = "0", actual = serialized)
+        assertEquals(expected = "0", actual = serialize(EPOCH))
     }
 
     @Test
     fun `epoch Instant can be deserialized`() {
-        val deserialized = Json.decodeFromString(serializer, "0")
-        assertEquals(expected = EPOCH, actual = deserialized)
+        assertEquals(expected = EPOCH, actual = deserialize("0"))
     }
 
 
     @Test
-    fun `Instant can be serialized`() {
-        val serialized = Json.encodeToString(serializer, instant)
-        assertEquals(expected = json, actual = serialized)
+    fun `future Instant can be serialized`() {
+        assertEquals(expected = json, actual = serialize(instant))
     }
 
     @Test
-    fun `Instant can be deserialized`() {
-        val deserialized = Json.decodeFromString(serializer, json)
-        assertEquals(expected = instant, actual = deserialized)
+    fun `future Instant can be deserialized`() {
+        assertEquals(expected = instant, actual = deserialize(json))
+    }
+
+
+    @Test
+    fun `past Instant can be serialized`() {
+        assertEquals(expected = "-$json", actual = serialize(mirroredInstant))
+    }
+
+    @Test
+    fun `past Instant can be deserialized`() {
+        assertEquals(expected = mirroredInstant, actual = deserialize("-$json"))
     }
 }
 

--- a/core/src/main/kotlin/Util.kt
+++ b/core/src/main/kotlin/Util.kt
@@ -16,8 +16,8 @@ import dev.kord.core.event.role.RoleDeleteEvent
 import dev.kord.core.event.role.RoleUpdateEvent
 import dev.kord.core.event.user.PresenceUpdateEvent
 import dev.kord.core.event.user.VoiceStateUpdateEvent
-import dev.kord.gateway.Intent.*
 import dev.kord.gateway.Intent
+import dev.kord.gateway.Intent.*
 import dev.kord.gateway.Intents
 import dev.kord.gateway.MessageDelete
 import dev.kord.gateway.PrivilegedIntent
@@ -31,8 +31,6 @@ import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 import kotlin.reflect.KClass
 import kotlinx.coroutines.flow.firstOrNull as coroutinesFirstOrNull
-
-internal fun Long.toInstant() = Instant.fromEpochMilliseconds(this)
 
 internal inline fun <T> catchNotFound(block: () -> T): T? {
     contract {

--- a/core/src/main/kotlin/cache/data/ActivityData.kt
+++ b/core/src/main/kotlin/cache/data/ActivityData.kt
@@ -4,8 +4,7 @@ import dev.kord.common.entity.*
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
 import dev.kord.common.entity.optional.OptionalSnowflake
-import dev.kord.common.serialization.InstantInEpochMillisecondsSerializer
-import kotlinx.datetime.Instant
+import dev.kord.common.serialization.InstantInEpochMilliseconds
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -13,8 +12,7 @@ public data class ActivityData(
     val name: String,
     val type: ActivityType,
     val url: Optional<String?> = Optional.Missing(),
-    @Serializable(with = InstantInEpochMillisecondsSerializer::class)
-    val createdAt: Instant,
+    val createdAt: InstantInEpochMilliseconds,
     val timestamps: Optional<DiscordActivityTimestamps> = Optional.Missing(),
     val applicationId: OptionalSnowflake = OptionalSnowflake.Missing,
     val details: Optional<String?> = Optional.Missing(),

--- a/core/src/main/kotlin/cache/data/ActivityData.kt
+++ b/core/src/main/kotlin/cache/data/ActivityData.kt
@@ -4,6 +4,8 @@ import dev.kord.common.entity.*
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
 import dev.kord.common.entity.optional.OptionalSnowflake
+import dev.kord.common.serialization.InstantInEpochMillisecondsSerializer
+import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -11,7 +13,8 @@ public data class ActivityData(
     val name: String,
     val type: ActivityType,
     val url: Optional<String?> = Optional.Missing(),
-    val createdAt: Long,
+    @Serializable(with = InstantInEpochMillisecondsSerializer::class)
+    val createdAt: Instant,
     val timestamps: Optional<DiscordActivityTimestamps> = Optional.Missing(),
     val applicationId: OptionalSnowflake = OptionalSnowflake.Missing,
     val details: Optional<String?> = Optional.Missing(),

--- a/core/src/main/kotlin/cache/data/ActivityData.kt
+++ b/core/src/main/kotlin/cache/data/ActivityData.kt
@@ -4,7 +4,8 @@ import dev.kord.common.entity.*
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
 import dev.kord.common.entity.optional.OptionalSnowflake
-import dev.kord.common.serialization.InstantInEpochMilliseconds
+import dev.kord.common.serialization.InstantInEpochMillisecondsSerializer
+import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -12,7 +13,8 @@ public data class ActivityData(
     val name: String,
     val type: ActivityType,
     val url: Optional<String?> = Optional.Missing(),
-    val createdAt: InstantInEpochMilliseconds,
+    @Serializable(with = InstantInEpochMillisecondsSerializer::class)
+    val createdAt: Instant,
     val timestamps: Optional<DiscordActivityTimestamps> = Optional.Missing(),
     val applicationId: OptionalSnowflake = OptionalSnowflake.Missing,
     val details: Optional<String?> = Optional.Missing(),

--- a/core/src/main/kotlin/cache/data/ChannelData.kt
+++ b/core/src/main/kotlin/cache/data/ChannelData.kt
@@ -27,7 +27,7 @@ public data class ChannelData(
     val ownerId: OptionalSnowflake = OptionalSnowflake.Missing,
     val applicationId: OptionalSnowflake = OptionalSnowflake.Missing,
     val parentId: OptionalSnowflake? = OptionalSnowflake.Missing,
-    val lastPinTimestamp: Optional<String?> = Optional.Missing(),
+    val lastPinTimestamp: Optional<Instant?> = Optional.Missing(),
     val rtcRegion: Optional<String?> = Optional.Missing(),
     val permissions: Optional<Permissions> = Optional.Missing(),
     val threadMetadata: Optional<ThreadMetadataData> = Optional.Missing(),

--- a/core/src/main/kotlin/cache/data/ChannelData.kt
+++ b/core/src/main/kotlin/cache/data/ChannelData.kt
@@ -77,7 +77,7 @@ public data class ChannelData(
 @Serializable
 public data class ThreadMetadataData(
     val archived: Boolean,
-    val archiveTimestamp: String,
+    val archiveTimestamp: Instant,
     val autoArchiveDuration: ArchiveDuration,
     val locked: OptionalBoolean = OptionalBoolean.Missing,
     val invitable: OptionalBoolean = OptionalBoolean.Missing,

--- a/core/src/main/kotlin/cache/data/EmbedData.kt
+++ b/core/src/main/kotlin/cache/data/EmbedData.kt
@@ -5,6 +5,7 @@ package dev.kord.core.cache.data
 import dev.kord.common.entity.DiscordEmbed
 import dev.kord.common.entity.EmbedType
 import dev.kord.common.entity.optional.*
+import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -14,7 +15,7 @@ public data class EmbedData(
     val type: Optional<EmbedType> = Optional.Missing(),
     val description: Optional<String> = Optional.Missing(),
     val url: Optional<String> = Optional.Missing(),
-    val timestamp: Optional<String> = Optional.Missing(),
+    val timestamp: Optional<Instant> = Optional.Missing(),
     val color: OptionalInt = OptionalInt.Missing,
     val footer: Optional<EmbedFooterData> = Optional.Missing(),
     val image: Optional<EmbedImageData> = Optional.Missing(),

--- a/core/src/main/kotlin/cache/data/GuildData.kt
+++ b/core/src/main/kotlin/cache/data/GuildData.kt
@@ -5,6 +5,7 @@ import dev.kord.cache.api.data.description
 import dev.kord.common.entity.*
 import dev.kord.common.entity.optional.*
 import dev.kord.common.serialization.DurationInSeconds
+import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
 
 private val MessageData.nullableGuildId get() = guildId.value
@@ -39,7 +40,7 @@ public data class GuildData(
     val systemChannelId: Snowflake? = null,
     val systemChannelFlags: SystemChannelFlags,
     val rulesChannelId: Snowflake? = null,
-    val joinedAt: Optional<String> = Optional.Missing(),
+    val joinedAt: Optional<Instant> = Optional.Missing(),
     val large: OptionalBoolean = OptionalBoolean.Missing,
     //val unavailable: OptionalBoolean = OptionalBoolean.Missing, useless?
     val memberCount: OptionalInt = OptionalInt.Missing,

--- a/core/src/main/kotlin/cache/data/IntegrationData.kt
+++ b/core/src/main/kotlin/cache/data/IntegrationData.kt
@@ -3,6 +3,7 @@ package dev.kord.core.cache.data
 import dev.kord.common.entity.*
 import dev.kord.common.entity.optional.OptionalBoolean
 import dev.kord.common.serialization.DurationInDays
+import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -19,7 +20,7 @@ public data class IntegrationData(
     val expireGracePeriod: DurationInDays,
     val user: DiscordUser,
     val account: IntegrationsAccountData,
-    val syncedAt: String,
+    val syncedAt: Instant,
     val subscriberCount: Int,
     val revoked: Boolean,
     val application: IntegrationApplication,

--- a/core/src/main/kotlin/cache/data/InviteCreateData.kt
+++ b/core/src/main/kotlin/cache/data/InviteCreateData.kt
@@ -8,13 +8,14 @@ import dev.kord.common.entity.optional.map
 import dev.kord.common.entity.optional.mapSnowflake
 import dev.kord.common.serialization.DurationInSeconds
 import dev.kord.gateway.DiscordCreatedInvite
+import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
 
 @Serializable
 public data class InviteCreateData(
     val channelId: Snowflake,
     val code: String,
-    val createdAt: String,
+    val createdAt: Instant,
     val guildId: OptionalSnowflake = OptionalSnowflake.Missing,
     val inviterId: OptionalSnowflake = OptionalSnowflake.Missing,
     val maxAge: DurationInSeconds,

--- a/core/src/main/kotlin/cache/data/MemberData.kt
+++ b/core/src/main/kotlin/cache/data/MemberData.kt
@@ -16,7 +16,7 @@ public data class MemberData(
     val guildId: Snowflake,
     val nick: Optional<String?> = Optional.Missing(),
     val roles: List<Snowflake>,
-    val joinedAt: String,
+    val joinedAt: Instant,
     val premiumSince: Optional<String?> = Optional.Missing(),
     val pending: OptionalBoolean = OptionalBoolean.Missing,
     val avatar: Optional<String?> = Optional.Missing(),

--- a/core/src/main/kotlin/cache/data/MemberData.kt
+++ b/core/src/main/kotlin/cache/data/MemberData.kt
@@ -17,7 +17,7 @@ public data class MemberData(
     val nick: Optional<String?> = Optional.Missing(),
     val roles: List<Snowflake>,
     val joinedAt: Instant,
-    val premiumSince: Optional<String?> = Optional.Missing(),
+    val premiumSince: Optional<Instant?> = Optional.Missing(),
     val pending: OptionalBoolean = OptionalBoolean.Missing,
     val avatar: Optional<String?> = Optional.Missing(),
     val communicationDisabledUntil: Optional<Instant?> = Optional.Missing()

--- a/core/src/main/kotlin/cache/data/MessageData.kt
+++ b/core/src/main/kotlin/cache/data/MessageData.kt
@@ -5,6 +5,7 @@ import dev.kord.cache.api.data.DataDescription
 import dev.kord.cache.api.data.description
 import dev.kord.common.entity.*
 import dev.kord.common.entity.optional.*
+import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
 
 internal val MessageData.authorId get() = author.id
@@ -16,8 +17,8 @@ public data class MessageData(
     val guildId: OptionalSnowflake = OptionalSnowflake.Missing,
     val author: UserData,
     val content: String,
-    val timestamp: String,
-    val editedTimestamp: String? = null,
+    val timestamp: Instant,
+    val editedTimestamp: Instant? = null,
     val tts: Boolean,
     val mentionEveryone: Boolean,
     val mentions: List<Snowflake>,

--- a/core/src/main/kotlin/cache/data/TemplateData.kt
+++ b/core/src/main/kotlin/cache/data/TemplateData.kt
@@ -2,6 +2,7 @@ package dev.kord.core.cache.data
 
 import dev.kord.common.entity.DiscordTemplate
 import dev.kord.common.entity.Snowflake
+import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -12,8 +13,8 @@ public data class TemplateData(
     val usageCount: Int,
     val creatorId: Snowflake,
     val creator: UserData,
-    val createdAt: String,
-    val updatedAt: String,
+    val createdAt: Instant,
+    val updatedAt: Instant,
     val sourceGuildId: Snowflake,
     val serializedSourceGuild: PartialGuildData,
     val isDirty: Boolean?

--- a/core/src/main/kotlin/cache/data/ThreadMemberData.kt
+++ b/core/src/main/kotlin/cache/data/ThreadMemberData.kt
@@ -5,6 +5,7 @@ import dev.kord.cache.api.data.description
 import dev.kord.common.entity.DiscordThreadMember
 import dev.kord.common.entity.Snowflake
 import dev.kord.common.entity.optional.OptionalSnowflake
+import kotlinx.datetime.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -14,7 +15,7 @@ public data class ThreadMemberData(
     @SerialName("user_id")
     val userId: OptionalSnowflake = OptionalSnowflake.Missing,
     @SerialName("join_timestamp")
-    val joinTimestamp: String,
+    val joinTimestamp: Instant,
     val flags: Int
 ) {
     public companion object {

--- a/core/src/main/kotlin/entity/Activity.kt
+++ b/core/src/main/kotlin/entity/Activity.kt
@@ -4,7 +4,6 @@ import dev.kord.common.annotation.DeprecatedSinceKord
 import dev.kord.common.entity.*
 import dev.kord.common.entity.optional.value
 import dev.kord.core.cache.data.ActivityData
-import dev.kord.core.toInstant
 import kotlinx.datetime.Instant
 
 public class Activity(public val data: ActivityData) {
@@ -12,13 +11,13 @@ public class Activity(public val data: ActivityData) {
     public val name: String get() = data.name
     public val type: ActivityType get() = data.type
     public val url: String? get() = data.url.value
-    public val start: Instant? get() = data.timestamps.value?.start.value?.toInstant()
+    public val start: Instant? get() = data.timestamps.value?.start?.value
 
     @DeprecatedSinceKord("0.7.0")
     @Deprecated("stop was renamed to end.", ReplaceWith("end"), DeprecationLevel.ERROR)
     public val stop: Instant? by ::end
 
-    public val end: Instant? get() = data.timestamps.value?.end.value?.toInstant()
+    public val end: Instant? get() = data.timestamps.value?.end?.value
 
     public val applicationId: Snowflake? get() = data.applicationId.value
 

--- a/core/src/main/kotlin/entity/Embed.kt
+++ b/core/src/main/kotlin/entity/Embed.kt
@@ -11,7 +11,6 @@ import dev.kord.core.KordObject
 import dev.kord.core.cache.data.*
 import dev.kord.rest.builder.message.EmbedBuilder
 import kotlinx.datetime.Instant
-import kotlinx.datetime.toInstant
 
 internal const val embedDeprecationMessage = """
 Embed types should be considered deprecated and might be removed in a future API version.
@@ -50,7 +49,7 @@ public data class Embed(val data: EmbedData, override val kord: Kord) : KordObje
     /**
      * The timestamp, if present. Unrelated to the creation time of the embed.
      */
-    val timestamp: Instant? get() = data.timestamp.value?.toInstant()
+    val timestamp: Instant? get() = data.timestamp.value
 
     /**
      * The color of the embed, if present.

--- a/core/src/main/kotlin/entity/Guild.kt
+++ b/core/src/main/kotlin/entity/Guild.kt
@@ -25,7 +25,6 @@ import dev.kord.rest.service.RestClient
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.datetime.Instant
-import kotlinx.datetime.toInstant
 import java.util.*
 import kotlin.time.Duration
 
@@ -191,8 +190,7 @@ public class Guild(
     /**
      * The time at which this guild was joined, if present.
      */
-    public val joinedTime: Instant?
-        get() = data.joinedAt.value?.toInstant()
+    public val joinedTime: Instant? get() = data.joinedAt.value
 
     /**
      * The id of the owner.

--- a/core/src/main/kotlin/entity/Integration.kt
+++ b/core/src/main/kotlin/entity/Integration.kt
@@ -14,7 +14,6 @@ import dev.kord.core.supplier.EntitySupplyStrategy
 import dev.kord.rest.builder.integration.IntegrationModifyBuilder
 import dev.kord.rest.request.RestRequestException
 import kotlinx.datetime.Instant
-import kotlinx.datetime.toInstant
 import java.util.*
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
@@ -113,8 +112,7 @@ public class Integration(
     /**
      * When this integration was last synced.
      */
-    public val syncedAt: Instant
-        get() = data.syncedAt.toInstant()
+    public val syncedAt: Instant get() = data.syncedAt
 
     /**
      * Requests to get the guild this integration is tied to.

--- a/core/src/main/kotlin/entity/Member.kt
+++ b/core/src/main/kotlin/entity/Member.kt
@@ -14,7 +14,6 @@ import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 import kotlinx.coroutines.flow.*
 import kotlinx.datetime.Instant
-import kotlinx.datetime.toInstant
 import java.util.*
 
 /**
@@ -54,7 +53,7 @@ public class Member(
     /**
      * When the user used their Nitro boost on the server.
      */
-    public val premiumSince: Instant? get() = memberData.premiumSince.value?.toInstant()
+    public val premiumSince: Instant? get() = memberData.premiumSince.value
 
     /**
      * The ids of the [roles][Role] that apply to this user.

--- a/core/src/main/kotlin/entity/Member.kt
+++ b/core/src/main/kotlin/entity/Member.kt
@@ -44,7 +44,7 @@ public class Member(
     /**
      * When the user joined this [guild].
      */
-    public val joinedAt: Instant get() = memberData.joinedAt.toInstant()
+    public val joinedAt: Instant get() = memberData.joinedAt
 
     /**
      * The guild-specific nickname of the user, if present.

--- a/core/src/main/kotlin/entity/Message.kt
+++ b/core/src/main/kotlin/entity/Message.kt
@@ -31,7 +31,6 @@ import dev.kord.core.supplier.getChannelOf
 import dev.kord.core.supplier.getChannelOfOrNull
 import kotlinx.coroutines.flow.*
 import kotlinx.datetime.Instant
-import kotlinx.datetime.toInstant
 import java.util.Objects
 
 /**
@@ -127,8 +126,7 @@ public class Message(
      *
      * Returns null if the message was never edited.
      */
-    public val editedTimestamp: Instant?
-        get() = data.editedTimestamp?.toInstant()
+    public val editedTimestamp: Instant? get() = data.editedTimestamp
 
     /**
      * The embedded content of this message.
@@ -266,7 +264,7 @@ public class Message(
     /**
      * The instant when this message was created.
      */
-    public val timestamp: Instant get() = data.timestamp.toInstant()
+    public val timestamp: Instant get() = data.timestamp
 
     /**
      * Whether this message was send using `\tts`.

--- a/core/src/main/kotlin/entity/Template.kt
+++ b/core/src/main/kotlin/entity/Template.kt
@@ -6,7 +6,6 @@ import dev.kord.core.KordObject
 import dev.kord.core.behavior.TemplateBehavior
 import dev.kord.core.cache.data.TemplateData
 import kotlinx.datetime.Instant
-import kotlinx.datetime.toInstant
 
 public class Template(public val data: TemplateData, override val kord: Kord) : KordObject, TemplateBehavior {
     override val code: String get() = data.code
@@ -21,9 +20,9 @@ public class Template(public val data: TemplateData, override val kord: Kord) : 
 
     public val creator: User get() = User(data.creator, kord)
 
-    public val createdAt: Instant get() = data.createdAt.toInstant()
+    public val createdAt: Instant get() = data.createdAt
 
-    public val updatedAt: Instant get() = data.updatedAt.toInstant()
+    public val updatedAt: Instant get() = data.updatedAt
 
     override val guildId: Snowflake get() = data.sourceGuildId
 

--- a/core/src/main/kotlin/entity/channel/MessageChannel.kt
+++ b/core/src/main/kotlin/entity/channel/MessageChannel.kt
@@ -8,7 +8,6 @@ import dev.kord.core.behavior.channel.MessageChannelBehavior
 import dev.kord.core.entity.Message
 import dev.kord.core.supplier.EntitySupplyStrategy
 import kotlinx.datetime.Instant
-import kotlinx.datetime.toInstant
 
 /**
  * An instance of a Discord channel that can use messages.
@@ -39,7 +38,7 @@ public interface MessageChannel : Channel, MessageChannelBehavior {
     /**
      * The timestamp of the last pin
      */
-    public val lastPinTimestamp: Instant? get() = data.lastPinTimestamp.value?.toInstant()
+    public val lastPinTimestamp: Instant? get() = data.lastPinTimestamp.value
 
     /**
      * Requests to get the last message sent to this channel,

--- a/core/src/main/kotlin/entity/channel/thread/ThreadChannel.kt
+++ b/core/src/main/kotlin/entity/channel/thread/ThreadChannel.kt
@@ -15,7 +15,6 @@ import dev.kord.core.entity.channel.GuildMessageChannel
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 import kotlinx.datetime.Instant
-import kotlinx.datetime.toInstant
 import kotlin.time.Duration
 
 public interface ThreadChannel : GuildMessageChannel, ThreadChannelBehavior {
@@ -68,7 +67,7 @@ public interface ThreadChannel : GuildMessageChannel, ThreadChannelBehavior {
     /**
      * The timestamp when the thread's archive status was last changed.
      */
-    public val archiveTimestamp: Instant get() = threadData.archiveTimestamp.toInstant()
+    public val archiveTimestamp: Instant get() = threadData.archiveTimestamp
 
     /**
      * The time in which the thread will be auto archived after inactivity.

--- a/core/src/main/kotlin/entity/channel/thread/ThreadMember.kt
+++ b/core/src/main/kotlin/entity/channel/thread/ThreadMember.kt
@@ -6,6 +6,7 @@ import dev.kord.core.behavior.ThreadMemberBehavior
 import dev.kord.core.cache.data.ThreadMemberData
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
+import kotlinx.datetime.Instant
 
 public class ThreadMember(
     public val data: ThreadMemberData,
@@ -18,7 +19,7 @@ public class ThreadMember(
     override val threadId: Snowflake get() = data.id
 
 
-    public val joinTimestamp: String get() = data.joinTimestamp
+    public val joinTimestamp: Instant get() = data.joinTimestamp
 
     public val flags: Int = data.flags
 

--- a/core/src/main/kotlin/event/channel/ChannelPinsUpdateEvent.kt
+++ b/core/src/main/kotlin/event/channel/ChannelPinsUpdateEvent.kt
@@ -15,8 +15,6 @@ import dev.kord.core.supplier.getChannelOf
 import dev.kord.core.supplier.getChannelOfOrNull
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.datetime.Instant
-import kotlinx.datetime.toInstant
-import kotlin.coroutines.CoroutineContext
 
 public class ChannelPinsUpdateEvent(
     public val data: ChannelPinsUpdateEventData,
@@ -30,7 +28,7 @@ public class ChannelPinsUpdateEvent(
 
     public val guildId: Snowflake? get() = data.guildId.value
 
-    public val lastPinTimestamp: Instant? get() = data.lastPinTimestamp.value?.toInstant()
+    public val lastPinTimestamp: Instant? get() = data.lastPinTimestamp.value
 
     public val guild: GuildBehavior? get() = guildId?.let { GuildBehavior(it, kord) }
 

--- a/core/src/main/kotlin/event/channel/TypingStartEvent.kt
+++ b/core/src/main/kotlin/event/channel/TypingStartEvent.kt
@@ -18,10 +18,8 @@ import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 import dev.kord.core.supplier.getChannelOf
 import dev.kord.core.supplier.getChannelOfOrNull
-import dev.kord.core.toInstant
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.datetime.Instant
-import kotlin.coroutines.CoroutineContext
 
 public class TypingStartEvent(
     public val data: TypingStartEventData,
@@ -37,7 +35,7 @@ public class TypingStartEvent(
 
     public val guildId: Snowflake? get() = data.guildId.value
 
-    public val started: Instant get() = data.timestamp.toInstant()
+    public val started: Instant get() = data.timestamp
 
     public val channel: MessageChannelBehavior get() = MessageChannelBehavior(channelId, kord)
 

--- a/core/src/main/kotlin/event/channel/data/ChannelPinsUpdateEventData.kt
+++ b/core/src/main/kotlin/event/channel/data/ChannelPinsUpdateEventData.kt
@@ -4,14 +4,14 @@ import dev.kord.common.entity.DiscordPinsUpdateData
 import dev.kord.common.entity.Snowflake
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalSnowflake
-import dev.kord.gateway.ChannelPinsUpdate
+import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
 
 @Serializable
 public data class ChannelPinsUpdateEventData(
     val guildId: OptionalSnowflake = OptionalSnowflake.Missing,
     val channelId: Snowflake,
-    val lastPinTimestamp: Optional<String?> = Optional.Missing()
+    val lastPinTimestamp: Optional<Instant?> = Optional.Missing()
 ) {
     public companion object {
         public fun from(entity: DiscordPinsUpdateData): ChannelPinsUpdateEventData = with(entity) {

--- a/core/src/main/kotlin/event/channel/data/TypingStartEventData.kt
+++ b/core/src/main/kotlin/event/channel/data/TypingStartEventData.kt
@@ -5,8 +5,7 @@ import dev.kord.common.entity.DiscordTyping
 import dev.kord.common.entity.Snowflake
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalSnowflake
-import dev.kord.common.serialization.InstantInEpochSecondsSerializer
-import kotlinx.datetime.Instant
+import dev.kord.common.serialization.InstantInEpochSeconds
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -14,8 +13,7 @@ public data class TypingStartEventData(
     val channelId: Snowflake,
     val guildId: OptionalSnowflake = OptionalSnowflake.Missing,
     val userId: Snowflake,
-    @Serializable(with = InstantInEpochSecondsSerializer::class)
-    val timestamp: Instant,
+    val timestamp: InstantInEpochSeconds,
     val member: Optional<DiscordGuildMember> = Optional.Missing()
 ) {
     public companion object {

--- a/core/src/main/kotlin/event/channel/data/TypingStartEventData.kt
+++ b/core/src/main/kotlin/event/channel/data/TypingStartEventData.kt
@@ -5,7 +5,8 @@ import dev.kord.common.entity.DiscordTyping
 import dev.kord.common.entity.Snowflake
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalSnowflake
-import kotlinx.serialization.SerialName
+import dev.kord.common.serialization.InstantInEpochSecondsSerializer
+import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -13,7 +14,8 @@ public data class TypingStartEventData(
     val channelId: Snowflake,
     val guildId: OptionalSnowflake = OptionalSnowflake.Missing,
     val userId: Snowflake,
-    val timestamp: Long,
+    @Serializable(with = InstantInEpochSecondsSerializer::class)
+    val timestamp: Instant,
     val member: Optional<DiscordGuildMember> = Optional.Missing()
 ) {
     public companion object {

--- a/core/src/main/kotlin/event/channel/data/TypingStartEventData.kt
+++ b/core/src/main/kotlin/event/channel/data/TypingStartEventData.kt
@@ -5,7 +5,8 @@ import dev.kord.common.entity.DiscordTyping
 import dev.kord.common.entity.Snowflake
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalSnowflake
-import dev.kord.common.serialization.InstantInEpochSeconds
+import dev.kord.common.serialization.InstantInEpochSecondsSerializer
+import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -13,7 +14,8 @@ public data class TypingStartEventData(
     val channelId: Snowflake,
     val guildId: OptionalSnowflake = OptionalSnowflake.Missing,
     val userId: Snowflake,
-    val timestamp: InstantInEpochSeconds,
+    @Serializable(with = InstantInEpochSecondsSerializer::class)
+    val timestamp: Instant,
     val member: Optional<DiscordGuildMember> = Optional.Missing()
 ) {
     public companion object {

--- a/core/src/main/kotlin/event/guild/InviteCreateEvent.kt
+++ b/core/src/main/kotlin/event/guild/InviteCreateEvent.kt
@@ -20,7 +20,6 @@ import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.datetime.Instant
-import kotlinx.datetime.toInstant
 import kotlin.time.Duration
 
 /**
@@ -52,7 +51,7 @@ public class InviteCreateEvent(
     /**
      * The time at which the invite was created.
      */
-    public val createdAt: Instant get() = data.createdAt.toInstant()
+    public val createdAt: Instant get() = data.createdAt
 
     /**
      * The id of the [Guild] of the invite.

--- a/core/src/main/kotlin/supplier/CacheEntitySupplier.kt
+++ b/core/src/main/kotlin/supplier/CacheEntitySupplier.kt
@@ -24,7 +24,6 @@ import dev.kord.core.exception.EntityNotFoundException
 import dev.kord.gateway.Gateway
 import kotlinx.coroutines.flow.*
 import kotlinx.datetime.Instant
-import kotlinx.datetime.toInstant
 import dev.kord.core.internalAny as any
 
 /**
@@ -329,10 +328,10 @@ public class CacheEntitySupplier(private val kord: Kord) : EntitySupplier {
         return flow {
             val result = cache.query<ChannelData> { idEq(ChannelData::parentId, channelId) }
                 .toCollection()
-                .sortedByDescending { it.threadMetadata.value?.archiveTimestamp?.toInstant() }
+                .sortedByDescending { it.threadMetadata.value?.archiveTimestamp }
                 .asFlow()
                 .filter {
-                    val time = it.threadMetadata.value?.archiveTimestamp?.toInstant()
+                    val time = it.threadMetadata.value?.archiveTimestamp
                     it.threadMetadata.value?.archived == true
                             && time != null
                             && (before == null || time < before)
@@ -350,10 +349,10 @@ public class CacheEntitySupplier(private val kord: Kord) : EntitySupplier {
         return flow {
             val result = cache.query<ChannelData> { idEq(ChannelData::parentId, channelId) }
                 .toCollection()
-                .sortedByDescending { it.threadMetadata.value?.archiveTimestamp?.toInstant() }
+                .sortedByDescending { it.threadMetadata.value?.archiveTimestamp }
                 .asFlow()
                 .filter {
-                    val time = it.threadMetadata.value?.archiveTimestamp?.toInstant()
+                    val time = it.threadMetadata.value?.archiveTimestamp
                     it.threadMetadata.value?.archived == true
                             && time != null
                             && (before == null || time < before)

--- a/core/src/test/kotlin/live/LiveGuildTest.kt
+++ b/core/src/test/kotlin/live/LiveGuildTest.kt
@@ -349,7 +349,7 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
                         roles = emptyList(),
                         deaf = false,
                         mute = false,
-                        joinedAt = ""
+                        joinedAt = Instant.fromEpochMilliseconds(0),
                     ),
                     0
                 )
@@ -376,7 +376,7 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
                             discriminator = "",
                             avatar = null
                         ),
-                        joinedAt = ""
+                        joinedAt = Instant.fromEpochMilliseconds(0),
                     ),
                     0
                 )

--- a/core/src/test/kotlin/live/LiveGuildTest.kt
+++ b/core/src/test/kotlin/live/LiveGuildTest.kt
@@ -14,6 +14,7 @@ import dev.kord.gateway.*
 import equality.randomId
 import kotlinx.coroutines.job
 import kotlinx.coroutines.runBlocking
+import kotlinx.datetime.Instant
 import kotlinx.serialization.json.JsonObject
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.TestInstance
@@ -559,7 +560,7 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
                             avatar = null
                         ),
                         content = "",
-                        timestamp = "",
+                        timestamp = Instant.fromEpochMilliseconds(0),
                         editedTimestamp = null,
                         tts = false,
                         mentionEveryone = false,

--- a/core/src/test/kotlin/live/LiveMemberTest.kt
+++ b/core/src/test/kotlin/live/LiveMemberTest.kt
@@ -19,6 +19,7 @@ import dev.kord.gateway.GuildMemberUpdate
 import equality.randomId
 import kotlinx.coroutines.job
 import kotlinx.coroutines.runBlocking
+import kotlinx.datetime.Instant
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.TestInstance
@@ -51,7 +52,7 @@ class LiveMemberTest : AbstractLiveEntityTest<LiveMember>() {
                     userId = userId,
                     guildId = guildId,
                     roles = emptyList(),
-                    joinedAt = "",
+                    joinedAt = Instant.fromEpochMilliseconds(0),
                     premiumSince = Optional.Missing(),
                     avatar = Optional.Missing(),
                 ),
@@ -83,7 +84,7 @@ class LiveMemberTest : AbstractLiveEntityTest<LiveMember>() {
                             discriminator = "",
                             avatar = null
                         ),
-                        joinedAt = ""
+                        joinedAt = Instant.fromEpochMilliseconds(0),
                     ),
                     0
                 )

--- a/core/src/test/kotlin/live/LiveMessageTest.kt
+++ b/core/src/test/kotlin/live/LiveMessageTest.kt
@@ -10,13 +10,13 @@ import dev.kord.core.event.channel.ChannelDeleteEvent
 import dev.kord.core.event.guild.GuildDeleteEvent
 import dev.kord.core.event.message.MessageBulkDeleteEvent
 import dev.kord.core.event.message.MessageDeleteEvent
-import dev.kord.core.event.role.RoleDeleteEvent
 import dev.kord.core.live.*
 import dev.kord.core.live.exception.LiveCancellationException
 import dev.kord.gateway.*
 import equality.randomId
 import kotlinx.coroutines.job
 import kotlinx.coroutines.runBlocking
+import kotlinx.datetime.Instant
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.TestInstance
@@ -59,7 +59,7 @@ class LiveMessageTest : AbstractLiveEntityTest<LiveMessage>() {
                         discriminator = ""
                     ),
                     content = "",
-                    timestamp = "",
+                    timestamp = Instant.fromEpochMilliseconds(0),
                     tts = false,
                     mentionEveryone = false,
                     mentions = emptyList(),

--- a/gateway/src/main/kotlin/Command.kt
+++ b/gateway/src/main/kotlin/Command.kt
@@ -4,9 +4,8 @@ import dev.kord.common.entity.*
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
 import dev.kord.common.entity.optional.OptionalInt
-import dev.kord.common.serialization.InstantInEpochMillisecondsSerializer
+import dev.kord.common.serialization.InstantInEpochMilliseconds
 import kotlinx.atomicfu.atomic
-import kotlinx.datetime.Instant
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Required
 import kotlinx.serialization.SerialName
@@ -125,8 +124,7 @@ public data class GuildMembersChunkData(
 public data class DiscordPresence(
     val status: PresenceStatus,
     val afk: Boolean,
-    @Serializable(with = InstantInEpochMillisecondsSerializer::class)
-    val since: Instant? = null,
+    val since: InstantInEpochMilliseconds? = null,
     val game: DiscordBotActivity? = null,
 )
 
@@ -201,8 +199,7 @@ public data class UpdateVoiceStatus(
 
 @Serializable
 public data class UpdateStatus(
-    @Serializable(with = InstantInEpochMillisecondsSerializer::class)
-    val since: Instant?,
+    val since: InstantInEpochMilliseconds?,
     val activities: List<DiscordBotActivity>,
     val status: PresenceStatus,
     val afk: Boolean,

--- a/gateway/src/main/kotlin/Command.kt
+++ b/gateway/src/main/kotlin/Command.kt
@@ -4,7 +4,9 @@ import dev.kord.common.entity.*
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
 import dev.kord.common.entity.optional.OptionalInt
+import dev.kord.common.serialization.InstantInEpochMillisecondsSerializer
 import kotlinx.atomicfu.atomic
+import kotlinx.datetime.Instant
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Required
 import kotlinx.serialization.SerialName
@@ -123,7 +125,8 @@ public data class GuildMembersChunkData(
 public data class DiscordPresence(
     val status: PresenceStatus,
     val afk: Boolean,
-    val since: Long? = null,
+    @Serializable(with = InstantInEpochMillisecondsSerializer::class)
+    val since: Instant? = null,
     val game: DiscordBotActivity? = null,
 )
 
@@ -198,7 +201,8 @@ public data class UpdateVoiceStatus(
 
 @Serializable
 public data class UpdateStatus(
-    val since: Long?,
+    @Serializable(with = InstantInEpochMillisecondsSerializer::class)
+    val since: Instant?,
     val activities: List<DiscordBotActivity>,
     val status: PresenceStatus,
     val afk: Boolean,

--- a/gateway/src/main/kotlin/Command.kt
+++ b/gateway/src/main/kotlin/Command.kt
@@ -4,8 +4,9 @@ import dev.kord.common.entity.*
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
 import dev.kord.common.entity.optional.OptionalInt
-import dev.kord.common.serialization.InstantInEpochMilliseconds
+import dev.kord.common.serialization.InstantInEpochMillisecondsSerializer
 import kotlinx.atomicfu.atomic
+import kotlinx.datetime.Instant
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Required
 import kotlinx.serialization.SerialName
@@ -124,7 +125,8 @@ public data class GuildMembersChunkData(
 public data class DiscordPresence(
     val status: PresenceStatus,
     val afk: Boolean,
-    val since: InstantInEpochMilliseconds? = null,
+    @Serializable(with = InstantInEpochMillisecondsSerializer::class)
+    val since: Instant? = null,
     val game: DiscordBotActivity? = null,
 )
 
@@ -199,7 +201,8 @@ public data class UpdateVoiceStatus(
 
 @Serializable
 public data class UpdateStatus(
-    val since: InstantInEpochMilliseconds?,
+    @Serializable(with = InstantInEpochMillisecondsSerializer::class)
+    val since: Instant?,
     val activities: List<DiscordBotActivity>,
     val status: PresenceStatus,
     val afk: Boolean,

--- a/gateway/src/main/kotlin/Event.kt
+++ b/gateway/src/main/kotlin/Event.kt
@@ -5,6 +5,7 @@ import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
 import dev.kord.common.entity.optional.OptionalSnowflake
 import dev.kord.common.serialization.DurationInSeconds
+import kotlinx.datetime.Instant
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
@@ -625,7 +626,7 @@ public data class DiscordCreatedInvite(
     val channelId: Snowflake,
     val code: String,
     @SerialName("created_at")
-    val createdAt: String,
+    val createdAt: Instant,
     @SerialName("guild_id")
     val guildId: OptionalSnowflake = OptionalSnowflake.Missing,
     val inviter: Optional<DiscordUser> = Optional.Missing(),

--- a/gateway/src/main/kotlin/builder/PresenceBuilder.kt
+++ b/gateway/src/main/kotlin/builder/PresenceBuilder.kt
@@ -36,8 +36,7 @@ public class PresenceBuilder {
         game = DiscordBotActivity(name, ActivityType.Competing)
     }
 
-    public fun toUpdateStatus(): UpdateStatus =
-        UpdateStatus(since?.toEpochMilliseconds(), game?.let(::listOf).orEmpty(), status, afk)
+    public fun toUpdateStatus(): UpdateStatus = UpdateStatus(since, game?.let(::listOf).orEmpty(), status, afk)
 
-    public fun toPresence(): DiscordPresence = DiscordPresence(status, afk, since?.toEpochMilliseconds(), game)
+    public fun toPresence(): DiscordPresence = DiscordPresence(status, afk, since, game)
 }

--- a/gateway/src/test/kotlin/json/CommandTest.kt
+++ b/gateway/src/test/kotlin/json/CommandTest.kt
@@ -9,6 +9,7 @@ import dev.kord.common.entity.optional.coerceToMissing
 import dev.kord.common.entity.optional.optional
 import dev.kord.common.entity.optional.optionalInt
 import dev.kord.gateway.*
+import kotlinx.datetime.Instant
 import kotlinx.serialization.json.*
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -111,8 +112,10 @@ class CommandTest {
         val status = PresenceStatus.Online
         val afk = false
 
-        val updateStatus =
-            json.encodeToString(Command.SerializationStrategy, UpdateStatus(since, activities, status, afk))
+        val updateStatus = json.encodeToString(
+            Command.SerializationStrategy,
+            UpdateStatus(Instant.fromEpochMilliseconds(since), activities, status, afk),
+        )
 
         val json = json.encodeToString(JsonObject.serializer(), buildJsonObject {
             put("op", OpCode.StatusUpdate.code)

--- a/gateway/src/test/kotlin/json/SerializationTest.kt
+++ b/gateway/src/test/kotlin/json/SerializationTest.kt
@@ -4,6 +4,7 @@ import dev.kord.common.entity.UserFlags
 import dev.kord.common.entity.UserPremium
 import dev.kord.common.entity.optional.value
 import dev.kord.gateway.*
+import kotlinx.datetime.Instant
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Test
 import kotlin.time.Duration.Companion.seconds
@@ -87,7 +88,7 @@ class SerializationTest {
         with(event.pins) {
             guildId.value?.toString() shouldBe "41771983423143937"
             channelId.toString() shouldBe "399942396007890945"
-            lastPinTimestamp.value shouldBe "2015-04-26T06:26:56.936000+00:00"
+            lastPinTimestamp.value shouldBe Instant.parse("2015-04-26T06:26:56.936000+00:00")
 
         }
     }

--- a/rest/src/main/kotlin/builder/guild/VoiceStateModifyBuilder.kt
+++ b/rest/src/main/kotlin/builder/guild/VoiceStateModifyBuilder.kt
@@ -4,7 +4,6 @@ import dev.kord.common.entity.Snowflake
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
 import dev.kord.common.entity.optional.delegate.delegate
-import dev.kord.common.entity.optional.map
 import dev.kord.rest.builder.RequestBuilder
 import dev.kord.rest.json.request.CurrentVoiceStateModifyRequest
 import dev.kord.rest.json.request.VoiceStateModifyRequest
@@ -13,7 +12,7 @@ import kotlinx.datetime.Instant
 public class CurrentVoiceStateModifyBuilder(public val channelId: Snowflake) :
     RequestBuilder<CurrentVoiceStateModifyRequest> {
 
-    private var _requestToSpeakTimestamp: Optional<Instant> = Optional.Missing()
+    private var _requestToSpeakTimestamp: Optional<Instant?> = Optional.Missing()
 
     private var _suppress: OptionalBoolean = OptionalBoolean.Missing
 
@@ -36,7 +35,7 @@ public class CurrentVoiceStateModifyBuilder(public val channelId: Snowflake) :
 
 
     override fun toRequest(): CurrentVoiceStateModifyRequest {
-        return CurrentVoiceStateModifyRequest(channelId, _suppress, _requestToSpeakTimestamp.map { it.toString() })
+        return CurrentVoiceStateModifyRequest(channelId, _suppress, _requestToSpeakTimestamp)
     }
 }
 

--- a/rest/src/main/kotlin/json/request/VoiceStateRequests.kt
+++ b/rest/src/main/kotlin/json/request/VoiceStateRequests.kt
@@ -3,6 +3,9 @@ package dev.kord.rest.json.request
 import dev.kord.common.entity.Snowflake
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
+import dev.kord.common.entity.optional.coerceToMissing
+import dev.kord.common.entity.optional.map
+import kotlinx.datetime.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -12,7 +15,7 @@ public data class CurrentVoiceStateModifyRequest(
     val channelId: Snowflake,
     val suppress: OptionalBoolean = OptionalBoolean.Missing,
     @SerialName("request_to_speak_timestamp")
-    val requestToSpeakTimestamp: Optional<String> = Optional.Missing(),
+    val requestToSpeakTimestamp: Optional<Instant?> = Optional.Missing(),
 ) {
     @Deprecated(
         "requestToSpeakTimeStamp was renamed to requestToSpeakTimestamp.",
@@ -20,7 +23,7 @@ public data class CurrentVoiceStateModifyRequest(
         DeprecationLevel.ERROR,
     )
     val requestToSpeakTimeStamp: Optional<String>
-        get() = requestToSpeakTimestamp
+        get() = requestToSpeakTimestamp.map { it.toString() }.coerceToMissing()
 }
 
 


### PR DESCRIPTION
Like https://github.com/kordlib/kord/pull/586 but for `Instant`:
- serialize timestamps with the default `InstantIso8601Serializer` or custom `InstantInEpochMillisecondsSerializer`/`InstantInEpochSecondsSerializer`
- change types to `Instant` where applicable

Because of https://github.com/Kotlin/kotlinx.serialization/issues/1895, using typealiases like those for `Duration` is not possible yet.