### PR TITLE
Improve RestClient's `StackTraceRecoveringKtorRequestHandler`

### DIFF
--- a/rest/src/main/kotlin/request/StackTraceRecoveringKtorRequestHandler.kt
+++ b/rest/src/main/kotlin/request/StackTraceRecoveringKtorRequestHandler.kt
@@ -25,10 +25,9 @@ public class StackTraceRecoveringKtorRequestHandler(private val delegate: KtorRe
         return try {
             delegate.handle(request)
         } catch (e: Exception) {
-            throw stacktrace.apply {
-                sanitizeStackTrace()
-                initCause(e)
-            }
+            stacktrace.sanitizeStackTrace()
+            e.initCause(stacktrace)
+            throw e
         }
     }
 }

--- a/rest/src/test/kotlin/request/StackTraceRecoveryTest.kt
+++ b/rest/src/test/kotlin/request/StackTraceRecoveryTest.kt
@@ -40,7 +40,7 @@ class StackTraceRecoveryTest {
         } catch (e: Exception) {
             e.printStackTrace()
 
-            val initCause = e.cause ?: error("Missing initCause exception!")
+            val initCause = e.cause ?: error("The thrown exception doesn't have a set cause! Is StackTrace Recovery enabled?")
             initCause.printStackTrace()
 
             //at dev.kord.rest.request.StackTraceRecoveryTest$test stack trace recovery$1.invokeSuspend(StackTraceRecoveryTest.kt:39)

--- a/rest/src/test/kotlin/request/StackTraceRecoveryTest.kt
+++ b/rest/src/test/kotlin/request/StackTraceRecoveryTest.kt
@@ -37,10 +37,14 @@ class StackTraceRecoveryTest {
         val stackTrace = Thread.currentThread().stackTrace[1] // 1st one would be Thread.run for some reason
         try {
             handler.handle(request)
-        } catch (e: ContextException) {
+        } catch (e: Exception) {
             e.printStackTrace()
+
+            val initCause = e.cause ?: error("Missing initCause exception!")
+            initCause.printStackTrace()
+
             //at dev.kord.rest.request.StackTraceRecoveryTest$test stack trace recovery$1.invokeSuspend(StackTraceRecoveryTest.kt:39)
-            with(e.stackTrace.first()) {
+            with(initCause.stackTrace.first()) {
                 assertEquals(stackTrace.className, className)
                 assertEquals(stackTrace.fileName, fileName)
                 assertEquals(stackTrace.lineNumber + 2, lineNumber) // +2 because capture is two lines deeper


### PR DESCRIPTION
Instead of throwing `ContextException`, we change the `Exception`'s `initCause` to our `ContextException`.

This fixes a huge pain point in the current implementation: Currently, if you enable stacktrace recovery, you need to change all your `try catch` blocks to catch `ContextException`, instead of catching `KtorRequestException`/`RequestException`/etc.

Recovered stacktrace example (please ignore the `net.perfectdreams.loritta.cinnamon.platform.utils.ContextException` package name, I was testing the fix in my own project :P):
```
dev.kord.rest.request.KtorRequestException: REST request returned an error: 404 Not Found  Unknown Message null
	at dev.kord.rest.request.KtorRequestHandler.handle(KtorRequestHandler.kt:61)
	at dev.kord.rest.request.KtorRequestHandler$handle$1.invokeSuspend(KtorRequestHandler.kt)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at io.ktor.util.pipeline.SuspendFunctionGun.resumeRootWith(SuspendFunctionGun.kt:138)
	at io.ktor.util.pipeline.SuspendFunctionGun.loop(SuspendFunctionGun.kt:112)
	at io.ktor.util.pipeline.SuspendFunctionGun.access$loop(SuspendFunctionGun.kt:14)
	at io.ktor.util.pipeline.SuspendFunctionGun$continuation$1.resumeWith(SuspendFunctionGun.kt:62)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:46)
	at io.ktor.util.pipeline.SuspendFunctionGun.resumeRootWith(SuspendFunctionGun.kt:138)
	at io.ktor.util.pipeline.SuspendFunctionGun.loop(SuspendFunctionGun.kt:112)
	at io.ktor.util.pipeline.SuspendFunctionGun.access$loop(SuspendFunctionGun.kt:14)
	at io.ktor.util.pipeline.SuspendFunctionGun$continuation$1.resumeWith(SuspendFunctionGun.kt:62)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:46)
	at io.ktor.util.pipeline.SuspendFunctionGun.resumeRootWith(SuspendFunctionGun.kt:138)
	at io.ktor.util.pipeline.SuspendFunctionGun.loop(SuspendFunctionGun.kt:112)
	at io.ktor.util.pipeline.SuspendFunctionGun.access$loop(SuspendFunctionGun.kt:14)
	at io.ktor.util.pipeline.SuspendFunctionGun$continuation$1.resumeWith(SuspendFunctionGun.kt:62)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:46)
	at io.ktor.util.pipeline.SuspendFunctionGun.resumeRootWith(SuspendFunctionGun.kt:138)
	at io.ktor.util.pipeline.SuspendFunctionGun.loop(SuspendFunctionGun.kt:112)
	at io.ktor.util.pipeline.SuspendFunctionGun.access$loop(SuspendFunctionGun.kt:14)
	at io.ktor.util.pipeline.SuspendFunctionGun$continuation$1.resumeWith(SuspendFunctionGun.kt:62)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:46)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:570)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:749)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:677)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:664)
Caused by: net.perfectdreams.loritta.cinnamon.platform.utils.ContextException: null
	at dev.kord.rest.service.ChannelService.deleteMessage(ChannelService.kt:703)
	at net.perfectdreams.loritta.cinnamon.microservices.discordgatewayeventsprocessor.modules.InviteBlockerModule.handleMessage(InviteBlockerModule.kt:170)
	at net.perfectdreams.loritta.cinnamon.microservices.discordgatewayeventsprocessor.modules.InviteBlockerModule$handleMessage$1.invokeSuspend(InviteBlockerModule.kt)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	... 5 common frames omitted
```