### PR TITLE
Snowflake destructuring

### DIFF
--- a/common/src/main/kotlin/entity/Snowflake.kt
+++ b/common/src/main/kotlin/entity/Snowflake.kt
@@ -63,7 +63,7 @@ public class Snowflake : Comparable<Snowflake> {
             .shl(TIMESTAMP_SHIFT)
     )
 
-    private val millisecondsSinceDiscordEpoch get() = value shr TIMESTAMP_SHIFT
+    private inline val millisecondsSinceDiscordEpoch get() = value shr TIMESTAMP_SHIFT
 
     /**
      * A [String] representation of this Snowflake's [value].
@@ -140,6 +140,7 @@ public class Snowflake : Comparable<Snowflake> {
     override fun hashCode(): Int = value.hashCode()
 
     override fun equals(other: Any?): Boolean = other is Snowflake && this.value == other.value
+
 
     public companion object {
         // see https://discord.com/developers/docs/reference#snowflakes-snowflake-id-format-structure-left-to-right

--- a/common/src/main/kotlin/entity/Snowflake.kt
+++ b/common/src/main/kotlin/entity/Snowflake.kt
@@ -116,16 +116,40 @@ public class Snowflake : Comparable<Snowflake> {
         get() = value.and(INCREMENT_MASK).toUShort()
 
 
-    /** Returns [timestamp] for use in destructuring declarations. */
+    /**
+     * Returns [timestamp] for use in destructuring declarations.
+     *
+     * ```kotlin
+     * val (timestamp, workerId, processId, increment) = snowflake
+     * ```
+     */
     public operator fun component1(): Instant = timestamp
 
-    /** Returns [workerId] for use in destructuring declarations. */
+    /**
+     * Returns [workerId] for use in destructuring declarations.
+     *
+     * ```kotlin
+     * val (timestamp, workerId, processId, increment) = snowflake
+     * ```
+     */
     public operator fun component2(): UByte = workerId
 
-    /** Returns [processId] for use in destructuring declarations. */
+    /**
+     * Returns [processId] for use in destructuring declarations.
+     *
+     * ```kotlin
+     * val (timestamp, workerId, processId, increment) = snowflake
+     * ```
+     */
     public operator fun component3(): UByte = processId
 
-    /** Returns [increment] for use in destructuring declarations. */
+    /**
+     * Returns [increment] for use in destructuring declarations.
+     *
+     * ```kotlin
+     * val (timestamp, workerId, processId, increment) = snowflake
+     * ```
+     */
     public operator fun component4(): UShort = increment
 
 

