### PR TITLE
Update Ktor, remove timeout workaround on WebSocket connections

### DIFF
--- a/core/src/main/kotlin/builder/kord/KordBuilderUtil.kt
+++ b/core/src/main/kotlin/builder/kord/KordBuilderUtil.kt
@@ -17,7 +17,6 @@ internal fun HttpClientConfig<*>.defaultConfig() {
         json()
     }
     install(WebSockets)
-    install(HttpTimeout)
 }
 
 internal fun HttpClient?.configure(): HttpClient {

--- a/gateway/src/main/kotlin/DefaultGateway.kt
+++ b/gateway/src/main/kotlin/DefaultGateway.kt
@@ -231,12 +231,6 @@ public class DefaultGateway(private val data: DefaultGatewayData) : Gateway {
     }
 
     private suspend fun webSocket(url: String) = data.client.webSocketSession {
-        // workaround until https://youtrack.jetbrains.com/issue/KTOR-4419 is fixed
-        // otherwise the gateway connection will die and fail to reconnect
-        timeout {
-            requestTimeoutMillis = HttpTimeout.INFINITE_TIMEOUT_MS
-        }
-
         url(url)
     }
 

--- a/gateway/src/main/kotlin/DefaultGatewayBuilder.kt
+++ b/gateway/src/main/kotlin/DefaultGatewayBuilder.kt
@@ -34,7 +34,6 @@ public class DefaultGatewayBuilder {
             install(ContentNegotiation) {
                 json()
             }
-            install(HttpTimeout)
         }
         val retry = reconnectRetry ?: LinearRetry(2.seconds, 20.seconds, 10)
         val sendRateLimiter = sendRateLimiter ?: IntervalRateLimiter(limit = 120, interval = 60.seconds)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -51,7 +51,7 @@ fun VersionCatalogBuilder.kotlinx() {
 }
 
 fun VersionCatalogBuilder.ktor() {
-    val ktor = version("ktor", "2.0.2")
+    val ktor = version("ktor", "2.0.3")
 
     library("ktor-client-json","io.ktor", "ktor-serialization-kotlinx-json").versionRef(ktor)
     library("ktor-client-content-negotiation", "io.ktor", "ktor-client-content-negotiation").versionRef(ktor)

--- a/voice/src/main/kotlin/gateway/DefaultVoiceGateway.kt
+++ b/voice/src/main/kotlin/gateway/DefaultVoiceGateway.kt
@@ -161,12 +161,6 @@ public class DefaultVoiceGateway(
 
     private suspend fun webSocket(url: String) = data.client.webSocketSession {
         url(url)
-
-        // workaround until https://youtrack.jetbrains.com/issue/KTOR-4419 is fixed
-        // otherwise the voice connection will die and fail to reconnect
-        timeout {
-            requestTimeoutMillis = HttpTimeout.INFINITE_TIMEOUT_MS
-        }
     }
 
     private suspend fun resetState(configuration: VoiceGatewayConfiguration) = stateMutex.withLock {

--- a/voice/src/main/kotlin/gateway/DefaultVoiceGatewayBuilder.kt
+++ b/voice/src/main/kotlin/gateway/DefaultVoiceGatewayBuilder.kt
@@ -28,7 +28,6 @@ public class DefaultVoiceGatewayBuilder(
     public fun build(): DefaultVoiceGateway {
         val client = client ?: HttpClient(CIO) {
             install(WebSockets)
-            install(HttpTimeout)
             install(ContentNegotiation) {
                 json()
             }


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTOR-4419 was fixed in 2.0.3, so we don't need the workaround anymore