### PR TITLE
Update dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ import org.gradle.api.tasks.wrapper.Wrapper.DistributionType.ALL
 plugins {
     kotlin("jvm")
     kotlin("plugin.serialization")
-    id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.9.0"
+    id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.10.1"
     id("org.jetbrains.dokka")
 
     id("org.ajoberstar.git-publish") version "3.0.1"

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,6 +1,8 @@
 plugins {
     groovy
     `kotlin-dsl`
+    kotlin("jvm") version "1.7.10"
+    kotlin("plugin.serialization") version "1.7.10"
 }
 
 repositories {
@@ -9,10 +11,10 @@ repositories {
 }
 
 dependencies {
-    implementation(kotlin("gradle-plugin", version = "1.7.0"))
-    implementation(kotlin("serialization", version = "1.6.21"))
-    implementation("org.jetbrains.dokka", "dokka-gradle-plugin", "1.6.21")
-    implementation("org.jetbrains.kotlinx", "atomicfu-gradle-plugin", "0.17.3")
+    implementation(kotlin("gradle-plugin"))
+    implementation(kotlin("serialization"))
+    implementation("org.jetbrains.dokka", "dokka-gradle-plugin", "1.7.0")
+    implementation("org.jetbrains.kotlinx", "atomicfu-gradle-plugin", "0.18.2")
     implementation(gradleApi())
     implementation(localGroovy())
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     groovy
     `kotlin-dsl`
@@ -17,4 +19,8 @@ dependencies {
     implementation("org.jetbrains.kotlinx", "atomicfu-gradle-plugin", "0.18.2")
     implementation(gradleApi())
     implementation(localGroovy())
+}
+
+tasks.withType<KotlinCompile> {
+    kotlinOptions.languageVersion = "1.5"
 }

--- a/buildSrc/src/main/kotlin/kord-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/kord-module.gradle.kts
@@ -102,10 +102,4 @@ tasks {
             artifact(dokkaJar.get())
         }
     }
-
-    java {
-        // We don't use java, but this prevents a Gradle warning,
-        // telling you to target the same java version for java and kt
-        sourceCompatibility = JavaVersion.VERSION_1_8
-    }
 }

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
     `kord-publishing`
 
     // see https://github.com/gmazzo/gradle-buildconfig-plugin
-    id("com.github.gmazzo.buildconfig") version "3.0.3"
+    id("com.github.gmazzo.buildconfig") version "3.1.0"
 }
 
 dependencies {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -47,13 +47,13 @@ fun VersionCatalogBuilder.cache() {
 }
 
 fun VersionCatalogBuilder.kotlinx() {
-    library("kotlinx-datetime", "org.jetbrains.kotlinx", "kotlinx-datetime").version("0.3.3")
+    library("kotlinx-datetime", "org.jetbrains.kotlinx", "kotlinx-datetime").version("0.4.0")
 }
 
 fun VersionCatalogBuilder.ktor() {
     val ktor = version("ktor", "2.0.3")
 
-    library("ktor-client-json","io.ktor", "ktor-serialization-kotlinx-json").versionRef(ktor)
+    library("ktor-client-json", "io.ktor", "ktor-serialization-kotlinx-json").versionRef(ktor)
     library("ktor-client-content-negotiation", "io.ktor", "ktor-client-content-negotiation").versionRef(ktor)
 
     library("ktor-client-cio", "io.ktor", "ktor-client-cio").versionRef(ktor)
@@ -69,10 +69,10 @@ fun VersionCatalogBuilder.ktor() {
 }
 
 fun VersionCatalogBuilder.common() {
-    version("kotlinx-coroutines", "1.6.2")
+    version("kotlinx-coroutines", "1.6.3")
     library("kotlinx-serialization", "org.jetbrains.kotlinx", "kotlinx-serialization-json").version("1.3.3")
     library("kotlinx-coroutines", "org.jetbrains.kotlinx", "kotlinx-coroutines-core").versionRef("kotlinx-coroutines")
-    library("kotlinx-atomicfu", "org.jetbrains.kotlinx", "atomicfu").version("0.17.3")
+    library("kotlinx-atomicfu", "org.jetbrains.kotlinx", "atomicfu").version("0.18.2")
     library("kotlin-logging", "io.github.microutils", "kotlin-logging").version("2.1.23")
 
     bundle("common", listOf("kotlinx-serialization", "kotlinx-coroutines", "kotlinx-atomicfu", "kotlin-logging"))


### PR DESCRIPTION
- Binary compatibility validator 0.9.0 -> 0.10.1
- Kotlin 1.7.0 -> 1.7.10
- Dokka 1.6.21 -> 1.7.0
- AtomicFU 0.17.3 -> 0.18.2
- gradle-buildconfig-plugin 3.0.3 -> 3.1.0
- kotlinx-datetime 0.3.3 -> 0.4.0
- kotlinx.coroutines 1.6.2 -> 1.6.3

- don't set java `sourceCompatibility`, the warning doesn't show anymore