### PR TITLE
Fix threads cache

### DIFF
--- a/core/src/main/kotlin/behavior/GuildBehavior.kt
+++ b/core/src/main/kotlin/behavior/GuildBehavior.kt
@@ -68,12 +68,25 @@ public interface GuildBehavior : KordEntity, Strategizable {
      * Returns all active public and private threads in this guild
      * Threads are ordered by their id, in descending order.
      *
-     *  The returned flow is lazily executed, any [RequestException] will be thrown on
+     * The returned flow is lazily executed, any [RequestException] will be thrown on
      * [terminal operators](https://kotlinlang.org/docs/reference/coroutines/flow.html#terminal-flow-operators) instead.
-
      */
     public val activeThreads: Flow<ThreadChannel>
         get() = supplier.getActiveThreads(id)
+
+    /**
+     * Requests to get all threads in this guild that are present in [cache][Kord.cache].
+     *
+     * This property is not resolvable through REST and will always use [Kord.cache] instead.
+     *
+     * The returned flow is lazily executed, any [RequestException] will be thrown on
+     * [terminal operators](https://kotlinlang.org/docs/reference/coroutines/flow.html#terminal-flow-operators) instead.
+     */
+    public val cachedThreads: Flow<ThreadChannel>
+        get() = kord.cache
+            .query { idEq(ChannelData::guildId, this@GuildBehavior.id) }
+            .asFlow()
+            .mapNotNull { Channel.from(it, kord) as? ThreadChannel }
 
     /**
      * Requests to get all present webhooks for this guild.

--- a/core/src/main/kotlin/behavior/GuildBehavior.kt
+++ b/core/src/main/kotlin/behavior/GuildBehavior.kt
@@ -84,7 +84,7 @@ public interface GuildBehavior : KordEntity, Strategizable {
      */
     public val cachedThreads: Flow<ThreadChannel>
         get() = kord.cache
-            .query { idEq(ChannelData::guildId, this@GuildBehavior.id) }
+            .query<ChannelData> { idEq(ChannelData::guildId, this@GuildBehavior.id) }
             .asFlow()
             .mapNotNull { Channel.from(it, kord) as? ThreadChannel }
 

--- a/core/src/main/kotlin/entity/Guild.kt
+++ b/core/src/main/kotlin/entity/Guild.kt
@@ -51,6 +51,7 @@ public class Guild(
     public val afkChannel: VoiceChannelBehavior?
         get() = afkChannelId?.let { VoiceChannelBehavior(guildId = id, id = it, kord = kord) }
 
+    @Deprecated("Use 'cachedThreads' instead.", ReplaceWith("cachedThreads"))
     public val threads: Flow<ThreadChannel>
         get() = flow {
             data.threads.mapList {

--- a/core/src/main/kotlin/gateway/handler/GuildEventHandler.kt
+++ b/core/src/main/kotlin/gateway/handler/GuildEventHandler.kt
@@ -68,6 +68,10 @@ internal class GuildEventHandler(
             cache.put(ChannelData.from(channel.copy(guildId = this.id.optionalSnowflake()))) //guild id always empty
         }
 
+        for (thread in threads.orEmpty()) {
+            cache.put(ChannelData.from(thread.copy(guildId = this.id.optionalSnowflake()))) //guild id always empty
+        }
+
         for (presence in presences.orEmpty()) {
             cache.put(PresenceData.from(id, presence))
         }
@@ -75,6 +79,7 @@ internal class GuildEventHandler(
         for (voiceState in voiceStates.orEmpty()) {
             cache.put(VoiceStateData.from(id, voiceState))
         }
+
         for (emoji in emojis) {
             cache.put(EmojiData.from(id, emoji.id!!, emoji))
         }


### PR DESCRIPTION
This PR fixes a bug that threads weren't cached when receiving Guild events.
It also deprecates `Guild.threads` (it does not behave like one might expect) and instead replaces it with `GuildBehavior.cachedThreads`.