### PR TITLE
Small changes to Kord's annotations

### DIFF
--- a/common/src/main/kotlin/annotation/Annotations.kt
+++ b/common/src/main/kotlin/annotation/Annotations.kt
@@ -1,11 +1,13 @@
 package dev.kord.common.annotation
 
+import kotlin.annotation.AnnotationRetention.RUNTIME
 import kotlin.annotation.AnnotationTarget.*
 
 /**
  * Dsl marker for Kord dsls.
  */
 @DslMarker
+@Retention(RUNTIME)
 @Target(CLASS)
 public annotation class KordDsl
 
@@ -72,5 +74,6 @@ public annotation class KordUnsafe
  * Marks the annotated declaration as deprecated since [version].
  */
 @MustBeDocumented
+@Retention(RUNTIME)
 @Target(CLASS, ANNOTATION_CLASS, PROPERTY, CONSTRUCTOR, FUNCTION, PROPERTY_GETTER, PROPERTY_SETTER, TYPEALIAS)
 public annotation class DeprecatedSinceKord(val version: String)

--- a/common/src/main/kotlin/annotation/Annotations.kt
+++ b/common/src/main/kotlin/annotation/Annotations.kt
@@ -20,7 +20,7 @@ public annotation class KordDsl
  * Features marked with this annotation will have its api evaluated and changed over time.
  */
 @MustBeDocumented
-@Retention(value = AnnotationRetention.BINARY)
+@Retention(RUNTIME)
 @RequiresOptIn(level = RequiresOptIn.Level.WARNING)
 @Target(CLASS, PROPERTY, FUNCTION, TYPEALIAS)
 public annotation class KordPreview
@@ -35,7 +35,7 @@ public annotation class KordPreview
  * and might not make it into the stable api.
  */
 @MustBeDocumented
-@Retention(value = AnnotationRetention.BINARY)
+@Retention(RUNTIME)
 @RequiresOptIn(level = RequiresOptIn.Level.WARNING)
 @Target(CLASS, PROPERTY, FUNCTION, TYPEALIAS)
 public annotation class KordExperimental
@@ -49,7 +49,7 @@ public annotation class KordExperimental
  * into the stable api.
  */
 @MustBeDocumented
-@Retention(value = AnnotationRetention.BINARY)
+@Retention(RUNTIME)
 @RequiresOptIn(level = RequiresOptIn.Level.WARNING)
 @Target(CLASS, PROPERTY, FUNCTION, TYPEALIAS)
 public annotation class KordVoice
@@ -65,7 +65,7 @@ public annotation class KordVoice
  * Functionality that is annotated with KordUnsafe should suggest a safer alternative approach in its documentation.
  */
 @MustBeDocumented
-@Retention(value = AnnotationRetention.BINARY)
+@Retention(RUNTIME)
 @RequiresOptIn(level = RequiresOptIn.Level.WARNING)
 @Target(CLASS, PROPERTY, FUNCTION, PROPERTY_SETTER, TYPEALIAS)
 public annotation class KordUnsafe

--- a/common/src/main/kotlin/annotation/Annotations.kt
+++ b/common/src/main/kotlin/annotation/Annotations.kt
@@ -1,11 +1,10 @@
 package dev.kord.common.annotation
 
+import kotlin.RequiresOptIn.Level.WARNING
 import kotlin.annotation.AnnotationRetention.RUNTIME
 import kotlin.annotation.AnnotationTarget.*
 
-/**
- * Dsl marker for Kord dsls.
- */
+/** [DslMarker] for Kord DSLs. */
 @DslMarker
 @Retention(RUNTIME)
 @Target(CLASS)
@@ -20,8 +19,8 @@ public annotation class KordDsl
  * Features marked with this annotation will have its api evaluated and changed over time.
  */
 @MustBeDocumented
+@RequiresOptIn(level = WARNING)
 @Retention(RUNTIME)
-@RequiresOptIn(level = RequiresOptIn.Level.WARNING)
 @Target(CLASS, PROPERTY, FUNCTION, TYPEALIAS)
 public annotation class KordPreview
 
@@ -31,17 +30,18 @@ public annotation class KordPreview
  * Kord experimental has **no** backward compatibility guarantees, including both binary and source compatibility.
  * Its API and semantics can and will be changed in next releases.
  *
- * Features marked with this annotation will have its use evaluated and changed over time
- * and might not make it into the stable api.
+ * Features marked with this annotation will have its use evaluated and changed over time, and might not make it
+ * into the stable api.
  */
 @MustBeDocumented
+@RequiresOptIn(level = WARNING)
 @Retention(RUNTIME)
-@RequiresOptIn(level = RequiresOptIn.Level.WARNING)
 @Target(CLASS, PROPERTY, FUNCTION, TYPEALIAS)
 public annotation class KordExperimental
 
 /**
  * Marks a Kord-voice related API as experimental.
+ *
  * Kord voice is experimental and has **no** backward compatibility guarantees, including both binary and source
  * compatibility. Its API and semantics can and will be changed in next releases.
  *
@@ -49,29 +49,31 @@ public annotation class KordExperimental
  * into the stable api.
  */
 @MustBeDocumented
+@RequiresOptIn(level = WARNING)
 @Retention(RUNTIME)
