### PR TITLE
fix(voice): ktor 2 migrations

### DIFF
--- a/voice/src/main/kotlin/VoiceConnectionBuilder.kt
+++ b/voice/src/main/kotlin/VoiceConnectionBuilder.kt
@@ -142,7 +142,7 @@ public class VoiceConnectionBuilder(
             voiceState.sessionId
         ) to VoiceGatewayConfiguration(
             voiceServer.token,
-            "wss://${voiceServer.endpoint}?v=4"
+            "wss://${voiceServer.endpoint}/?v=4"
         )
     }
 

--- a/voice/src/main/kotlin/gateway/DefaultVoiceGatewayBuilder.kt
+++ b/voice/src/main/kotlin/gateway/DefaultVoiceGatewayBuilder.kt
@@ -6,6 +6,7 @@ import dev.kord.gateway.retry.LinearRetry
 import dev.kord.gateway.retry.Retry
 import io.ktor.client.*
 import io.ktor.client.engine.cio.*
+import io.ktor.client.plugins.*
 import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.client.plugins.websocket.*
 import io.ktor.client.request.*
@@ -25,10 +26,10 @@ public class DefaultVoiceGatewayBuilder(
     public var reconnectRetry: Retry? = null
     public var eventFlow: MutableSharedFlow<VoiceEvent> = MutableSharedFlow(extraBufferCapacity = Int.MAX_VALUE)
 
-    @OptIn(InternalAPI::class)
     public fun build(): DefaultVoiceGateway {
         val client = client ?: HttpClient(CIO) {
             install(WebSockets)
+            install(HttpTimeout)
             install(ContentNegotiation) {
                 json()
             }

--- a/voice/src/main/kotlin/handlers/StreamsHandler.kt
+++ b/voice/src/main/kotlin/handlers/StreamsHandler.kt
@@ -7,7 +7,7 @@ import dev.kord.voice.gateway.SessionDescription
 import dev.kord.voice.gateway.VoiceEvent
 import dev.kord.voice.gateway.handler.GatewayEventHandler
 import dev.kord.voice.streams.Streams
-import io.ktor.util.network.*
+import io.ktor.network.sockets.*
 import kotlinx.atomicfu.AtomicRef
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.Job
@@ -20,14 +20,14 @@ internal class StreamsHandler(
     flow: Flow<VoiceEvent>,
     private val streams: Streams,
 ) : GatewayEventHandler(flow, "HandshakeHandler") {
-    private val server: AtomicRef<NetworkAddress?> = atomic(null)
+    private val server: AtomicRef<SocketAddress?> = atomic(null)
 
     private var streamsJob: Job? by atomic(null)
 
     @OptIn(ExperimentalUnsignedTypes::class)
     override suspend fun start() = coroutineScope {
         on<Ready> {
-            server.value = NetworkAddress(it.ip, it.port)
+            server.value = InetSocketAddress(it.ip, it.port)
         }
 
         on<SessionDescription> {

--- a/voice/src/main/kotlin/handlers/VoiceUpdateEventHandler.kt
+++ b/voice/src/main/kotlin/handlers/VoiceUpdateEventHandler.kt
@@ -64,7 +64,7 @@ internal class VoiceUpdateEventHandler(
             // update the gateway configuration accordingly
             connection.voiceGatewayConfiguration = connection.voiceGatewayConfiguration.copy(
                 token = voiceServerUpdate.voiceServerUpdateData.token,
-                endpoint = "wss://${voiceServerUpdate.voiceServerUpdateData.endpoint}?v=4"
+                endpoint = "wss://${voiceServerUpdate.voiceServerUpdateData.endpoint}/?v=4"
             )
 
             // reconnect...

--- a/voice/src/main/kotlin/streams/DefaultStreams.kt
+++ b/voice/src/main/kotlin/streams/DefaultStreams.kt
@@ -12,6 +12,7 @@ import dev.kord.voice.io.*
 import dev.kord.voice.udp.PayloadType
 import dev.kord.voice.udp.RTPPacket
 import dev.kord.voice.udp.VoiceUdpSocket
+import io.ktor.network.sockets.*
 import io.ktor.util.network.*
 import kotlinx.atomicfu.AtomicRef
 import kotlinx.atomicfu.atomic
@@ -30,7 +31,7 @@ public class DefaultStreams(
     private val udp: VoiceUdpSocket,
     private val nonceStrategy: NonceStrategy
 ) : Streams {
-    private fun CoroutineScope.listenForIncoming(key: ByteArray, server: NetworkAddress) {
+    private fun CoroutineScope.listenForIncoming(key: ByteArray, server: SocketAddress) {
         udp.incoming
             .filter { it.address == server }
             .mapNotNull { RTPPacket.fromPacket(it.packet) }
@@ -62,7 +63,7 @@ public class DefaultStreams(
             }.launchIn(this)
     }
 
-    override suspend fun listen(key: ByteArray, server: NetworkAddress): Unit = coroutineScope {
+    override suspend fun listen(key: ByteArray, server: SocketAddress): Unit = coroutineScope {
         listenForIncoming(key, server)
         listenForUserFrames()
     }

--- a/voice/src/main/kotlin/streams/NOPStreams.kt
+++ b/voice/src/main/kotlin/streams/NOPStreams.kt
@@ -4,13 +4,13 @@ import dev.kord.common.annotation.KordVoice
 import dev.kord.common.entity.Snowflake
 import dev.kord.voice.AudioFrame
 import dev.kord.voice.udp.RTPPacket
-import io.ktor.util.network.*
+import io.ktor.network.sockets.*
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
 @KordVoice
 public object NOPStreams : Streams {
-    override suspend fun listen(key: ByteArray, server: NetworkAddress) {}
+    override suspend fun listen(key: ByteArray, server: SocketAddress) {}
 
     override val incomingAudioPackets: Flow<RTPPacket> = flow { }
     override val incomingAudioFrames: Flow<Pair<UInt, AudioFrame>> = flow { }

--- a/voice/src/main/kotlin/streams/Streams.kt
+++ b/voice/src/main/kotlin/streams/Streams.kt
@@ -4,6 +4,7 @@ import dev.kord.common.annotation.KordVoice
 import dev.kord.common.entity.Snowflake
 import dev.kord.voice.AudioFrame
 import dev.kord.voice.udp.RTPPacket
+import io.ktor.network.sockets.*
 import io.ktor.util.network.*
 import kotlinx.coroutines.flow.Flow
 
@@ -15,7 +16,7 @@ public interface Streams {
     /**
      * Starts propagating packets from [server] with the following [key] to decrypt the incoming frames.
      */
-    public suspend fun listen(key: ByteArray, server: NetworkAddress)
+    public suspend fun listen(key: ByteArray, server: SocketAddress)
 
     /**
      * A flow of all incoming [dev.kord.voice.udp.RTPPacket]s through the UDP connection.


### PR DESCRIPTION
The move over to Ktor 2.0 has been merged into Kord, and everything compiles, however a few migrations were needed to be done to ensure voice was working. This PR takes care of that and should fix kordlib/kord#613 as well.