--- a/common/src/main/kotlin/entity/Snowflake.kt
+++ b/common/src/main/kotlin/entity/Snowflake.kt
@@ -142,6 +142,8 @@ public class Snowflake : Comparable<Snowflake> {
     override fun equals(other: Any?): Boolean = other is Snowflake && this.value == other.value
 
     public companion object {
+        // see https://discord.com/developers/docs/reference#snowflakes-snowflake-id-format-structure-left-to-right
+
         private const val DISCORD_EPOCH_LONG = 1420070400000L
 
         private const val TIMESTAMP_SHIFT = 22

--- a/common/src/main/kotlin/entity/Snowflake.kt
+++ b/common/src/main/kotlin/entity/Snowflake.kt
@@ -56,14 +56,14 @@ public class Snowflake : Comparable<Snowflake> {
      */
     public constructor(timestamp: Instant) : this(
         timestamp.toEpochMilliseconds()
-            .coerceAtLeast(discordEpochLong) // time before is unknown to Snowflakes
-            .minus(discordEpochLong)
+            .coerceAtLeast(DISCORD_EPOCH_LONG) // time before is unknown to Snowflakes
+            .minus(DISCORD_EPOCH_LONG)
             .toULong()
             .coerceAtMost(maxMillisecondsSinceDiscordEpoch) // time after is unknown to Snowflakes
-            .shl(nonTimestampBitCount)
+            .shl(TIMESTAMP_SHIFT)
     )
 
-    private val millisecondsSinceDiscordEpoch get() = value shr nonTimestampBitCount
+    private val millisecondsSinceDiscordEpoch get() = value shr TIMESTAMP_SHIFT
 
     /**
      * A [String] representation of this Snowflake's [value].
@@ -83,13 +83,51 @@ public class Snowflake : Comparable<Snowflake> {
      * The point in time this Snowflake represents.
      */
     public val timestamp: Instant
-        get() = Instant.fromEpochMilliseconds(discordEpochLong + millisecondsSinceDiscordEpoch.toLong())
+        get() = Instant.fromEpochMilliseconds(DISCORD_EPOCH_LONG + millisecondsSinceDiscordEpoch.toLong())
 
     /**
      * A [TimeMark] for the point in time this Snowflake represents.
      */
     public val timeMark: TimeMark
         get() = SnowflakeTimeMark(timestamp)
+
+    /**
+     * Internal ID of the worker that generated this Snowflake ID.
+     *
+     * Only the 5 least significant bits are used. This value is therefore always in the range `0..31`.
+     */
+    public val workerId: UByte
+        get() = value.and(WORKER_MASK).shr(WORKER_SHIFT).toUByte()
+
+    /**
+     * Internal ID of the process that generated this Snowflake ID.
+     *
+     * Only the 5 least significant bits are used. This value is therefore always in the range `0..31`.
+     */
+    public val processId: UByte
+        get() = value.and(PROCESS_MASK).shr(PROCESS_SHIFT).toUByte()
+
+    /**
+     * Increment. For every Snowflake ID that is generated on a [process][processId], this number is incremented.
+     *
+     * Only the 12 least significant bits are used. This value is therefore always in the range `0..4095`.
+     */
+    public val increment: UShort
+        get() = value.and(INCREMENT_MASK).toUShort()
+
+
+    /** Returns [timestamp] for use in destructuring declarations. */
+    public operator fun component1(): Instant = timestamp
+
+    /** Returns [workerId] for use in destructuring declarations. */
+    public operator fun component2(): UByte = workerId
+
+    /** Returns [processId] for use in destructuring declarations. */
+    public operator fun component3(): UByte = processId
+
+    /** Returns [increment] for use in destructuring declarations. */
+    public operator fun component4(): UShort = increment
+
 
     override fun compareTo(other: Snowflake): Int =
         millisecondsSinceDiscordEpoch.compareTo(other.millisecondsSinceDiscordEpoch)
@@ -104,8 +142,18 @@ public class Snowflake : Comparable<Snowflake> {
     override fun equals(other: Any?): Boolean = other is Snowflake && this.value == other.value
 
     public companion object {
-        private const val nonTimestampBitCount = 22
-        private const val discordEpochLong = 1420070400000L
+        private const val DISCORD_EPOCH_LONG = 1420070400000L
+
+        private const val TIMESTAMP_SHIFT = 22
+
+        private const val WORKER_MASK = 0x3E0000uL
+        private const val WORKER_SHIFT = 17
+
+        private const val PROCESS_MASK = 0x1F000uL
+        private const val PROCESS_SHIFT = 12
+
+        private const val INCREMENT_MASK = 0xFFFuL
+
 
         /**
          * A range that contains all valid raw Snowflake [value]s.
@@ -140,7 +188,7 @@ public class Snowflake : Comparable<Snowflake> {
         /**
          * The point in time that marks the Discord Epoch (the first second of 2015).
          */
-        public val discordEpoch: Instant = Instant.fromEpochMilliseconds(discordEpochLong)
+        public val discordEpoch: Instant = Instant.fromEpochMilliseconds(DISCORD_EPOCH_LONG)
 
         /**
          * The last point in time a Snowflake can represent.

--- a/common/src/test/kotlin/entity/SnowflakeTest.kt
+++ b/common/src/test/kotlin/entity/SnowflakeTest.kt
@@ -2,11 +2,10 @@ package entity
 
 import dev.kord.common.entity.Snowflake
 import kotlinx.datetime.Clock
-import kotlinx.datetime.DateTimeUnit.Companion.MILLISECOND
 import kotlinx.datetime.Instant
-import kotlinx.datetime.minus
-import kotlinx.datetime.plus
 import kotlin.test.*
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.nanoseconds
 
 class SnowflakeTest {
 
@@ -56,7 +55,8 @@ class SnowflakeTest {
         val snowflake = Snowflake(instant)
 
         // snowflake timestamps have a millisecond accuracy -> allow +/-1 millisecond from original instant
-        val validTimeRange = instant.minus(1, MILLISECOND)..instant.plus(1, MILLISECOND)
+        val delta = 1.milliseconds - 1.nanoseconds
+        val validTimeRange = (instant - delta)..(instant + delta)
 
         assertContains(validTimeRange, snowflake.timestamp)
     }
@@ -69,5 +69,21 @@ class SnowflakeTest {
     @Test
     fun `max Snowflake's timeMark has not passed`() {
         assertFalse(Snowflake.max.timeMark.hasPassedNow())
+    }
+
+    @Test
+    fun `Snowflake can be destructured`() {
+        val snowflake = Snowflake(0b110010110111_10111_01101_101100111101_u)
+        val (timestamp, worker, process, increment) = snowflake
+
+        assertEquals(snowflake.timestamp, timestamp)
+        assertEquals(snowflake.workerId, worker)
+        assertEquals(snowflake.processId, process)
+        assertEquals(snowflake.increment, increment)
+
+        assertEquals(Instant.fromEpochMilliseconds(0b110010110111 + 1420070400000), timestamp)
+        assertEquals(0b10111u, worker)
+        assertEquals(0b01101u, process)
+        assertEquals(0b101100111101u, increment)
     }
 }


### PR DESCRIPTION
This PR adds the properties `workerId: UByte`, `processId: UByte` and `increment: UShort` to `Snowflake`. They provide an easy way to get all available information out of the snowflake id format specified [here](https://discord.com/developers/docs/reference#snowflakes).

It also adds `componentN()` operator functions to allow destructuring:
```kt
val (timestamp, workerId, processId, increment) = snowflake
```
