### PR TITLE
Fix nonce deserialization

### DIFF
--- a/common/src/test/kotlin/json/MessageTest.kt
+++ b/common/src/test/kotlin/json/MessageTest.kt
@@ -46,6 +46,7 @@ class MessageTest {
             channelId shouldBe "290926798999357250"
             mentions shouldBe emptyList()
             type.code shouldBe 0
+            nonce shouldBe DiscordMessageNonce.StringNonce("hello")
         }
     }
 

--- a/common/src/test/resources/json/message/message.json
+++ b/common/src/test/resources/json/message/message.json
@@ -27,5 +27,6 @@
   "content": "Supa Hot",
   "channel_id": "290926798999357250",
   "mentions": [],
-  "type": 0
+  "type": 0,
+  "nonce": 1234
 }

--- a/common/src/test/resources/json/message/message.json
+++ b/common/src/test/resources/json/message/message.json
@@ -28,5 +28,5 @@
   "channel_id": "290926798999357250",
   "mentions": [],
   "type": 0,
-  "nonce": 1234
+  "nonce": "hello"
 }

--- a/core/src/main/kotlin/cache/data/MessageData.kt
+++ b/core/src/main/kotlin/cache/data/MessageData.kt
@@ -27,7 +27,7 @@ public data class MessageData(
     val attachments: List<AttachmentData>,
     val embeds: List<EmbedData>,
     val reactions: Optional<List<ReactionData>> = Optional.Missing(),
-    val nonce: Optional<String> = Optional.Missing(),
+    val nonce: Optional<DiscordMessageNonce> = Optional.Missing(),
     val pinned: Boolean,
     val webhookId: OptionalSnowflake = OptionalSnowflake.Missing,
     val type: MessageType,


### PR DESCRIPTION
Deserializes the message nonce based on the primitive type.

Fixes #629

(While the build failed, it does work, GitHub Actions cancelled the build automatically because it was taking more than 6 hours to complete)