### PR TITLE
Fix MessageStickerType constructor initialization deadlock

### DIFF
--- a/common/src/main/kotlin/entity/DiscordMessage.kt
+++ b/common/src/main/kotlin/entity/DiscordMessage.kt
@@ -171,7 +171,8 @@ public sealed class MessageStickerType(public val value: Int) {
     public object LOTTIE : MessageStickerType(3)
 
     public companion object {
-        public val values: Set<MessageStickerType> = setOf(PNG, APNG, LOTTIE)
+        public val values: Set<MessageStickerType>
+            get() = setOf(PNG, APNG, LOTTIE)
     }
 
     internal object Serializer : KSerializer<MessageStickerType> {


### PR DESCRIPTION
Instead of initializing the set during class load, the set will be created when calling the `values` list.

Fixes #669

Other Kord classes also handles `values` lists in the same manner (`Image`, `DiscordChannel`, `DiscordMessage`, etc), so I've decided to keep it in the same way.

However, Lost and Lukellmann pointed out that using `by lazy` also fixes the issue, and I have tested it and it also does work, so maybe this is something to keep in mind for the future to avoid unnecessary set allocations.