### PR TITLE
Use suppressed exceptions for stack trace recovery

### DIFF
--- a/rest/src/main/kotlin/request/StackTraceRecoveringKtorRequestHandler.kt
+++ b/rest/src/main/kotlin/request/StackTraceRecoveringKtorRequestHandler.kt
@@ -22,7 +22,7 @@ public class StackTraceRecoveringKtorRequestHandler(private val delegate: KtorRe
 
         return try {
             delegate.handle(request)
-        } catch (e: Exception) {
+        } catch (e: Throwable) {
             recoveredStackTrace.sanitizeStackTrace()
             e.addSuppressed(recoveredStackTrace)
             throw e

--- a/rest/src/main/kotlin/request/StackTraceRecoveringKtorRequestHandler.kt
+++ b/rest/src/main/kotlin/request/StackTraceRecoveringKtorRequestHandler.kt
@@ -1,48 +1,48 @@
 package dev.kord.rest.request
 
+import kotlin.DeprecationLevel.ERROR
 
 /**
  * Extension of [KtorRequestHandler] which tries to recover stack trace information lost through Ktor's
  * [io.ktor.util.pipeline.SuspendFunctionGun].
  *
- * This is done by creating a [ContextException] to capture the stack trace up until the point just before
- * [KtorRequestHandler.handle] gets called, then if that call throws any type of [Throwable] the [ContextException] gets
- * thrown instead (See [ContextException.cause])
+ * This is done by creating a [RecoveredStackTrace] to capture the stack trace up until the point just before
+ * [KtorRequestHandler.handle] gets called, then if that call throws any type of [Throwable] the [RecoveredStackTrace]
+ * gets added to the original [Throwable] as a [suppressed exception][addSuppressed] and the original [Throwable] is
+ * rethrown.
  *
- * @see ContextException
  * @see withStackTraceRecovery
  */
 public class StackTraceRecoveringKtorRequestHandler(private val delegate: KtorRequestHandler) :
     RequestHandler by delegate {
 
-    /**
-     * @throws ContextException if any exception occurs (this is also the only exception which can be thrown)
-     * @see KtorRequestHandler.handle
-     */
+    /** @see KtorRequestHandler.handle */
     override suspend fun <B : Any, R> handle(request: Request<B, R>): R {
-        val stacktrace = ContextException()
+        val recoveredStackTrace = RecoveredStackTrace()
 
         return try {
             delegate.handle(request)
         } catch (e: Exception) {
-            stacktrace.sanitizeStackTrace()
-            e.initCause(stacktrace)
+            recoveredStackTrace.sanitizeStackTrace()
+            e.addSuppressed(recoveredStackTrace)
             throw e
         }
     }
 }
 
-/**
- * Exception used to save the current stack trace before executing a request.
- *
- * @see StackTraceRecoveringKtorRequestHandler
- */
-public class ContextException internal constructor() : RuntimeException() {
+@Deprecated(
+    "'ContextException' is no longer thrown. 'stackTraceRecovery' uses a suppressed exception instead.",
+    level = ERROR,
+)
+public class ContextException internal constructor() : RuntimeException()
 
-    internal fun sanitizeStackTrace() {
-        // Remove artifacts of stack trace capturing
-        // This is the stack trace element is the creation of the ContextException
-        // at dev.kord.rest.request.StackTraceRecoveringKtorRequestHandler.handle(StackTraceRecoveringKtorRequestHandler.kt:23)
+/** A [Throwable] used to save the current stack trace before executing a request. */
+internal class RecoveredStackTrace : Throwable("This is the recovered stack trace:") {
+
+    fun sanitizeStackTrace() {
+        // Remove artifacts of stack trace capturing.
+        // The first stack trace element is the creation of the RecoveredStackTrace:
+        // at dev.kord.rest.request.StackTraceRecoveringKtorRequestHandler.handle(StackTraceRecoveringKtorRequestHandler.kt:21)
         stackTrace = stackTrace.copyOfRange(1, stackTrace.size)
     }
 }

--- a/rest/src/test/kotlin/request/StackTraceRecoveryTest.kt
+++ b/rest/src/test/kotlin/request/StackTraceRecoveryTest.kt
@@ -40,11 +40,11 @@ class StackTraceRecoveryTest {
         } catch (e: Exception) {
             e.printStackTrace()
 
-            val initCause = e.cause ?: error("The thrown exception doesn't have a set cause! Is StackTrace Recovery enabled?")
-            initCause.printStackTrace()
+            val recovered = e.suppressedExceptions.first { it is RecoveredStackTrace }
+            recovered.printStackTrace()
 
-            //at dev.kord.rest.request.StackTraceRecoveryTest$test stack trace recovery$1.invokeSuspend(StackTraceRecoveryTest.kt:39)
-            with(initCause.stackTrace.first()) {
+            // at dev.kord.rest.request.StackTraceRecoveryTest$test stack trace recovery$1.invokeSuspend(StackTraceRecoveryTest.kt:39)
+            with(recovered.stackTrace.first()) {
                 assertEquals(stackTrace.className, className)
                 assertEquals(stackTrace.fileName, fileName)
                 assertEquals(stackTrace.lineNumber + 2, lineNumber) // +2 because capture is two lines deeper

--- a/rest/src/test/kotlin/request/StackTraceRecoveryTest.kt
+++ b/rest/src/test/kotlin/request/StackTraceRecoveryTest.kt
@@ -37,7 +37,7 @@ class StackTraceRecoveryTest {
         val stackTrace = Thread.currentThread().stackTrace[1] // 1st one would be Thread.run for some reason
         try {
             handler.handle(request)
-        } catch (e: Exception) {
+        } catch (e: Throwable) {
             e.printStackTrace()
 
             val recovered = e.suppressedExceptions.first { it is RecoveredStackTrace }


### PR DESCRIPTION
This PR changes stack trace recovery to use [suppressed exceptions](https://docs.oracle.com/javase/8/docs/api/java/lang/Throwable.html#addSuppressed-java.lang.Throwable-) instead of [`initCause`](https://docs.oracle.com/javase/8/docs/api/java/lang/Throwable.html#initCause-java.lang.Throwable-).

This brings the same benefits as https://github.com/kordlib/kord/pull/648 (rethrowing the original exception) while also avoiding problems with exceptions that already have a cause (described [here](https://github.com/kordlib/kord/pull/648#issuecomment-1176738729)).

<details>
<summary>What an exception with recovered stack trace will look like after this PR</summary>

```
Exception in thread "main" dev.kord.rest.request.KtorRequestException: REST request returned an error: 403 Forbidden  Missing Access null
	at dev.kord.rest.request.KtorRequestHandler.handle(KtorRequestHandler.kt:61)
	at dev.kord.rest.request.KtorRequestHandler$handle$1.invokeSuspend(KtorRequestHandler.kt)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at io.ktor.utils.io.internal.CancellableReusableContinuation.resumeWith(CancellableReusableContinuation.kt:93)
	at io.ktor.utils.io.ByteBufferChannel.resumeReadOp(ByteBufferChannel.kt:2121)
	at io.ktor.utils.io.ByteBufferChannel.tryTerminate$ktor_io(ByteBufferChannel.kt:383)
	at io.ktor.utils.io.ByteBufferChannel.close(ByteBufferChannel.kt:133)
	at io.ktor.utils.io.CoroutinesKt$launchChannel$1.invoke(Coroutines.kt:145)
	at io.ktor.utils.io.CoroutinesKt$launchChannel$1.invoke(Coroutines.kt:144)
	at kotlinx.coroutines.InvokeOnCompletion.invoke(JobSupport.kt:1391)
	at kotlinx.coroutines.JobSupport.notifyCompletion(JobSupport.kt:1519)
	at kotlinx.coroutines.JobSupport.completeStateFinalization(JobSupport.kt:323)
	at kotlinx.coroutines.JobSupport.finalizeFinishingState(JobSupport.kt:240)
	at kotlinx.coroutines.JobSupport.tryMakeCompletingSlowPath(JobSupport.kt:906)
	at kotlinx.coroutines.JobSupport.tryMakeCompleting(JobSupport.kt:863)
	at kotlinx.coroutines.JobSupport.makeCompletingOnce$kotlinx_coroutines_core(JobSupport.kt:828)
	at kotlinx.coroutines.AbstractCoroutine.resumeWith(AbstractCoroutine.kt:100)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:46)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
	at kotlinx.coroutines.internal.LimitedDispatcher.run(LimitedDispatcher.kt:42)
	at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:95)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:570)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:749)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:677)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:664)
	Suppressed: dev.kord.rest.request.RecoveredStackTrace: This is the recovered stack trace:
		at dev.kord.rest.service.GuildService.getGuild(GuildService.kt:659)
		at dev.kord.rest.service.GuildService.getGuild$default(GuildService.kt:42)
		at dev.kord.core.supplier.RestEntitySupplier.getGuildOrNull(RestEntitySupplier.kt:89)
		at dev.kord.core.supplier.FallbackEntitySupplier.getGuildOrNull(FallbackEntitySupplier.kt:34)
		at dev.kord.core.Kord.getGuild(Kord.kt:249)
		at dev.kord.core.Kord.getGuild$default(Kord.kt:245)
		at MainKt.main(Main.kt:133)
		at MainKt$main$1.invokeSuspend(Main.kt)
		at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
		at kotlinx.coroutines.DispatchedTaskKt.resume(DispatchedTask.kt:178)
		at kotlinx.coroutines.DispatchedTaskKt.dispatch(DispatchedTask.kt:166)
		at kotlinx.coroutines.CancellableContinuationImpl.dispatchResume(CancellableContinuationImpl.kt:397)
		at kotlinx.coroutines.CancellableContinuationImpl.resumeImpl(CancellableContinuationImpl.kt:431)
		at kotlinx.coroutines.CancellableContinuationImpl.resumeImpl$default(CancellableContinuationImpl.kt:420)
		at kotlinx.coroutines.CancellableContinuationImpl.resumeWith(CancellableContinuationImpl.kt:328)
		at kotlinx.coroutines.ResumeOnCompletion.invoke(JobSupport.kt:1397)
		at kotlinx.coroutines.JobSupport.notifyCompletion(JobSupport.kt:1519)
		at kotlinx.coroutines.JobSupport.completeStateFinalization(JobSupport.kt:323)
		at kotlinx.coroutines.JobSupport.finalizeFinishingState(JobSupport.kt:240)
		at kotlinx.coroutines.JobSupport.continueCompleting(JobSupport.kt:935)
		at kotlinx.coroutines.JobSupport.access$continueCompleting(JobSupport.kt:27)
		at kotlinx.coroutines.JobSupport$ChildCompletion.invoke(JobSupport.kt:1155)
		... 15 more
```
</details>

Additional changes:
- deprecate public `ContextException` - it isn't thrown and therefore can't be caught
- catch and rethrow all `Throwable`s as specified in the documentation (only caught `Exception`s before)