### PR TITLE
Update application command fields

### DIFF
--- a/common/src/main/kotlin/entity/Interactions.kt
+++ b/common/src/main/kotlin/entity/Interactions.kt
@@ -34,9 +34,9 @@ public data class DiscordApplicationCommand(
     val guildId: OptionalSnowflake = OptionalSnowflake.Missing,
     val options: Optional<List<ApplicationCommandOption>> = Optional.Missing(),
     @SerialName("default_member_permissions")
-    val defaultMemberPermissions: Optional<Permissions?> = Optional.Missing(),
+    val defaultMemberPermissions: Permissions?,
     @SerialName("dm_permission")
-    val dmPermission: OptionalBoolean? = OptionalBoolean.Missing,
+    val dmPermission: OptionalBoolean = OptionalBoolean.Missing,
     @SerialName("default_permission")
     @Deprecated("'defaultPermission' is deprecated in favor of 'defaultMemberPermissions' and 'dmPermission'.")
     val defaultPermission: OptionalBoolean? = OptionalBoolean.Missing,

--- a/core/src/main/kotlin/cache/data/ApplicationCommandData.kt
+++ b/core/src/main/kotlin/cache/data/ApplicationCommandData.kt
@@ -18,8 +18,8 @@ public data class ApplicationCommandData(
     val descriptionLocalizations: Optional<Map<Locale, String>?> = Optional.Missing(),
     val guildId: OptionalSnowflake = OptionalSnowflake.Missing,
     val options: Optional<List<ApplicationCommandOptionData>> = Optional.Missing(),
-    val defaultMemberPermissions: Optional<Permissions?> = Optional.Missing(),
-    val dmPermission: OptionalBoolean? = OptionalBoolean.Missing,
+    val defaultMemberPermissions: Permissions?,
+    val dmPermission: OptionalBoolean = OptionalBoolean.Missing,
     @Deprecated("'defaultPermission' is deprecated in favor of 'defaultMemberPermissions' and 'dmPermission'.")
     val defaultPermission: OptionalBoolean? = OptionalBoolean.Missing,
     val version: Snowflake

--- a/core/src/main/kotlin/entity/application/ApplicationCommand.kt
+++ b/core/src/main/kotlin/entity/application/ApplicationCommand.kt
@@ -50,7 +50,7 @@ public sealed interface ApplicationCommand : ApplicationCommandBehavior {
     /**
      * Set of [Permissions] required to execute this command unless a server admin changed them.
      */
-    public val defaultMemberPermissions: Permissions? get() = data.defaultMemberPermissions.value
+    public val defaultMemberPermissions: Permissions? get() = data.defaultMemberPermissions
 
     /**
      * whether the command is enabled by default when the app is added to a guild.
@@ -66,7 +66,7 @@ public interface GlobalApplicationCommand : ApplicationCommand, GlobalApplicatio
     /**
      * Whether this command is available in DMs with the application.
      */
-    public val dmPermission: Boolean get() = data.dmPermission?.value ?: true
+    public val dmPermission: Boolean get() = data.dmPermission.orElse(true)
 }
 public class UnknownGlobalApplicationCommand(
     override val data: ApplicationCommandData,


### PR DESCRIPTION
- `default_member_permissions` no longer optional
- `dm_permission` no longer nullable

see https://github.com/discord/discord-api-docs/pull/4991, merged in https://github.com/discord/discord-api-docs/commit/ad81ed31372245d2b4f7006924bd8dd68130a87f