### PR TITLE
fix(voice): heartbeat nonce is zero

### DIFF
--- a/voice/src/main/kotlin/gateway/handler/HeartbeatHandler.kt
+++ b/voice/src/main/kotlin/gateway/handler/HeartbeatHandler.kt
@@ -29,8 +29,8 @@ internal class HeartbeatHandler(
         on<Ready> {
             launch {
                 ticker.tickAt(interval) {
-                    timestamp = timeSource.markNow()
                     send(Heartbeat(timestamp.elapsedNow().inWholeMilliseconds))
+                    timestamp = timeSource.markNow()
                 }
             }
         }


### PR DESCRIPTION
The nonce, which is based off the last heartbeat timestamp, is set immediately before sending, hence resulting in a zero value. While this doesn't cause any major issues, it should not stay constant for the sake of being a nonce.