### PR TITLE
Breaking: `Event` is no longer a `CoroutineScope`

### DIFF
--- a/core/src/main/kotlin/Kord.kt
+++ b/core/src/main/kotlin/Kord.kt
@@ -631,6 +631,6 @@ public inline fun <reified T : Event> Kord.on(
 ): Job =
     events.buffer(CoroutineChannel.UNLIMITED).filterIsInstance<T>()
         .onEach { event ->
-            scope.launch(event.coroutineContext) { runCatching { consumer(event) }.onFailure { kordLogger.catching(it) } }
+            scope.launch { runCatching { consumer(event) }.onFailure { kordLogger.catching(it) } }
         }
         .launchIn(scope)

--- a/core/src/main/kotlin/event/Event.kt
+++ b/core/src/main/kotlin/event/Event.kt
@@ -2,12 +2,8 @@ package dev.kord.core.event
 
 import dev.kord.core.Kord
 import dev.kord.gateway.Gateway
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.job
-import kotlin.coroutines.CoroutineContext
 
-public interface Event : CoroutineScope {
+public interface Event {
     /**
      * The Gateway that spawned this event.
      */
@@ -21,5 +17,3 @@ public interface Event : CoroutineScope {
     public val shard: Int
 
 }
-
-internal fun kordCoroutineScope(kord: Kord): CoroutineScope = CoroutineScope(kord.coroutineContext + SupervisorJob(kord.coroutineContext.job))

--- a/core/src/main/kotlin/event/channel/ChannelCreateEvent.kt
+++ b/core/src/main/kotlin/event/channel/ChannelCreateEvent.kt
@@ -3,8 +3,6 @@ package dev.kord.core.event.channel
 import dev.kord.core.Kord
 import dev.kord.core.entity.channel.*
 import dev.kord.core.event.Event
-import dev.kord.core.event.kordCoroutineScope
-import kotlinx.coroutines.CoroutineScope
 import kotlin.DeprecationLevel.ERROR
 
 public interface ChannelCreateEvent : Event {
@@ -16,8 +14,7 @@ public interface ChannelCreateEvent : Event {
 public class CategoryCreateEvent(
     override val channel: Category,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
-) : ChannelCreateEvent, CoroutineScope by coroutineScope {
+) : ChannelCreateEvent {
     override fun toString(): String {
         return "CategoryCreateEvent(channel=$channel, shard=$shard)"
     }
@@ -26,8 +23,7 @@ public class CategoryCreateEvent(
 public class DMChannelCreateEvent(
     override val channel: DmChannel,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
-) : ChannelCreateEvent, CoroutineScope by coroutineScope {
+) : ChannelCreateEvent {
     override fun toString(): String {
         return "DMChannelCreateEvent(channel=$channel, shard=$shard)"
     }
@@ -36,8 +32,7 @@ public class DMChannelCreateEvent(
 public class NewsChannelCreateEvent(
     override val channel: NewsChannel,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
-) : ChannelCreateEvent, CoroutineScope by coroutineScope {
+) : ChannelCreateEvent {
     override fun toString(): String {
         return "NewsChannelCreateEvent(channel=$channel, shard=$shard)"
     }
@@ -56,8 +51,7 @@ public class NewsChannelCreateEvent(
 public class StoreChannelCreateEvent(
     override val channel: StoreChannel,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
-) : ChannelCreateEvent, CoroutineScope by coroutineScope {
+) : ChannelCreateEvent {
     override fun toString(): String {
         return "StoreChannelCreateEvent(channel=$channel, shard=$shard)"
     }
@@ -66,8 +60,7 @@ public class StoreChannelCreateEvent(
 public class TextChannelCreateEvent(
     override val channel: TextChannel,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
-) : ChannelCreateEvent, CoroutineScope by coroutineScope {
+) : ChannelCreateEvent {
     override fun toString(): String {
         return "TextChannelCreateEvent(channel=$channel, shard=$shard)"
     }
@@ -76,8 +69,7 @@ public class TextChannelCreateEvent(
 public class VoiceChannelCreateEvent(
     override val channel: VoiceChannel,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
-) : ChannelCreateEvent, CoroutineScope by coroutineScope {
+) : ChannelCreateEvent {
     override fun toString(): String {
         return "VoiceChannelCreateEvent(channel=$channel, shard=$shard)"
     }
@@ -87,8 +79,7 @@ public class VoiceChannelCreateEvent(
 public class StageChannelCreateEvent(
     override val channel: StageChannel,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
-) : ChannelCreateEvent, CoroutineScope by coroutineScope {
+) : ChannelCreateEvent {
     override fun toString(): String {
         return "StageChannelCreateEvent(channel=$channel, shard=$shard)"
     }
@@ -97,8 +88,7 @@ public class StageChannelCreateEvent(
 public class UnknownChannelCreateEvent(
     override val channel: Channel,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
-) : ChannelCreateEvent, CoroutineScope by coroutineScope {
+) : ChannelCreateEvent {
     override fun toString(): String {
         return "UnknownChannelCreateEvent(channel=$channel, shard=$shard)"
     }

--- a/core/src/main/kotlin/event/channel/ChannelDeleteEvent.kt
+++ b/core/src/main/kotlin/event/channel/ChannelDeleteEvent.kt
@@ -3,8 +3,6 @@ package dev.kord.core.event.channel
 import dev.kord.core.Kord
 import dev.kord.core.entity.channel.*
 import dev.kord.core.event.Event
-import dev.kord.core.event.kordCoroutineScope
-import kotlinx.coroutines.CoroutineScope
 import kotlin.DeprecationLevel.ERROR
 
 public interface ChannelDeleteEvent : Event {
@@ -16,9 +14,7 @@ public interface ChannelDeleteEvent : Event {
 public class CategoryDeleteEvent(
     override val channel: Category,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
-
-) : ChannelDeleteEvent, CoroutineScope by coroutineScope {
+) : ChannelDeleteEvent {
     override fun toString(): String {
         return "CategoryDeleteEvent(channel=$channel, shard=$shard)"
     }
@@ -27,9 +23,7 @@ public class CategoryDeleteEvent(
 public class DMChannelDeleteEvent(
     override val channel: DmChannel,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
-
-) : ChannelDeleteEvent, CoroutineScope by coroutineScope {
+) : ChannelDeleteEvent {
     override fun toString(): String {
         return "DMChannelDeleteEvent(channel=$channel, shard=$shard)"
     }
@@ -38,9 +32,7 @@ public class DMChannelDeleteEvent(
 public class NewsChannelDeleteEvent(
     override val channel: NewsChannel,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
-
-) : ChannelDeleteEvent, CoroutineScope by coroutineScope {
+) : ChannelDeleteEvent {
     override fun toString(): String {
         return "NewsChannelDeleteEvent(channel=$channel, shard=$shard)"
     }
@@ -59,9 +51,7 @@ public class NewsChannelDeleteEvent(
 public class StoreChannelDeleteEvent(
     override val channel: StoreChannel,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
-
-) : ChannelDeleteEvent, CoroutineScope by coroutineScope {
+) : ChannelDeleteEvent {
     override fun toString(): String {
         return "StoreChannelDeleteEvent(channel=$channel, shard=$shard)"
     }
@@ -70,9 +60,7 @@ public class StoreChannelDeleteEvent(
 public class TextChannelDeleteEvent(
     override val channel: TextChannel,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
-
-) : ChannelDeleteEvent, CoroutineScope by coroutineScope {
+) : ChannelDeleteEvent {
     override fun toString(): String {
         return "TextChannelDeleteEvent(channel=$channel, shard=$shard)"
     }
@@ -81,9 +69,7 @@ public class TextChannelDeleteEvent(
 public class VoiceChannelDeleteEvent(
     override val channel: VoiceChannel,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
-
-) : ChannelDeleteEvent, CoroutineScope by coroutineScope {
+) : ChannelDeleteEvent {
     override fun toString(): String {
         return "VoiceChannelDeleteEvent(channel=$channel, shard=$shard)"
     }
@@ -92,9 +78,7 @@ public class VoiceChannelDeleteEvent(
 public class StageChannelDeleteEvent(
     override val channel: StageChannel,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
-
-) : ChannelDeleteEvent, CoroutineScope by coroutineScope {
+) : ChannelDeleteEvent {
     override fun toString(): String {
         return "StageChannelDeleteEvent(channel=$channel, shard=$shard)"
     }
@@ -103,9 +87,7 @@ public class StageChannelDeleteEvent(
 public class UnknownChannelDeleteEvent(
     override val channel: Channel,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
-
-) : ChannelDeleteEvent, CoroutineScope by coroutineScope {
+) : ChannelDeleteEvent {
     override fun toString(): String {
         return "UnknownChannelDeleteEvent(channel=$channel, shard=$shard)"
     }

--- a/core/src/main/kotlin/event/channel/ChannelPinsUpdateEvent.kt
+++ b/core/src/main/kotlin/event/channel/ChannelPinsUpdateEvent.kt
@@ -8,12 +8,10 @@ import dev.kord.core.entity.Strategizable
 import dev.kord.core.entity.channel.MessageChannel
 import dev.kord.core.event.Event
 import dev.kord.core.event.channel.data.ChannelPinsUpdateEventData
-import dev.kord.core.event.kordCoroutineScope
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 import dev.kord.core.supplier.getChannelOf
 import dev.kord.core.supplier.getChannelOfOrNull
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.datetime.Instant
 
 public class ChannelPinsUpdateEvent(
@@ -21,8 +19,7 @@ public class ChannelPinsUpdateEvent(
     override val kord: Kord,
     override val shard: Int,
     override val supplier: EntitySupplier = kord.defaultSupplier,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : Event, CoroutineScope by coroutineScope,Strategizable {
+) : Event, Strategizable {
 
     public val channelId: Snowflake get() = data.channelId
 

--- a/core/src/main/kotlin/event/channel/ChannelUpdateEvent.kt
+++ b/core/src/main/kotlin/event/channel/ChannelUpdateEvent.kt
@@ -3,8 +3,6 @@ package dev.kord.core.event.channel
 import dev.kord.core.Kord
 import dev.kord.core.entity.channel.*
 import dev.kord.core.event.Event
-import dev.kord.core.event.kordCoroutineScope
-import kotlinx.coroutines.CoroutineScope
 import kotlin.DeprecationLevel.ERROR
 
 
@@ -19,8 +17,7 @@ public class CategoryUpdateEvent(
     override val channel: Category,
     override val old: Category?,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
-) : ChannelUpdateEvent, CoroutineScope by coroutineScope {
+) : ChannelUpdateEvent {
     override fun toString(): String {
         return "CategoryUpdateEvent(channel=$channel, old=$old, shard=$shard)"
     }
@@ -30,8 +27,7 @@ public class DMChannelUpdateEvent(
     override val channel: DmChannel,
     override val old: DmChannel?,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
-) : ChannelUpdateEvent, CoroutineScope by coroutineScope {
+) : ChannelUpdateEvent {
     override fun toString(): String {
         return "DMChannelUpdateEvent(channel=$channel, old=$old, shard=$shard)"
     }
@@ -41,8 +37,7 @@ public class NewsChannelUpdateEvent(
     override val channel: NewsChannel,
     override val old: NewsChannel?,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
-) : ChannelUpdateEvent, CoroutineScope by coroutineScope {
+) : ChannelUpdateEvent {
     override fun toString(): String {
         return "NewsChannelUpdateEvent(channel=$channel, old=$old, shard=$shard)"
     }
@@ -62,8 +57,7 @@ public class StoreChannelUpdateEvent(
     override val channel: StoreChannel,
     override val old: StoreChannel?,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
-) : ChannelUpdateEvent, CoroutineScope by coroutineScope {
+) : ChannelUpdateEvent {
     override fun toString(): String {
         return "StoreChannelUpdateEvent(channel=$channel, old=$old, shard=$shard)"
     }
@@ -73,8 +67,7 @@ public class TextChannelUpdateEvent(
     override val channel: TextChannel,
     override val old: TextChannel?,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
-) : ChannelUpdateEvent, CoroutineScope by coroutineScope {
+) : ChannelUpdateEvent {
     override fun toString(): String {
         return "TextChannelUpdateEvent(channel=$channel, old=$old, shard=$shard)"
     }
@@ -84,8 +77,7 @@ public class VoiceChannelUpdateEvent(
     override val channel: VoiceChannel,
     override val old: VoiceChannel?,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
-) : ChannelUpdateEvent, CoroutineScope by coroutineScope{
+) : ChannelUpdateEvent {
     override fun toString(): String {
         return "VoiceChannelUpdateEvent(channel=$channel, old=$old, shard=$shard)"
     }
@@ -96,8 +88,7 @@ public class StageChannelUpdateEvent(
     override val channel: StageChannel,
     override val old: StageChannel?,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
-) : ChannelUpdateEvent, CoroutineScope by coroutineScope {
+) : ChannelUpdateEvent {
     override fun toString(): String {
         return "StageChannelUpdateEvent(channel=$channel, old=$old, shard=$shard)"
     }
@@ -107,8 +98,7 @@ public class UnknownChannelUpdateEvent(
     override val channel: Channel,
     override val old: Channel?,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
-) : ChannelUpdateEvent, CoroutineScope by coroutineScope {
+) : ChannelUpdateEvent {
     override fun toString(): String {
         return "UnknownChannelUpdateEvent(channel=$channel, old=$old, shard=$shard)"
     }

--- a/core/src/main/kotlin/event/channel/TypingStartEvent.kt
+++ b/core/src/main/kotlin/event/channel/TypingStartEvent.kt
@@ -12,13 +12,11 @@ import dev.kord.core.entity.User
 import dev.kord.core.entity.channel.MessageChannel
 import dev.kord.core.event.Event
 import dev.kord.core.event.channel.data.TypingStartEventData
-import dev.kord.core.event.kordCoroutineScope
 import dev.kord.core.exception.EntityNotFoundException
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 import dev.kord.core.supplier.getChannelOf
 import dev.kord.core.supplier.getChannelOfOrNull
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.datetime.Instant
 
 public class TypingStartEvent(
@@ -26,8 +24,7 @@ public class TypingStartEvent(
     override val kord: Kord,
     override val shard: Int,
     override val supplier: EntitySupplier = kord.defaultSupplier,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : Event, CoroutineScope by coroutineScope, Strategizable {
+) : Event, Strategizable {
 
     public val channelId: Snowflake get() = data.channelId
 

--- a/core/src/main/kotlin/event/channel/thread/ThreadCreateEvent.kt
+++ b/core/src/main/kotlin/event/channel/thread/ThreadCreateEvent.kt
@@ -4,9 +4,6 @@ import dev.kord.core.entity.channel.thread.NewsChannelThread
 import dev.kord.core.entity.channel.thread.TextChannelThread
 import dev.kord.core.entity.channel.thread.ThreadChannel
 import dev.kord.core.event.channel.ChannelCreateEvent
-import dev.kord.core.event.kordCoroutineScope
-import kotlinx.coroutines.CoroutineScope
-import kotlin.coroutines.CoroutineContext
 
 public sealed interface ThreadChannelCreateEvent : ChannelCreateEvent {
     override val channel: ThreadChannel
@@ -16,8 +13,7 @@ public sealed interface ThreadChannelCreateEvent : ChannelCreateEvent {
 public class TextChannelThreadCreateEvent(
     override val channel: TextChannelThread,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
-) : ThreadChannelCreateEvent, CoroutineScope by coroutineScope {
+) : ThreadChannelCreateEvent {
     override fun toString(): String {
         return "TextThreadChannelCreateEvent(channel=$channel, shard=$shard)"
     }
@@ -27,8 +23,7 @@ public class TextChannelThreadCreateEvent(
 public class NewsChannelThreadCreateEvent(
     override val channel: NewsChannelThread,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
-) : ThreadChannelCreateEvent, CoroutineScope by coroutineScope {
+) : ThreadChannelCreateEvent {
     override fun toString(): String {
         return "NewsThreadChannelCreateEvent(channel=$channel, shard=$shard)"
     }
@@ -37,8 +32,7 @@ public class NewsChannelThreadCreateEvent(
 public class UnknownChannelThreadCreateEvent(
     override val channel: ThreadChannel,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
-) : ThreadChannelCreateEvent, CoroutineScope by coroutineScope {
+) : ThreadChannelCreateEvent {
     override fun toString(): String {
         return "UnknownChannelThreadCreateEvent(channel=$channel, shard=$shard)"
     }

--- a/core/src/main/kotlin/event/channel/thread/ThreadDeleteEvent.kt
+++ b/core/src/main/kotlin/event/channel/thread/ThreadDeleteEvent.kt
@@ -6,9 +6,6 @@ import dev.kord.core.entity.channel.thread.NewsChannelThread
 import dev.kord.core.entity.channel.thread.TextChannelThread
 import dev.kord.core.entity.channel.thread.ThreadChannel
 import dev.kord.core.event.Event
-import dev.kord.core.event.kordCoroutineScope
-import kotlinx.coroutines.CoroutineScope
-import kotlin.coroutines.CoroutineContext
 
 public sealed interface ThreadChannelDeleteEvent : Event {
     public val channel: DeletedThreadChannel
@@ -25,8 +22,7 @@ public class TextChannelThreadDeleteEvent(
     override val channel: DeletedThreadChannel,
     override val old: TextChannelThread?,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
-) : ThreadChannelDeleteEvent, CoroutineScope by coroutineScope {
+) : ThreadChannelDeleteEvent {
     override fun toString(): String {
         return "TextThreadChannelDeleteEvent(channel=$channel, shard=$shard)"
     }
@@ -37,8 +33,7 @@ public class NewsChannelThreadDeleteEvent(
     override val channel: DeletedThreadChannel,
     override val old: NewsChannelThread?,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
-) : ThreadChannelDeleteEvent, CoroutineScope by coroutineScope {
+) : ThreadChannelDeleteEvent {
     override fun toString(): String {
         return "NewsThreadChannelDeleteEvent(channel=$channel, shard=$shard)"
     }
@@ -49,8 +44,7 @@ public class UnknownChannelThreadDeleteEvent(
     override val channel: DeletedThreadChannel,
     override val old: ThreadChannel?,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
-) : ThreadChannelDeleteEvent, CoroutineScope by coroutineScope {
+) : ThreadChannelDeleteEvent {
     override fun toString(): String {
         return "UnknownChannelThreadDeleteEvent(channel=$channel, shard=$shard)"
     }

--- a/core/src/main/kotlin/event/channel/thread/ThreadListSyncEvent.kt
+++ b/core/src/main/kotlin/event/channel/thread/ThreadListSyncEvent.kt
@@ -13,13 +13,10 @@ import dev.kord.core.entity.channel.TopGuildChannel
 import dev.kord.core.entity.channel.thread.ThreadChannel
 import dev.kord.core.entity.channel.thread.ThreadMember
 import dev.kord.core.event.Event
-import dev.kord.core.event.kordCoroutineScope
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filter
-import kotlin.coroutines.CoroutineContext
 
 
 public class ThreadListSyncEvent(
@@ -27,8 +24,7 @@ public class ThreadListSyncEvent(
     override val kord: Kord,
     override val shard: Int,
     override val supplier: EntitySupplier = kord.defaultSupplier,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : Event, CoroutineScope by coroutineScope, Strategizable {
+) : Event, Strategizable {
 
     public val guildId: Snowflake get() = data.guildId
 

--- a/core/src/main/kotlin/event/channel/thread/ThreadMemberUpdateEvent.kt
+++ b/core/src/main/kotlin/event/channel/thread/ThreadMemberUpdateEvent.kt
@@ -3,13 +3,9 @@ package dev.kord.core.event.channel.thread
 import dev.kord.core.Kord
 import dev.kord.core.entity.channel.thread.ThreadMember
 import dev.kord.core.event.Event
-import dev.kord.core.event.kordCoroutineScope
-import kotlinx.coroutines.CoroutineScope
-import kotlin.coroutines.CoroutineContext
 
 public class ThreadMemberUpdateEvent(
     public val member: ThreadMember,
     override val kord: Kord,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : Event, CoroutineScope by coroutineScope
+) : Event

--- a/core/src/main/kotlin/event/channel/thread/ThreadMembersUpdateEvent.kt
+++ b/core/src/main/kotlin/event/channel/thread/ThreadMembersUpdateEvent.kt
@@ -7,16 +7,12 @@ import dev.kord.core.behavior.MemberBehavior
 import dev.kord.core.cache.data.ThreadMembersUpdateEventData
 import dev.kord.core.entity.channel.thread.ThreadMember
 import dev.kord.core.event.Event
-import dev.kord.core.event.kordCoroutineScope
-import kotlinx.coroutines.CoroutineScope
-import kotlin.coroutines.CoroutineContext
 
 public class ThreadMembersUpdateEvent(
     public val data: ThreadMembersUpdateEventData,
     override val kord: Kord,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : Event, CoroutineScope by coroutineScope {
+) : Event {
 
     public val id: Snowflake get() = data.id
 

--- a/core/src/main/kotlin/event/channel/thread/ThreadUpdateEvent.kt
+++ b/core/src/main/kotlin/event/channel/thread/ThreadUpdateEvent.kt
@@ -4,8 +4,6 @@ import dev.kord.core.entity.channel.thread.NewsChannelThread
 import dev.kord.core.entity.channel.thread.TextChannelThread
 import dev.kord.core.entity.channel.thread.ThreadChannel
 import dev.kord.core.event.channel.ChannelUpdateEvent
-import dev.kord.core.event.kordCoroutineScope
-import kotlinx.coroutines.CoroutineScope
 
 public sealed interface ThreadUpdateEvent : ChannelUpdateEvent {
     override val channel: ThreadChannel
@@ -16,9 +14,7 @@ public class TextChannelThreadUpdateEvent(
     override val channel: TextChannelThread,
     override val old: TextChannelThread?,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
-) :
-    ThreadUpdateEvent, CoroutineScope by coroutineScope {
+) : ThreadUpdateEvent {
     override fun toString(): String {
         return "TextThreadChannelUpdateEvent(channel=$channel, old=$old, shard=$shard)"
     }
@@ -29,8 +25,7 @@ public class NewsChannelThreadUpdateEvent(
     override val channel: NewsChannelThread,
     override val old: NewsChannelThread?,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
-) : ThreadUpdateEvent, CoroutineScope by coroutineScope {
+) : ThreadUpdateEvent {
     override fun toString(): String {
         return "NewsThreadChannelUpdateEvent(channel=$channel, old=$old, shard=$shard)"
     }
@@ -41,8 +36,7 @@ public class UnknownChannelThreadUpdateEvent(
     override val channel: ThreadChannel,
     override val old: ThreadChannel?,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(channel.kord)
-) : ThreadUpdateEvent, CoroutineScope by coroutineScope {
+) : ThreadUpdateEvent {
     override fun toString(): String {
         return "UnknownChannelThreadUpdateEvent(channel=$channel, old=$old, shard=$shard)"
     }

--- a/core/src/main/kotlin/event/gateway/Events.kt
+++ b/core/src/main/kotlin/event/gateway/Events.kt
@@ -7,24 +7,20 @@ import dev.kord.core.entity.Guild
 import dev.kord.core.entity.Strategizable
 import dev.kord.core.entity.User
 import dev.kord.core.event.Event
-import dev.kord.core.event.kordCoroutineScope
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 import dev.kord.gateway.Command
 import dev.kord.gateway.Gateway
 import dev.kord.gateway.GatewayCloseCode
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filter
-import kotlin.coroutines.CoroutineContext
 
 public sealed class GatewayEvent : Event
 
 public class ConnectEvent(
     override val kord: Kord,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : GatewayEvent(), CoroutineScope by coroutineScope
+) : GatewayEvent()
 
 public sealed class DisconnectEvent : GatewayEvent() {
 
@@ -34,8 +30,7 @@ public sealed class DisconnectEvent : GatewayEvent() {
     public class DetachEvent(
         override val kord: Kord,
         override val shard: Int,
-        public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-    ) : DisconnectEvent(), CoroutineScope by coroutineScope {
+    ) : DisconnectEvent() {
         override fun toString(): String {
             return "DetachEvent(kord=$kord, shard=$shard)"
         }
@@ -47,8 +42,7 @@ public sealed class DisconnectEvent : GatewayEvent() {
     public class UserCloseEvent(
         override val kord: Kord,
         override val shard: Int,
-        public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-    ) : DisconnectEvent(), CoroutineScope by coroutineScope {
+    ) : DisconnectEvent() {
         override fun toString(): String {
             return "UserCloseEvent(kord=$kord, shard=$shard)"
         }
@@ -60,8 +54,7 @@ public sealed class DisconnectEvent : GatewayEvent() {
     public class TimeoutEvent(
         override val kord: Kord,
         override val shard: Int,
-        public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-    ) : DisconnectEvent(), CoroutineScope by coroutineScope {
+    ) : DisconnectEvent() {
         override fun toString(): String {
             return "TimeoutEvent(kord=$kord, shard=$shard)"
         }
@@ -77,8 +70,7 @@ public sealed class DisconnectEvent : GatewayEvent() {
         override val shard: Int,
         public val closeCode: GatewayCloseCode,
         public val recoverable: Boolean,
-        public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-    ) : DisconnectEvent(), CoroutineScope by coroutineScope {
+    ) : DisconnectEvent() {
         override fun toString(): String {
             return "DiscordCloseEvent(kord=$kord, shard=$shard, closeCode=$closeCode, recoverable=$recoverable)"
         }
@@ -91,8 +83,7 @@ public sealed class DisconnectEvent : GatewayEvent() {
     public class RetryLimitReachedEvent(
         override val kord: Kord,
         override val shard: Int,
-        public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-    ) : DisconnectEvent(), CoroutineScope by coroutineScope {
+    ) : DisconnectEvent() {
         override fun toString(): String {
             return "RetryLimitReachedEvent(kord=$kord, shard=$shard)"
         }
@@ -104,8 +95,7 @@ public sealed class DisconnectEvent : GatewayEvent() {
     public class ReconnectingEvent(
         override val kord: Kord,
         override val shard: Int,
-        public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-    ) : DisconnectEvent(), CoroutineScope by coroutineScope {
+    ) : DisconnectEvent() {
         override fun toString(): String {
             return "ReconnectingEvent(kord=$kord, shard=$shard)"
         }
@@ -117,8 +107,7 @@ public sealed class DisconnectEvent : GatewayEvent() {
     public class SessionReset(
         override val kord: Kord,
         override val shard: Int,
-        public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-    ) : DisconnectEvent(), CoroutineScope by coroutineScope {
+    ) : DisconnectEvent() {
         override fun toString(): String {
             return "SessionReset(kord=$kord, shard=$shard)"
         }
@@ -131,8 +120,7 @@ public sealed class DisconnectEvent : GatewayEvent() {
     public class ZombieConnectionEvent(
         override val kord: Kord,
         override val shard: Int,
-        public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-    ) : DisconnectEvent(), CoroutineScope by coroutineScope {
+    ) : DisconnectEvent() {
         override fun toString(): String {
             return "ZombieConnectionEvent(kord=$kord, shard=$shard)"
         }
@@ -148,8 +136,7 @@ public class ReadyEvent(
     override val kord: Kord,
     override val shard: Int,
     override val supplier: EntitySupplier = kord.defaultSupplier,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : GatewayEvent(), CoroutineScope by coroutineScope, Strategizable {
+) : GatewayEvent(), Strategizable {
 
     public val guilds: Set<GuildBehavior> get() = guildIds.map { GuildBehavior(it, kord) }.toSet()
 
@@ -166,8 +153,7 @@ public class ReadyEvent(
 public class ResumedEvent(
     override val kord: Kord,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : GatewayEvent(), CoroutineScope by coroutineScope {
+) : GatewayEvent() {
     override fun toString(): String {
         return "ResumedEvent(kord=$kord, shard=$shard)"
     }

--- a/core/src/main/kotlin/event/guild/BanAddEvent.kt
+++ b/core/src/main/kotlin/event/guild/BanAddEvent.kt
@@ -9,20 +9,16 @@ import dev.kord.core.entity.Guild
 import dev.kord.core.entity.Strategizable
 import dev.kord.core.entity.User
 import dev.kord.core.event.Event
-import dev.kord.core.event.kordCoroutineScope
 import dev.kord.core.exception.EntityNotFoundException
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
-import kotlinx.coroutines.CoroutineScope
-import kotlin.coroutines.CoroutineContext
 
 public class BanAddEvent(
     public val user: User,
     public val guildId: Snowflake,
     override val shard: Int,
     override val supplier: EntitySupplier = user.kord.defaultSupplier,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(user.kord)
-) : Event, CoroutineScope by coroutineScope, Strategizable {
+) : Event, Strategizable {
 
     override val kord: Kord get() = user.kord
 

--- a/core/src/main/kotlin/event/guild/BanRemoveEvent.kt
+++ b/core/src/main/kotlin/event/guild/BanRemoveEvent.kt
@@ -7,19 +7,15 @@ import dev.kord.core.entity.Guild
 import dev.kord.core.entity.Strategizable
 import dev.kord.core.entity.User
 import dev.kord.core.event.Event
-import dev.kord.core.event.kordCoroutineScope
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
-import kotlinx.coroutines.CoroutineScope
-import kotlin.coroutines.CoroutineContext
 
 public class BanRemoveEvent(
     public val user: User,
     public val guildId: Snowflake,
     override val shard: Int,
     override val supplier: EntitySupplier = user.kord.defaultSupplier,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(user.kord)
-) : Event, CoroutineScope by coroutineScope, Strategizable {
+) : Event, Strategizable {
 
     override val kord: Kord get() = user.kord
 

--- a/core/src/main/kotlin/event/guild/EmojisUpdateEvent.kt
+++ b/core/src/main/kotlin/event/guild/EmojisUpdateEvent.kt
@@ -7,11 +7,8 @@ import dev.kord.core.entity.Guild
 import dev.kord.core.entity.GuildEmoji
 import dev.kord.core.entity.Strategizable
 import dev.kord.core.event.Event
-import dev.kord.core.event.kordCoroutineScope
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
-import kotlinx.coroutines.CoroutineScope
-import kotlin.coroutines.CoroutineContext
 
 public class EmojisUpdateEvent(
     public val guildId: Snowflake,
@@ -20,8 +17,7 @@ public class EmojisUpdateEvent(
     override val kord: Kord,
     override val shard: Int,
     override val supplier: EntitySupplier = kord.defaultSupplier,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : Event, CoroutineScope by coroutineScope, Strategizable {
+) : Event, Strategizable {
 
     public val guild: GuildBehavior get() = GuildBehavior(guildId, kord)
 

--- a/core/src/main/kotlin/event/guild/GuildCreateEvent.kt
+++ b/core/src/main/kotlin/event/guild/GuildCreateEvent.kt
@@ -3,15 +3,11 @@ package dev.kord.core.event.guild
 import dev.kord.core.Kord
 import dev.kord.core.entity.Guild
 import dev.kord.core.event.Event
-import dev.kord.core.event.kordCoroutineScope
-import kotlinx.coroutines.CoroutineScope
-import kotlin.coroutines.CoroutineContext
 
 public class GuildCreateEvent(
     public val guild: Guild,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(guild.kord)
-) : Event, CoroutineScope by coroutineScope {
+) : Event {
     override val kord: Kord get() = guild.kord
 
     override fun toString(): String {

--- a/core/src/main/kotlin/event/guild/GuildDeleteEvent.kt
+++ b/core/src/main/kotlin/event/guild/GuildDeleteEvent.kt
@@ -4,9 +4,6 @@ import dev.kord.common.entity.Snowflake
 import dev.kord.core.Kord
 import dev.kord.core.entity.Guild
 import dev.kord.core.event.Event
-import dev.kord.core.event.kordCoroutineScope
-import kotlinx.coroutines.CoroutineScope
-import kotlin.coroutines.CoroutineContext
 
 public class GuildDeleteEvent(
     public val guildId: Snowflake,
@@ -14,8 +11,7 @@ public class GuildDeleteEvent(
     public val guild: Guild?,
     override val kord: Kord,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : Event, CoroutineScope by coroutineScope {
+) : Event {
 
     override fun toString(): String {
         return "GuildDeleteEvent(guildId=$guildId, unavailable=$unavailable, guild=$guild, kord=$kord, shard=$shard)"

--- a/core/src/main/kotlin/event/guild/GuildScheduledEventCreateEvent.kt
+++ b/core/src/main/kotlin/event/guild/GuildScheduledEventCreateEvent.kt
@@ -2,10 +2,8 @@ package dev.kord.core.event.guild
 
 import dev.kord.core.Kord
 import dev.kord.core.entity.GuildScheduledEvent
-import dev.kord.core.event.kordCoroutineScope
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
-import kotlinx.coroutines.CoroutineScope
 
 /**
  * Event fired when a scheduled event got created.
@@ -18,8 +16,7 @@ public data class GuildScheduledEventCreateEvent(
     override val kord: Kord,
     override val shard: Int,
     override val supplier: EntitySupplier = kord.defaultSupplier,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : GuildScheduledEventEvent, CoroutineScope by coroutineScope {
+) : GuildScheduledEventEvent {
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): GuildScheduledEventCreateEvent =
         copy(supplier = strategy.supply(kord))
 }

--- a/core/src/main/kotlin/event/guild/GuildScheduledEventDeleteEvent.kt
+++ b/core/src/main/kotlin/event/guild/GuildScheduledEventDeleteEvent.kt
@@ -2,10 +2,8 @@ package dev.kord.core.event.guild
 
 import dev.kord.core.Kord
 import dev.kord.core.entity.GuildScheduledEvent
-import dev.kord.core.event.kordCoroutineScope
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
-import kotlinx.coroutines.CoroutineScope
 
 /**
  * Event fired when a scheduled event got deleted.
@@ -19,8 +17,7 @@ public data class GuildScheduledEventDeleteEvent(
     override val kord: Kord,
     override val shard: Int,
     override val supplier: EntitySupplier = kord.defaultSupplier,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : GuildScheduledEventEvent, CoroutineScope by coroutineScope {
+) : GuildScheduledEventEvent {
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): GuildScheduledEventDeleteEvent =
         copy(supplier = strategy.supply(kord))
 }

--- a/core/src/main/kotlin/event/guild/GuildScheduledEventEvent.kt
+++ b/core/src/main/kotlin/event/guild/GuildScheduledEventEvent.kt
@@ -10,7 +10,6 @@ import dev.kord.core.event.Event
 import dev.kord.core.exception.EntityNotFoundException
 import dev.kord.core.supplier.EntitySupplyStrategy
 import dev.kord.core.supplier.getChannelOfOrNull
-import kotlinx.coroutines.CoroutineScope
 
 /**
  * Interface of all events related to [GuildScheduledEvents][GuildScheduledEvent].
@@ -19,7 +18,7 @@ import kotlinx.coroutines.CoroutineScope
  * @see GuildScheduledEventUpdateEvent
  * @see GuildScheduledEventDeleteEvent
  */
-public sealed interface GuildScheduledEventEvent : Event, CoroutineScope, Strategizable {
+public sealed interface GuildScheduledEventEvent : Event, Strategizable {
 
     /**
      * The [GuildScheduledEvent].

--- a/core/src/main/kotlin/event/guild/GuildScheduledEventUpdateEvent.kt
+++ b/core/src/main/kotlin/event/guild/GuildScheduledEventUpdateEvent.kt
@@ -5,10 +5,8 @@ import dev.kord.common.exception.RequestException
 import dev.kord.core.Kord
 import dev.kord.core.entity.GuildScheduledEvent
 import dev.kord.core.entity.channel.TopGuildChannel
-import dev.kord.core.event.kordCoroutineScope
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
-import kotlinx.coroutines.CoroutineScope
 
 /**
  * Event fired if a [GuildScheduledEvent] gets updated.
@@ -25,8 +23,7 @@ public data class GuildScheduledEventUpdateEvent(
     override val kord: Kord,
     override val shard: Int,
     override val supplier: EntitySupplier = kord.defaultSupplier,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : GuildScheduledEventEvent, CoroutineScope by coroutineScope {
+) : GuildScheduledEventEvent {
 
     /**
      * The channel id of the channel the event is in.

--- a/core/src/main/kotlin/event/guild/GuildScheduledEventUserEvent.kt
+++ b/core/src/main/kotlin/event/guild/GuildScheduledEventUserEvent.kt
@@ -4,16 +4,14 @@ import dev.kord.common.entity.Snowflake
 import dev.kord.core.Kord
 import dev.kord.core.entity.*
 import dev.kord.core.event.Event
-import dev.kord.core.event.kordCoroutineScope
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
-import kotlinx.coroutines.CoroutineScope
 
 /**
  * Sent when a user has [subscribed to][GuildScheduledEventUserAddEvent] or
  * [unsubscribed from][GuildScheduledEventUserRemoveEvent] a [GuildScheduledEvent].
  */
-public sealed interface GuildScheduledEventUserEvent : Event, CoroutineScope, Strategizable {
+public sealed interface GuildScheduledEventUserEvent : Event, Strategizable {
     public val scheduledEventId: Snowflake
     public val userId: Snowflake
     public val guildId: Snowflake
@@ -42,8 +40,7 @@ public data class GuildScheduledEventUserAddEvent(
     override val kord: Kord,
     override val shard: Int,
     override val supplier: EntitySupplier = kord.defaultSupplier,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord),
-) : GuildScheduledEventUserEvent, CoroutineScope by coroutineScope {
+) : GuildScheduledEventUserEvent {
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): GuildScheduledEventUserAddEvent =
         GuildScheduledEventUserAddEvent(scheduledEventId, userId, guildId, kord, shard, strategy.supply(kord))
 }
@@ -56,8 +53,7 @@ public data class GuildScheduledEventUserRemoveEvent(
     override val kord: Kord,
     override val shard: Int,
     override val supplier: EntitySupplier = kord.defaultSupplier,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord),
-) : GuildScheduledEventUserEvent, CoroutineScope by coroutineScope {
+) : GuildScheduledEventUserEvent {
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): GuildScheduledEventUserRemoveEvent =
         GuildScheduledEventUserRemoveEvent(scheduledEventId, userId, guildId, kord, shard, strategy.supply(kord))
 }

--- a/core/src/main/kotlin/event/guild/GuildUpdateEvent.kt
+++ b/core/src/main/kotlin/event/guild/GuildUpdateEvent.kt
@@ -3,16 +3,12 @@ package dev.kord.core.event.guild
 import dev.kord.core.Kord
 import dev.kord.core.entity.Guild
 import dev.kord.core.event.Event
-import dev.kord.core.event.kordCoroutineScope
-import kotlinx.coroutines.CoroutineScope
-import kotlin.coroutines.CoroutineContext
 
 public class GuildUpdateEvent(
     public val guild: Guild,
     public val old: Guild?,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(guild.kord)
-) : Event, CoroutineScope by coroutineScope {
+) : Event {
     override val kord: Kord get() = guild.kord
     override fun toString(): String {
         return "GuildUpdateEvent(guild=$guild, shard=$shard)"

--- a/core/src/main/kotlin/event/guild/IntegrationsUpdateEvent.kt
+++ b/core/src/main/kotlin/event/guild/IntegrationsUpdateEvent.kt
@@ -6,19 +6,15 @@ import dev.kord.core.behavior.GuildBehavior
 import dev.kord.core.entity.Guild
 import dev.kord.core.entity.Strategizable
 import dev.kord.core.event.Event
-import dev.kord.core.event.kordCoroutineScope
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
-import kotlinx.coroutines.CoroutineScope
-import kotlin.coroutines.CoroutineContext
 
 public class IntegrationsUpdateEvent(
     public val guildId: Snowflake,
     override val kord: Kord,
     override val shard: Int,
     override val supplier: EntitySupplier = kord.defaultSupplier,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : Event, CoroutineScope by coroutineScope, Strategizable {
+) : Event, Strategizable {
 
     public val guild: GuildBehavior get() = GuildBehavior(guildId, kord)
 

--- a/core/src/main/kotlin/event/guild/InviteCreateEvent.kt
+++ b/core/src/main/kotlin/event/guild/InviteCreateEvent.kt
@@ -14,11 +14,9 @@ import dev.kord.core.cache.data.InviteData
 import dev.kord.core.entity.*
 import dev.kord.core.entity.channel.Channel
 import dev.kord.core.event.Event
-import dev.kord.core.event.kordCoroutineScope
 import dev.kord.core.exception.EntityNotFoundException
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.datetime.Instant
 import kotlin.DeprecationLevel.HIDDEN
 import kotlin.time.Duration
@@ -31,8 +29,7 @@ public class InviteCreateEvent(
     override val kord: Kord,
     override val shard: Int,
     override val supplier: EntitySupplier = kord.defaultSupplier,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : Event, CoroutineScope by coroutineScope, Strategizable {
+) : Event, Strategizable {
 
     /**
      * The id of the [Channel] the invite is for.

--- a/core/src/main/kotlin/event/guild/InviteDeleteEvent.kt
+++ b/core/src/main/kotlin/event/guild/InviteDeleteEvent.kt
@@ -10,11 +10,9 @@ import dev.kord.core.entity.Guild
 import dev.kord.core.entity.Strategizable
 import dev.kord.core.entity.channel.Channel
 import dev.kord.core.event.Event
-import dev.kord.core.event.kordCoroutineScope
 import dev.kord.core.exception.EntityNotFoundException
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
-import kotlinx.coroutines.CoroutineScope
 import kotlin.DeprecationLevel.HIDDEN
 
 /**
@@ -25,8 +23,7 @@ public class InviteDeleteEvent(
     override val kord: Kord,
     override val shard: Int,
     override val supplier: EntitySupplier = kord.defaultSupplier,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : Event, CoroutineScope by coroutineScope, Strategizable {
+) : Event, Strategizable {
 
     /**
      * The id of the [Channel] the invite is for.

--- a/core/src/main/kotlin/event/guild/MemberJoinEvent.kt
+++ b/core/src/main/kotlin/event/guild/MemberJoinEvent.kt
@@ -7,18 +7,14 @@ import dev.kord.core.entity.Guild
 import dev.kord.core.entity.Member
 import dev.kord.core.entity.Strategizable
 import dev.kord.core.event.Event
-import dev.kord.core.event.kordCoroutineScope
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
-import kotlinx.coroutines.CoroutineScope
-import kotlin.coroutines.CoroutineContext
 
 public class MemberJoinEvent(
     public val member: Member,
     override val shard: Int,
     override val supplier: EntitySupplier = member.kord.defaultSupplier,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(member.kord)
-) : Event, CoroutineScope by coroutineScope, Strategizable {
+) : Event, Strategizable {
 
     override val kord: Kord get() = member.kord
 

--- a/core/src/main/kotlin/event/guild/MemberLeaveEvent.kt
+++ b/core/src/main/kotlin/event/guild/MemberLeaveEvent.kt
@@ -7,17 +7,13 @@ import dev.kord.core.entity.Guild
 import dev.kord.core.entity.Member
 import dev.kord.core.entity.User
 import dev.kord.core.event.Event
-import dev.kord.core.event.kordCoroutineScope
-import kotlinx.coroutines.CoroutineScope
-import kotlin.coroutines.CoroutineContext
 
 public class MemberLeaveEvent(
     public val user: User,
     public val old: Member?,
     public val guildId: Snowflake,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(user.kord)
-) : Event, CoroutineScope by coroutineScope {
+) : Event {
 
     override val kord: Kord get() = user.kord
 

--- a/core/src/main/kotlin/event/guild/MemberUpdateEvent.kt
+++ b/core/src/main/kotlin/event/guild/MemberUpdateEvent.kt
@@ -6,10 +6,8 @@ import dev.kord.core.Kord
 import dev.kord.core.behavior.GuildBehavior
 import dev.kord.core.entity.*
 import dev.kord.core.event.Event
-import dev.kord.core.event.kordCoroutineScope
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.datetime.Instant
 import kotlin.DeprecationLevel.HIDDEN
@@ -22,8 +20,7 @@ public class MemberUpdateEvent(
     override val kord: Kord,
     override val shard: Int,
     override val supplier: EntitySupplier = kord.defaultSupplier,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : Event, CoroutineScope by coroutineScope, Strategizable {
+) : Event, Strategizable {
 
     public val guildId: Snowflake get() = member.guildId
 

--- a/core/src/main/kotlin/event/guild/MembersChunkEvent.kt
+++ b/core/src/main/kotlin/event/guild/MembersChunkEvent.kt
@@ -10,18 +10,15 @@ import dev.kord.core.entity.Member
 import dev.kord.core.entity.Presence
 import dev.kord.core.entity.Strategizable
 import dev.kord.core.event.Event
-import dev.kord.core.event.kordCoroutineScope
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
-import kotlinx.coroutines.CoroutineScope
 
 public class MembersChunkEvent(
     public val data: MembersChunkData,
     override val kord: Kord,
     override val shard: Int,
     override val supplier: EntitySupplier = kord.defaultSupplier,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : Event, CoroutineScope by coroutineScope, Strategizable {
+) : Event, Strategizable {
 
     public val guildId: Snowflake get() = data.guildId
 

--- a/core/src/main/kotlin/event/guild/VoiceServerUpdateEvent.kt
+++ b/core/src/main/kotlin/event/guild/VoiceServerUpdateEvent.kt
@@ -6,11 +6,8 @@ import dev.kord.core.behavior.GuildBehavior
 import dev.kord.core.entity.Guild
 import dev.kord.core.entity.Strategizable
 import dev.kord.core.event.Event
-import dev.kord.core.event.kordCoroutineScope
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
-import kotlinx.coroutines.CoroutineScope
-import kotlin.coroutines.CoroutineContext
 
 public class VoiceServerUpdateEvent(
     public val token: String,
@@ -19,8 +16,7 @@ public class VoiceServerUpdateEvent(
     override val kord: Kord,
     override val shard: Int,
     override val supplier: EntitySupplier = kord.defaultSupplier,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : Event, CoroutineScope by coroutineScope, Strategizable {
+) : Event, Strategizable {
 
     public val guild: GuildBehavior get() = GuildBehavior(guildId, kord)
 

--- a/core/src/main/kotlin/event/guild/WebhookUpdateEvent.kt
+++ b/core/src/main/kotlin/event/guild/WebhookUpdateEvent.kt
@@ -8,13 +8,10 @@ import dev.kord.core.entity.Guild
 import dev.kord.core.entity.Strategizable
 import dev.kord.core.entity.channel.TopGuildMessageChannel
 import dev.kord.core.event.Event
-import dev.kord.core.event.kordCoroutineScope
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 import dev.kord.core.supplier.getChannelOf
 import dev.kord.core.supplier.getChannelOfOrNull
-import kotlinx.coroutines.CoroutineScope
-import kotlin.coroutines.CoroutineContext
 
 public class WebhookUpdateEvent(
     public val guildId: Snowflake,
@@ -22,8 +19,7 @@ public class WebhookUpdateEvent(
     override val kord: Kord,
     override val shard: Int,
     override val supplier: EntitySupplier = kord.defaultSupplier,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : Event, CoroutineScope by coroutineScope, Strategizable {
+) : Event, Strategizable {
 
     public val channel: TopGuildMessageChannelBehavior get() = TopGuildMessageChannelBehavior(guildId, channelId, kord)
 

--- a/core/src/main/kotlin/event/interaction/ApplicationCommandCreate.kt
+++ b/core/src/main/kotlin/event/interaction/ApplicationCommandCreate.kt
@@ -3,11 +3,6 @@ package dev.kord.core.event.interaction
 import dev.kord.core.Kord
 import dev.kord.core.entity.application.*
 import dev.kord.core.event.Event
-import dev.kord.core.event.kordCoroutineScope
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.job
-import kotlin.coroutines.CoroutineContext
 
 
 public sealed interface ApplicationCommandCreateEvent : Event {
@@ -18,29 +13,25 @@ public class ChatInputCommandCreateEvent(
     override val command: GuildChatInputCommand,
     override val kord: Kord,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = CoroutineScope(kord.coroutineContext + SupervisorJob(kord.coroutineContext.job)),
-) : ApplicationCommandCreateEvent, CoroutineScope by coroutineScope
+) : ApplicationCommandCreateEvent
 
 
 public class UserCommandCreateEvent(
     override val command: GuildUserCommand,
     override val kord: Kord,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : ApplicationCommandCreateEvent, CoroutineScope by coroutineScope
+) : ApplicationCommandCreateEvent
 
 
 public class MessageCommandCreateEvent(
     override val command: GuildMessageCommand,
     override val kord: Kord,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : ApplicationCommandCreateEvent, CoroutineScope by coroutineScope
+) : ApplicationCommandCreateEvent
 
 
 public class UnknownApplicationCommandCreateEvent(
     override val command: UnknownGuildApplicationCommand,
     override val kord: Kord,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : ApplicationCommandCreateEvent, CoroutineScope by coroutineScope
+) : ApplicationCommandCreateEvent

--- a/core/src/main/kotlin/event/interaction/ApplicationCommandDelete.kt
+++ b/core/src/main/kotlin/event/interaction/ApplicationCommandDelete.kt
@@ -3,9 +3,6 @@ package dev.kord.core.event.interaction
 import dev.kord.core.Kord
 import dev.kord.core.entity.application.*
 import dev.kord.core.event.Event
-import dev.kord.core.event.kordCoroutineScope
-import kotlinx.coroutines.CoroutineScope
-import kotlin.coroutines.CoroutineContext
 
 
 public sealed interface ApplicationCommandDeleteEvent : Event {
@@ -16,29 +13,25 @@ public class ChatInputCommandDeleteEvent(
     override val command: GuildChatInputCommand,
     override val kord: Kord,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : ApplicationCommandDeleteEvent, CoroutineScope by coroutineScope
+) : ApplicationCommandDeleteEvent
 
 
 public class UserCommandDeleteEvent(
     override val command: GuildUserCommand,
     override val kord: Kord,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : ApplicationCommandDeleteEvent, CoroutineScope by coroutineScope
+) : ApplicationCommandDeleteEvent
 
 
 public class MessageCommandDeleteEvent(
     override val command: GuildMessageCommand,
     override val kord: Kord,
     override val shard: Int,
-    public  val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : ApplicationCommandDeleteEvent, CoroutineScope by coroutineScope
+) : ApplicationCommandDeleteEvent
 
 
 public class UnknownApplicationCommandDeleteEvent(
     override val command: UnknownGuildApplicationCommand,
     override val kord: Kord,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : ApplicationCommandDeleteEvent, CoroutineScope by coroutineScope
+) : ApplicationCommandDeleteEvent

--- a/core/src/main/kotlin/event/interaction/ApplicationCommandInteractionCreate.kt
+++ b/core/src/main/kotlin/event/interaction/ApplicationCommandInteractionCreate.kt
@@ -3,8 +3,6 @@ package dev.kord.core.event.interaction
 import dev.kord.core.Kord
 import dev.kord.core.entity.interaction.*
 import dev.kord.core.event.Event
-import dev.kord.core.event.kordCoroutineScope
-import kotlinx.coroutines.CoroutineScope
 
 /** An [Event] that fires when an [ApplicationCommandInteraction] is created. */
 public sealed interface ApplicationCommandInteractionCreateEvent : ActionInteractionCreateEvent {
@@ -35,16 +33,14 @@ public class GuildUserCommandInteractionCreateEvent(
     override val interaction: GuildUserCommandInteraction,
     override val kord: Kord,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : GuildApplicationCommandInteractionCreateEvent, UserCommandInteractionCreateEvent, CoroutineScope by coroutineScope
+) : GuildApplicationCommandInteractionCreateEvent, UserCommandInteractionCreateEvent
 
 /** An [Event] that fires when a [GlobalUserCommandInteraction] is created. */
 public class GlobalUserCommandInteractionCreateEvent(
     override val interaction: GlobalUserCommandInteraction,
     override val kord: Kord,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : GlobalApplicationCommandInteractionCreateEvent, UserCommandInteractionCreateEvent, CoroutineScope by coroutineScope
+) : GlobalApplicationCommandInteractionCreateEvent, UserCommandInteractionCreateEvent
 
 
 /** An [Event] that fires when a [MessageCommandInteraction] is created. */
@@ -57,20 +53,14 @@ public class GuildMessageCommandInteractionCreateEvent(
     override val interaction: GuildMessageCommandInteraction,
     override val kord: Kord,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : GuildApplicationCommandInteractionCreateEvent,
-    MessageCommandInteractionCreateEvent,
-    CoroutineScope by coroutineScope
+) : GuildApplicationCommandInteractionCreateEvent, MessageCommandInteractionCreateEvent
 
 /** An [Event] that fires when a [GlobalMessageCommandInteraction] is created. */
 public class GlobalMessageCommandInteractionCreateEvent(
     override val interaction: GlobalMessageCommandInteraction,
     override val kord: Kord,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : GlobalApplicationCommandInteractionCreateEvent,
-    MessageCommandInteractionCreateEvent,
-    CoroutineScope by coroutineScope
+) : GlobalApplicationCommandInteractionCreateEvent, MessageCommandInteractionCreateEvent
 
 
 /** An [Event] that fires when a [ChatInputCommandInteraction] is created. */
@@ -83,17 +73,11 @@ public class GuildChatInputCommandInteractionCreateEvent(
     override val interaction: GuildChatInputCommandInteraction,
     override val kord: Kord,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : GuildApplicationCommandInteractionCreateEvent,
-    ChatInputCommandInteractionCreateEvent,
-    CoroutineScope by coroutineScope
+) : GuildApplicationCommandInteractionCreateEvent, ChatInputCommandInteractionCreateEvent
 
 /** An [Event] that fires when a [GlobalChatInputCommandInteraction] is created. */
 public class GlobalChatInputCommandInteractionCreateEvent(
     override val interaction: GlobalChatInputCommandInteraction,
     override val kord: Kord,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : GlobalApplicationCommandInteractionCreateEvent,
-    ChatInputCommandInteractionCreateEvent,
-    CoroutineScope by coroutineScope
+) : GlobalApplicationCommandInteractionCreateEvent, ChatInputCommandInteractionCreateEvent

--- a/core/src/main/kotlin/event/interaction/ApplicationCommandPermissionsUpdateEvent.kt
+++ b/core/src/main/kotlin/event/interaction/ApplicationCommandPermissionsUpdateEvent.kt
@@ -3,12 +3,9 @@ package dev.kord.core.event.interaction
 import dev.kord.core.Kord
 import dev.kord.core.entity.application.ApplicationCommandPermissions
 import dev.kord.core.event.Event
-import dev.kord.core.event.kordCoroutineScope
-import kotlinx.coroutines.CoroutineScope
 
 public class ApplicationCommandPermissionsUpdateEvent(
     public val permissions: ApplicationCommandPermissions,
     override val kord: Kord,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord),
-) : Event, CoroutineScope by coroutineScope
+) : Event

--- a/core/src/main/kotlin/event/interaction/ApplicationCommandUpdate.kt
+++ b/core/src/main/kotlin/event/interaction/ApplicationCommandUpdate.kt
@@ -3,9 +3,6 @@ package dev.kord.core.event.interaction
 import dev.kord.core.Kord
 import dev.kord.core.entity.application.*
 import dev.kord.core.event.Event
-import dev.kord.core.event.kordCoroutineScope
-import kotlinx.coroutines.CoroutineScope
-import kotlin.coroutines.CoroutineContext
 
 
 public sealed interface ApplicationCommandUpdateEvent : Event {
@@ -16,28 +13,24 @@ public class ChatInputCommandUpdateEvent(
     override val command: GuildChatInputCommand,
     override val kord: Kord,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : ApplicationCommandUpdateEvent, CoroutineScope by coroutineScope
+) : ApplicationCommandUpdateEvent
 
 
 public class UserCommandUpdateEvent(
     override val command: GuildUserCommand,
     override val kord: Kord,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : ApplicationCommandUpdateEvent, CoroutineScope by coroutineScope
+) : ApplicationCommandUpdateEvent
 
 
 public class MessageCommandUpdateEvent(
     override val command: GuildMessageCommand,
     override val kord: Kord,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : ApplicationCommandUpdateEvent, CoroutineScope by coroutineScope
+) : ApplicationCommandUpdateEvent
 
 public class UnknownApplicationCommandUpdateEvent(
     override val command: UnknownGuildApplicationCommand,
     override val kord: Kord,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : ApplicationCommandUpdateEvent, CoroutineScope by coroutineScope
+) : ApplicationCommandUpdateEvent

--- a/core/src/main/kotlin/event/interaction/AutoCompleteInteractionCreate.kt
+++ b/core/src/main/kotlin/event/interaction/AutoCompleteInteractionCreate.kt
@@ -5,8 +5,6 @@ import dev.kord.core.entity.interaction.AutoCompleteInteraction
 import dev.kord.core.entity.interaction.GlobalAutoCompleteInteraction
 import dev.kord.core.entity.interaction.GuildAutoCompleteInteraction
 import dev.kord.core.event.Event
-import dev.kord.core.event.kordCoroutineScope
-import kotlinx.coroutines.CoroutineScope
 
 /** An [Event] that fires when an [AutoCompleteInteraction] is created. */
 public sealed interface AutoCompleteInteractionCreateEvent : DataInteractionCreateEvent {
@@ -18,13 +16,11 @@ public class GlobalAutoCompleteInteractionCreateEvent(
     override val kord: Kord,
     override val shard: Int,
     override val interaction: GlobalAutoCompleteInteraction,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord),
-) : AutoCompleteInteractionCreateEvent, CoroutineScope by coroutineScope
+) : AutoCompleteInteractionCreateEvent
 
 /** An [Event] that fires when a [GuildAutoCompleteInteraction] is created. */
 public class GuildAutoCompleteInteractionCreateEvent(
     override val kord: Kord,
     override val shard: Int,
     override val interaction: GuildAutoCompleteInteraction,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord),
-) : AutoCompleteInteractionCreateEvent, CoroutineScope by coroutineScope
+) : AutoCompleteInteractionCreateEvent

--- a/core/src/main/kotlin/event/interaction/ComponentInteractionCreate.kt
+++ b/core/src/main/kotlin/event/interaction/ComponentInteractionCreate.kt
@@ -3,8 +3,6 @@ package dev.kord.core.event.interaction
 import dev.kord.core.Kord
 import dev.kord.core.entity.interaction.*
 import dev.kord.core.event.Event
-import dev.kord.core.event.kordCoroutineScope
-import kotlinx.coroutines.CoroutineScope
 
 /** An [Event] that fires when a [ComponentInteraction] is created. */
 public sealed interface ComponentInteractionCreateEvent : ActionInteractionCreateEvent {
@@ -36,29 +34,25 @@ public class GuildButtonInteractionCreateEvent(
     override val interaction: GuildButtonInteraction,
     override val kord: Kord,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : ButtonInteractionCreateEvent, GuildComponentInteractionCreateEvent, CoroutineScope by coroutineScope
+) : ButtonInteractionCreateEvent, GuildComponentInteractionCreateEvent
 
 /** An [Event] that fires when a [GlobalButtonInteraction] is created. */
 public class GlobalButtonInteractionCreateEvent(
     override val interaction: GlobalButtonInteraction,
     override val kord: Kord,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : ButtonInteractionCreateEvent, GlobalComponentInteractionCreateEvent, CoroutineScope by coroutineScope
+) : ButtonInteractionCreateEvent, GlobalComponentInteractionCreateEvent
 
 /** An [Event] that fires when a [GuildSelectMenuInteraction] is created. */
 public class GuildSelectMenuInteractionCreateEvent(
     override val interaction: GuildSelectMenuInteraction,
     override val kord: Kord,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : SelectMenuInteractionCreateEvent, GuildComponentInteractionCreateEvent, CoroutineScope by coroutineScope
+) : SelectMenuInteractionCreateEvent, GuildComponentInteractionCreateEvent
 
 /** An [Event] that fires when a [GlobalSelectMenuInteraction] is created. */
 public class GlobalSelectMenuInteractionCreateEvent(
     override val interaction: GlobalSelectMenuInteraction,
     override val kord: Kord,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : SelectMenuInteractionCreateEvent, GlobalComponentInteractionCreateEvent, CoroutineScope by coroutineScope
+) : SelectMenuInteractionCreateEvent, GlobalComponentInteractionCreateEvent

--- a/core/src/main/kotlin/event/interaction/ModalSubmitInteractionCreate.kt
+++ b/core/src/main/kotlin/event/interaction/ModalSubmitInteractionCreate.kt
@@ -5,8 +5,6 @@ import dev.kord.core.entity.interaction.GlobalModalSubmitInteraction
 import dev.kord.core.entity.interaction.GuildModalSubmitInteraction
 import dev.kord.core.entity.interaction.ModalSubmitInteraction
 import dev.kord.core.event.Event
-import dev.kord.core.event.kordCoroutineScope
-import kotlinx.coroutines.CoroutineScope
 
 /** An [Event] that fires when a [ModalSubmitInteraction] is created. */
 public sealed interface ModalSubmitInteractionCreateEvent : ActionInteractionCreateEvent {
@@ -18,13 +16,11 @@ public class GuildModalSubmitInteractionCreateEvent(
     override val interaction: GuildModalSubmitInteraction,
     override val kord: Kord,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord),
-) : ModalSubmitInteractionCreateEvent, CoroutineScope by coroutineScope
+) : ModalSubmitInteractionCreateEvent
 
 /** An [Event] that fires when a [GlobalModalSubmitInteraction] is created. */
 public class GlobalModalSubmitInteractionCreateEvent(
     override val interaction: GlobalModalSubmitInteraction,
     override val shard: Int,
     override val kord: Kord,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord),
-) : ModalSubmitInteractionCreateEvent, CoroutineScope by coroutineScope
+) : ModalSubmitInteractionCreateEvent

--- a/core/src/main/kotlin/event/message/MessageBulkDeleteEvent.kt
+++ b/core/src/main/kotlin/event/message/MessageBulkDeleteEvent.kt
@@ -9,13 +9,10 @@ import dev.kord.core.entity.Message
 import dev.kord.core.entity.Strategizable
 import dev.kord.core.entity.channel.MessageChannel
 import dev.kord.core.event.Event
-import dev.kord.core.event.kordCoroutineScope
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 import dev.kord.core.supplier.getChannelOf
 import dev.kord.core.supplier.getChannelOfOrNull
-import kotlinx.coroutines.CoroutineScope
-import kotlin.coroutines.CoroutineContext
 
 public class MessageBulkDeleteEvent(
     public val messageIds: Set<Snowflake>,
@@ -25,8 +22,7 @@ public class MessageBulkDeleteEvent(
     override val kord: Kord,
     override val shard: Int,
     override val supplier: EntitySupplier = kord.defaultSupplier,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : Event, CoroutineScope by coroutineScope, Strategizable {
+) : Event, Strategizable {
 
     public val channel: MessageChannelBehavior get() = MessageChannelBehavior(channelId, kord)
 

--- a/core/src/main/kotlin/event/message/MessageCreateEvent.kt
+++ b/core/src/main/kotlin/event/message/MessageCreateEvent.kt
@@ -7,13 +7,10 @@ import dev.kord.core.entity.Guild
 import dev.kord.core.entity.Member
 import dev.kord.core.entity.Message
 import dev.kord.core.entity.Strategizable
+import dev.kord.core.entity.channel.DmChannel
 import dev.kord.core.event.Event
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
-import dev.kord.core.entity.channel.DmChannel
-import dev.kord.core.event.kordCoroutineScope
-import kotlinx.coroutines.CoroutineScope
-import kotlin.coroutines.CoroutineContext
 
 public class MessageCreateEvent(
     public val message: Message,
@@ -21,8 +18,7 @@ public class MessageCreateEvent(
     public val member: Member?,
     override val shard: Int,
     override val supplier: EntitySupplier = message.kord.defaultSupplier,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(message.kord)
-) : Event, CoroutineScope by coroutineScope, Strategizable {
+) : Event, Strategizable {
     override val kord: Kord get() = message.kord
 
     /**

--- a/core/src/main/kotlin/event/message/MessageDeleteEvent.kt
+++ b/core/src/main/kotlin/event/message/MessageDeleteEvent.kt
@@ -9,13 +9,10 @@ import dev.kord.core.entity.Message
 import dev.kord.core.entity.Strategizable
 import dev.kord.core.entity.channel.MessageChannel
 import dev.kord.core.event.Event
-import dev.kord.core.event.kordCoroutineScope
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 import dev.kord.core.supplier.getChannelOf
 import dev.kord.core.supplier.getChannelOfOrNull
-import kotlinx.coroutines.CoroutineScope
-import kotlin.coroutines.CoroutineContext
 
 public class MessageDeleteEvent(
     public val messageId: Snowflake,
@@ -25,8 +22,7 @@ public class MessageDeleteEvent(
     override val kord: Kord,
     override val shard: Int,
     override val supplier: EntitySupplier = kord.defaultSupplier,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : Event, CoroutineScope by coroutineScope, Strategizable {
+) : Event, Strategizable {
 
     public val channel: MessageChannelBehavior get() = MessageChannelBehavior(channelId, kord)
 

--- a/core/src/main/kotlin/event/message/MessageUpdateEvent.kt
+++ b/core/src/main/kotlin/event/message/MessageUpdateEvent.kt
@@ -8,11 +8,8 @@ import dev.kord.core.behavior.channel.MessageChannelBehavior
 import dev.kord.core.entity.Message
 import dev.kord.core.entity.Strategizable
 import dev.kord.core.event.Event
-import dev.kord.core.event.kordCoroutineScope
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
-import kotlinx.coroutines.CoroutineScope
-import kotlin.coroutines.CoroutineContext
 
 public class MessageUpdateEvent(
     public val messageId: Snowflake,
@@ -22,8 +19,7 @@ public class MessageUpdateEvent(
     override val kord: Kord,
     override val shard: Int,
     override val supplier: EntitySupplier = kord.defaultSupplier,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : Event, CoroutineScope by coroutineScope, Strategizable {
+) : Event, Strategizable {
 
     /**
      * The behavior of the message that was updated.

--- a/core/src/main/kotlin/event/message/ReactionAddEvent.kt
+++ b/core/src/main/kotlin/event/message/ReactionAddEvent.kt
@@ -10,13 +10,10 @@ import dev.kord.core.behavior.channel.MessageChannelBehavior
 import dev.kord.core.entity.*
 import dev.kord.core.entity.channel.MessageChannel
 import dev.kord.core.event.Event
-import dev.kord.core.event.kordCoroutineScope
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 import dev.kord.core.supplier.getChannelOf
 import dev.kord.core.supplier.getChannelOfOrNull
-import kotlinx.coroutines.CoroutineScope
-import kotlin.coroutines.CoroutineContext
 
 public class ReactionAddEvent(
     public val userId: Snowflake,
@@ -27,8 +24,7 @@ public class ReactionAddEvent(
     override val kord: Kord,
     override val shard: Int,
     override val supplier: EntitySupplier = kord.defaultSupplier,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : Event, CoroutineScope by coroutineScope, Strategizable {
+) : Event, Strategizable {
 
     public val channel: MessageChannelBehavior get() = MessageChannelBehavior(channelId, kord)
 

--- a/core/src/main/kotlin/event/message/ReactionRemoveAllEvent.kt
+++ b/core/src/main/kotlin/event/message/ReactionRemoveAllEvent.kt
@@ -10,13 +10,10 @@ import dev.kord.core.entity.Message
 import dev.kord.core.entity.Strategizable
 import dev.kord.core.entity.channel.MessageChannel
 import dev.kord.core.event.Event
-import dev.kord.core.event.kordCoroutineScope
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 import dev.kord.core.supplier.getChannelOf
 import dev.kord.core.supplier.getChannelOfOrNull
-import kotlinx.coroutines.CoroutineScope
-import kotlin.coroutines.CoroutineContext
 
 public class ReactionRemoveAllEvent(
     public val channelId: Snowflake,
@@ -25,8 +22,7 @@ public class ReactionRemoveAllEvent(
     override val kord: Kord,
     override val shard: Int,
     override val supplier: EntitySupplier = kord.defaultSupplier,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : Event, CoroutineScope by coroutineScope, Strategizable {
+) : Event, Strategizable {
 
     public val channel: MessageChannelBehavior get() = MessageChannelBehavior(channelId, kord)
 

--- a/core/src/main/kotlin/event/message/ReactionRemoveEmojiEvent.kt
+++ b/core/src/main/kotlin/event/message/ReactionRemoveEmojiEvent.kt
@@ -12,21 +12,17 @@ import dev.kord.core.entity.ReactionEmoji
 import dev.kord.core.entity.Strategizable
 import dev.kord.core.entity.channel.TopGuildMessageChannel
 import dev.kord.core.event.Event
-import dev.kord.core.event.kordCoroutineScope
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 import dev.kord.core.supplier.getChannelOf
 import dev.kord.core.supplier.getChannelOfOrNull
-import kotlinx.coroutines.CoroutineScope
-import kotlin.coroutines.CoroutineContext
 
 public class ReactionRemoveEmojiEvent(
     public val data: ReactionRemoveEmojiData,
     override val kord: Kord,
     override val shard: Int,
     override val supplier: EntitySupplier = kord.defaultSupplier,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : Event, CoroutineScope by coroutineScope, Strategizable {
+) : Event, Strategizable {
 
     /**
      * The id of the [TopGuildMessageChannel].

--- a/core/src/main/kotlin/event/message/ReactionRemoveEvent.kt
+++ b/core/src/main/kotlin/event/message/ReactionRemoveEvent.kt
@@ -10,13 +10,10 @@ import dev.kord.core.behavior.channel.MessageChannelBehavior
 import dev.kord.core.entity.*
 import dev.kord.core.entity.channel.MessageChannel
 import dev.kord.core.event.Event
-import dev.kord.core.event.kordCoroutineScope
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
 import dev.kord.core.supplier.getChannelOf
 import dev.kord.core.supplier.getChannelOfOrNull
-import kotlinx.coroutines.CoroutineScope
-import kotlin.coroutines.CoroutineContext
 
 public class ReactionRemoveEvent(
     public val userId: Snowflake,
@@ -27,8 +24,7 @@ public class ReactionRemoveEvent(
     override val kord: Kord,
     override val shard: Int,
     override val supplier: EntitySupplier = kord.defaultSupplier,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : Event, CoroutineScope by coroutineScope, Strategizable {
+) : Event, Strategizable {
 
     public val channel: MessageChannelBehavior get() = MessageChannelBehavior(channelId, kord)
 

--- a/core/src/main/kotlin/event/role/RoleCreateEvent.kt
+++ b/core/src/main/kotlin/event/role/RoleCreateEvent.kt
@@ -7,18 +7,14 @@ import dev.kord.core.entity.Guild
 import dev.kord.core.entity.Role
 import dev.kord.core.entity.Strategizable
 import dev.kord.core.event.Event
-import dev.kord.core.event.kordCoroutineScope
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
-import kotlinx.coroutines.CoroutineScope
-import kotlin.coroutines.CoroutineContext
 
 public class RoleCreateEvent(
     public val role: Role,
     override val shard: Int,
     override val supplier: EntitySupplier = role.kord.defaultSupplier,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(role.kord)
-) : Event, CoroutineScope by coroutineScope, Strategizable {
+) : Event, Strategizable {
 
     override val kord: Kord get() = role.kord
 

--- a/core/src/main/kotlin/event/role/RoleDeleteEvent.kt
+++ b/core/src/main/kotlin/event/role/RoleDeleteEvent.kt
@@ -7,11 +7,8 @@ import dev.kord.core.entity.Guild
 import dev.kord.core.entity.Role
 import dev.kord.core.entity.Strategizable
 import dev.kord.core.event.Event
-import dev.kord.core.event.kordCoroutineScope
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
-import kotlinx.coroutines.CoroutineScope
-import kotlin.coroutines.CoroutineContext
 
 public class RoleDeleteEvent(
     public val guildId: Snowflake,
@@ -20,8 +17,7 @@ public class RoleDeleteEvent(
     override val kord: Kord,
     override val shard: Int,
     override val supplier: EntitySupplier = kord.defaultSupplier,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(kord)
-) : Event, CoroutineScope by coroutineScope, Strategizable {
+) : Event, Strategizable {
 
     public val guild: GuildBehavior get() = GuildBehavior(guildId, kord)
 

--- a/core/src/main/kotlin/event/role/RoleUpdateEvent.kt
+++ b/core/src/main/kotlin/event/role/RoleUpdateEvent.kt
@@ -7,19 +7,15 @@ import dev.kord.core.entity.Guild
 import dev.kord.core.entity.Role
 import dev.kord.core.entity.Strategizable
 import dev.kord.core.event.Event
-import dev.kord.core.event.kordCoroutineScope
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
-import kotlinx.coroutines.CoroutineScope
-import kotlin.coroutines.CoroutineContext
 
 public class RoleUpdateEvent(
     public val role: Role,
     public val old: Role?,
     override val shard: Int,
     override val supplier: EntitySupplier = role.kord.defaultSupplier,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(role.kord)
-) : Event, CoroutineScope by coroutineScope, Strategizable {
+) : Event, Strategizable {
 
     override val kord: Kord get() = role.kord
 

--- a/core/src/main/kotlin/event/user/PresenceUpdateEvent.kt
+++ b/core/src/main/kotlin/event/user/PresenceUpdateEvent.kt
@@ -8,12 +8,9 @@ import dev.kord.core.behavior.GuildBehavior
 import dev.kord.core.behavior.MemberBehavior
 import dev.kord.core.entity.*
 import dev.kord.core.event.Event
-import dev.kord.core.event.kordCoroutineScope
 import dev.kord.core.exception.EntityNotFoundException
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
-import kotlinx.coroutines.CoroutineScope
-import kotlin.coroutines.CoroutineContext
 
 public class PresenceUpdateEvent(
     public val oldUser: User?,
@@ -23,8 +20,7 @@ public class PresenceUpdateEvent(
     public val presence: Presence,
     override val shard: Int,
     override val supplier: EntitySupplier = presence.kord.defaultSupplier,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(presence.kord)
-) : Event, CoroutineScope by coroutineScope, Strategizable {
+) : Event, Strategizable {
     override val kord: Kord get() = presence.kord
 
     /**

--- a/core/src/main/kotlin/event/user/UserUpdateEvent.kt
+++ b/core/src/main/kotlin/event/user/UserUpdateEvent.kt
@@ -3,16 +3,12 @@ package dev.kord.core.event.user
 import dev.kord.core.Kord
 import dev.kord.core.entity.User
 import dev.kord.core.event.Event
-import dev.kord.core.event.kordCoroutineScope
-import kotlinx.coroutines.CoroutineScope
-import kotlin.coroutines.CoroutineContext
 
 public class UserUpdateEvent(
     public val old: User?,
     public val user: User,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(user.kord)
-) : Event, CoroutineScope by coroutineScope {
+) : Event {
     override val kord: Kord get() = user.kord
 
     override fun toString(): String {

--- a/core/src/main/kotlin/event/user/VoiceStateUpdateEvent.kt
+++ b/core/src/main/kotlin/event/user/VoiceStateUpdateEvent.kt
@@ -3,16 +3,12 @@ package dev.kord.core.event.user
 import dev.kord.core.Kord
 import dev.kord.core.entity.VoiceState
 import dev.kord.core.event.Event
-import dev.kord.core.event.kordCoroutineScope
-import kotlinx.coroutines.CoroutineScope
-import kotlin.coroutines.CoroutineContext
 
 public class VoiceStateUpdateEvent(
     public val old: VoiceState?,
     public val state: VoiceState,
     override val shard: Int,
-    public val coroutineScope: CoroutineScope = kordCoroutineScope(state.kord)
-) : Event, CoroutineScope by coroutineScope{
+) : Event {
     override val kord: Kord get() = state.kord
 
     override fun toString(): String {

--- a/core/src/main/kotlin/gateway/handler/BaseGatewayEventHandler.kt
+++ b/core/src/main/kotlin/gateway/handler/BaseGatewayEventHandler.kt
@@ -2,8 +2,6 @@ package dev.kord.core.gateway.handler
 
 import dev.kord.cache.api.DataCache
 import dev.kord.core.Kord
-import kotlinx.coroutines.CoroutineScope
-import kotlin.coroutines.CoroutineContext
 import dev.kord.core.event.Event as CoreEvent
 import dev.kord.gateway.Event as GatewayEvent
 
@@ -11,6 +9,6 @@ public abstract class BaseGatewayEventHandler(
     protected val cache: DataCache
 ) {
 
-    public abstract suspend fun handle(event: GatewayEvent, shard: Int, kord: Kord, coroutineScope: CoroutineScope): CoreEvent?
+    public abstract suspend fun handle(event: GatewayEvent, shard: Int, kord: Kord): CoreEvent?
 
 }

--- a/core/src/main/kotlin/gateway/handler/ChannelEventHandler.kt
+++ b/core/src/main/kotlin/gateway/handler/ChannelEventHandler.kt
@@ -14,7 +14,6 @@ import dev.kord.core.event.channel.*
 import dev.kord.core.event.channel.data.ChannelPinsUpdateEventData
 import dev.kord.core.event.channel.data.TypingStartEventData
 import dev.kord.gateway.*
-import dev.kord.core.event.Event as CoreEvent
 
 internal class ChannelEventHandler(
     cache: DataCache
@@ -24,7 +23,7 @@ internal class ChannelEventHandler(
         event: Event,
         shard: Int,
         kord: Kord,
-    ): CoreEvent? = when (event) {
+    ): dev.kord.core.event.Event? = when (event) {
         is ChannelCreate -> handle(event, shard, kord)
         is ChannelUpdate -> handle(event, shard, kord)
         is ChannelDelete -> handle(event, shard, kord)

--- a/core/src/main/kotlin/gateway/handler/ChannelEventHandler.kt
+++ b/core/src/main/kotlin/gateway/handler/ChannelEventHandler.kt
@@ -20,7 +20,11 @@ internal class ChannelEventHandler(
     cache: DataCache
 ) : BaseGatewayEventHandler(cache) {
 
-    override suspend fun handle(event: Event, shard: Int, kord: Kord): CoreEvent? = when (event) {
+    override suspend fun handle(
+        event: Event,
+        shard: Int,
+        kord: Kord,
+    ): CoreEvent? = when (event) {
         is ChannelCreate -> handle(event, shard, kord)
         is ChannelUpdate -> handle(event, shard, kord)
         is ChannelDelete -> handle(event, shard, kord)
@@ -89,9 +93,17 @@ internal class ChannelEventHandler(
         return coreEvent
     }
 
-    private suspend fun handle(event: ChannelPinsUpdate, shard: Int, kord: Kord): ChannelPinsUpdateEvent =
+    private suspend fun handle(
+        event: ChannelPinsUpdate,
+        shard: Int,
+        kord: Kord,
+    ): ChannelPinsUpdateEvent =
         with(event.pins) {
-            val coreEvent = ChannelPinsUpdateEvent(ChannelPinsUpdateEventData.from(this), kord, shard)
+            val coreEvent = ChannelPinsUpdateEvent(
+                ChannelPinsUpdateEventData.from(this),
+                kord,
+                shard,
+            )
 
             cache.query<ChannelData> { idEq(ChannelData::id, channelId) }.update {
                 it.copy(lastPinTimestamp = lastPinTimestamp)
@@ -100,12 +112,20 @@ internal class ChannelEventHandler(
             coreEvent
         }
 
-    private suspend fun handle(event: TypingStart, shard: Int, kord: Kord): TypingStartEvent = with(event.data) {
+    private suspend fun handle(
+        event: TypingStart,
+        shard: Int,
+        kord: Kord,
+    ): TypingStartEvent = with(event.data) {
         member.value?.let {
             cache.put(MemberData.from(userId = it.user.value!!.id, guildId = guildId.value!!, it))
         }
 
-        TypingStartEvent(TypingStartEventData.from(this), kord, shard)
+        TypingStartEvent(
+            TypingStartEventData.from(this),
+            kord,
+            shard,
+        )
     }
 
 }

--- a/core/src/main/kotlin/gateway/handler/ChannelEventHandler.kt
+++ b/core/src/main/kotlin/gateway/handler/ChannelEventHandler.kt
@@ -14,124 +14,98 @@ import dev.kord.core.event.channel.*
 import dev.kord.core.event.channel.data.ChannelPinsUpdateEventData
 import dev.kord.core.event.channel.data.TypingStartEventData
 import dev.kord.gateway.*
-import kotlinx.coroutines.CoroutineScope
 import dev.kord.core.event.Event as CoreEvent
 
 internal class ChannelEventHandler(
     cache: DataCache
 ) : BaseGatewayEventHandler(cache) {
 
-    override suspend fun handle(
-        event: Event,
-        shard: Int,
-        kord: Kord,
-        coroutineScope: CoroutineScope
-    ): dev.kord.core.event.Event? = when (event) {
-        is ChannelCreate -> handle(event, shard, kord, coroutineScope)
-        is ChannelUpdate -> handle(event, shard, kord, coroutineScope)
-        is ChannelDelete -> handle(event, shard, kord, coroutineScope)
-        is ChannelPinsUpdate -> handle(event, shard, kord, coroutineScope)
-        is TypingStart -> handle(event, shard, kord, coroutineScope)
+    override suspend fun handle(event: Event, shard: Int, kord: Kord): CoreEvent? = when (event) {
+        is ChannelCreate -> handle(event, shard, kord)
+        is ChannelUpdate -> handle(event, shard, kord)
+        is ChannelDelete -> handle(event, shard, kord)
+        is ChannelPinsUpdate -> handle(event, shard, kord)
+        is TypingStart -> handle(event, shard, kord)
         else -> null
     }
 
-    private suspend fun handle(event: ChannelCreate, shard: Int, kord: Kord, coroutineScope: CoroutineScope): CoreEvent? {
+    private suspend fun handle(event: ChannelCreate, shard: Int, kord: Kord): ChannelCreateEvent? {
         val data = ChannelData.from(event.channel)
         cache.put(data)
 
         val coreEvent = when (val channel = Channel.from(data, kord)) {
-            is NewsChannel -> NewsChannelCreateEvent(channel, shard, coroutineScope)
-            is @Suppress("DEPRECATION_ERROR") StoreChannel -> @Suppress("DEPRECATION_ERROR") StoreChannelCreateEvent(channel, shard, coroutineScope)
-            is DmChannel -> DMChannelCreateEvent(channel, shard, coroutineScope)
-            is TextChannel -> TextChannelCreateEvent(channel, shard, coroutineScope)
-            is StageChannel -> StageChannelCreateEvent(channel, shard, coroutineScope)
-            is VoiceChannel -> VoiceChannelCreateEvent(channel, shard, coroutineScope)
-            is Category -> CategoryCreateEvent(channel, shard, coroutineScope)
+            is NewsChannel -> NewsChannelCreateEvent(channel, shard)
+            is @Suppress("DEPRECATION_ERROR") StoreChannel -> @Suppress("DEPRECATION_ERROR") StoreChannelCreateEvent(channel, shard)
+            is DmChannel -> DMChannelCreateEvent(channel, shard)
+            is TextChannel -> TextChannelCreateEvent(channel, shard)
+            is StageChannel -> StageChannelCreateEvent(channel, shard)
+            is VoiceChannel -> VoiceChannelCreateEvent(channel, shard)
+            is Category -> CategoryCreateEvent(channel, shard)
             is ThreadChannel -> return null
-            else -> UnknownChannelCreateEvent(channel, shard, coroutineScope)
+            else -> UnknownChannelCreateEvent(channel, shard)
 
         }
 
         return coreEvent
     }
 
-    private suspend fun handle(event: ChannelUpdate, shard: Int, kord: Kord, coroutineScope: CoroutineScope): CoreEvent? {
+    private suspend fun handle(event: ChannelUpdate, shard: Int, kord: Kord): ChannelUpdateEvent? {
         val data = ChannelData.from(event.channel)
         val oldData = cache.query<ChannelData> { idEq(ChannelData::id, data.id) }.singleOrNull()
         cache.put(data)
         val old = oldData?.let { Channel.from(it, kord) }
         val coreEvent = when (val channel = Channel.from(data, kord)) {
-            is NewsChannel -> NewsChannelUpdateEvent(channel, old as? NewsChannel, shard, coroutineScope)
-            is @Suppress("DEPRECATION_ERROR") StoreChannel -> @Suppress("DEPRECATION_ERROR") StoreChannelUpdateEvent(channel, old as? StoreChannel, shard, coroutineScope)
-            is DmChannel -> DMChannelUpdateEvent(channel, old as? DmChannel, shard, coroutineScope)
-            is TextChannel -> TextChannelUpdateEvent(channel, old as? TextChannel, shard, coroutineScope)
-            is StageChannel -> StageChannelUpdateEvent(channel, old as? StageChannel, shard, coroutineScope)
-            is VoiceChannel -> VoiceChannelUpdateEvent(channel, old as? VoiceChannel, shard, coroutineScope)
-            is Category -> CategoryUpdateEvent(channel, old as? Category, shard, coroutineScope)
+            is NewsChannel -> NewsChannelUpdateEvent(channel, old as? NewsChannel, shard)
+            is @Suppress("DEPRECATION_ERROR") StoreChannel -> @Suppress("DEPRECATION_ERROR") StoreChannelUpdateEvent(channel, old as? StoreChannel, shard)
+            is DmChannel -> DMChannelUpdateEvent(channel, old as? DmChannel, shard)
+            is TextChannel -> TextChannelUpdateEvent(channel, old as? TextChannel, shard)
+            is StageChannel -> StageChannelUpdateEvent(channel, old as? StageChannel, shard)
+            is VoiceChannel -> VoiceChannelUpdateEvent(channel, old as? VoiceChannel, shard)
+            is Category -> CategoryUpdateEvent(channel, old as? Category, shard)
             is ThreadChannel -> return null
-            else -> UnknownChannelUpdateEvent(channel, old, shard, coroutineScope)
+            else -> UnknownChannelUpdateEvent(channel, old, shard)
 
         }
 
         return coreEvent
     }
 
-    private suspend fun handle(event: ChannelDelete, shard: Int, kord: Kord, coroutineScope: CoroutineScope): CoreEvent? {
+    private suspend fun handle(event: ChannelDelete, shard: Int, kord: Kord): ChannelDeleteEvent? {
         cache.remove<ChannelData> { idEq(ChannelData::id, event.channel.id) }
         val data = ChannelData.from(event.channel)
 
         val coreEvent = when (val channel = Channel.from(data, kord)) {
-            is NewsChannel -> NewsChannelDeleteEvent(channel, shard, coroutineScope)
-            is @Suppress("DEPRECATION_ERROR") StoreChannel -> @Suppress("DEPRECATION_ERROR") StoreChannelDeleteEvent(channel, shard, coroutineScope)
-            is DmChannel -> DMChannelDeleteEvent(channel, shard, coroutineScope)
-            is TextChannel -> TextChannelDeleteEvent(channel, shard, coroutineScope)
-            is StageChannel -> StageChannelDeleteEvent(channel, shard, coroutineScope)
-            is VoiceChannel -> VoiceChannelDeleteEvent(channel, shard, coroutineScope)
-            is Category -> CategoryDeleteEvent(channel, shard, coroutineScope)
+            is NewsChannel -> NewsChannelDeleteEvent(channel, shard)
+            is @Suppress("DEPRECATION_ERROR") StoreChannel -> @Suppress("DEPRECATION_ERROR") StoreChannelDeleteEvent(channel, shard)
+            is DmChannel -> DMChannelDeleteEvent(channel, shard)
+            is TextChannel -> TextChannelDeleteEvent(channel, shard)
+            is StageChannel -> StageChannelDeleteEvent(channel, shard)
+            is VoiceChannel -> VoiceChannelDeleteEvent(channel, shard)
+            is Category -> CategoryDeleteEvent(channel, shard)
             is ThreadChannel -> return null
-            else -> UnknownChannelDeleteEvent(channel, shard, coroutineScope)
+            else -> UnknownChannelDeleteEvent(channel, shard)
         }
 
         return coreEvent
     }
 
-    private suspend fun handle(
-        event: ChannelPinsUpdate,
-        shard: Int,
-        kord: Kord,
-        coroutineScope: CoroutineScope
-    ): ChannelPinsUpdateEvent =
+    private suspend fun handle(event: ChannelPinsUpdate, shard: Int, kord: Kord): ChannelPinsUpdateEvent =
         with(event.pins) {
-            val coreEvent = ChannelPinsUpdateEvent(
-                ChannelPinsUpdateEventData.from(this),
-                kord,
-                shard,
-                coroutineScope = coroutineScope
-            )
+            val coreEvent = ChannelPinsUpdateEvent(ChannelPinsUpdateEventData.from(this), kord, shard)
 
             cache.query<ChannelData> { idEq(ChannelData::id, channelId) }.update {
                 it.copy(lastPinTimestamp = lastPinTimestamp)
             }
 
-            return coreEvent
+            coreEvent
         }
 
-    private suspend fun handle(
-        event: TypingStart,
-        shard: Int,
-        kord: Kord,
-        coroutineScope: CoroutineScope
-    ): TypingStartEvent = with(event.data) {
+    private suspend fun handle(event: TypingStart, shard: Int, kord: Kord): TypingStartEvent = with(event.data) {
         member.value?.let {
             cache.put(MemberData.from(userId = it.user.value!!.id, guildId = guildId.value!!, it))
         }
 
-        return TypingStartEvent(
-            TypingStartEventData.from(this),
-            kord,
-            shard,
-            coroutineScope = coroutineScope
-        )
+        TypingStartEvent(TypingStartEventData.from(this), kord, shard)
     }
 
 }

--- a/core/src/main/kotlin/gateway/handler/DefaultGatewayEventInterceptor.kt
+++ b/core/src/main/kotlin/gateway/handler/DefaultGatewayEventInterceptor.kt
@@ -2,19 +2,14 @@ package dev.kord.core.gateway.handler
 
 import dev.kord.cache.api.DataCache
 import dev.kord.core.Kord
-import dev.kord.core.event.kordCoroutineScope
 import dev.kord.core.gateway.ShardEvent
 import io.ktor.util.logging.*
-import kotlinx.coroutines.CoroutineScope
 import mu.KotlinLogging
 import dev.kord.core.event.Event as CoreEvent
 
 private val logger = KotlinLogging.logger { }
 
-public class DefaultGatewayEventInterceptor(
-    cache: DataCache,
-    private val eventScope: ((ShardEvent, Kord) -> CoroutineScope) = { _, kord -> kordCoroutineScope(kord) }
-) : GatewayEventInterceptor {
+public class DefaultGatewayEventInterceptor(cache: DataCache) : GatewayEventInterceptor {
 
     private val listeners = listOf(
         MessageEventHandler(cache),
@@ -31,12 +26,7 @@ public class DefaultGatewayEventInterceptor(
     override suspend fun handle(event: ShardEvent, kord: Kord): CoreEvent? {
         return runCatching {
             for (listener in listeners) {
-                val coreEvent = listener.handle(
-                    event.event,
-                    event.shard,
-                    kord,
-                    eventScope.invoke(event, kord)
-                )
+                val coreEvent = listener.handle(event.event, event.shard, kord)
                 if (coreEvent != null) {
                     return coreEvent
                 }

--- a/core/src/main/kotlin/gateway/handler/GuildEventHandler.kt
+++ b/core/src/main/kotlin/gateway/handler/GuildEventHandler.kt
@@ -26,31 +26,32 @@ internal class GuildEventHandler(
     cache: DataCache
 ) : BaseGatewayEventHandler(cache) {
 
-    override suspend fun handle(event: Event, shard: Int, kord: Kord): CoreEvent? = when (event) {
-        is GuildCreate -> handle(event, shard, kord)
-        is GuildUpdate -> handle(event, shard, kord)
-        is GuildDelete -> handle(event, shard, kord)
-        is GuildBanAdd -> handle(event, shard, kord)
-        is GuildBanRemove -> handle(event, shard, kord)
-        is GuildEmojisUpdate -> handle(event, shard, kord)
-        is GuildIntegrationsUpdate -> handle(event, shard, kord)
-        is GuildMemberAdd -> handle(event, shard, kord)
-        is GuildMemberRemove -> handle(event, shard, kord)
-        is GuildMemberUpdate -> handle(event, shard, kord)
-        is GuildRoleCreate -> handle(event, shard, kord)
-        is GuildRoleUpdate -> handle(event, shard, kord)
-        is GuildRoleDelete -> handle(event, shard, kord)
-        is GuildMembersChunk -> handle(event, shard, kord)
-        is GuildScheduledEventCreate -> handle(event, shard, kord)
-        is GuildScheduledEventUpdate -> handle(event, shard, kord)
-        is GuildScheduledEventDelete -> handle(event, shard, kord)
-        is GuildScheduledEventUserAdd -> handle(event, shard, kord)
-        is GuildScheduledEventUserRemove -> handle(event, shard, kord)
-        is PresenceUpdate -> handle(event, shard, kord)
-        is InviteCreate -> handle(event, shard, kord)
-        is InviteDelete -> handle(event, shard, kord)
-        else -> null
-    }
+    override suspend fun handle(event: Event, shard: Int, kord: Kord): CoreEvent? =
+        when (event) {
+            is GuildCreate -> handle(event, shard, kord)
+            is GuildUpdate -> handle(event, shard, kord)
+            is GuildDelete -> handle(event, shard, kord)
+            is GuildBanAdd -> handle(event, shard, kord)
+            is GuildBanRemove -> handle(event, shard, kord)
+            is GuildEmojisUpdate -> handle(event, shard, kord)
+            is GuildIntegrationsUpdate -> handle(event, shard, kord)
+            is GuildMemberAdd -> handle(event, shard, kord)
+            is GuildMemberRemove -> handle(event, shard, kord)
+            is GuildMemberUpdate -> handle(event, shard, kord)
+            is GuildRoleCreate -> handle(event, shard, kord)
+            is GuildRoleUpdate -> handle(event, shard, kord)
+            is GuildRoleDelete -> handle(event, shard, kord)
+            is GuildMembersChunk -> handle(event, shard, kord)
+            is GuildScheduledEventCreate -> handle(event, shard, kord)
+            is GuildScheduledEventUpdate -> handle(event, shard, kord)
+            is GuildScheduledEventDelete -> handle(event, shard, kord)
+            is GuildScheduledEventUserAdd -> handle(event, shard, kord)
+            is GuildScheduledEventUserRemove -> handle(event, shard, kord)
+            is PresenceUpdate -> handle(event, shard, kord)
+            is InviteCreate -> handle(event, shard, kord)
+            is InviteDelete -> handle(event, shard, kord)
+            else -> null
+        }
 
     private suspend fun GatewayGuild.cache() {
         for (member in members.orEmpty()) {
@@ -83,7 +84,11 @@ internal class GuildEventHandler(
         }
     }
 
-    private suspend fun handle(event: GuildCreate, shard: Int, kord: Kord): GuildCreateEvent {
+    private suspend fun handle(
+        event: GuildCreate,
+        shard: Int,
+        kord: Kord,
+    ): GuildCreateEvent {
         val data = GuildData.from(event.guild)
         cache.put(data)
         event.guild.cache()
@@ -91,7 +96,11 @@ internal class GuildEventHandler(
         return GuildCreateEvent(Guild(data, kord), shard)
     }
 
-    private suspend fun handle(event: GuildUpdate, shard: Int, kord: Kord): GuildUpdateEvent {
+    private suspend fun handle(
+        event: GuildUpdate,
+        shard: Int,
+        kord: Kord,
+    ): GuildUpdateEvent {
         val data = GuildData.from(event.guild)
         val old = cache.query<GuildData> { idEq(GuildData::id, event.guild.id) }.singleOrNull()
         cache.put(data)
@@ -100,7 +109,11 @@ internal class GuildEventHandler(
         return GuildUpdateEvent(Guild(data, kord), old?.let { Guild(it, kord) }, shard)
     }
 
-    private suspend fun handle(event: GuildDelete, shard: Int, kord: Kord): GuildDeleteEvent = with(event.guild) {
+    private suspend fun handle(
+        event: GuildDelete,
+        shard: Int,
+        kord: Kord,
+    ): GuildDeleteEvent = with(event.guild) {
         val query = cache.query<GuildData> { idEq(GuildData::id, id) }
 
         val old = query.asFlow().map { Guild(it, kord) }.singleOrNull()
@@ -109,15 +122,24 @@ internal class GuildEventHandler(
         GuildDeleteEvent(id, unavailable.orElse(false), old, kord, shard)
     }
 
-    private suspend fun handle(event: GuildBanAdd, shard: Int, kord: Kord): BanAddEvent = with(event.ban) {
-        val data = UserData.from(user)
-        cache.put(user)
-        val user = User(data, kord)
+    private suspend fun handle(
+        event: GuildBanAdd,
+        shard: Int,
+        kord: Kord,
+    ): BanAddEvent =
+        with(event.ban) {
+            val data = UserData.from(user)
+            cache.put(user)
+            val user = User(data, kord)
 
-        BanAddEvent(user, guildId, shard)
-    }
+            BanAddEvent(user, guildId, shard)
+        }
 
-    private suspend fun handle(event: GuildBanRemove, shard: Int, kord: Kord): BanRemoveEvent = with(event.ban) {
+    private suspend fun handle(
+        event: GuildBanRemove,
+        shard: Int,
+        kord: Kord,
+    ): BanRemoveEvent = with(event.ban) {
         val data = UserData.from(user)
         cache.put(user)
         val user = User(data, kord)
@@ -125,7 +147,11 @@ internal class GuildEventHandler(
         BanRemoveEvent(user, guildId, shard)
     }
 
-    private suspend fun handle(event: GuildEmojisUpdate, shard: Int, kord: Kord): EmojisUpdateEvent =
+    private suspend fun handle(
+        event: GuildEmojisUpdate,
+        shard: Int,
+        kord: Kord,
+    ): EmojisUpdateEvent =
         with(event.emoji) {
 
             val data = emojis.map { EmojiData.from(guildId, it.id!!, it) }
@@ -144,11 +170,19 @@ internal class GuildEventHandler(
         }
 
 
-    private fun handle(event: GuildIntegrationsUpdate, shard: Int, kord: Kord): IntegrationsUpdateEvent {
+    private fun handle(
+        event: GuildIntegrationsUpdate,
+        shard: Int,
+        kord: Kord,
+    ): IntegrationsUpdateEvent {
         return IntegrationsUpdateEvent(event.integrations.guildId, kord, shard)
     }
 
-    private suspend fun handle(event: GuildMemberAdd, shard: Int, kord: Kord): MemberJoinEvent = with(event.member) {
+    private suspend fun handle(
+        event: GuildMemberAdd,
+        shard: Int,
+        kord: Kord,
+    ): MemberJoinEvent = with(event.member) {
         val userData = UserData.from(user.value!!)
         val memberData = MemberData.from(user.value!!.id, event.member)
 
@@ -157,10 +191,14 @@ internal class GuildEventHandler(
 
         val member = Member(memberData, userData, kord)
 
-        return MemberJoinEvent(member, shard)
+        MemberJoinEvent(member, shard)
     }
 
-    private suspend fun handle(event: GuildMemberRemove, shard: Int, kord: Kord): MemberLeaveEvent =
+    private suspend fun handle(
+        event: GuildMemberRemove,
+        shard: Int,
+        kord: Kord,
+    ): MemberLeaveEvent =
         with(event.member) {
             val userData = UserData.from(user)
 
@@ -177,7 +215,11 @@ internal class GuildEventHandler(
             MemberLeaveEvent(user, old, guildId, shard)
         }
 
-    private suspend fun handle(event: GuildMemberUpdate, shard: Int, kord: Kord): MemberUpdateEvent =
+    private suspend fun handle(
+        event: GuildMemberUpdate,
+        shard: Int,
+        kord: Kord,
+    ): MemberUpdateEvent =
         with(event.member) {
             val userData = UserData.from(user)
             cache.put(userData)
@@ -194,14 +236,22 @@ internal class GuildEventHandler(
             MemberUpdateEvent(new, old, kord, shard)
         }
 
-    private suspend fun handle(event: GuildRoleCreate, shard: Int, kord: Kord): RoleCreateEvent {
+    private suspend fun handle(
+        event: GuildRoleCreate,
+        shard: Int,
+        kord: Kord,
+    ): RoleCreateEvent {
         val data = RoleData.from(event.role)
         cache.put(data)
 
         return RoleCreateEvent(Role(data, kord), shard)
     }
 
-    private suspend fun handle(event: GuildRoleUpdate, shard: Int, kord: Kord): RoleUpdateEvent {
+    private suspend fun handle(
+        event: GuildRoleUpdate,
+        shard: Int,
+        kord: Kord,
+    ): RoleUpdateEvent {
         val data = RoleData.from(event.role)
 
         val oldData = cache.query<RoleData> {
@@ -215,7 +265,11 @@ internal class GuildEventHandler(
         return RoleUpdateEvent(Role(data, kord), old, shard)
     }
 
-    private suspend fun handle(event: GuildRoleDelete, shard: Int, kord: Kord): RoleDeleteEvent = with(event.role) {
+    private suspend fun handle(
+        event: GuildRoleDelete,
+        shard: Int,
+        kord: Kord,
+    ): RoleDeleteEvent = with(event.role) {
         val query = cache.query<RoleData> { idEq(RoleData::id, event.role.id) }
 
         val old = run {
@@ -228,7 +282,11 @@ internal class GuildEventHandler(
         RoleDeleteEvent(guildId, id, old, kord, shard)
     }
 
-    private suspend fun handle(event: GuildMembersChunk, shard: Int, kord: Kord): MembersChunkEvent = with(event.data) {
+    private suspend fun handle(
+        event: GuildMembersChunk,
+        shard: Int,
+        kord: Kord,
+    ): MembersChunkEvent = with(event.data) {
         val presences = presences.orEmpty().map { PresenceData.from(guildId, it) }
         cache.putAll(presences)
 
@@ -286,20 +344,39 @@ internal class GuildEventHandler(
         return GuildScheduledEventDeleteEvent(scheduledEvent, kord, shard)
     }
 
-    private fun handle(event: GuildScheduledEventUserAdd, shard: Int, kord: Kord): GuildScheduledEventUserAddEvent =
-        with(event.data) {
-            GuildScheduledEventUserAddEvent(guildScheduledEventId, userId, guildId, kord, shard)
-        }
+    private fun handle(
+        event: GuildScheduledEventUserAdd,
+        shard: Int,
+        kord: Kord,
+    ): GuildScheduledEventUserAddEvent = with(event.data) {
+        GuildScheduledEventUserAddEvent(
+            guildScheduledEventId,
+            userId,
+            guildId,
+            kord,
+            shard,
+        )
+    }
 
     private fun handle(
         event: GuildScheduledEventUserRemove,
         shard: Int,
         kord: Kord,
     ): GuildScheduledEventUserRemoveEvent = with(event.data) {
-        GuildScheduledEventUserRemoveEvent(guildScheduledEventId, userId, guildId, kord, shard)
+        GuildScheduledEventUserRemoveEvent(
+            guildScheduledEventId,
+            userId,
+            guildId,
+            kord,
+            shard,
+        )
     }
 
-    private suspend fun handle(event: PresenceUpdate, shard: Int, kord: Kord): PresenceUpdateEvent =
+    private suspend fun handle(
+        event: PresenceUpdate,
+        shard: Int,
+        kord: Kord,
+    ): PresenceUpdateEvent =
         with(event.presence) {
             val data = PresenceData.from(this.guildId.value!!, this)
 
@@ -314,10 +391,21 @@ internal class GuildEventHandler(
                 .singleOrNull()
                 ?.let { User(it, kord) }
 
-            PresenceUpdateEvent(user, this.user, guildId.value!!, old, new, shard)
+            PresenceUpdateEvent(
+                user,
+                this.user,
+                guildId.value!!,
+                old,
+                new,
+                shard,
+            )
         }
 
-    private suspend fun handle(event: InviteCreate, shard: Int, kord: Kord): InviteCreateEvent = with(event) {
+    private suspend fun handle(
+        event: InviteCreate,
+        shard: Int,
+        kord: Kord,
+    ): InviteCreateEvent = with(event) {
         val data = InviteCreateData.from(invite)
 
         invite.inviter.value?.let { cache.put(UserData.from(it)) }
@@ -326,7 +414,11 @@ internal class GuildEventHandler(
         InviteCreateEvent(data, kord, shard)
     }
 
-    private fun handle(event: InviteDelete, shard: Int, kord: Kord): InviteDeleteEvent = with(event) {
+    private fun handle(
+        event: InviteDelete,
+        shard: Int,
+        kord: Kord,
+    ): InviteDeleteEvent = with(event) {
         val data = InviteDeleteData.from(invite)
         InviteDeleteEvent(data, kord, shard)
     }

--- a/core/src/main/kotlin/gateway/handler/GuildEventHandler.kt
+++ b/core/src/main/kotlin/gateway/handler/GuildEventHandler.kt
@@ -16,7 +16,6 @@ import dev.kord.core.event.role.RoleDeleteEvent
 import dev.kord.core.event.role.RoleUpdateEvent
 import dev.kord.core.event.user.PresenceUpdateEvent
 import dev.kord.gateway.*
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.singleOrNull
 import kotlinx.coroutines.flow.toSet
@@ -27,32 +26,31 @@ internal class GuildEventHandler(
     cache: DataCache
 ) : BaseGatewayEventHandler(cache) {
 
-    override suspend fun handle(event: Event, shard: Int, kord: Kord, coroutineScope: CoroutineScope): CoreEvent? =
-        when (event) {
-            is GuildCreate -> handle(event, shard, kord, coroutineScope)
-            is GuildUpdate -> handle(event, shard, kord, coroutineScope)
-            is GuildDelete -> handle(event, shard, kord, coroutineScope)
-            is GuildBanAdd -> handle(event, shard, kord, coroutineScope)
-            is GuildBanRemove -> handle(event, shard, kord, coroutineScope)
-            is GuildEmojisUpdate -> handle(event, shard, kord, coroutineScope)
-            is GuildIntegrationsUpdate -> handle(event, shard, kord, coroutineScope)
-            is GuildMemberAdd -> handle(event, shard, kord, coroutineScope)
-            is GuildMemberRemove -> handle(event, shard, kord, coroutineScope)
-            is GuildMemberUpdate -> handle(event, shard, kord, coroutineScope)
-            is GuildRoleCreate -> handle(event, shard, kord, coroutineScope)
-            is GuildRoleUpdate -> handle(event, shard, kord, coroutineScope)
-            is GuildRoleDelete -> handle(event, shard, kord, coroutineScope)
-            is GuildMembersChunk -> handle(event, shard, kord, coroutineScope)
-            is GuildScheduledEventCreate -> handle(event, shard, kord, coroutineScope)
-            is GuildScheduledEventUpdate -> handle(event, shard, kord, coroutineScope)
-            is GuildScheduledEventDelete -> handle(event, shard, kord, coroutineScope)
-            is GuildScheduledEventUserAdd -> handle(event, shard, kord, coroutineScope)
-            is GuildScheduledEventUserRemove -> handle(event, shard, kord, coroutineScope)
-            is PresenceUpdate -> handle(event, shard, kord, coroutineScope)
-            is InviteCreate -> handle(event, shard, kord, coroutineScope)
-            is InviteDelete -> handle(event, shard, kord, coroutineScope)
-            else -> null
-        }
+    override suspend fun handle(event: Event, shard: Int, kord: Kord): CoreEvent? = when (event) {
+        is GuildCreate -> handle(event, shard, kord)
+        is GuildUpdate -> handle(event, shard, kord)
+        is GuildDelete -> handle(event, shard, kord)
+        is GuildBanAdd -> handle(event, shard, kord)
+        is GuildBanRemove -> handle(event, shard, kord)
+        is GuildEmojisUpdate -> handle(event, shard, kord)
+        is GuildIntegrationsUpdate -> handle(event, shard, kord)
+        is GuildMemberAdd -> handle(event, shard, kord)
+        is GuildMemberRemove -> handle(event, shard, kord)
+        is GuildMemberUpdate -> handle(event, shard, kord)
+        is GuildRoleCreate -> handle(event, shard, kord)
+        is GuildRoleUpdate -> handle(event, shard, kord)
+        is GuildRoleDelete -> handle(event, shard, kord)
+        is GuildMembersChunk -> handle(event, shard, kord)
+        is GuildScheduledEventCreate -> handle(event, shard, kord)
+        is GuildScheduledEventUpdate -> handle(event, shard, kord)
+        is GuildScheduledEventDelete -> handle(event, shard, kord)
+        is GuildScheduledEventUserAdd -> handle(event, shard, kord)
+        is GuildScheduledEventUserRemove -> handle(event, shard, kord)
+        is PresenceUpdate -> handle(event, shard, kord)
+        is InviteCreate -> handle(event, shard, kord)
+        is InviteDelete -> handle(event, shard, kord)
+        else -> null
+    }
 
     private suspend fun GatewayGuild.cache() {
         for (member in members.orEmpty()) {
@@ -85,80 +83,49 @@ internal class GuildEventHandler(
         }
     }
 
-    private suspend fun handle(
-        event: GuildCreate,
-        shard: Int,
-        kord: Kord,
-        coroutineScope: CoroutineScope
-    ): GuildCreateEvent {
+    private suspend fun handle(event: GuildCreate, shard: Int, kord: Kord): GuildCreateEvent {
         val data = GuildData.from(event.guild)
         cache.put(data)
         event.guild.cache()
 
-        return GuildCreateEvent(Guild(data, kord), shard, coroutineScope = coroutineScope)
+        return GuildCreateEvent(Guild(data, kord), shard)
     }
 
-    private suspend fun handle(
-        event: GuildUpdate,
-        shard: Int,
-        kord: Kord,
-        coroutineScope: CoroutineScope
-    ): GuildUpdateEvent {
+    private suspend fun handle(event: GuildUpdate, shard: Int, kord: Kord): GuildUpdateEvent {
         val data = GuildData.from(event.guild)
         val old = cache.query<GuildData> { idEq(GuildData::id, event.guild.id) }.singleOrNull()
         cache.put(data)
         event.guild.cache()
 
-        return GuildUpdateEvent(Guild(data, kord), old?.let { Guild(it, kord) }, shard, coroutineScope = coroutineScope)
+        return GuildUpdateEvent(Guild(data, kord), old?.let { Guild(it, kord) }, shard)
     }
 
-    private suspend fun handle(
-        event: GuildDelete,
-        shard: Int,
-        kord: Kord,
-        coroutineScope: CoroutineScope
-    ): GuildDeleteEvent = with(event.guild) {
+    private suspend fun handle(event: GuildDelete, shard: Int, kord: Kord): GuildDeleteEvent = with(event.guild) {
         val query = cache.query<GuildData> { idEq(GuildData::id, id) }
 
         val old = query.asFlow().map { Guild(it, kord) }.singleOrNull()
         query.remove()
 
-        return GuildDeleteEvent(id, unavailable.orElse(false), old, kord, shard, coroutineScope = coroutineScope)
+        GuildDeleteEvent(id, unavailable.orElse(false), old, kord, shard)
     }
 
-    private suspend fun handle(
-        event: GuildBanAdd,
-        shard: Int,
-        kord: Kord,
-        coroutineScope: CoroutineScope
-    ): BanAddEvent =
-        with(event.ban) {
-            val data = UserData.from(user)
-            cache.put(user)
-            val user = User(data, kord)
-
-            return BanAddEvent(user, guildId, shard, coroutineScope = coroutineScope)
-        }
-
-    private suspend fun handle(
-        event: GuildBanRemove,
-        shard: Int,
-        kord: Kord,
-        coroutineScope: CoroutineScope
-    ): BanRemoveEvent = with(event.ban) {
+    private suspend fun handle(event: GuildBanAdd, shard: Int, kord: Kord): BanAddEvent = with(event.ban) {
         val data = UserData.from(user)
         cache.put(user)
         val user = User(data, kord)
 
-        return BanRemoveEvent(user, guildId, shard, coroutineScope = coroutineScope)
+        BanAddEvent(user, guildId, shard)
     }
 
-    private suspend fun handle(
-        event: GuildEmojisUpdate,
-        shard: Int,
-        kord: Kord,
-        coroutineScope: CoroutineScope
-    ): EmojisUpdateEvent =
+    private suspend fun handle(event: GuildBanRemove, shard: Int, kord: Kord): BanRemoveEvent = with(event.ban) {
+        val data = UserData.from(user)
+        cache.put(user)
+        val user = User(data, kord)
+
+        BanRemoveEvent(user, guildId, shard)
+    }
+
+    private suspend fun handle(event: GuildEmojisUpdate, shard: Int, kord: Kord): EmojisUpdateEvent =
         with(event.emoji) {
 
             val data = emojis.map { EmojiData.from(guildId, it.id!!, it) }
@@ -173,25 +140,15 @@ internal class GuildEventHandler(
                 it.copy(emojis = emojis.map { emoji -> emoji.id })
             }
 
-            return EmojisUpdateEvent(guildId, emojis.toSet(), old, kord, shard, coroutineScope = coroutineScope)
+            EmojisUpdateEvent(guildId, emojis.toSet(), old, kord, shard)
         }
 
 
-    private fun handle(
-        event: GuildIntegrationsUpdate,
-        shard: Int,
-        kord: Kord,
-        coroutineScope: CoroutineScope
-    ): IntegrationsUpdateEvent {
-        return IntegrationsUpdateEvent(event.integrations.guildId, kord, shard, coroutineScope = coroutineScope)
+    private fun handle(event: GuildIntegrationsUpdate, shard: Int, kord: Kord): IntegrationsUpdateEvent {
+        return IntegrationsUpdateEvent(event.integrations.guildId, kord, shard)
     }
 
-    private suspend fun handle(
-        event: GuildMemberAdd,
-        shard: Int,
-        kord: Kord,
-        coroutineScope: CoroutineScope
-    ): MemberJoinEvent = with(event.member) {
+    private suspend fun handle(event: GuildMemberAdd, shard: Int, kord: Kord): MemberJoinEvent = with(event.member) {
         val userData = UserData.from(user.value!!)
         val memberData = MemberData.from(user.value!!.id, event.member)
 
@@ -200,15 +157,10 @@ internal class GuildEventHandler(
 
         val member = Member(memberData, userData, kord)
 
-        return MemberJoinEvent(member, shard, coroutineScope = coroutineScope)
+        return MemberJoinEvent(member, shard)
     }
 
-    private suspend fun handle(
-        event: GuildMemberRemove,
-        shard: Int,
-        kord: Kord,
-        coroutineScope: CoroutineScope
-    ): MemberLeaveEvent =
+    private suspend fun handle(event: GuildMemberRemove, shard: Int, kord: Kord): MemberLeaveEvent =
         with(event.member) {
             val userData = UserData.from(user)
 
@@ -222,15 +174,10 @@ internal class GuildEventHandler(
             val user = User(userData, kord)
             val old = oldData?.let { Member(it, userData, kord) }
 
-            return MemberLeaveEvent(user, old, guildId, shard, coroutineScope = coroutineScope)
+            MemberLeaveEvent(user, old, guildId, shard)
         }
 
-    private suspend fun handle(
-        event: GuildMemberUpdate,
-        shard: Int,
-        kord: Kord,
-        coroutineScope: CoroutineScope
-    ): MemberUpdateEvent =
+    private suspend fun handle(event: GuildMemberUpdate, shard: Int, kord: Kord): MemberUpdateEvent =
         with(event.member) {
             val userData = UserData.from(user)
             cache.put(userData)
@@ -244,27 +191,17 @@ internal class GuildEventHandler(
             val new = Member(MemberData.from(this), userData, kord)
             cache.put(new.memberData)
 
-            return MemberUpdateEvent(new, old, kord, shard, coroutineScope = coroutineScope)
+            MemberUpdateEvent(new, old, kord, shard)
         }
 
-    private suspend fun handle(
-        event: GuildRoleCreate,
-        shard: Int,
-        kord: Kord,
-        coroutineScope: CoroutineScope
-    ): RoleCreateEvent {
+    private suspend fun handle(event: GuildRoleCreate, shard: Int, kord: Kord): RoleCreateEvent {
         val data = RoleData.from(event.role)
         cache.put(data)
 
-        return RoleCreateEvent(Role(data, kord), shard, coroutineScope = coroutineScope)
+        return RoleCreateEvent(Role(data, kord), shard)
     }
 
-    private suspend fun handle(
-        event: GuildRoleUpdate,
-        shard: Int,
-        kord: Kord,
-        coroutineScope: CoroutineScope
-    ): RoleUpdateEvent {
+    private suspend fun handle(event: GuildRoleUpdate, shard: Int, kord: Kord): RoleUpdateEvent {
         val data = RoleData.from(event.role)
 
         val oldData = cache.query<RoleData> {
@@ -275,15 +212,10 @@ internal class GuildEventHandler(
         val old = oldData?.let { Role(it, kord) }
         cache.put(data)
 
-        return RoleUpdateEvent(Role(data, kord), old, shard, coroutineScope = coroutineScope)
+        return RoleUpdateEvent(Role(data, kord), old, shard)
     }
 
-    private suspend fun handle(
-        event: GuildRoleDelete,
-        shard: Int,
-        kord: Kord,
-        coroutineScope: CoroutineScope
-    ): RoleDeleteEvent = with(event.role) {
+    private suspend fun handle(event: GuildRoleDelete, shard: Int, kord: Kord): RoleDeleteEvent = with(event.role) {
         val query = cache.query<RoleData> { idEq(RoleData::id, event.role.id) }
 
         val old = run {
@@ -293,15 +225,10 @@ internal class GuildEventHandler(
 
         query.remove()
 
-        return RoleDeleteEvent(guildId, id, old, kord, shard, coroutineScope = coroutineScope)
+        RoleDeleteEvent(guildId, id, old, kord, shard)
     }
 
-    private suspend fun handle(
-        event: GuildMembersChunk,
-        shard: Int,
-        kord: Kord,
-        coroutineScope: CoroutineScope
-    ): MembersChunkEvent = with(event.data) {
+    private suspend fun handle(event: GuildMembersChunk, shard: Int, kord: Kord): MembersChunkEvent = with(event.data) {
         val presences = presences.orEmpty().map { PresenceData.from(guildId, it) }
         cache.putAll(presences)
 
@@ -312,27 +239,25 @@ internal class GuildEventHandler(
             cache.put(userData)
         }
 
-        return MembersChunkEvent(MembersChunkData.from(this), kord, shard, coroutineScope = coroutineScope)
+        MembersChunkEvent(MembersChunkData.from(this), kord, shard)
     }
 
     private suspend fun handle(
         event: GuildScheduledEventCreate,
         shard: Int,
         kord: Kord,
-        coroutineScope: CoroutineScope
     ): GuildScheduledEventCreateEvent {
         val eventData = GuildScheduledEventData.from(event.event)
         cache.put(eventData)
         val scheduledEvent = GuildScheduledEvent(eventData, kord)
 
-        return GuildScheduledEventCreateEvent(scheduledEvent, kord, shard, coroutineScope = coroutineScope)
+        return GuildScheduledEventCreateEvent(scheduledEvent, kord, shard)
     }
 
     private suspend fun handle(
         event: GuildScheduledEventUpdate,
         shard: Int,
         kord: Kord,
-        coroutineScope: CoroutineScope
     ): GuildScheduledEventUpdateEvent {
         val eventData = GuildScheduledEventData.from(event.event)
         val oldData = cache.query<GuildScheduledEventData> {
@@ -342,14 +267,13 @@ internal class GuildEventHandler(
         cache.put(eventData)
         val scheduledEvent = GuildScheduledEvent(eventData, kord)
 
-        return GuildScheduledEventUpdateEvent(scheduledEvent, old, kord, shard, coroutineScope = coroutineScope)
+        return GuildScheduledEventUpdateEvent(scheduledEvent, old, kord, shard)
     }
 
     private suspend fun handle(
         event: GuildScheduledEventDelete,
         shard: Int,
         kord: Kord,
-        coroutineScope: CoroutineScope
     ): GuildScheduledEventDeleteEvent {
         val query = cache.query<GuildScheduledEvent> {
             idEq(GuildScheduledEvent::id, event.event.id)
@@ -359,47 +283,23 @@ internal class GuildEventHandler(
         val eventData = GuildScheduledEventData.from(event.event)
         val scheduledEvent = GuildScheduledEvent(eventData, kord)
 
-        return GuildScheduledEventDeleteEvent(scheduledEvent, kord, shard, coroutineScope = coroutineScope)
+        return GuildScheduledEventDeleteEvent(scheduledEvent, kord, shard)
     }
 
-    private fun handle(
-        event: GuildScheduledEventUserAdd,
-        shard: Int,
-        kord: Kord,
-        coroutineScope: CoroutineScope,
-    ): GuildScheduledEventUserAddEvent = with(event.data) {
-        GuildScheduledEventUserAddEvent(
-            guildScheduledEventId,
-            userId,
-            guildId,
-            kord,
-            shard,
-            coroutineScope = coroutineScope,
-        )
-    }
+    private fun handle(event: GuildScheduledEventUserAdd, shard: Int, kord: Kord): GuildScheduledEventUserAddEvent =
+        with(event.data) {
+            GuildScheduledEventUserAddEvent(guildScheduledEventId, userId, guildId, kord, shard)
+        }
 
     private fun handle(
         event: GuildScheduledEventUserRemove,
         shard: Int,
         kord: Kord,
-        coroutineScope: CoroutineScope,
     ): GuildScheduledEventUserRemoveEvent = with(event.data) {
-        GuildScheduledEventUserRemoveEvent(
-            guildScheduledEventId,
-            userId,
-            guildId,
-            kord,
-            shard,
-            coroutineScope = coroutineScope,
-        )
+        GuildScheduledEventUserRemoveEvent(guildScheduledEventId, userId, guildId, kord, shard)
     }
 
-    private suspend fun handle(
-        event: PresenceUpdate,
-        shard: Int,
-        kord: Kord,
-        coroutineScope: CoroutineScope
-    ): PresenceUpdateEvent =
+    private suspend fun handle(event: PresenceUpdate, shard: Int, kord: Kord): PresenceUpdateEvent =
         with(event.presence) {
             val data = PresenceData.from(this.guildId.value!!, this)
 
@@ -414,38 +314,20 @@ internal class GuildEventHandler(
                 .singleOrNull()
                 ?.let { User(it, kord) }
 
-            return PresenceUpdateEvent(
-                user,
-                this.user,
-                guildId.value!!,
-                old,
-                new,
-                shard,
-                coroutineScope = coroutineScope
-            )
+            PresenceUpdateEvent(user, this.user, guildId.value!!, old, new, shard)
         }
 
-    private suspend fun handle(
-        event: InviteCreate,
-        shard: Int,
-        kord: Kord,
-        coroutineScope: CoroutineScope
-    ): InviteCreateEvent = with(event) {
+    private suspend fun handle(event: InviteCreate, shard: Int, kord: Kord): InviteCreateEvent = with(event) {
         val data = InviteCreateData.from(invite)
 
         invite.inviter.value?.let { cache.put(UserData.from(it)) }
         invite.targetUser.value?.let { cache.put(UserData.from(it)) }
 
-        return InviteCreateEvent(data, kord, shard, coroutineScope = coroutineScope)
+        InviteCreateEvent(data, kord, shard)
     }
 
-    private fun handle(
-        event: InviteDelete,
-        shard: Int,
-        kord: Kord,
-        coroutineScope: CoroutineScope
-    ): InviteDeleteEvent = with(event) {
+    private fun handle(event: InviteDelete, shard: Int, kord: Kord): InviteDeleteEvent = with(event) {
         val data = InviteDeleteData.from(invite)
-        return InviteDeleteEvent(data, kord, shard, coroutineScope = coroutineScope)
+        InviteDeleteEvent(data, kord, shard)
     }
 }

--- a/core/src/main/kotlin/gateway/handler/InteractionEventHandler.kt
+++ b/core/src/main/kotlin/gateway/handler/InteractionEventHandler.kt
@@ -19,20 +19,21 @@ public class InteractionEventHandler(
     cache: DataCache
 ) : BaseGatewayEventHandler(cache) {
 
-    override suspend fun handle(event: Event, shard: Int, kord: Kord): CoreEvent? = when (event) {
-        is InteractionCreate -> handle(event, shard, kord)
-        is ApplicationCommandCreate -> handle(event, shard, kord)
-        is ApplicationCommandUpdate -> handle(event, shard, kord)
-        is ApplicationCommandDelete -> handle(event, shard, kord)
-        is ApplicationCommandPermissionsUpdate -> {
-            val data = GuildApplicationCommandPermissionsData.from(event.permissions)
-            ApplicationCommandPermissionsUpdateEvent(
-                ApplicationCommandPermissions(data),
-                kord, shard,
-            )
+    override suspend fun handle(event: Event, shard: Int, kord: Kord): CoreEvent? =
+        when (event) {
+            is InteractionCreate -> handle(event, shard, kord)
+            is ApplicationCommandCreate -> handle(event, shard, kord)
+            is ApplicationCommandUpdate -> handle(event, shard, kord)
+            is ApplicationCommandDelete -> handle(event, shard, kord)
+            is ApplicationCommandPermissionsUpdate -> {
+                val data = GuildApplicationCommandPermissionsData.from(event.permissions)
+                ApplicationCommandPermissionsUpdateEvent(
+                    ApplicationCommandPermissions(data),
+                    kord, shard,
+                )
+            }
+            else -> null
         }
-        else -> null
-    }
 
     private fun handle(event: InteractionCreate, shard: Int, kord: Kord): InteractionCreateEvent {
         val data = InteractionData.from(event.interaction)
@@ -55,7 +56,11 @@ public class InteractionEventHandler(
         return coreEvent
     }
 
-    private suspend fun handle(event: ApplicationCommandCreate, shard: Int, kord: Kord): ApplicationCommandCreateEvent {
+    private suspend fun handle(
+        event: ApplicationCommandCreate,
+        shard: Int,
+        kord: Kord,
+    ): ApplicationCommandCreateEvent {
         val data = ApplicationCommandData.from(event.application)
         cache.put(data)
         val coreEvent = when (val application = GuildApplicationCommand(data, kord.rest.interaction)) {
@@ -68,7 +73,11 @@ public class InteractionEventHandler(
     }
 
 
-    private suspend fun handle(event: ApplicationCommandUpdate, shard: Int, kord: Kord): ApplicationCommandUpdateEvent {
+    private suspend fun handle(
+        event: ApplicationCommandUpdate,
+        shard: Int,
+        kord: Kord,
+    ): ApplicationCommandUpdateEvent {
         val data = ApplicationCommandData.from(event.application)
         cache.put(data)
 
@@ -81,7 +90,11 @@ public class InteractionEventHandler(
         return coreEvent
     }
 
-    private suspend fun handle(event: ApplicationCommandDelete, shard: Int, kord: Kord): ApplicationCommandDeleteEvent {
+    private suspend fun handle(
+        event: ApplicationCommandDelete,
+        shard: Int,
+        kord: Kord,
+    ): ApplicationCommandDeleteEvent {
         val data = ApplicationCommandData.from(event.application)
         cache.remove<ApplicationCommandData> { idEq(ApplicationCommandData::id, data.id) }
         val coreEvent = when (val application = GuildApplicationCommand(data, kord.rest.interaction)) {

--- a/core/src/main/kotlin/gateway/handler/InteractionEventHandler.kt
+++ b/core/src/main/kotlin/gateway/handler/InteractionEventHandler.kt
@@ -5,7 +5,6 @@ import dev.kord.cache.api.put
 import dev.kord.cache.api.remove
 import dev.kord.core.Kord
 import dev.kord.core.cache.data.ApplicationCommandData
-import dev.kord.core.cache.data.GuildApplicationCommandPermissionData
 import dev.kord.core.cache.data.GuildApplicationCommandPermissionsData
 import dev.kord.core.cache.data.InteractionData
 import dev.kord.core.cache.idEq
@@ -13,7 +12,6 @@ import dev.kord.core.entity.application.*
 import dev.kord.core.entity.interaction.*
 import dev.kord.core.event.interaction.*
 import dev.kord.gateway.*
-import kotlinx.coroutines.CoroutineScope
 import dev.kord.core.event.Event as CoreEvent
 
 
@@ -21,92 +19,76 @@ public class InteractionEventHandler(
     cache: DataCache
 ) : BaseGatewayEventHandler(cache) {
 
-    override suspend fun handle(event: Event, shard: Int, kord: Kord, coroutineScope: CoroutineScope): CoreEvent? =
-        when (event) {
-            is InteractionCreate -> handle(event, shard, kord, coroutineScope)
-            is ApplicationCommandCreate -> handle(event, shard, kord, coroutineScope)
-            is ApplicationCommandUpdate -> handle(event, shard, kord, coroutineScope)
-            is ApplicationCommandDelete -> handle(event, shard, kord, coroutineScope)
-            is ApplicationCommandPermissionsUpdate -> {
-                val data = GuildApplicationCommandPermissionsData.from(event.permissions)
-                ApplicationCommandPermissionsUpdateEvent(
-                    ApplicationCommandPermissions(data),
-                    kord, shard, coroutineScope
-                )
-            }
-            else -> null
+    override suspend fun handle(event: Event, shard: Int, kord: Kord): CoreEvent? = when (event) {
+        is InteractionCreate -> handle(event, shard, kord)
+        is ApplicationCommandCreate -> handle(event, shard, kord)
+        is ApplicationCommandUpdate -> handle(event, shard, kord)
+        is ApplicationCommandDelete -> handle(event, shard, kord)
+        is ApplicationCommandPermissionsUpdate -> {
+            val data = GuildApplicationCommandPermissionsData.from(event.permissions)
+            ApplicationCommandPermissionsUpdateEvent(
+                ApplicationCommandPermissions(data),
+                kord, shard,
+            )
         }
+        else -> null
+    }
 
-    private fun handle(event: InteractionCreate, shard: Int, kord: Kord, coroutineScope: CoroutineScope): CoreEvent {
+    private fun handle(event: InteractionCreate, shard: Int, kord: Kord): InteractionCreateEvent {
         val data = InteractionData.from(event.interaction)
-        val coreEvent = when(val interaction = Interaction.from(data, kord)) {
-            is GlobalAutoCompleteInteraction -> GlobalAutoCompleteInteractionCreateEvent(kord, shard, interaction, coroutineScope)
-            is GlobalChatInputCommandInteraction -> GlobalChatInputCommandInteractionCreateEvent(interaction, kord, shard, coroutineScope)
-            is GlobalUserCommandInteraction -> GlobalUserCommandInteractionCreateEvent(interaction, kord, shard, coroutineScope)
-            is GlobalMessageCommandInteraction -> GlobalMessageCommandInteractionCreateEvent(interaction, kord, shard, coroutineScope)
-            is GlobalButtonInteraction -> GlobalButtonInteractionCreateEvent(interaction, kord, shard, coroutineScope)
-            is GlobalSelectMenuInteraction -> GlobalSelectMenuInteractionCreateEvent(interaction, kord, shard, coroutineScope)
-            is GlobalModalSubmitInteraction -> GlobalModalSubmitInteractionCreateEvent(interaction, shard, kord, coroutineScope)
-            is GuildAutoCompleteInteraction -> GuildAutoCompleteInteractionCreateEvent(kord, shard, interaction, coroutineScope)
-            is GuildChatInputCommandInteraction -> GuildChatInputCommandInteractionCreateEvent(interaction, kord, shard, coroutineScope)
-            is GuildMessageCommandInteraction -> GuildMessageCommandInteractionCreateEvent(interaction, kord, shard, coroutineScope)
-            is GuildUserCommandInteraction -> GuildUserCommandInteractionCreateEvent(interaction, kord, shard, coroutineScope)
-            is GuildButtonInteraction -> GuildButtonInteractionCreateEvent(interaction, kord, shard, coroutineScope)
-            is GuildSelectMenuInteraction -> GuildSelectMenuInteractionCreateEvent(interaction, kord, shard, coroutineScope)
-            is GuildModalSubmitInteraction -> GuildModalSubmitInteractionCreateEvent(interaction, kord, shard, coroutineScope)
+        val coreEvent = when (val interaction = Interaction.from(data, kord)) {
+            is GlobalAutoCompleteInteraction -> GlobalAutoCompleteInteractionCreateEvent(kord, shard, interaction)
+            is GlobalChatInputCommandInteraction -> GlobalChatInputCommandInteractionCreateEvent(interaction, kord, shard)
+            is GlobalUserCommandInteraction -> GlobalUserCommandInteractionCreateEvent(interaction, kord, shard)
+            is GlobalMessageCommandInteraction -> GlobalMessageCommandInteractionCreateEvent(interaction, kord, shard)
+            is GlobalButtonInteraction -> GlobalButtonInteractionCreateEvent(interaction, kord, shard)
+            is GlobalSelectMenuInteraction -> GlobalSelectMenuInteractionCreateEvent(interaction, kord, shard)
+            is GlobalModalSubmitInteraction -> GlobalModalSubmitInteractionCreateEvent(interaction, shard, kord)
+            is GuildAutoCompleteInteraction -> GuildAutoCompleteInteractionCreateEvent(kord, shard, interaction)
+            is GuildChatInputCommandInteraction -> GuildChatInputCommandInteractionCreateEvent(interaction, kord, shard)
+            is GuildMessageCommandInteraction -> GuildMessageCommandInteractionCreateEvent(interaction, kord, shard)
+            is GuildUserCommandInteraction -> GuildUserCommandInteractionCreateEvent(interaction, kord, shard)
+            is GuildButtonInteraction -> GuildButtonInteractionCreateEvent(interaction, kord, shard)
+            is GuildSelectMenuInteraction -> GuildSelectMenuInteractionCreateEvent(interaction, kord, shard)
+            is GuildModalSubmitInteraction -> GuildModalSubmitInteractionCreateEvent(interaction, kord, shard)
         }
         return coreEvent
     }
 
-    private suspend fun handle(
-        event: ApplicationCommandCreate,
-        shard: Int,
-        kord: Kord,
-        coroutineScope: CoroutineScope
-    ): CoreEvent {
+    private suspend fun handle(event: ApplicationCommandCreate, shard: Int, kord: Kord): ApplicationCommandCreateEvent {
         val data = ApplicationCommandData.from(event.application)
         cache.put(data)
         val coreEvent = when (val application = GuildApplicationCommand(data, kord.rest.interaction)) {
-            is GuildChatInputCommand -> ChatInputCommandCreateEvent(application, kord, shard, coroutineScope)
-            is GuildMessageCommand -> MessageCommandCreateEvent(application, kord, shard, coroutineScope)
-            is GuildUserCommand -> UserCommandCreateEvent(application, kord, shard, coroutineScope)
-            is UnknownGuildApplicationCommand -> UnknownApplicationCommandCreateEvent(application, kord, shard, coroutineScope)
+            is GuildChatInputCommand -> ChatInputCommandCreateEvent(application, kord, shard)
+            is GuildMessageCommand -> MessageCommandCreateEvent(application, kord, shard)
+            is GuildUserCommand -> UserCommandCreateEvent(application, kord, shard)
+            is UnknownGuildApplicationCommand -> UnknownApplicationCommandCreateEvent(application, kord, shard)
         }
         return coreEvent
     }
 
 
-    private suspend fun handle(
-        event: ApplicationCommandUpdate,
-        shard: Int,
-        kord: Kord,
-        coroutineScope: CoroutineScope
-    ): CoreEvent {
+    private suspend fun handle(event: ApplicationCommandUpdate, shard: Int, kord: Kord): ApplicationCommandUpdateEvent {
         val data = ApplicationCommandData.from(event.application)
         cache.put(data)
 
         val coreEvent = when (val application = GuildApplicationCommand(data, kord.rest.interaction)) {
-            is GuildChatInputCommand -> ChatInputCommandUpdateEvent(application, kord, shard, coroutineScope)
-            is GuildMessageCommand -> MessageCommandUpdateEvent(application, kord, shard, coroutineScope)
-            is GuildUserCommand -> UserCommandUpdateEvent(application, kord, shard, coroutineScope)
-            is UnknownGuildApplicationCommand -> UnknownApplicationCommandUpdateEvent(application, kord, shard, coroutineScope)
+            is GuildChatInputCommand -> ChatInputCommandUpdateEvent(application, kord, shard)
+            is GuildMessageCommand -> MessageCommandUpdateEvent(application, kord, shard)
+            is GuildUserCommand -> UserCommandUpdateEvent(application, kord, shard)
+            is UnknownGuildApplicationCommand -> UnknownApplicationCommandUpdateEvent(application, kord, shard)
         }
         return coreEvent
     }
 
-    private suspend fun handle(
-        event: ApplicationCommandDelete,
-        shard: Int,
-        kord: Kord,
-        coroutineScope: CoroutineScope
-    ): CoreEvent {
+    private suspend fun handle(event: ApplicationCommandDelete, shard: Int, kord: Kord): ApplicationCommandDeleteEvent {
         val data = ApplicationCommandData.from(event.application)
         cache.remove<ApplicationCommandData> { idEq(ApplicationCommandData::id, data.id) }
         val coreEvent = when (val application = GuildApplicationCommand(data, kord.rest.interaction)) {
-            is GuildChatInputCommand -> ChatInputCommandDeleteEvent(application, kord, shard, coroutineScope)
-            is GuildMessageCommand -> MessageCommandDeleteEvent(application, kord, shard, coroutineScope)
-            is GuildUserCommand -> UserCommandDeleteEvent(application, kord, shard, coroutineScope)
-            is UnknownGuildApplicationCommand -> UnknownApplicationCommandDeleteEvent(application, kord, shard, coroutineScope)
+            is GuildChatInputCommand -> ChatInputCommandDeleteEvent(application, kord, shard)
+            is GuildMessageCommand -> MessageCommandDeleteEvent(application, kord, shard)
+            is GuildUserCommand -> UserCommandDeleteEvent(application, kord, shard)
+            is UnknownGuildApplicationCommand -> UnknownApplicationCommandDeleteEvent(application, kord, shard)
         }
         return coreEvent
     }

--- a/core/src/main/kotlin/gateway/handler/LifeCycleEventHandler.kt
+++ b/core/src/main/kotlin/gateway/handler/LifeCycleEventHandler.kt
@@ -10,52 +10,35 @@ import dev.kord.core.event.gateway.DisconnectEvent
 import dev.kord.core.event.gateway.ReadyEvent
 import dev.kord.core.event.gateway.ResumedEvent
 import dev.kord.gateway.*
-import kotlinx.coroutines.CoroutineScope
 import dev.kord.core.event.Event as CoreEvent
 
 internal class LifeCycleEventHandler(
     cache: DataCache
 ) : BaseGatewayEventHandler(cache) {
 
-    override suspend fun handle(event: Event, shard: Int, kord: Kord, coroutineScope: CoroutineScope): CoreEvent? =
-        when (event) {
-            is Ready -> handle(event, shard, kord, coroutineScope)
-            is Resumed -> ResumedEvent(kord, shard, coroutineScope)
-            Reconnect -> ConnectEvent(kord, shard, coroutineScope)
-            is Close -> when (event) {
-                Close.Detach -> DisconnectEvent.DetachEvent(kord, shard, coroutineScope)
-                Close.UserClose -> DisconnectEvent.UserCloseEvent(kord, shard, coroutineScope)
-                Close.Timeout -> DisconnectEvent.TimeoutEvent(kord, shard, coroutineScope)
-                is Close.DiscordClose -> DisconnectEvent.DiscordCloseEvent(
-                    kord,
-                    shard,
-                    event.closeCode,
-                    event.recoverable,
-                    coroutineScope
-                )
-                Close.Reconnecting -> DisconnectEvent.ReconnectingEvent(kord, shard, coroutineScope)
-                Close.ZombieConnection -> DisconnectEvent.ZombieConnectionEvent(kord, shard, coroutineScope)
-                Close.RetryLimitReached -> DisconnectEvent.RetryLimitReachedEvent(kord, shard, coroutineScope)
-                Close.SessionReset -> DisconnectEvent.SessionReset(kord, shard, coroutineScope)
-            }
-            else -> null
+    override suspend fun handle(event: Event, shard: Int, kord: Kord): CoreEvent? = when (event) {
+        is Ready -> handle(event, shard, kord)
+        is Resumed -> ResumedEvent(kord, shard)
+        Reconnect -> ConnectEvent(kord, shard)
+        is Close -> when (event) {
+            Close.Detach -> DisconnectEvent.DetachEvent(kord, shard)
+            Close.UserClose -> DisconnectEvent.UserCloseEvent(kord, shard)
+            Close.Timeout -> DisconnectEvent.TimeoutEvent(kord, shard)
+            is Close.DiscordClose -> DisconnectEvent.DiscordCloseEvent(kord, shard, event.closeCode, event.recoverable)
+            Close.Reconnecting -> DisconnectEvent.ReconnectingEvent(kord, shard)
+            Close.ZombieConnection -> DisconnectEvent.ZombieConnectionEvent(kord, shard)
+            Close.RetryLimitReached -> DisconnectEvent.RetryLimitReachedEvent(kord, shard)
+            Close.SessionReset -> DisconnectEvent.SessionReset(kord, shard)
         }
+        else -> null
+    }
 
-    private suspend fun handle(event: Ready, shard: Int, kord: Kord, coroutineScope: CoroutineScope): ReadyEvent =
-        with(event.data) {
-            val guilds = guilds.map { it.id }.toSet()
-            val self = UserData.from(event.data.user)
+    private suspend fun handle(event: Ready, shard: Int, kord: Kord): ReadyEvent = with(event.data) {
+        val guilds = guilds.map { it.id }.toSet()
+        val self = UserData.from(event.data.user)
 
-            cache.put(self)
+        cache.put(self)
 
-            return ReadyEvent(
-                event.data.version,
-                guilds,
-                User(self, kord),
-                sessionId,
-                kord,
-                shard,
-                coroutineScope = coroutineScope
-            )
-        }
+        ReadyEvent(event.data.version, guilds, User(self, kord), sessionId, kord, shard)
+    }
 }

--- a/core/src/main/kotlin/gateway/handler/MessageEventHandler.kt
+++ b/core/src/main/kotlin/gateway/handler/MessageEventHandler.kt
@@ -15,7 +15,6 @@ import dev.kord.gateway.*
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.singleOrNull
 import kotlinx.coroutines.flow.toSet
-import dev.kord.core.event.Event as CoreEvent
 
 internal class MessageEventHandler(
     cache: DataCache
@@ -25,7 +24,7 @@ internal class MessageEventHandler(
         event: Event,
         shard: Int,
         kord: Kord,
-    ): CoreEvent? = when (event) {
+    ): dev.kord.core.event.Event? = when (event) {
         is MessageCreate -> handle(event, shard, kord)
         is MessageUpdate -> handle(event, shard, kord)
         is MessageDelete -> handle(event, shard, kord)

--- a/core/src/main/kotlin/gateway/handler/MessageEventHandler.kt
+++ b/core/src/main/kotlin/gateway/handler/MessageEventHandler.kt
@@ -21,7 +21,11 @@ internal class MessageEventHandler(
     cache: DataCache
 ) : BaseGatewayEventHandler(cache) {
 
-    override suspend fun handle(event: Event, shard: Int, kord: Kord): CoreEvent? = when (event) {
+    override suspend fun handle(
+        event: Event,
+        shard: Int,
+        kord: Kord,
+    ): CoreEvent? = when (event) {
         is MessageCreate -> handle(event, shard, kord)
         is MessageUpdate -> handle(event, shard, kord)
         is MessageDelete -> handle(event, shard, kord)
@@ -33,7 +37,11 @@ internal class MessageEventHandler(
         else -> null
     }
 
-    private suspend fun handle(event: MessageCreate, shard: Int, kord: Kord): MessageCreateEvent = with(event.message) {
+    private suspend fun handle(
+        event: MessageCreate,
+        shard: Int,
+        kord: Kord,
+    ): MessageCreateEvent = with(event.message) {
         val data = MessageData.from(this)
         cache.put(data)
 
@@ -70,7 +78,11 @@ internal class MessageEventHandler(
         MessageCreateEvent(Message(data, kord), guildId.value, member, shard)
     }
 
-    private suspend fun handle(event: MessageUpdate, shard: Int, kord: Kord): MessageUpdateEvent = with(event.message) {
+    private suspend fun handle(
+        event: MessageUpdate,
+        shard: Int,
+        kord: Kord,
+    ): MessageUpdateEvent = with(event.message) {
         val query = cache.query<MessageData> { idEq(MessageData::id, id) }
 
         val old = query.asFlow().map { Message(it, kord) }.singleOrNull()
@@ -87,7 +99,11 @@ internal class MessageEventHandler(
         MessageUpdateEvent(id, channelId, this, old, kord, shard)
     }
 
-    private suspend fun handle(event: MessageDelete, shard: Int, kord: Kord): MessageDeleteEvent = with(event.message) {
+    private suspend fun handle(
+        event: MessageDelete,
+        shard: Int,
+        kord: Kord,
+    ): MessageDeleteEvent = with(event.message) {
         val query = cache.query<MessageData> { idEq(MessageData::id, id) }
 
         val removed = query.singleOrNull()?.let { Message(it, kord) }
@@ -96,7 +112,11 @@ internal class MessageEventHandler(
         MessageDeleteEvent(id, channelId, guildId.value, removed, kord, shard)
     }
 
-    private suspend fun handle(event: MessageDeleteBulk, shard: Int, kord: Kord): MessageBulkDeleteEvent =
+    private suspend fun handle(
+        event: MessageDeleteBulk,
+        shard: Int,
+        kord: Kord,
+    ): MessageBulkDeleteEvent =
         with(event.messageBulk) {
             val query = cache.query<MessageData> { MessageData::id `in` ids }
 
@@ -105,10 +125,21 @@ internal class MessageEventHandler(
 
             val ids = ids.asSequence().map { it }.toSet()
 
-            MessageBulkDeleteEvent(ids, removed, channelId, guildId.value, kord, shard)
+            MessageBulkDeleteEvent(
+                ids,
+                removed,
+                channelId,
+                guildId.value,
+                kord,
+                shard,
+            )
         }
 
-    private suspend fun handle(event: MessageReactionAdd, shard: Int, kord: Kord): ReactionAddEvent =
+    private suspend fun handle(
+        event: MessageReactionAdd,
+        shard: Int,
+        kord: Kord,
+    ): ReactionAddEvent =
         with(event.reaction) {
             /**
              * Reactions added will *always* have a name, the only case in which name is null is when a guild reaction
@@ -143,10 +174,22 @@ internal class MessageEventHandler(
                 it.copy(reactions = Optional.Value(reactions))
             }
 
-            ReactionAddEvent(userId, channelId, messageId, guildId.value, reaction, kord, shard)
+            ReactionAddEvent(
+                userId,
+                channelId,
+                messageId,
+                guildId.value,
+                reaction,
+                kord,
+                shard,
+            )
         }
 
-    private suspend fun handle(event: MessageReactionRemove, shard: Int, kord: Kord): ReactionRemoveEvent =
+    private suspend fun handle(
+        event: MessageReactionRemove,
+        shard: Int,
+        kord: Kord,
+    ): ReactionRemoveEvent =
         with(event.reaction) {
             /**
              * Reactions removed will *sometimes* have a name, the only case in which name is null is when a guild reaction
@@ -179,18 +222,40 @@ internal class MessageEventHandler(
                 it.copy(reactions = Optional.Value(reactions))
             }
 
-            ReactionRemoveEvent(userId, channelId, messageId, guildId.value, reaction, kord, shard)
+            ReactionRemoveEvent(
+                userId,
+                channelId,
+                messageId,
+                guildId.value,
+                reaction,
+                kord,
+                shard,
+            )
         }
 
-    private suspend fun handle(event: MessageReactionRemoveAll, shard: Int, kord: Kord): ReactionRemoveAllEvent =
+    private suspend fun handle(
+        event: MessageReactionRemoveAll,
+        shard: Int,
+        kord: Kord,
+    ): ReactionRemoveAllEvent =
         with(event.reactions) {
             cache.query<MessageData> { idEq(MessageData::id, messageId) }
                 .update { it.copy(reactions = Optional.Missing()) }
 
-            ReactionRemoveAllEvent(channelId, messageId, guildId.value, kord, shard)
+            ReactionRemoveAllEvent(
+                channelId,
+                messageId,
+                guildId.value,
+                kord,
+                shard,
+            )
         }
 
-    private suspend fun handle(event: MessageReactionRemoveEmoji, shard: Int, kord: Kord): ReactionRemoveEmojiEvent =
+    private suspend fun handle(
+        event: MessageReactionRemoveEmoji,
+        shard: Int,
+        kord: Kord,
+    ): ReactionRemoveEmojiEvent =
         with(event.reaction) {
             cache.query<MessageData> { idEq(MessageData::id, messageId) }
                 .update { it.copy(reactions = it.reactions.map { list -> list.filter { data -> data.emojiName != emoji.name } }) }

--- a/core/src/main/kotlin/gateway/handler/ThreadEventHandler.kt
+++ b/core/src/main/kotlin/gateway/handler/ThreadEventHandler.kt
@@ -19,7 +19,11 @@ public class ThreadEventHandler(
     cache: DataCache
 ) : BaseGatewayEventHandler(cache) {
 
-    override suspend fun handle(event: Event, shard: Int, kord: Kord): CoreEvent? = when (event) {
+    override suspend fun handle(
+        event: Event,
+        shard: Int,
+        kord: Kord,
+    ): CoreEvent? = when (event) {
         is ThreadCreate -> handle(event, shard, kord)
         is ThreadUpdate -> handle(event, shard, kord)
         is ThreadDelete -> handle(event, shard, kord)
@@ -71,7 +75,11 @@ public class ThreadEventHandler(
         val channel = DeletedThreadChannel(channelData, kord)
         val old = cachedData?.let { Channel.from(cachedData, kord) }
         val coreEvent = when (channel.type) {
-            is ChannelType.PublicNewsThread -> NewsChannelThreadDeleteEvent(channel, old as? NewsChannelThread, shard)
+            is ChannelType.PublicNewsThread -> NewsChannelThreadDeleteEvent(
+                channel,
+                old as? NewsChannelThread,
+                shard,
+            )
             is ChannelType.PrivateThread,
             is ChannelType.GuildText -> TextChannelThreadDeleteEvent(channel, old as? TextChannelThread, shard)
             else -> UnknownChannelThreadDeleteEvent(channel, old as? ThreadChannel, shard)

--- a/core/src/main/kotlin/gateway/handler/ThreadEventHandler.kt
+++ b/core/src/main/kotlin/gateway/handler/ThreadEventHandler.kt
@@ -13,7 +13,6 @@ import dev.kord.core.entity.channel.Channel
 import dev.kord.core.entity.channel.thread.*
 import dev.kord.core.event.channel.thread.*
 import dev.kord.gateway.*
-import dev.kord.core.event.Event as CoreEvent
 
 public class ThreadEventHandler(
     cache: DataCache
@@ -23,7 +22,7 @@ public class ThreadEventHandler(
         event: Event,
         shard: Int,
         kord: Kord,
-    ): CoreEvent? = when (event) {
+    ): dev.kord.core.event.Event? = when (event) {
         is ThreadCreate -> handle(event, shard, kord)
         is ThreadUpdate -> handle(event, shard, kord)
         is ThreadDelete -> handle(event, shard, kord)

--- a/core/src/main/kotlin/gateway/handler/UserEventHandler.kt
+++ b/core/src/main/kotlin/gateway/handler/UserEventHandler.kt
@@ -10,7 +10,6 @@ import dev.kord.core.entity.User
 import dev.kord.core.event.user.UserUpdateEvent
 import dev.kord.gateway.Event
 import dev.kord.gateway.UserUpdate
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.singleOrNull
 import dev.kord.core.event.Event as CoreEvent
@@ -19,12 +18,12 @@ internal class UserEventHandler(
     cache: DataCache
 ) : BaseGatewayEventHandler(cache) {
 
-    override suspend fun handle(event: Event, shard: Int, kord: Kord, coroutineScope: CoroutineScope): CoreEvent? = when (event) {
-        is UserUpdate -> handle(event, shard, kord, coroutineScope)
+    override suspend fun handle(event: Event, shard: Int, kord: Kord): CoreEvent? = when (event) {
+        is UserUpdate -> handle(event, shard, kord)
         else -> null
     }
 
-    private suspend fun handle(event: UserUpdate, shard: Int, kord: Kord, coroutineScope: CoroutineScope): UserUpdateEvent {
+    private suspend fun handle(event: UserUpdate, shard: Int, kord: Kord): UserUpdateEvent {
         val data = UserData.from(event.user)
 
         val old = cache.query<UserData> { idEq(UserData::id, data.id) }
@@ -33,7 +32,7 @@ internal class UserEventHandler(
         cache.put(data)
         val new = User(data, kord)
 
-        return UserUpdateEvent(old, new, shard, coroutineScope)
+        return UserUpdateEvent(old, new, shard)
     }
 
 }

--- a/core/src/main/kotlin/gateway/handler/VoiceEventHandler.kt
+++ b/core/src/main/kotlin/gateway/handler/VoiceEventHandler.kt
@@ -21,13 +21,18 @@ internal class VoiceEventHandler(
     cache: DataCache
 ) : BaseGatewayEventHandler(cache) {
 
-    override suspend fun handle(event: Event, shard: Int, kord: Kord): CoreEvent? = when (event) {
-        is VoiceStateUpdate -> handle(event, shard, kord)
-        is VoiceServerUpdate -> handle(event, shard, kord)
-        else -> null
-    }
+    override suspend fun handle(event: Event, shard: Int, kord: Kord): CoreEvent? =
+        when (event) {
+            is VoiceStateUpdate -> handle(event, shard, kord)
+            is VoiceServerUpdate -> handle(event, shard, kord)
+            else -> null
+        }
 
-    private suspend fun handle(event: VoiceStateUpdate, shard: Int, kord: Kord): VoiceStateUpdateEvent {
+    private suspend fun handle(
+        event: VoiceStateUpdate,
+        shard: Int,
+        kord: Kord,
+    ): VoiceStateUpdateEvent {
         val data = VoiceStateData.from(event.voiceState.guildId.value!!, event.voiceState)
 
         val old = cache.query<VoiceStateData> { idEq(VoiceStateData::id, data.id) }
@@ -39,6 +44,12 @@ internal class VoiceEventHandler(
         return VoiceStateUpdateEvent(old, new, shard)
     }
 
-    private fun handle(event: VoiceServerUpdate, shard: Int, kord: Kord): VoiceServerUpdateEvent =
-        with(event.voiceServerUpdateData) { VoiceServerUpdateEvent(token, guildId, endpoint, kord, shard) }
+    private fun handle(
+        event: VoiceServerUpdate,
+        shard: Int,
+        kord: Kord,
+    ): VoiceServerUpdateEvent =
+        with(event.voiceServerUpdateData) {
+            VoiceServerUpdateEvent(token, guildId, endpoint, kord, shard)
+        }
 }

--- a/core/src/main/kotlin/gateway/handler/VoiceEventHandler.kt
+++ b/core/src/main/kotlin/gateway/handler/VoiceEventHandler.kt
@@ -4,7 +4,8 @@ import dev.kord.cache.api.DataCache
 import dev.kord.cache.api.put
 import dev.kord.cache.api.query
 import dev.kord.core.Kord
-import dev.kord.core.cache.data.*
+import dev.kord.core.cache.data.VoiceStateData
+import dev.kord.core.cache.data.id
 import dev.kord.core.cache.idEq
 import dev.kord.core.entity.VoiceState
 import dev.kord.core.event.guild.VoiceServerUpdateEvent
@@ -12,7 +13,6 @@ import dev.kord.core.event.user.VoiceStateUpdateEvent
 import dev.kord.gateway.Event
 import dev.kord.gateway.VoiceServerUpdate
 import dev.kord.gateway.VoiceStateUpdate
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.singleOrNull
 import dev.kord.core.event.Event as CoreEvent
@@ -21,19 +21,13 @@ internal class VoiceEventHandler(
     cache: DataCache
 ) : BaseGatewayEventHandler(cache) {
 
-    override suspend fun handle(event: Event, shard: Int, kord: Kord, coroutineScope: CoroutineScope): CoreEvent? =
-        when (event) {
-            is VoiceStateUpdate -> handle(event, shard, kord, coroutineScope)
-            is VoiceServerUpdate -> handle(event, shard, kord, coroutineScope)
-            else -> null
-        }
+    override suspend fun handle(event: Event, shard: Int, kord: Kord): CoreEvent? = when (event) {
+        is VoiceStateUpdate -> handle(event, shard, kord)
+        is VoiceServerUpdate -> handle(event, shard, kord)
+        else -> null
+    }
 
-    private suspend fun handle(
-        event: VoiceStateUpdate,
-        shard: Int,
-        kord: Kord,
-        coroutineScope: CoroutineScope
-    ): VoiceStateUpdateEvent {
+    private suspend fun handle(event: VoiceStateUpdate, shard: Int, kord: Kord): VoiceStateUpdateEvent {
         val data = VoiceStateData.from(event.voiceState.guildId.value!!, event.voiceState)
 
         val old = cache.query<VoiceStateData> { idEq(VoiceStateData::id, data.id) }
@@ -42,17 +36,9 @@ internal class VoiceEventHandler(
         cache.put(data)
         val new = VoiceState(data, kord)
 
-        return VoiceStateUpdateEvent(old, new, shard, coroutineScope)
+        return VoiceStateUpdateEvent(old, new, shard)
     }
 
-    private fun handle(
-        event: VoiceServerUpdate,
-        shard: Int,
-        kord: Kord,
-        coroutineScope: CoroutineScope
-    ): VoiceServerUpdateEvent =
-        with(event.voiceServerUpdateData) {
-            return VoiceServerUpdateEvent(token, guildId, endpoint, kord, shard, coroutineScope = coroutineScope)
-        }
-
+    private fun handle(event: VoiceServerUpdate, shard: Int, kord: Kord): VoiceServerUpdateEvent =
+        with(event.voiceServerUpdateData) { VoiceServerUpdateEvent(token, guildId, endpoint, kord, shard) }
 }

--- a/core/src/main/kotlin/gateway/handler/WebhookEventHandler.kt
+++ b/core/src/main/kotlin/gateway/handler/WebhookEventHandler.kt
@@ -5,22 +5,18 @@ import dev.kord.core.Kord
 import dev.kord.core.event.guild.WebhookUpdateEvent
 import dev.kord.gateway.Event
 import dev.kord.gateway.WebhooksUpdate
-import kotlinx.coroutines.CoroutineScope
 import dev.kord.core.event.Event as CoreEvent
 
 internal class WebhookEventHandler(
     cache: DataCache
 ) : BaseGatewayEventHandler(cache) {
 
-    override suspend fun handle(event: Event, shard: Int, kord: Kord, coroutineScope: CoroutineScope): CoreEvent? =
+    override suspend fun handle(event: Event, shard: Int, kord: Kord): CoreEvent? =
         when (event) {
-            is WebhooksUpdate -> handle(event, shard, kord, coroutineScope)
+            is WebhooksUpdate -> handle(event, shard, kord)
             else -> null
         }
 
-    private fun handle(event: WebhooksUpdate, shard: Int, kord: Kord, coroutineScope: CoroutineScope): WebhookUpdateEvent =
-        with(event.webhooksUpdateData) {
-            return WebhookUpdateEvent(guildId, channelId, kord, shard, coroutineScope = coroutineScope)
-        }
-
+    private fun handle(event: WebhooksUpdate, shard: Int, kord: Kord): WebhookUpdateEvent =
+        with(event.webhooksUpdateData) { WebhookUpdateEvent(guildId, channelId, kord, shard) }
 }

--- a/core/src/main/kotlin/gateway/handler/WebhookEventHandler.kt
+++ b/core/src/main/kotlin/gateway/handler/WebhookEventHandler.kt
@@ -18,5 +18,7 @@ internal class WebhookEventHandler(
         }
 
     private fun handle(event: WebhooksUpdate, shard: Int, kord: Kord): WebhookUpdateEvent =
-        with(event.webhooksUpdateData) { WebhookUpdateEvent(guildId, channelId, kord, shard) }
+        with(event.webhooksUpdateData) {
+            WebhookUpdateEvent(guildId, channelId, kord, shard)
+        }
 }


### PR DESCRIPTION
# Problem

Currently, the `dev.kord.core.event.Event` interface extends `CoroutineScope`, but this is problematic.

The reason is that events don't have a well-defined lifecycle, as we never call `CoroutineScope.cancel()` for them (and there is no obvious place to do so). The [documentation](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/-coroutine-scope/) even highlights that the "**key part of custom usage of `CoroutineScope` is cancelling it at the end of the lifecycle**".

This wouldn't be too much of a problem in itself, but it leads to a memory leak, as @Stonedestroyer discovered.

### Memory Leak Details

The way we create the `CoroutineScope` instances for use by `Event`s (via delegation) is the following:
```kotlin
fun kordCoroutineScope(kord: Kord) = CoroutineScope(kord.coroutineContext + SupervisorJob(kord.coroutineContext.job))
```

This means that we create a parent-child hierarchy between the `Job`s of the scope of `Kord` (parent) and the newly created scope of `Event` (child).

The hierarchy has a relevant impact: the parent now holds a reference to the child. When the child is cancelled, this reference is released so that the child can be garbage collected.
But we actually never cancel the child, which results in a memory leak as the parent keeps accumulating references to children that will never be released.

It can even happen that multiple scopes will leak for a single event, as [this for loop](https://github.com/kordlib/kord/blob/8b875195b7225e410bbb916c9bc5309ab0629d5b/core/src/main/kotlin/gateway/handler/DefaultGatewayEventInterceptor.kt#L33) creates a new scope with the described parent-child hierarchy for every listener it tries to call.

See also [this thread](https://discord.com/channels/556525343595298817/1005983735746936913) on the Kord Discord Server.

# Solution

As a solution, this PR removes `CoroutineScope` as a supertype of `Event`.

This is a breaking change, however there are easy replacements for cases where `Event` was used as a `CoroutineScope`:
- for coroutines that need a local scope, the [`coroutineScope { ... }`](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/coroutine-scope.html) scoping function can be used, it "is designed for _parallel decomposition_ of work" and enforces structured concurrency
- for coroutines that need a scope which is more global, the `Kord` instance can be used, it is also a `CoroutineScope` but one that has a well-defined lifecycle (see `Kord.shutdown()`)

# Migration

Code like this
```kotlin
kord.on<SomeEvent> {
    launch { /* ... */ } // launched in event scope
}
```
can be replaced relatively easy with
```kotlin
kord.on<SomeEvent> {
    coroutineScope {
        launch { /* ... */ } // for coroutines that need a local scope, coroutineScope {} waits for its children
    }
    // or
    kord.launch { /* ... */ } // for coroutines that need a more global scope
}
```

If you used the `CoroutineScope` of `Event` as a way to associate a custom context to an event, take a look at #667.