### PR TITLE
Add nsfw to creating and modifying voice channels

### DIFF
--- a/rest/src/main/kotlin/builder/channel/EditGuildChannelBuilder.kt
+++ b/rest/src/main/kotlin/builder/channel/EditGuildChannelBuilder.kt
@@ -79,6 +79,9 @@ public class VoiceChannelModifyBuilder : PermissionOverwritesModifyBuilder,
     private var _topic: Optional<String?> = Optional.Missing()
     public var topic: String? by ::_topic.delegate()
 
+    private var _nsfw: OptionalBoolean? = OptionalBoolean.Missing
+    public var nsfw: Boolean? by ::_nsfw.delegate()
+
     private var _parentId: OptionalSnowflake? = OptionalSnowflake.Missing
     public var parentId: Snowflake? by ::_parentId.delegate()
 
@@ -99,6 +102,7 @@ public class VoiceChannelModifyBuilder : PermissionOverwritesModifyBuilder,
     override fun toRequest(): ChannelModifyPatchRequest = ChannelModifyPatchRequest(
         name = _name,
         position = _position,
+        nsfw = _nsfw,
         parentId = _parentId,
         bitrate = _bitrate,
         userLimit = _userLimit,

--- a/rest/src/main/kotlin/builder/channel/VoiceChannelCreateBuilder.kt
+++ b/rest/src/main/kotlin/builder/channel/VoiceChannelCreateBuilder.kt
@@ -5,6 +5,7 @@ import dev.kord.common.entity.ChannelType
 import dev.kord.common.entity.Overwrite
 import dev.kord.common.entity.Snowflake
 import dev.kord.common.entity.optional.Optional
+import dev.kord.common.entity.optional.OptionalBoolean
 import dev.kord.common.entity.optional.OptionalInt
 import dev.kord.common.entity.optional.OptionalSnowflake
 import dev.kord.common.entity.optional.delegate.delegate
@@ -26,6 +27,9 @@ public class VoiceChannelCreateBuilder(public var name: String) :
     private var _parentId: OptionalSnowflake = OptionalSnowflake.Missing
     public var parentId: Snowflake? by ::_parentId.delegate()
 
+    private var _nsfw: OptionalBoolean = OptionalBoolean.Missing
+    public var nsfw: Boolean? by ::_nsfw.delegate()
+
     private var _position: OptionalInt = OptionalInt.Missing
     public var position: Int? by ::_position.delegate()
 
@@ -36,6 +40,7 @@ public class VoiceChannelCreateBuilder(public var name: String) :
         bitrate = _bitrate,
         userLimit = _userLimit,
         parentId = _parentId,
+        nsfw = _nsfw,
         position = _position,
         permissionOverwrite = Optional.missingOnEmpty(permissionOverwrites),
         type = ChannelType.GuildVoice


### PR DESCRIPTION
Text-in-voice now allows voice channels to be marked as nsfw.
This PR adds the `nsfw` param to the corresponding builders.

see https://github.com/discord/discord-api-docs/pull/5013, merged in https://github.com/discord/discord-api-docs/commit/aff1236f0e36b4e52b98cdc487b31c4ee52ab14e