-@RequiresOptIn(level = RequiresOptIn.Level.WARNING)
 @Target(CLASS, PROPERTY, FUNCTION, TYPEALIAS)
 public annotation class KordVoice
 
 /**
  * Marks a Kord-related API as potentially unsafe.
  *
- * Kord marks targets as unsafe if it exposes functionality in a way that is more error prone than alternatives
+ * Kord marks targets as unsafe if it exposes functionality in a way that is more error-prone than alternatives
  * and can lead to *inconsistent state* and *fail silent* or *fail slow* code.
  *
- * The trade off is usually increased performance by reducing cache hits and requests to the discord api.
+ * The trade-off is usually increased performance by reducing cache hits and requests to the discord api.
  *
- * Functionality that is annotated with KordUnsafe should suggest a safer alternative approach in its documentation.
+ * Functionality that is annotated with [KordUnsafe] should suggest a safer alternative approach in its documentation.
  */
 @MustBeDocumented
+@RequiresOptIn("This API is potentially unsafe.", level = WARNING)
 @Retention(RUNTIME)
-@RequiresOptIn(level = RequiresOptIn.Level.WARNING)
 @Target(CLASS, PROPERTY, FUNCTION, PROPERTY_SETTER, TYPEALIAS)
 public annotation class KordUnsafe
 
 /**
  * Marks the annotated declaration as deprecated since [version].
+ *
+ * These declarations must also be annotated with [Deprecated].
  */
 @MustBeDocumented
 @Retention(RUNTIME)

--- a/gateway/src/main/kotlin/Intent.kt
+++ b/gateway/src/main/kotlin/Intent.kt
@@ -11,6 +11,7 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlin.RequiresOptIn.Level
+import kotlin.annotation.AnnotationRetention.RUNTIME
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -27,6 +28,7 @@ import kotlin.contracts.contract
     See https://discord.com/developers/docs/topics/gateway#privileged-intents for more info on how to enable these.
 """, Level.ERROR
 )
+@Retention(RUNTIME)
 public annotation class PrivilegedIntent
 
 /**

--- a/gateway/src/main/kotlin/Intent.kt
+++ b/gateway/src/main/kotlin/Intent.kt
@@ -10,25 +10,25 @@ import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
-import kotlin.RequiresOptIn.Level
+import kotlin.RequiresOptIn.Level.ERROR
 import kotlin.annotation.AnnotationRetention.RUNTIME
 import kotlin.annotation.AnnotationTarget.*
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
 /**
- * Some intents are defined as "Privileged" due to the sensitive nature of the data and cannot be used by Kord without enabling them.
+ * Some intents are defined as "Privileged" due to the sensitive nature of the data and cannot be used by Kord without
+ * enabling them.
  *
- * See [the official documentation](https://discord.com/developers/docs/topics/gateway#privileged-intents) for more info on
- * how to enable these.
+ * See [the official documentation](https://discord.com/developers/docs/topics/gateway#privileged-intents) for more info
+ * on how to enable these.
  */
 @MustBeDocumented
 @RequiresOptIn(
-    """
-    Some intents are defined as "Privileged" due to the sensitive nature of the data and cannot be used by Kord without enabling them.
-    
-    See https://discord.com/developers/docs/topics/gateway#privileged-intents for more info on how to enable these.
-""", Level.ERROR
+    "Some intents are defined as \"Privileged\" due to the sensitive nature of the data and cannot be used by Kord " +
+            "without enabling them. See https://discord.com/developers/docs/topics/gateway#privileged-intents for " +
+            "more info on how to enable these.",
+    level = ERROR,
 )
 @Retention(RUNTIME)
 @Target(CLASS, PROPERTY, FUNCTION)

--- a/gateway/src/main/kotlin/Intent.kt
+++ b/gateway/src/main/kotlin/Intent.kt
@@ -12,6 +12,7 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlin.RequiresOptIn.Level
 import kotlin.annotation.AnnotationRetention.RUNTIME
+import kotlin.annotation.AnnotationTarget.*
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -21,6 +22,7 @@ import kotlin.contracts.contract
  * See [the official documentation](https://discord.com/developers/docs/topics/gateway#privileged-intents) for more info on
  * how to enable these.
  */
+@MustBeDocumented
 @RequiresOptIn(
     """
     Some intents are defined as "Privileged" due to the sensitive nature of the data and cannot be used by Kord without enabling them.
@@ -29,6 +31,7 @@ import kotlin.contracts.contract
 """, Level.ERROR
 )
 @Retention(RUNTIME)
+@Target(CLASS, PROPERTY, FUNCTION)
 public annotation class PrivilegedIntent
 
 /**


### PR DESCRIPTION
This PR's main goal was to add `@MustBeDocumented` to `PrivilegedIntent`.

While I was at this, I also did some other small changes:
- explicit `@Target` for `PrivilegedIntent`
- explicit `RUNTIME` retention for `KordDsl`, `DeprecatedSinceKord` and `PrivilegedIntent` - this is the default retention if no retention is specified, but I think it's better to be explicit here
- change retention from `BINARY` to `RUNTIME` for `KordPreview`, `KordExperimental`, `KordVoice` and `KordUnsafe` - if somebody wants to use reflection for these, why shouldn't we allow it? Please tell me when there is a reason why this shouldn't be changed, maybe I'm missing something.
- small documentation and code style adjustments