### PR TITLE
Upgrade to Gradle 7.5.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,7 @@ tasks {
     wrapper {
         gradleVersion = "7.5"
         distributionType = ALL
+        distributionSha256Sum = "97a52d145762adc241bad7fd18289bf7f6801e08ece6badf80402fe2b9f250b1"
     }
 
     val dokkaOutputDir = "${rootProject.projectDir}/dokka"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,9 +32,9 @@ tasks {
         //    (might update 'gradle/wrapper/gradle-wrapper.jar', 'gradlew' and 'gradlew.bat')
         // 4. commit all changes
 
-        gradleVersion = "7.5"
+        gradleVersion = "7.5.1"
         distributionType = ALL
-        distributionSha256Sum = "97a52d145762adc241bad7fd18289bf7f6801e08ece6badf80402fe2b9f250b1"
+        distributionSha256Sum = "db9c8211ed63f61f60292c69e80d89196f9eb36665e369e7f00ac4cc841c2219"
     }
 
     val dokkaOutputDir = "${rootProject.projectDir}/dokka"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,15 @@ version = Library.version
 
 tasks {
     wrapper {
+        // Steps for upgrading Gradle:
+        // 1. update `gradleVersion` and `distributionSha256Sum`
+        //    (use 'Complete (-all) ZIP Checksum' found here: https://gradle.org/release-checksums/)
+        // 2. run `./gradlew wrapper`
+        //    (will update 'gradle/wrapper/gradle-wrapper.properties')
+        // 3. run `./gradlew wrapper` again
+        //    (might update 'gradle/wrapper/gradle-wrapper.jar', 'gradlew' and 'gradlew.bat')
+        // 4. commit all changes
+
         gradleVersion = "7.5"
         distributionType = ALL
         distributionSha256Sum = "97a52d145762adc241bad7fd18289bf7f6801e08ece6badf80402fe2b9f250b1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=97a52d145762adc241bad7fd18289bf7f6801e08ece6badf80402fe2b9f250b1
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionSha256Sum=db9c8211ed63f61f60292c69e80d89196f9eb36665e369e7f00ac4cc841c2219
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionSha256Sum=97a52d145762adc241bad7fd18289bf7f6801e08ece6badf80402fe2b9f250b1
 distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Why have Gradle 7.5 when you could have Gradle 7.5.1? :D
- Gradle 7.5 -> 7.5.1
- verify downloaded Gradle distribution (see [here](https://docs.gradle.org/current/userguide/gradle_wrapper.html#sec:verification))
- document steps for upgrading Gradle