### PR TITLE
Stricter compilation, clean up opt-ins

### DIFF
--- a/buildSrc/src/main/kotlin/Compiler.kt
+++ b/buildSrc/src/main/kotlin/Compiler.kt
@@ -1,5 +1,4 @@
 object CompilerArguments {
-    const val coroutines = "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"
     const val time = "-opt-in=kotlin.time.ExperimentalTime"
     const val contracts = "-opt-in=kotlin.contracts.ExperimentalContracts"
 

--- a/buildSrc/src/main/kotlin/Compiler.kt
+++ b/buildSrc/src/main/kotlin/Compiler.kt
@@ -2,6 +2,11 @@ object CompilerArguments {
     const val coroutines = "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"
     const val time = "-opt-in=kotlin.time.ExperimentalTime"
     const val contracts = "-opt-in=kotlin.contracts.ExperimentalContracts"
+
+    const val kordPreview = "-opt-in=dev.kord.common.annotation.KordPreview"
+    const val kordExperimental = "-opt-in=dev.kord.common.annotation.KordExperimental"
+    const val kordVoice = "-opt-in=dev.kord.common.annotation.KordVoice"
+
     const val progressive = "-progressive"
 }
 

--- a/buildSrc/src/main/kotlin/Compiler.kt
+++ b/buildSrc/src/main/kotlin/Compiler.kt
@@ -1,7 +1,6 @@
 object CompilerArguments {
     const val coroutines = "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"
     const val time = "-opt-in=kotlin.time.ExperimentalTime"
-    const val stdLib = "-opt-in=kotlin.ExperimentalStdlibApi"
     const val contracts = "-opt-in=kotlin.contracts.ExperimentalContracts"
     const val progressive = "-progressive"
 }

--- a/buildSrc/src/main/kotlin/Compiler.kt
+++ b/buildSrc/src/main/kotlin/Compiler.kt
@@ -3,6 +3,7 @@ object CompilerArguments {
     const val time = "-opt-in=kotlin.time.ExperimentalTime"
     const val stdLib = "-opt-in=kotlin.ExperimentalStdlibApi"
     const val contracts = "-opt-in=kotlin.contracts.ExperimentalContracts"
+    const val progressive = "-progressive"
 }
 
 object Jvm {

--- a/buildSrc/src/main/kotlin/kord-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/kord-module.gradle.kts
@@ -41,6 +41,11 @@ tasks {
                 CompilerArguments.coroutines,
                 CompilerArguments.time,
                 CompilerArguments.contracts,
+
+                CompilerArguments.kordPreview,
+                CompilerArguments.kordExperimental,
+                CompilerArguments.kordVoice,
+
                 CompilerArguments.progressive,
             )
         }

--- a/buildSrc/src/main/kotlin/kord-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/kord-module.gradle.kts
@@ -21,6 +21,9 @@ dependencies {
 
 kotlin {
     explicitApi()
+
+    // allow ExperimentalCoroutinesApi for `runTest {}`
+    sourceSets["test"].languageSettings.optIn("kotlinx.coroutines.ExperimentalCoroutinesApi")
 }
 
 tasks {
@@ -38,7 +41,6 @@ tasks {
             jvmTarget = Jvm.target
             allWarningsAsErrors = true
             freeCompilerArgs = listOf(
-                CompilerArguments.coroutines,
                 CompilerArguments.time,
                 CompilerArguments.contracts,
 

--- a/buildSrc/src/main/kotlin/kord-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/kord-module.gradle.kts
@@ -29,17 +29,19 @@ tasks {
     }
 
     withType<JavaCompile> {
-        sourceCompatibility = "1.8"
-        targetCompatibility = "1.8"
+        sourceCompatibility = Jvm.target
+        targetCompatibility = Jvm.target
     }
 
     withType<KotlinCompile> {
         kotlinOptions {
             jvmTarget = Jvm.target
+            allWarningsAsErrors = true
             freeCompilerArgs = listOf(
                 CompilerArguments.coroutines,
                 CompilerArguments.time,
                 CompilerArguments.contracts,
+                CompilerArguments.progressive,
             )
         }
     }

--- a/common/src/main/kotlin/entity/DiscordUser.kt
+++ b/common/src/main/kotlin/entity/DiscordUser.kt
@@ -73,7 +73,6 @@ public data class DiscordUser(
  * @param premiumType The type of Nitro subscription on a user's account.
  * @param publicFlags The public flags on a user's account. Unlike [flags], these **are** visible ot other users.
  */
-@OptIn(ExperimentalSerializationApi::class)
 @Serializable
 public data class DiscordOptionallyMemberUser(
     val id: Snowflake,
@@ -92,6 +91,7 @@ public data class DiscordOptionallyMemberUser(
     val premiumType: Optional<UserPremium> = Optional.Missing(),
     @SerialName("public_flags")
     val publicFlags: Optional<UserFlags> = Optional.Missing(),
+    @OptIn(ExperimentalSerializationApi::class)
     @JsonNames("member", "guild_member")
     val member: Optional<DiscordGuildMember> = Optional.Missing(),
 )

--- a/common/src/main/kotlin/entity/Interactions.kt
+++ b/common/src/main/kotlin/entity/Interactions.kt
@@ -78,7 +78,6 @@ public data class ApplicationCommandOption(
     val descriptionLocalizations: Optional<Map<Locale, String>?> = Optional.Missing(),
     val default: OptionalBoolean = OptionalBoolean.Missing,
     val required: OptionalBoolean = OptionalBoolean.Missing,
-    @OptIn(KordExperimental::class)
     val choices: Optional<List<Choice<@Serializable(NotSerializable::class) Any?>>> = Optional.Missing(),
     val autocomplete: OptionalBoolean = OptionalBoolean.Missing,
     val options: Optional<List<ApplicationCommandOption>> = Optional.Missing(),

--- a/common/src/test/kotlin/json/InteractionTest.kt
+++ b/common/src/test/kotlin/json/InteractionTest.kt
@@ -1,23 +1,15 @@
 package json
 
-import dev.kord.common.annotation.KordPreview
 import dev.kord.common.entity.*
-import dev.kord.common.entity.optional.Optional
-import dev.kord.common.entity.optional.filterList
 import dev.kord.common.entity.optional.orEmpty
-import kotlinx.coroutines.coroutineScope
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Test
-import kotlin.coroutines.suspendCoroutine
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
 
 private fun file(name: String): String {
     val loader = InteractionTest::class.java.classLoader
     return loader.getResource("json/interaction/$name.json")!!.readText()
 }
 
-@OptIn(KordPreview::class)
 class InteractionTest {
 
     val json = Json {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 plugins {
     java
     `kord-module`
@@ -31,14 +29,6 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(libs.bundles.test.implementation)
     testRuntimeOnly(libs.bundles.test.runtime)
-}
-
-tasks {
-    withType<KotlinCompile> {
-        kotlinOptions {
-            freeCompilerArgs = freeCompilerArgs + CompilerArguments.stdLib
-        }
-    }
 }
 
 java {

--- a/core/src/main/kotlin/Kord.kt
+++ b/core/src/main/kotlin/Kord.kt
@@ -83,7 +83,7 @@ public class Kord(
     /**
      * A reference to all exposed [unsafe][KordUnsafe] entity constructors for this instance.
      */
-    @OptIn(KordUnsafe::class, KordExperimental::class)
+    @OptIn(KordUnsafe::class)
     public val unsafe: Unsafe = Unsafe(this)
 
     /**

--- a/core/src/main/kotlin/Util.kt
+++ b/core/src/main/kotlin/Util.kt
@@ -1,6 +1,5 @@
 package dev.kord.core
 
-import dev.kord.common.annotation.KordPreview
 import dev.kord.common.entity.Snowflake
 import dev.kord.core.entity.Entity
 import dev.kord.core.entity.KordEntity
@@ -348,7 +347,7 @@ public fun Intents.IntentsBuilder.enableEvents(vararg events: KClass<out Event>)
  * Note that enabling one type of event might also enable several other types of events since most [Intent]s enable more
  * than one event.
  */
-@OptIn(PrivilegedIntent::class, KordPreview::class)
+@OptIn(PrivilegedIntent::class)
 public fun Intents.IntentsBuilder.enableEvent(event: KClass<out Event>): Unit = when (event) {
 // see https://discord.com/developers/docs/topics/gateway#list-of-intents
 

--- a/core/src/main/kotlin/behavior/StickerBehavior.kt
+++ b/core/src/main/kotlin/behavior/StickerBehavior.kt
@@ -9,7 +9,6 @@ import dev.kord.core.entity.Strategizable
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 import dev.kord.rest.builder.guild.StickerModifyBuilder
-import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -48,7 +47,6 @@ public fun StickerBehavior(guildId: Snowflake, id: Snowflake, kord: Kord, suppli
 
     }
 
-@OptIn(ExperimentalContracts::class)
 public suspend inline fun StickerBehavior.edit(builder: StickerModifyBuilder.() -> Unit): Sticker {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
     val response = kord.rest.sticker.modifyGuildSticker(guildId, id, builder)

--- a/core/src/main/kotlin/builder/kord/KordBuilder.kt
+++ b/core/src/main/kotlin/builder/kord/KordBuilder.kt
@@ -2,7 +2,6 @@ package dev.kord.core.builder.kord
 
 import dev.kord.cache.api.DataCache
 import dev.kord.common.KordConstants
-import dev.kord.common.annotation.KordExperimental
 import dev.kord.common.entity.Snowflake
 import dev.kord.common.ratelimit.IntervalRateLimiter
 import dev.kord.core.ClientResources
@@ -195,7 +194,6 @@ public class KordBuilder(public val token: String) {
      */
     private suspend fun HttpClient.getGatewayInfo(): BotGatewayResponse {
         val response = get("${Route.baseUrl}${Route.GatewayBotGet.path}") {
-            @OptIn(KordExperimental::class)
             header(UserAgent, KordConstants.USER_AGENT)
             header(Authorization, "Bot $token")
         }

--- a/core/src/main/kotlin/builder/kord/KordRestOnlyBuilder.kt
+++ b/core/src/main/kotlin/builder/kord/KordRestOnlyBuilder.kt
@@ -17,6 +17,7 @@ import dev.kord.rest.service.RestClient
 import io.ktor.client.HttpClient
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 
 /**
@@ -73,6 +74,7 @@ public class KordRestOnlyBuilder(public val token: String) {
 
         return Kord(
             resources,
+            @OptIn(ExperimentalCoroutinesApi::class)
             DataCache.none(),
             DefaultMasterGateway(mapOf(0 to Gateway.none())),
             rest,

--- a/core/src/main/kotlin/cache/data/ApplicationCommandData.kt
+++ b/core/src/main/kotlin/cache/data/ApplicationCommandData.kt
@@ -42,7 +42,7 @@ public data class ApplicationCommandData(
                     options.mapList { ApplicationCommandOptionData.from(it) },
                     defaultMemberPermissions,
                     dmPermission,
-                    defaultPermission,
+                    @Suppress("DEPRECATION") defaultPermission,
                     version
                 )
             }

--- a/core/src/main/kotlin/cache/data/InteractionData.kt
+++ b/core/src/main/kotlin/cache/data/InteractionData.kt
@@ -121,9 +121,7 @@ public data class ApplicationInteractionData(
 @Serializable
 public data class OptionData(
     val name: String,
-    @OptIn(KordExperimental::class)
     val value: Optional<CommandArgument<@Serializable(NotSerializable::class) Any?>> = Optional.Missing(),
-    @OptIn(KordExperimental::class)
     val values: Optional<List<CommandArgument<@Serializable(NotSerializable::class) Any?>>> = Optional.Missing(),
     val subCommands: Optional<List<SubCommand>> = Optional.Missing(),
     val focused: OptionalBoolean = OptionalBoolean.Missing

--- a/core/src/main/kotlin/entity/application/ApplicationCommand.kt
+++ b/core/src/main/kotlin/entity/application/ApplicationCommand.kt
@@ -55,8 +55,9 @@ public sealed interface ApplicationCommand : ApplicationCommandBehavior {
     /**
      * whether the command is enabled by default when the app is added to a guild.
      */
+    @Suppress("DeprecatedCallableAddReplaceWith")
     @Deprecated("'defaultPermission' is deprecated in favor of 'defaultMemberPermissions' and 'dmPermission'.")
-    public val defaultPermission: Boolean? get() = data.defaultPermission.value
+    public val defaultPermission: Boolean? get() = @Suppress("DEPRECATION") data.defaultPermission.value
 
 
 }

--- a/core/src/test/kotlin/KordTest.kt
+++ b/core/src/test/kotlin/KordTest.kt
@@ -1,20 +1,15 @@
-package dev.kord.core
-
-import dev.kord.common.annotation.KordExperimental
+import dev.kord.core.Kord
 import dev.kord.core.event.gateway.ReadyEvent
-import kotlinx.coroutines.*
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onCompletion
+import dev.kord.core.on
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
-import java.util.concurrent.CountDownLatch
 import kotlin.test.assertEquals
 
 @EnabledIfEnvironmentVariable(named = "KORD_TEST_TOKEN", matches = ".+")
 internal class KordTest {
 
     @Test
-    @OptIn(KordExperimental::class, kotlinx.coroutines.DelicateCoroutinesApi::class)
     fun `Kord life cycle is correctly ended on shutdown`() = runBlocking {
         val kord = Kord.restOnly(System.getenv("KORD_TEST_TOKEN"))
         val job = kord.on<ReadyEvent> {}
@@ -23,4 +18,3 @@ internal class KordTest {
 
     }
 }
-

--- a/core/src/test/kotlin/live/AbstractLiveEntityTest.kt
+++ b/core/src/test/kotlin/live/AbstractLiveEntityTest.kt
@@ -1,7 +1,6 @@
 package live
 
 import dev.kord.cache.api.DataCache
-import dev.kord.common.annotation.KordPreview
 import dev.kord.common.entity.Snowflake
 import dev.kord.core.ClientResources
 import dev.kord.core.Kord
@@ -31,7 +30,6 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.time.Duration
 
-@OptIn(KordPreview::class)
 abstract class AbstractLiveEntityTest<LIVE : AbstractLiveKordEntity> {
 
     companion object {

--- a/core/src/test/kotlin/live/LiveGuildTest.kt
+++ b/core/src/test/kotlin/live/LiveGuildTest.kt
@@ -1,6 +1,5 @@
 package live
 
-import dev.kord.common.annotation.KordPreview
 import dev.kord.common.entity.*
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.optionalSnowflake
@@ -26,7 +25,6 @@ import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.seconds
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@OptIn(KordPreview::class)
 @Timeout(value = 5, unit = TimeUnit.SECONDS)
 @Disabled
 class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {

--- a/core/src/test/kotlin/live/LiveKordEntityTest.kt
+++ b/core/src/test/kotlin/live/LiveKordEntityTest.kt
@@ -1,6 +1,5 @@
 package live
 
-import dev.kord.common.annotation.KordPreview
 import dev.kord.common.entity.*
 import dev.kord.core.Kord
 import dev.kord.core.entity.ReactionEmoji
@@ -23,7 +22,6 @@ import java.util.concurrent.TimeUnit
 import kotlin.test.*
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@OptIn(KordPreview::class)
 @Timeout(value = 5, unit = TimeUnit.SECONDS)
 @Disabled
 class LiveKordEntityTest : AbstractLiveEntityTest<LiveKordEntityTest.LiveEntityMock>() {

--- a/core/src/test/kotlin/live/LiveMemberTest.kt
+++ b/core/src/test/kotlin/live/LiveMemberTest.kt
@@ -1,6 +1,5 @@
 package live
 
-import dev.kord.common.annotation.KordPreview
 import dev.kord.common.entity.*
 import dev.kord.common.entity.optional.Optional
 import dev.kord.core.cache.data.MemberData
@@ -30,7 +29,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@OptIn(KordPreview::class)
 @Timeout(value = 5, unit = TimeUnit.SECONDS)
 @Disabled
 class LiveMemberTest : AbstractLiveEntityTest<LiveMember>() {

--- a/core/src/test/kotlin/live/LiveMessageTest.kt
+++ b/core/src/test/kotlin/live/LiveMessageTest.kt
@@ -1,6 +1,5 @@
 package live
 
-import dev.kord.common.annotation.KordPreview
 import dev.kord.common.entity.*
 import dev.kord.core.cache.data.MessageData
 import dev.kord.core.cache.data.UserData
@@ -28,7 +27,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@OptIn(KordPreview::class)
 @Timeout(value = 5, unit = TimeUnit.SECONDS)
 @Disabled
 class LiveMessageTest : AbstractLiveEntityTest<LiveMessage>() {

--- a/core/src/test/kotlin/live/LiveRoleTest.kt
+++ b/core/src/test/kotlin/live/LiveRoleTest.kt
@@ -1,6 +1,5 @@
 package live
 
-import dev.kord.common.annotation.KordPreview
 import dev.kord.common.entity.*
 import dev.kord.common.entity.optional.Optional
 import dev.kord.core.cache.data.RoleData
@@ -25,7 +24,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@OptIn(KordPreview::class)
 @Timeout(value = 5, unit = TimeUnit.SECONDS)
 @Disabled
 class LiveRoleTest : AbstractLiveEntityTest<LiveRole>() {

--- a/core/src/test/kotlin/live/LiveUserTest.kt
+++ b/core/src/test/kotlin/live/LiveUserTest.kt
@@ -1,6 +1,5 @@
 package live
 
-import dev.kord.common.annotation.KordPreview
 import dev.kord.common.entity.DiscordUser
 import dev.kord.common.entity.Snowflake
 import dev.kord.core.cache.data.UserData
@@ -20,7 +19,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@OptIn(KordPreview::class)
 @Timeout(value = 5, unit = TimeUnit.SECONDS)
 @Disabled
 class LiveUserTest : AbstractLiveEntityTest<LiveUser>() {

--- a/core/src/test/kotlin/live/channel/LiveCategoryTest.kt
+++ b/core/src/test/kotlin/live/channel/LiveCategoryTest.kt
@@ -1,6 +1,5 @@
 package live.channel
 
-import dev.kord.common.annotation.KordPreview
 import dev.kord.common.entity.ChannelType
 import dev.kord.common.entity.DiscordChannel
 import dev.kord.common.entity.Snowflake
@@ -22,7 +21,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@OptIn(KordPreview::class)
 @Timeout(value = 5, unit = TimeUnit.SECONDS)
 @Disabled
 class LiveCategoryTest : LiveChannelTest<LiveCategory>() {

--- a/core/src/test/kotlin/live/channel/LiveChannelTest.kt
+++ b/core/src/test/kotlin/live/channel/LiveChannelTest.kt
@@ -1,6 +1,5 @@
 package live.channel
 
-import dev.kord.common.annotation.KordPreview
 import dev.kord.common.entity.ChannelType
 import dev.kord.common.entity.DiscordChannel
 import dev.kord.common.entity.DiscordUnavailableGuild
@@ -26,7 +25,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@OptIn(KordPreview::class)
 @Timeout(value = 5, unit = TimeUnit.SECONDS)
 @Disabled
 abstract class LiveChannelTest<LIVE : LiveChannel> : AbstractLiveEntityTest<LIVE>() {

--- a/core/src/test/kotlin/live/channel/LiveDmChannelTest.kt
+++ b/core/src/test/kotlin/live/channel/LiveDmChannelTest.kt
@@ -1,6 +1,5 @@
 package live.channel
 
-import dev.kord.common.annotation.KordPreview
 import dev.kord.common.entity.ChannelType
 import dev.kord.common.entity.DiscordChannel
 import dev.kord.common.entity.Snowflake
@@ -22,7 +21,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@OptIn(KordPreview::class)
 @Timeout(value = 5, unit = TimeUnit.SECONDS)
 @Disabled
 class LiveDmChannelTest : LiveChannelTest<LiveDmChannel>() {

--- a/core/src/test/kotlin/live/channel/LiveGuildChannelTest.kt
+++ b/core/src/test/kotlin/live/channel/LiveGuildChannelTest.kt
@@ -1,6 +1,5 @@
 package live.channel
 
-import dev.kord.common.annotation.KordPreview
 import dev.kord.common.entity.ChannelType
 import dev.kord.common.entity.DiscordChannel
 import dev.kord.common.entity.Snowflake
@@ -25,7 +24,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@OptIn(KordPreview::class)
 @Timeout(value = 5, unit = TimeUnit.SECONDS)
 @Disabled
 class LiveGuildChannelTest : LiveChannelTest<LiveGuildChannel>() {

--- a/core/src/test/kotlin/live/channel/LiveGuildTextTest.kt
+++ b/core/src/test/kotlin/live/channel/LiveGuildTextTest.kt
@@ -1,6 +1,5 @@
 package live.channel
 
-import dev.kord.common.annotation.KordPreview
 import dev.kord.common.entity.ChannelType
 import dev.kord.common.entity.DiscordChannel
 import dev.kord.common.entity.Snowflake
@@ -25,7 +24,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@OptIn(KordPreview::class)
 @Timeout(value = 5, unit = TimeUnit.SECONDS)
 @Disabled
 class LiveGuildTextTest : LiveChannelTest<LiveGuildChannel>() {

--- a/core/src/test/kotlin/live/channel/LiveVoiceChannelTest.kt
+++ b/core/src/test/kotlin/live/channel/LiveVoiceChannelTest.kt
@@ -1,6 +1,5 @@
 package live.channel
 
-import dev.kord.common.annotation.KordPreview
 import dev.kord.common.entity.ChannelType
 import dev.kord.common.entity.DiscordChannel
 import dev.kord.common.entity.Snowflake
@@ -22,7 +21,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@OptIn(KordPreview::class)
 @Timeout(value = 5, unit = TimeUnit.SECONDS)
 @Disabled
 class LiveVoiceChannelTest : LiveChannelTest<LiveVoiceChannel>() {

--- a/core/src/test/kotlin/rest/RestTest.kt
+++ b/core/src/test/kotlin/rest/RestTest.kt
@@ -1,7 +1,6 @@
 package rest
 
 import dev.kord.common.Color
-import dev.kord.common.annotation.KordExperimental
 import dev.kord.common.entity.*
 import dev.kord.core.Kord
 import dev.kord.core.behavior.*
@@ -58,7 +57,6 @@ class RestServiceTest {
     private lateinit var userId: Snowflake
 
     @BeforeAll
-    @OptIn(KordExperimental::class)
     fun setup() = runBlocking {
         kord = Kord.restOnly(token)
 
@@ -412,7 +410,6 @@ class RestServiceTest {
 
     @Test
     @Order(25)
-    @OptIn(KordExperimental::class)
     fun `channel moves in guild`(): Unit = runBlocking {
         val category = guild.createCategory("move category")
         val textChannel = guild.createTextChannel("move me to a category")

--- a/core/src/test/kotlin/supplier/CacheEntitySupplierTest.kt
+++ b/core/src/test/kotlin/supplier/CacheEntitySupplierTest.kt
@@ -1,6 +1,5 @@
 package supplier
 
-import dev.kord.common.annotation.KordExperimental
 import dev.kord.common.annotation.KordUnsafe
 import dev.kord.common.entity.Snowflake
 import dev.kord.core.ClientResources
@@ -22,7 +21,7 @@ import org.junit.jupiter.api.Test
 internal class CacheEntitySupplierTest {
 
     @Test
-    @OptIn(KordUnsafe::class, KordExperimental::class)
+    @OptIn(KordUnsafe::class)
     fun `cache does not throw when accessing unregistered entities`(): Unit = runBlocking {
         val kord = Kord(
             ClientResources("", Snowflake(0u), Shards(0), HttpClient(), EntitySupplyStrategy.cache),

--- a/core/src/test/kotlin/supplier/CacheEntitySupplierTest.kt
+++ b/core/src/test/kotlin/supplier/CacheEntitySupplierTest.kt
@@ -1,4 +1,4 @@
-package dev.kord.core.supplier
+package supplier
 
 import dev.kord.common.annotation.KordExperimental
 import dev.kord.common.annotation.KordUnsafe
@@ -7,8 +7,8 @@ import dev.kord.core.ClientResources
 import dev.kord.core.Kord
 import dev.kord.core.cache.KordCacheBuilder
 import dev.kord.core.gateway.DefaultMasterGateway
+import dev.kord.core.supplier.EntitySupplyStrategy
 import dev.kord.gateway.Gateway
-import dev.kord.gateway.PrivilegedIntent
 import dev.kord.gateway.builder.Shards
 import dev.kord.rest.request.KtorRequestHandler
 import dev.kord.rest.service.RestClient
@@ -22,16 +22,16 @@ import org.junit.jupiter.api.Test
 internal class CacheEntitySupplierTest {
 
     @Test
-    @OptIn(PrivilegedIntent::class, KordUnsafe::class, KordExperimental::class)
+    @OptIn(KordUnsafe::class, KordExperimental::class)
     fun `cache does not throw when accessing unregistered entities`(): Unit = runBlocking {
         val kord = Kord(
-                ClientResources("", Snowflake(0u), Shards(0), HttpClient(), EntitySupplyStrategy.cache, ),
-                KordCacheBuilder().build(),
-                DefaultMasterGateway(mapOf(0 to Gateway.none())),
-                RestClient(KtorRequestHandler("")),
-                Snowflake(0u),
-                MutableSharedFlow(),
-                Dispatchers.Default
+            ClientResources("", Snowflake(0u), Shards(0), HttpClient(), EntitySupplyStrategy.cache),
+            KordCacheBuilder().build(),
+            DefaultMasterGateway(mapOf(0 to Gateway.none())),
+            RestClient(KtorRequestHandler("")),
+            Snowflake(0u),
+            MutableSharedFlow(),
+            Dispatchers.Default
         )
 
         kord.unsafe.guild(Snowflake(0u)).regions.toList()

--- a/gateway/src/main/kotlin/DefaultGateway.kt
+++ b/gateway/src/main/kotlin/DefaultGateway.kt
@@ -290,6 +290,7 @@ public class DefaultGateway(private val data: DefaultGatewayData) : Gateway {
         socket.send(Frame.Text(json))
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     private val socketOpen get() = ::socket.isInitialized && !socket.outgoing.isClosedForSend && !socket.incoming.isClosedForReceive
 
     public companion object {

--- a/gateway/src/main/kotlin/DefaultGatewayBuilder.kt
+++ b/gateway/src/main/kotlin/DefaultGatewayBuilder.kt
@@ -1,7 +1,6 @@
 package dev.kord.gateway
 
 import dev.kord.common.KordConfiguration
-import dev.kord.common.annotation.KordExperimental
 import dev.kord.common.ratelimit.IntervalRateLimiter
 import dev.kord.common.ratelimit.RateLimiter
 import dev.kord.gateway.retry.LinearRetry
@@ -20,7 +19,6 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlin.time.Duration.Companion.seconds
 
 public class DefaultGatewayBuilder {
-    @OptIn(KordExperimental::class)
     public var url: String =
         "wss://gateway.discord.gg/?v=${KordConfiguration.GATEWAY_VERSION}&encoding=json&compress=zlib-stream"
     public var client: HttpClient? = null

--- a/rest/src/main/kotlin/builder/channel/GuildChannelPositionModifyBuilder.kt
+++ b/rest/src/main/kotlin/builder/channel/GuildChannelPositionModifyBuilder.kt
@@ -65,7 +65,6 @@ public class GuildChannelSwapBuilder(public var channelId: Snowflake) {
     @KordExperimental
     public var lockPermissionsToParent: Boolean? = null
 
-    @OptIn(KordExperimental::class)
     public fun toRequest(): ChannelPositionSwapRequest = ChannelPositionSwapRequest(
         channelId, _position, lockPermissionsToParent, parentId
     )

--- a/rest/src/main/kotlin/builder/interaction/InputChatBuilders.kt
+++ b/rest/src/main/kotlin/builder/interaction/InputChatBuilders.kt
@@ -150,7 +150,7 @@ internal class ChatInputCreateBuilderImpl(
     override var dmPermission: Boolean? by state::dmPermission.delegate()
 
     @Deprecated("'defaultPermission' is deprecated in favor of 'defaultMemberPermissions' and 'dmPermission'. Setting 'defaultPermission' to false can be replaced by setting 'defaultMemberPermissions' to empty Permissions and 'dmPermission' to false ('dmPermission' is only available for global commands).")
-    override var defaultPermission: Boolean? by state::defaultPermission.delegate()
+    override var defaultPermission: Boolean? by @Suppress("DEPRECATION") state::defaultPermission.delegate()
 
 
     override fun toRequest(): ApplicationCommandCreateRequest {
@@ -163,7 +163,7 @@ internal class ChatInputCreateBuilderImpl(
             state.options.mapList { it.toRequest() },
             state.defaultMemberPermissions,
             state.dmPermission,
-            state.defaultPermission
+            @Suppress("DEPRECATION") state.defaultPermission,
         )
 
     }
@@ -193,7 +193,7 @@ internal class ChatInputModifyBuilderImpl : GlobalChatInputModifyBuilder {
     override var dmPermission: Boolean? by state::dmPermission.delegate()
 
     @Deprecated("'defaultPermission' is deprecated in favor of 'defaultMemberPermissions' and 'dmPermission'. Setting 'defaultPermission' to false can be replaced by setting 'defaultMemberPermissions' to empty Permissions and 'dmPermission' to false ('dmPermission' is only available for global commands).")
-    override var defaultPermission: Boolean? by state::defaultPermission.delegate()
+    override var defaultPermission: Boolean? by @Suppress("DEPRECATION") state::defaultPermission.delegate()
 
     override fun toRequest(): ApplicationCommandModifyRequest {
         return ApplicationCommandModifyRequest(
@@ -204,7 +204,7 @@ internal class ChatInputModifyBuilderImpl : GlobalChatInputModifyBuilder {
             state.options.mapList { it.toRequest() },
             state.defaultMemberPermissions,
             state.dmPermission,
-            state.defaultPermission
+            @Suppress("DEPRECATION") state.defaultPermission,
         )
 
     }

--- a/rest/src/main/kotlin/builder/interaction/MessageCommandBuilders.kt
+++ b/rest/src/main/kotlin/builder/interaction/MessageCommandBuilders.kt
@@ -27,7 +27,7 @@ internal class MessageCommandModifyBuilderImpl : GlobalMessageCommandModifyBuild
     override var dmPermission: Boolean? by state::dmPermission.delegate()
 
     @Deprecated("'defaultPermission' is deprecated in favor of 'defaultMemberPermissions' and 'dmPermission'. Setting 'defaultPermission' to false can be replaced by setting 'defaultMemberPermissions' to empty Permissions and 'dmPermission' to false ('dmPermission' is only available for global commands).")
-    override var defaultPermission: Boolean? by state::defaultPermission.delegate()
+    override var defaultPermission: Boolean? by @Suppress("DEPRECATION") state::defaultPermission.delegate()
 
     override fun toRequest(): ApplicationCommandModifyRequest {
         return ApplicationCommandModifyRequest(
@@ -35,7 +35,7 @@ internal class MessageCommandModifyBuilderImpl : GlobalMessageCommandModifyBuild
             nameLocalizations = state.nameLocalizations,
             dmPermission = state.dmPermission,
             defaultMemberPermissions = state.defaultMemberPermissions,
-            defaultPermission = state.defaultPermission
+            defaultPermission = @Suppress("DEPRECATION") state.defaultPermission,
         )
 
     }
@@ -62,7 +62,7 @@ internal class MessageCommandCreateBuilderImpl(override var name: String) : Glob
     override var dmPermission: Boolean? by state::dmPermission.delegate()
 
     @Deprecated("'defaultPermission' is deprecated in favor of 'defaultMemberPermissions' and 'dmPermission'. Setting 'defaultPermission' to false can be replaced by setting 'defaultMemberPermissions' to empty Permissions and 'dmPermission' to false ('dmPermission' is only available for global commands).")
-    override var defaultPermission: Boolean? by state::defaultPermission.delegate()
+    override var defaultPermission: Boolean? by @Suppress("DEPRECATION") state::defaultPermission.delegate()
 
     override fun toRequest(): ApplicationCommandCreateRequest {
         return ApplicationCommandCreateRequest(
@@ -71,7 +71,7 @@ internal class MessageCommandCreateBuilderImpl(override var name: String) : Glob
             type = type,
             dmPermission = state.dmPermission,
             defaultMemberPermissions = state.defaultMemberPermissions,
-            defaultPermission = state.defaultPermission
+            defaultPermission = @Suppress("DEPRECATION") state.defaultPermission,
         )
     }
 }

--- a/rest/src/main/kotlin/builder/interaction/UserCommandBuilders.kt
+++ b/rest/src/main/kotlin/builder/interaction/UserCommandBuilders.kt
@@ -26,7 +26,7 @@ internal class UserCommandModifyBuilderImpl : GlobalUserCommandModifyBuilder {
     override var dmPermission: Boolean? by state::dmPermission.delegate()
 
     @Deprecated("'defaultPermission' is deprecated in favor of 'defaultMemberPermissions' and 'dmPermission'. Setting 'defaultPermission' to false can be replaced by setting 'defaultMemberPermissions' to empty Permissions and 'dmPermission' to false ('dmPermission' is only available for global commands).")
-    override var defaultPermission: Boolean? by state::defaultPermission.delegate()
+    override var defaultPermission: Boolean? by @Suppress("DEPRECATION") state::defaultPermission.delegate()
 
     override fun toRequest(): ApplicationCommandModifyRequest {
         return ApplicationCommandModifyRequest(
@@ -34,7 +34,7 @@ internal class UserCommandModifyBuilderImpl : GlobalUserCommandModifyBuilder {
             nameLocalizations = state.nameLocalizations,
             dmPermission = state.dmPermission,
             defaultMemberPermissions = state.defaultMemberPermissions,
-            defaultPermission = state.defaultPermission
+            defaultPermission = @Suppress("DEPRECATION") state.defaultPermission,
         )
     }
 }
@@ -57,7 +57,7 @@ internal class UserCommandCreateBuilderImpl(override var name: String) : GlobalU
     override var dmPermission: Boolean? by state::dmPermission.delegate()
 
     @Deprecated("'defaultPermission' is deprecated in favor of 'defaultMemberPermissions' and 'dmPermission'. Setting 'defaultPermission' to false can be replaced by setting 'defaultMemberPermissions' to empty Permissions and 'dmPermission' to false ('dmPermission' is only available for global commands).")
-    override var defaultPermission: Boolean? by state::defaultPermission.delegate()
+    override var defaultPermission: Boolean? by @Suppress("DEPRECATION") state::defaultPermission.delegate()
 
     override fun toRequest(): ApplicationCommandCreateRequest {
         return ApplicationCommandCreateRequest(
@@ -66,7 +66,7 @@ internal class UserCommandCreateBuilderImpl(override var name: String) : GlobalU
             type = type,
             defaultMemberPermissions = state.defaultMemberPermissions,
             dmPermission = state.dmPermission,
-            defaultPermission = state.defaultPermission
+            defaultPermission = @Suppress("DEPRECATION") state.defaultPermission,
         )
     }
 }

--- a/rest/src/main/kotlin/builder/message/create/UserMessageCreateBuilder.kt
+++ b/rest/src/main/kotlin/builder/message/create/UserMessageCreateBuilder.kt
@@ -1,6 +1,5 @@
 package dev.kord.rest.builder.message.create
 
-import dev.kord.common.annotation.KordPreview
 import dev.kord.common.entity.DiscordMessageReference
 import dev.kord.common.entity.Snowflake
 import dev.kord.common.entity.optional.*
@@ -52,7 +51,6 @@ public class UserMessageCreateBuilder
 
     override val files: MutableList<NamedFile> = mutableListOf()
 
-    @OptIn(KordPreview::class)
     override fun toRequest(): MultipartMessageCreateRequest {
         return MultipartMessageCreateRequest(
             MessageCreateRequest(

--- a/rest/src/main/kotlin/builder/message/create/WebhookMessageCreateBuilder.kt
+++ b/rest/src/main/kotlin/builder/message/create/WebhookMessageCreateBuilder.kt
@@ -1,6 +1,5 @@
 package dev.kord.rest.builder.message.create
 
-import dev.kord.common.annotation.KordPreview
 import dev.kord.common.entity.optional.*
 import dev.kord.rest.NamedFile
 import dev.kord.rest.builder.RequestBuilder
@@ -34,7 +33,6 @@ public class WebhookMessageCreateBuilder :
 
     override val files: MutableList<NamedFile> = mutableListOf()
 
-    @OptIn(KordPreview::class)
     override fun toRequest(): MultiPartWebhookExecuteRequest {
         return MultiPartWebhookExecuteRequest(
             WebhookExecuteRequest(

--- a/rest/src/main/kotlin/builder/message/modify/MessageModifyBuilder.kt
+++ b/rest/src/main/kotlin/builder/message/modify/MessageModifyBuilder.kt
@@ -1,6 +1,5 @@
 package dev.kord.rest.builder.message.modify
 
-import dev.kord.common.annotation.KordPreview
 import dev.kord.common.entity.DiscordAttachment
 import dev.kord.rest.NamedFile
 import dev.kord.rest.builder.component.ActionRowBuilder
@@ -23,7 +22,6 @@ public sealed interface MessageModifyBuilder {
 
     public var allowedMentions: AllowedMentionsBuilder?
 
-    @OptIn(KordPreview::class)
     public var components: MutableList<MessageComponentBuilder>?
 
 

--- a/rest/src/main/kotlin/builder/message/modify/UserMessageModifyBuilder.kt
+++ b/rest/src/main/kotlin/builder/message/modify/UserMessageModifyBuilder.kt
@@ -1,6 +1,5 @@
 package dev.kord.rest.builder.message.modify
 
-import dev.kord.common.annotation.KordPreview
 import dev.kord.common.entity.DiscordAttachment
 import dev.kord.common.entity.MessageFlags
 import dev.kord.common.entity.optional.delegate.delegate
@@ -35,7 +34,6 @@ public class UserMessageModifyBuilder
 
     override var components: MutableList<MessageComponentBuilder>? by state::components.delegate()
 
-    @OptIn(KordPreview::class)
     override fun toRequest(): MultipartMessagePatchRequest = MultipartMessagePatchRequest(
         MessageEditPatchRequest(
             content = state.content,

--- a/rest/src/main/kotlin/builder/message/modify/WebhookMessageModifyBuilder.kt
+++ b/rest/src/main/kotlin/builder/message/modify/WebhookMessageModifyBuilder.kt
@@ -1,6 +1,5 @@
 package dev.kord.rest.builder.message.modify
 
-import dev.kord.common.annotation.KordPreview
 import dev.kord.common.entity.DiscordAttachment
 import dev.kord.common.entity.optional.delegate.delegate
 import dev.kord.common.entity.optional.map
@@ -32,7 +31,6 @@ public class WebhookMessageModifyBuilder :
 
     override var components: MutableList<MessageComponentBuilder>? by state::components.delegate()
 
-    @OptIn(KordPreview::class)
     override fun toRequest(): MultipartWebhookEditMessageRequest {
         return MultipartWebhookEditMessageRequest(
             WebhookEditMessageRequest(

--- a/rest/src/main/kotlin/json/request/GuildRequests.kt
+++ b/rest/src/main/kotlin/json/request/GuildRequests.kt
@@ -77,7 +77,7 @@ public data class GuildChannelPositionModifyRequest(
     internal object Serializer : KSerializer<GuildChannelPositionModifyRequest> {
         private val delegate = ListSerializer(ChannelPositionSwapRequest.serializer())
 
-        @OptIn(InternalSerializationApi::class, ExperimentalSerializationApi::class)
+        @OptIn(ExperimentalSerializationApi::class)
         override val descriptor: SerialDescriptor
             get() = listSerialDescriptor(ChannelPositionSwapRequest.serializer().descriptor)
 
@@ -148,7 +148,7 @@ public data class GuildRolePositionModifyRequest(val swaps: List<Pair<Snowflake,
 
     internal object Serializer : KSerializer<GuildRolePositionModifyRequest> {
 
-        @OptIn(InternalSerializationApi::class, ExperimentalSerializationApi::class)
+        @OptIn(ExperimentalSerializationApi::class)
         override val descriptor: SerialDescriptor
             get() = listSerialDescriptor(RolePosition.serializer().descriptor)
 

--- a/rest/src/main/kotlin/route/Route.kt
+++ b/rest/src/main/kotlin/route/Route.kt
@@ -54,7 +54,6 @@ public sealed class Route<T>(
 ) {
 
     public companion object {
-        @OptIn(KordExperimental::class)
         public val baseUrl: String get() = "https://discord.com/api/v${KordConfiguration.REST_VERSION}"
     }
 

--- a/rest/src/main/kotlin/service/RestService.kt
+++ b/rest/src/main/kotlin/service/RestService.kt
@@ -1,7 +1,6 @@
 package dev.kord.rest.service
 
 import dev.kord.common.KordConstants
-import dev.kord.common.annotation.KordExperimental
 import dev.kord.rest.request.RequestBuilder
 import dev.kord.rest.request.RequestHandler
 import dev.kord.rest.route.Route
@@ -20,7 +19,6 @@ public abstract class RestService(@PublishedApi internal val requestHandler: Req
         val request = RequestBuilder(route)
             .apply(builder)
             .apply {
-                @OptIn(KordExperimental::class)
                 unencodedHeader(UserAgent, KordConstants.USER_AGENT)
                 if (route.requiresAuthorizationHeader) {
                     unencodedHeader(Authorization, "Bot ${requestHandler.token}")

--- a/rest/src/test/kotlin/ratelimit/TestClock.kt
+++ b/rest/src/test/kotlin/ratelimit/TestClock.kt
@@ -1,13 +1,11 @@
 package dev.kord.rest.ratelimit
 
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.currentTime
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlin.time.Duration.Companion.milliseconds
 
-@ExperimentalCoroutinesApi
 class TestClock(val instant: Instant, val scope: TestScope) : Clock {
     override fun now(): Instant = instant + scope.currentTime.milliseconds
 }

--- a/voice/src/main/kotlin/VoiceConnectionBuilder.kt
+++ b/voice/src/main/kotlin/VoiceConnectionBuilder.kt
@@ -1,7 +1,6 @@
 package dev.kord.voice
 
 import dev.kord.common.KordConfiguration
-import dev.kord.common.annotation.KordExperimental
 import dev.kord.common.annotation.KordVoice
 import dev.kord.common.entity.Snowflake
 import dev.kord.gateway.Gateway
@@ -144,7 +143,6 @@ public class VoiceConnectionBuilder(
             voiceState.sessionId
         ) to VoiceGatewayConfiguration(
             voiceServer.token,
-            @OptIn(KordExperimental::class)
             "wss://${voiceServer.endpoint}/?v=${KordConfiguration.VOICE_GATEWAY_VERSION}",
         )
     }

--- a/voice/src/main/kotlin/gateway/Command.kt
+++ b/voice/src/main/kotlin/gateway/Command.kt
@@ -22,7 +22,6 @@ public sealed class Command {
         override fun serialize(encoder: Encoder, value: Command) {
             val composite = encoder.beginStructure(descriptor)
 
-            @OptIn(KordVoice::class)
             when (value) {
                 is Identify -> {
                     composite.encodeSerializableElement(descriptor, 0, OpCode.Serializer, OpCode.Identify)

--- a/voice/src/main/kotlin/gateway/DefaultVoiceGateway.kt
+++ b/voice/src/main/kotlin/gateway/DefaultVoiceGateway.kt
@@ -209,6 +209,7 @@ public class DefaultVoiceGateway(
         socket.send(Frame.Text(json))
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     private val socketOpen get() = ::socket.isInitialized && !socket.outgoing.isClosedForSend && !socket.incoming.isClosedForReceive
 
     override suspend fun detach() {

--- a/voice/src/main/kotlin/gateway/DefaultVoiceGatewayBuilder.kt
+++ b/voice/src/main/kotlin/gateway/DefaultVoiceGatewayBuilder.kt
@@ -12,7 +12,6 @@ import io.ktor.client.plugins.websocket.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*
-import io.ktor.util.*
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlin.time.Duration.Companion.seconds
 

--- a/voice/src/main/kotlin/gateway/VoiceEvent.kt
+++ b/voice/src/main/kotlin/gateway/VoiceEvent.kt
@@ -1,8 +1,5 @@
-@file:OptIn(KordVoice::class)
-
 package dev.kord.voice.gateway
 
-import dev.kord.common.annotation.KordVoice
 import dev.kord.common.entity.Snowflake
 import dev.kord.voice.EncryptionMode
 import dev.kord.voice.SpeakingFlags

--- a/voice/src/main/kotlin/gateway/handler/HandshakeHandler.kt
+++ b/voice/src/main/kotlin/gateway/handler/HandshakeHandler.kt
@@ -1,11 +1,9 @@
 package dev.kord.voice.gateway.handler
 
-import dev.kord.common.annotation.KordVoice
 import dev.kord.voice.gateway.*
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 
-@OptIn(KordVoice::class)
 internal class HandshakeHandler(
     flow: Flow<VoiceEvent>,
     private val data: DefaultVoiceGatewayData,

--- a/voice/src/main/kotlin/handlers/StreamsHandler.kt
+++ b/voice/src/main/kotlin/handlers/StreamsHandler.kt
@@ -1,6 +1,5 @@
 package dev.kord.voice.handlers
 
-import dev.kord.common.annotation.KordVoice
 import dev.kord.voice.gateway.Close
 import dev.kord.voice.gateway.Ready
 import dev.kord.voice.gateway.SessionDescription
@@ -15,7 +14,6 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 
-@OptIn(KordVoice::class)
 internal class StreamsHandler(
     flow: Flow<VoiceEvent>,
     private val streams: Streams,

--- a/voice/src/main/kotlin/handlers/UdpLifeCycleHandler.kt
+++ b/voice/src/main/kotlin/handlers/UdpLifeCycleHandler.kt
@@ -1,8 +1,5 @@
-@file:OptIn(KordVoice::class)
-
 package dev.kord.voice.handlers
 
-import dev.kord.common.annotation.KordVoice
 import dev.kord.voice.EncryptionMode
 import dev.kord.voice.FrameInterceptorConfiguration
 import dev.kord.voice.VoiceConnection
@@ -21,7 +18,6 @@ import mu.KotlinLogging
 
 private val udpLifeCycleLogger = KotlinLogging.logger { }
 
-@OptIn(KordVoice::class)
 internal class UdpLifeCycleHandler(
     flow: Flow<VoiceEvent>,
     private val connection: VoiceConnection

--- a/voice/src/main/kotlin/handlers/VoiceUpdateEventHandler.kt
+++ b/voice/src/main/kotlin/handlers/VoiceUpdateEventHandler.kt
@@ -1,7 +1,6 @@
 package dev.kord.voice.handlers
 
 import dev.kord.common.KordConfiguration
-import dev.kord.common.annotation.KordExperimental
 import dev.kord.common.annotation.KordVoice
 import dev.kord.gateway.VoiceServerUpdate
 import dev.kord.gateway.VoiceStateUpdate
@@ -63,7 +62,6 @@ internal class VoiceUpdateEventHandler(
 
             voiceUpdateLogger.trace { "changing voice servers for session ${connection.data.sessionId}" }
 
-            @OptIn(KordExperimental::class)
             // update the gateway configuration accordingly
             connection.voiceGatewayConfiguration = connection.voiceGatewayConfiguration.copy(
                 token = voiceServerUpdate.voiceServerUpdateData.token,


### PR DESCRIPTION
This PR changes some compilation settings and opt-in behavior.

### Stricter compilation
- enable [progressive mode](https://kotlinlang.org/docs/whatsnew13.html#progressive-mode) - will give us fixes earlier
- enable [`allWarningsAsErrors`](https://kotlinlang.org/docs/gradle.html#attributes-common-to-jvm-js-and-js-dce) - will force us to care about warnings

### Clean up opt-ins
- remove project-wide opt-in for `ExperimentalStdlibApi` - we don't use it
- add project-wide opt-in for our own `KordPreview`, `KordExperimental` and `KordVoice` - we know where we can use our own experimental stuff and this way we don't need to opt-in manually everywhere
- remove project-wide opt-in for `ExperimentalCoroutinesApi` - only keep it in "test" source sets for `runTest {}`