### PR TITLE
Update dependencies and binary compatibility validator workflow

### DIFF
--- a/.github/workflows/deployment-ci.yml
+++ b/.github/workflows/deployment-ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: --stacktrace --info build -x apiCheck
+          arguments: --stacktrace --info build
 
 
   release:
@@ -74,14 +74,7 @@ jobs:
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: --stacktrace --info build -x apiCheck
-
-      - name: API Checking with Gradle
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: apiCheck
-
-
+          arguments: --stacktrace --info build
 
       - name: Publish with Gradle
         uses: gradle/gradle-build-action@v2

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ import org.gradle.api.tasks.wrapper.Wrapper.DistributionType.ALL
 plugins {
     kotlin("jvm")
     kotlin("plugin.serialization")
-    id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.10.1"
+    id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.11.0"
     id("org.jetbrains.dokka")
 
     id("org.ajoberstar.git-publish") version "3.0.1"

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -12,6 +12,6 @@ dependencies {
     implementation(kotlin("gradle-plugin", kotlinVersion))
     implementation(kotlin("serialization", kotlinVersion))
     implementation("org.jetbrains.dokka", "dokka-gradle-plugin", "1.7.10")
-    implementation("org.jetbrains.kotlinx", "atomicfu-gradle-plugin", "0.18.2")
+    implementation("org.jetbrains.kotlinx", "atomicfu-gradle-plugin", "0.18.3")
     implementation(gradleApi())
 }

--- a/buildSrc/src/main/kotlin/Projects.kt
+++ b/buildSrc/src/main/kotlin/Projects.kt
@@ -31,9 +31,6 @@ object Library {
 
     val isSnapshot: Boolean get() = version.endsWith("-SNAPSHOT")
 
-    /**
-     * Whether the current API is considered stable, and should be compared to the 'golden' API dump.
-     */
     val isRelease: Boolean get() = !isSnapshot && !isUndefined
 
     val isUndefined get() = version == "undefined"

--- a/buildSrc/src/main/kotlin/kord-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/kord-module.gradle.kts
@@ -29,10 +29,6 @@ kotlin {
 }
 
 tasks {
-    getByName("apiCheck") {
-        onlyIf { Library.isRelease }
-    }
-
     withType<JavaCompile> {
         sourceCompatibility = Jvm.targetString
         targetCompatibility = Jvm.targetString

--- a/common/api/common.api
+++ b/common/api/common.api
@@ -6730,8 +6730,8 @@ public final class dev/kord/common/entity/Permission$ChangeNickname : dev/kord/c
 }
 
 public final class dev/kord/common/entity/Permission$Companion {
-	public final fun getManageEmojis ()Ldev/kord/common/entity/Permission$ManageEmojisAndStickers;
-	public final fun getUseSlashCommands ()Ldev/kord/common/entity/Permission$UseApplicationCommands;
+	public final synthetic fun getManageEmojis ()Ldev/kord/common/entity/Permission$ManageEmojisAndStickers;
+	public final synthetic fun getUseSlashCommands ()Ldev/kord/common/entity/Permission$UseApplicationCommands;
 	public final fun getValues ()Ljava/util/Set;
 }
 
@@ -7124,7 +7124,7 @@ public final class dev/kord/common/entity/Snowflake : java/lang/Comparable {
 	public final fun getIncrement-Mh2AYeg ()S
 	public final fun getProcessId-w2LRezQ ()B
 	public final fun getTimeMark ()Lkotlin/time/TimeMark;
-	public final fun getTimeStamp ()Lkotlinx/datetime/Instant;
+	public final synthetic fun getTimeStamp ()Lkotlinx/datetime/Instant;
 	public final fun getTimestamp ()Lkotlinx/datetime/Instant;
 	public final fun getValue-s-VKNKU ()J
 	public final fun getWorkerId-w2LRezQ ()B
@@ -7134,7 +7134,7 @@ public final class dev/kord/common/entity/Snowflake : java/lang/Comparable {
 
 public final class dev/kord/common/entity/Snowflake$Companion {
 	public final fun getDiscordEpoch ()Lkotlinx/datetime/Instant;
-	public final fun getDiscordEpochStart ()Lkotlinx/datetime/Instant;
+	public final synthetic fun getDiscordEpochStart ()Lkotlinx/datetime/Instant;
 	public final fun getEndOfTime ()Lkotlinx/datetime/Instant;
 	public final fun getMax ()Ldev/kord/common/entity/Snowflake;
 	public final fun getMin ()Ldev/kord/common/entity/Snowflake;

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -10187,7 +10187,7 @@ public final class dev/kord/core/entity/interaction/response/PublicMessageIntera
 	public fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/entity/interaction/response/PublicMessageInteractionResponse;
 }
 
-public abstract interface class dev/kord/core/event/Event : kotlinx/coroutines/CoroutineScope {
+public abstract interface class dev/kord/core/event/Event {
 	public abstract fun getGateway ()Ldev/kord/gateway/Gateway;
 	public abstract fun getKord ()Ldev/kord/core/Kord;
 	public abstract fun getShard ()I
@@ -10197,39 +10197,30 @@ public final class dev/kord/core/event/Event$DefaultImpls {
 	public static fun getGateway (Ldev/kord/core/event/Event;)Ldev/kord/gateway/Gateway;
 }
 
-public final class dev/kord/core/event/channel/CategoryCreateEvent : dev/kord/core/event/channel/ChannelCreateEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/channel/Category;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/channel/Category;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/channel/CategoryCreateEvent : dev/kord/core/event/channel/ChannelCreateEvent {
+	public fun <init> (Ldev/kord/core/entity/channel/Category;I)V
 	public fun getChannel ()Ldev/kord/core/entity/channel/Category;
 	public synthetic fun getChannel ()Ldev/kord/core/entity/channel/Channel;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/kord/core/event/channel/CategoryDeleteEvent : dev/kord/core/event/channel/ChannelDeleteEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/channel/Category;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/channel/Category;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/channel/CategoryDeleteEvent : dev/kord/core/event/channel/ChannelDeleteEvent {
+	public fun <init> (Ldev/kord/core/entity/channel/Category;I)V
 	public fun getChannel ()Ldev/kord/core/entity/channel/Category;
 	public synthetic fun getChannel ()Ldev/kord/core/entity/channel/Channel;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/kord/core/event/channel/CategoryUpdateEvent : dev/kord/core/event/channel/ChannelUpdateEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/channel/Category;Ldev/kord/core/entity/channel/Category;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/channel/Category;Ldev/kord/core/entity/channel/Category;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/channel/CategoryUpdateEvent : dev/kord/core/event/channel/ChannelUpdateEvent {
+	public fun <init> (Ldev/kord/core/entity/channel/Category;Ldev/kord/core/entity/channel/Category;I)V
 	public fun getChannel ()Ldev/kord/core/entity/channel/Category;
 	public synthetic fun getChannel ()Ldev/kord/core/entity/channel/Channel;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getOld ()Ldev/kord/core/entity/channel/Category;
@@ -10258,15 +10249,13 @@ public final class dev/kord/core/event/channel/ChannelDeleteEvent$DefaultImpls {
 	public static fun getKord (Ldev/kord/core/event/channel/ChannelDeleteEvent;)Ldev/kord/core/Kord;
 }
 
-public final class dev/kord/core/event/channel/ChannelPinsUpdateEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/event/channel/data/ChannelPinsUpdateEventData;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/event/channel/data/ChannelPinsUpdateEventData;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/channel/ChannelPinsUpdateEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event {
+	public fun <init> (Ldev/kord/core/event/channel/data/ChannelPinsUpdateEventData;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;)V
+	public synthetic fun <init> (Ldev/kord/core/event/channel/data/ChannelPinsUpdateEventData;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getChannel ()Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public final fun getChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
 	public final fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public final fun getData ()Ldev/kord/core/event/channel/data/ChannelPinsUpdateEventData;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
@@ -10291,39 +10280,30 @@ public final class dev/kord/core/event/channel/ChannelUpdateEvent$DefaultImpls {
 	public static fun getKord (Ldev/kord/core/event/channel/ChannelUpdateEvent;)Ldev/kord/core/Kord;
 }
 
-public final class dev/kord/core/event/channel/DMChannelCreateEvent : dev/kord/core/event/channel/ChannelCreateEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/channel/DmChannel;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/channel/DmChannel;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/channel/DMChannelCreateEvent : dev/kord/core/event/channel/ChannelCreateEvent {
+	public fun <init> (Ldev/kord/core/entity/channel/DmChannel;I)V
 	public synthetic fun getChannel ()Ldev/kord/core/entity/channel/Channel;
 	public fun getChannel ()Ldev/kord/core/entity/channel/DmChannel;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/kord/core/event/channel/DMChannelDeleteEvent : dev/kord/core/event/channel/ChannelDeleteEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/channel/DmChannel;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/channel/DmChannel;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/channel/DMChannelDeleteEvent : dev/kord/core/event/channel/ChannelDeleteEvent {
+	public fun <init> (Ldev/kord/core/entity/channel/DmChannel;I)V
 	public synthetic fun getChannel ()Ldev/kord/core/entity/channel/Channel;
 	public fun getChannel ()Ldev/kord/core/entity/channel/DmChannel;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/kord/core/event/channel/DMChannelUpdateEvent : dev/kord/core/event/channel/ChannelUpdateEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/channel/DmChannel;Ldev/kord/core/entity/channel/DmChannel;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/channel/DmChannel;Ldev/kord/core/entity/channel/DmChannel;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/channel/DMChannelUpdateEvent : dev/kord/core/event/channel/ChannelUpdateEvent {
+	public fun <init> (Ldev/kord/core/entity/channel/DmChannel;Ldev/kord/core/entity/channel/DmChannel;I)V
 	public synthetic fun getChannel ()Ldev/kord/core/entity/channel/Channel;
 	public fun getChannel ()Ldev/kord/core/entity/channel/DmChannel;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public synthetic fun getOld ()Ldev/kord/core/entity/channel/Channel;
@@ -10332,39 +10312,30 @@ public final class dev/kord/core/event/channel/DMChannelUpdateEvent : dev/kord/c
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/kord/core/event/channel/NewsChannelCreateEvent : dev/kord/core/event/channel/ChannelCreateEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/channel/NewsChannel;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/channel/NewsChannel;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/channel/NewsChannelCreateEvent : dev/kord/core/event/channel/ChannelCreateEvent {
+	public fun <init> (Ldev/kord/core/entity/channel/NewsChannel;I)V
 	public synthetic fun getChannel ()Ldev/kord/core/entity/channel/Channel;
 	public fun getChannel ()Ldev/kord/core/entity/channel/NewsChannel;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/kord/core/event/channel/NewsChannelDeleteEvent : dev/kord/core/event/channel/ChannelDeleteEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/channel/NewsChannel;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/channel/NewsChannel;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/channel/NewsChannelDeleteEvent : dev/kord/core/event/channel/ChannelDeleteEvent {
+	public fun <init> (Ldev/kord/core/entity/channel/NewsChannel;I)V
 	public synthetic fun getChannel ()Ldev/kord/core/entity/channel/Channel;
 	public fun getChannel ()Ldev/kord/core/entity/channel/NewsChannel;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/kord/core/event/channel/NewsChannelUpdateEvent : dev/kord/core/event/channel/ChannelUpdateEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/channel/NewsChannel;Ldev/kord/core/entity/channel/NewsChannel;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/channel/NewsChannel;Ldev/kord/core/entity/channel/NewsChannel;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/channel/NewsChannelUpdateEvent : dev/kord/core/event/channel/ChannelUpdateEvent {
+	public fun <init> (Ldev/kord/core/entity/channel/NewsChannel;Ldev/kord/core/entity/channel/NewsChannel;I)V
 	public synthetic fun getChannel ()Ldev/kord/core/entity/channel/Channel;
 	public fun getChannel ()Ldev/kord/core/entity/channel/NewsChannel;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public synthetic fun getOld ()Ldev/kord/core/entity/channel/Channel;
@@ -10373,39 +10344,30 @@ public final class dev/kord/core/event/channel/NewsChannelUpdateEvent : dev/kord
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/kord/core/event/channel/StageChannelCreateEvent : dev/kord/core/event/channel/ChannelCreateEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/channel/StageChannel;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/channel/StageChannel;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/channel/StageChannelCreateEvent : dev/kord/core/event/channel/ChannelCreateEvent {
+	public fun <init> (Ldev/kord/core/entity/channel/StageChannel;I)V
 	public synthetic fun getChannel ()Ldev/kord/core/entity/channel/Channel;
 	public fun getChannel ()Ldev/kord/core/entity/channel/StageChannel;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/kord/core/event/channel/StageChannelDeleteEvent : dev/kord/core/event/channel/ChannelDeleteEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/channel/StageChannel;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/channel/StageChannel;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/channel/StageChannelDeleteEvent : dev/kord/core/event/channel/ChannelDeleteEvent {
+	public fun <init> (Ldev/kord/core/entity/channel/StageChannel;I)V
 	public synthetic fun getChannel ()Ldev/kord/core/entity/channel/Channel;
 	public fun getChannel ()Ldev/kord/core/entity/channel/StageChannel;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/kord/core/event/channel/StageChannelUpdateEvent : dev/kord/core/event/channel/ChannelUpdateEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/channel/StageChannel;Ldev/kord/core/entity/channel/StageChannel;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/channel/StageChannel;Ldev/kord/core/entity/channel/StageChannel;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/channel/StageChannelUpdateEvent : dev/kord/core/event/channel/ChannelUpdateEvent {
+	public fun <init> (Ldev/kord/core/entity/channel/StageChannel;Ldev/kord/core/entity/channel/StageChannel;I)V
 	public synthetic fun getChannel ()Ldev/kord/core/entity/channel/Channel;
 	public fun getChannel ()Ldev/kord/core/entity/channel/StageChannel;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public synthetic fun getOld ()Ldev/kord/core/entity/channel/Channel;
@@ -10414,39 +10376,30 @@ public final class dev/kord/core/event/channel/StageChannelUpdateEvent : dev/kor
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/kord/core/event/channel/StoreChannelCreateEvent : dev/kord/core/event/channel/ChannelCreateEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/channel/StoreChannel;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/channel/StoreChannel;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/channel/StoreChannelCreateEvent : dev/kord/core/event/channel/ChannelCreateEvent {
+	public fun <init> (Ldev/kord/core/entity/channel/StoreChannel;I)V
 	public synthetic fun getChannel ()Ldev/kord/core/entity/channel/Channel;
 	public fun getChannel ()Ldev/kord/core/entity/channel/StoreChannel;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/kord/core/event/channel/StoreChannelDeleteEvent : dev/kord/core/event/channel/ChannelDeleteEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/channel/StoreChannel;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/channel/StoreChannel;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/channel/StoreChannelDeleteEvent : dev/kord/core/event/channel/ChannelDeleteEvent {
+	public fun <init> (Ldev/kord/core/entity/channel/StoreChannel;I)V
 	public synthetic fun getChannel ()Ldev/kord/core/entity/channel/Channel;
 	public fun getChannel ()Ldev/kord/core/entity/channel/StoreChannel;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/kord/core/event/channel/StoreChannelUpdateEvent : dev/kord/core/event/channel/ChannelUpdateEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/channel/StoreChannel;Ldev/kord/core/entity/channel/StoreChannel;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/channel/StoreChannel;Ldev/kord/core/entity/channel/StoreChannel;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/channel/StoreChannelUpdateEvent : dev/kord/core/event/channel/ChannelUpdateEvent {
+	public fun <init> (Ldev/kord/core/entity/channel/StoreChannel;Ldev/kord/core/entity/channel/StoreChannel;I)V
 	public synthetic fun getChannel ()Ldev/kord/core/entity/channel/Channel;
 	public fun getChannel ()Ldev/kord/core/entity/channel/StoreChannel;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public synthetic fun getOld ()Ldev/kord/core/entity/channel/Channel;
@@ -10455,39 +10408,30 @@ public final class dev/kord/core/event/channel/StoreChannelUpdateEvent : dev/kor
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/kord/core/event/channel/TextChannelCreateEvent : dev/kord/core/event/channel/ChannelCreateEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/channel/TextChannel;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/channel/TextChannel;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/channel/TextChannelCreateEvent : dev/kord/core/event/channel/ChannelCreateEvent {
+	public fun <init> (Ldev/kord/core/entity/channel/TextChannel;I)V
 	public synthetic fun getChannel ()Ldev/kord/core/entity/channel/Channel;
 	public fun getChannel ()Ldev/kord/core/entity/channel/TextChannel;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/kord/core/event/channel/TextChannelDeleteEvent : dev/kord/core/event/channel/ChannelDeleteEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/channel/TextChannel;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/channel/TextChannel;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/channel/TextChannelDeleteEvent : dev/kord/core/event/channel/ChannelDeleteEvent {
+	public fun <init> (Ldev/kord/core/entity/channel/TextChannel;I)V
 	public synthetic fun getChannel ()Ldev/kord/core/entity/channel/Channel;
 	public fun getChannel ()Ldev/kord/core/entity/channel/TextChannel;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/kord/core/event/channel/TextChannelUpdateEvent : dev/kord/core/event/channel/ChannelUpdateEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/channel/TextChannel;Ldev/kord/core/entity/channel/TextChannel;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/channel/TextChannel;Ldev/kord/core/entity/channel/TextChannel;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/channel/TextChannelUpdateEvent : dev/kord/core/event/channel/ChannelUpdateEvent {
+	public fun <init> (Ldev/kord/core/entity/channel/TextChannel;Ldev/kord/core/entity/channel/TextChannel;I)V
 	public synthetic fun getChannel ()Ldev/kord/core/entity/channel/Channel;
 	public fun getChannel ()Ldev/kord/core/entity/channel/TextChannel;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public synthetic fun getOld ()Ldev/kord/core/entity/channel/Channel;
@@ -10496,15 +10440,13 @@ public final class dev/kord/core/event/channel/TextChannelUpdateEvent : dev/kord
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/kord/core/event/channel/TypingStartEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/event/channel/data/TypingStartEventData;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/event/channel/data/TypingStartEventData;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/channel/TypingStartEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event {
+	public fun <init> (Ldev/kord/core/event/channel/data/TypingStartEventData;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;)V
+	public synthetic fun <init> (Ldev/kord/core/event/channel/data/TypingStartEventData;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getChannel ()Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public final fun getChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
 	public final fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public final fun getData ()Ldev/kord/core/event/channel/data/TypingStartEventData;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
@@ -10522,36 +10464,27 @@ public final class dev/kord/core/event/channel/TypingStartEvent : dev/kord/core/
 	public fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/entity/Strategizable;
 }
 
-public final class dev/kord/core/event/channel/UnknownChannelCreateEvent : dev/kord/core/event/channel/ChannelCreateEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/channel/Channel;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/channel/Channel;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/channel/UnknownChannelCreateEvent : dev/kord/core/event/channel/ChannelCreateEvent {
+	public fun <init> (Ldev/kord/core/entity/channel/Channel;I)V
 	public fun getChannel ()Ldev/kord/core/entity/channel/Channel;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/kord/core/event/channel/UnknownChannelDeleteEvent : dev/kord/core/event/channel/ChannelDeleteEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/channel/Channel;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/channel/Channel;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/channel/UnknownChannelDeleteEvent : dev/kord/core/event/channel/ChannelDeleteEvent {
+	public fun <init> (Ldev/kord/core/entity/channel/Channel;I)V
 	public fun getChannel ()Ldev/kord/core/entity/channel/Channel;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/kord/core/event/channel/UnknownChannelUpdateEvent : dev/kord/core/event/channel/ChannelUpdateEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/channel/Channel;Ldev/kord/core/entity/channel/Channel;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/channel/Channel;Ldev/kord/core/entity/channel/Channel;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/channel/UnknownChannelUpdateEvent : dev/kord/core/event/channel/ChannelUpdateEvent {
+	public fun <init> (Ldev/kord/core/entity/channel/Channel;Ldev/kord/core/entity/channel/Channel;I)V
 	public fun getChannel ()Ldev/kord/core/entity/channel/Channel;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getOld ()Ldev/kord/core/entity/channel/Channel;
@@ -10559,39 +10492,30 @@ public final class dev/kord/core/event/channel/UnknownChannelUpdateEvent : dev/k
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/kord/core/event/channel/VoiceChannelCreateEvent : dev/kord/core/event/channel/ChannelCreateEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/channel/VoiceChannel;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/channel/VoiceChannel;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/channel/VoiceChannelCreateEvent : dev/kord/core/event/channel/ChannelCreateEvent {
+	public fun <init> (Ldev/kord/core/entity/channel/VoiceChannel;I)V
 	public synthetic fun getChannel ()Ldev/kord/core/entity/channel/Channel;
 	public fun getChannel ()Ldev/kord/core/entity/channel/VoiceChannel;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/kord/core/event/channel/VoiceChannelDeleteEvent : dev/kord/core/event/channel/ChannelDeleteEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/channel/VoiceChannel;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/channel/VoiceChannel;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/channel/VoiceChannelDeleteEvent : dev/kord/core/event/channel/ChannelDeleteEvent {
+	public fun <init> (Ldev/kord/core/entity/channel/VoiceChannel;I)V
 	public synthetic fun getChannel ()Ldev/kord/core/entity/channel/Channel;
 	public fun getChannel ()Ldev/kord/core/entity/channel/VoiceChannel;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/kord/core/event/channel/VoiceChannelUpdateEvent : dev/kord/core/event/channel/ChannelUpdateEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/channel/VoiceChannel;Ldev/kord/core/entity/channel/VoiceChannel;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/channel/VoiceChannel;Ldev/kord/core/entity/channel/VoiceChannel;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/channel/VoiceChannelUpdateEvent : dev/kord/core/event/channel/ChannelUpdateEvent {
+	public fun <init> (Ldev/kord/core/entity/channel/VoiceChannel;Ldev/kord/core/entity/channel/VoiceChannel;I)V
 	public synthetic fun getChannel ()Ldev/kord/core/entity/channel/Channel;
 	public fun getChannel ()Ldev/kord/core/entity/channel/VoiceChannel;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public synthetic fun getOld ()Ldev/kord/core/entity/channel/Channel;
@@ -10676,26 +10600,20 @@ public final class dev/kord/core/event/channel/data/TypingStartEventData$Compani
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class dev/kord/core/event/channel/thread/NewsChannelThreadCreateEvent : dev/kord/core/event/channel/thread/ThreadChannelCreateEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/channel/thread/NewsChannelThread;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/channel/thread/NewsChannelThread;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/channel/thread/NewsChannelThreadCreateEvent : dev/kord/core/event/channel/thread/ThreadChannelCreateEvent {
+	public fun <init> (Ldev/kord/core/entity/channel/thread/NewsChannelThread;I)V
 	public synthetic fun getChannel ()Ldev/kord/core/entity/channel/Channel;
 	public fun getChannel ()Ldev/kord/core/entity/channel/thread/NewsChannelThread;
 	public synthetic fun getChannel ()Ldev/kord/core/entity/channel/thread/ThreadChannel;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/kord/core/event/channel/thread/NewsChannelThreadDeleteEvent : dev/kord/core/event/channel/thread/ThreadChannelDeleteEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/channel/thread/DeletedThreadChannel;Ldev/kord/core/entity/channel/thread/NewsChannelThread;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/channel/thread/DeletedThreadChannel;Ldev/kord/core/entity/channel/thread/NewsChannelThread;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/channel/thread/NewsChannelThreadDeleteEvent : dev/kord/core/event/channel/thread/ThreadChannelDeleteEvent {
+	public fun <init> (Ldev/kord/core/entity/channel/thread/DeletedThreadChannel;Ldev/kord/core/entity/channel/thread/NewsChannelThread;I)V
 	public fun getChannel ()Ldev/kord/core/entity/channel/thread/DeletedThreadChannel;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getOld ()Ldev/kord/core/entity/channel/thread/NewsChannelThread;
@@ -10704,14 +10622,11 @@ public final class dev/kord/core/event/channel/thread/NewsChannelThreadDeleteEve
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/kord/core/event/channel/thread/NewsChannelThreadUpdateEvent : dev/kord/core/event/channel/thread/ThreadUpdateEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/channel/thread/NewsChannelThread;Ldev/kord/core/entity/channel/thread/NewsChannelThread;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/channel/thread/NewsChannelThread;Ldev/kord/core/entity/channel/thread/NewsChannelThread;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/channel/thread/NewsChannelThreadUpdateEvent : dev/kord/core/event/channel/thread/ThreadUpdateEvent {
+	public fun <init> (Ldev/kord/core/entity/channel/thread/NewsChannelThread;Ldev/kord/core/entity/channel/thread/NewsChannelThread;I)V
 	public synthetic fun getChannel ()Ldev/kord/core/entity/channel/Channel;
 	public fun getChannel ()Ldev/kord/core/entity/channel/thread/NewsChannelThread;
 	public synthetic fun getChannel ()Ldev/kord/core/entity/channel/thread/ThreadChannel;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public synthetic fun getOld ()Ldev/kord/core/entity/channel/Channel;
@@ -10720,26 +10635,20 @@ public final class dev/kord/core/event/channel/thread/NewsChannelThreadUpdateEve
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/kord/core/event/channel/thread/TextChannelThreadCreateEvent : dev/kord/core/event/channel/thread/ThreadChannelCreateEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/channel/thread/TextChannelThread;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/channel/thread/TextChannelThread;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/channel/thread/TextChannelThreadCreateEvent : dev/kord/core/event/channel/thread/ThreadChannelCreateEvent {
+	public fun <init> (Ldev/kord/core/entity/channel/thread/TextChannelThread;I)V
 	public synthetic fun getChannel ()Ldev/kord/core/entity/channel/Channel;
 	public fun getChannel ()Ldev/kord/core/entity/channel/thread/TextChannelThread;
 	public synthetic fun getChannel ()Ldev/kord/core/entity/channel/thread/ThreadChannel;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/kord/core/event/channel/thread/TextChannelThreadDeleteEvent : dev/kord/core/event/channel/thread/ThreadChannelDeleteEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/channel/thread/DeletedThreadChannel;Ldev/kord/core/entity/channel/thread/TextChannelThread;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/channel/thread/DeletedThreadChannel;Ldev/kord/core/entity/channel/thread/TextChannelThread;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/channel/thread/TextChannelThreadDeleteEvent : dev/kord/core/event/channel/thread/ThreadChannelDeleteEvent {
+	public fun <init> (Ldev/kord/core/entity/channel/thread/DeletedThreadChannel;Ldev/kord/core/entity/channel/thread/TextChannelThread;I)V
 	public fun getChannel ()Ldev/kord/core/entity/channel/thread/DeletedThreadChannel;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getOld ()Ldev/kord/core/entity/channel/thread/TextChannelThread;
@@ -10748,14 +10657,11 @@ public final class dev/kord/core/event/channel/thread/TextChannelThreadDeleteEve
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/kord/core/event/channel/thread/TextChannelThreadUpdateEvent : dev/kord/core/event/channel/thread/ThreadUpdateEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/channel/thread/TextChannelThread;Ldev/kord/core/entity/channel/thread/TextChannelThread;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/channel/thread/TextChannelThread;Ldev/kord/core/entity/channel/thread/TextChannelThread;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/channel/thread/TextChannelThreadUpdateEvent : dev/kord/core/event/channel/thread/ThreadUpdateEvent {
+	public fun <init> (Ldev/kord/core/entity/channel/thread/TextChannelThread;Ldev/kord/core/entity/channel/thread/TextChannelThread;I)V
 	public synthetic fun getChannel ()Ldev/kord/core/entity/channel/Channel;
 	public fun getChannel ()Ldev/kord/core/entity/channel/thread/TextChannelThread;
 	public synthetic fun getChannel ()Ldev/kord/core/entity/channel/thread/ThreadChannel;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public synthetic fun getOld ()Ldev/kord/core/entity/channel/Channel;
@@ -10784,14 +10690,12 @@ public final class dev/kord/core/event/channel/thread/ThreadChannelDeleteEvent$D
 	public static fun getKord (Ldev/kord/core/event/channel/thread/ThreadChannelDeleteEvent;)Ldev/kord/core/Kord;
 }
 
-public final class dev/kord/core/event/channel/thread/ThreadListSyncEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/cache/data/ThreadListSyncData;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/cache/data/ThreadListSyncData;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/channel/thread/ThreadListSyncEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event {
+	public fun <init> (Ldev/kord/core/cache/data/ThreadListSyncData;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;)V
+	public synthetic fun <init> (Ldev/kord/core/cache/data/ThreadListSyncData;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getChannelBehaviors ()Ljava/util/List;
 	public final fun getChannelIds ()Ljava/util/List;
 	public final fun getChannels (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public final fun getData ()Ldev/kord/core/cache/data/ThreadListSyncData;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
@@ -10806,23 +10710,17 @@ public final class dev/kord/core/event/channel/thread/ThreadListSyncEvent : dev/
 	public fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/entity/Strategizable;
 }
 
-public final class dev/kord/core/event/channel/thread/ThreadMemberUpdateEvent : dev/kord/core/event/Event, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/channel/thread/ThreadMember;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/channel/thread/ThreadMember;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+public final class dev/kord/core/event/channel/thread/ThreadMemberUpdateEvent : dev/kord/core/event/Event {
+	public fun <init> (Ldev/kord/core/entity/channel/thread/ThreadMember;Ldev/kord/core/Kord;I)V
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getMember ()Ldev/kord/core/entity/channel/thread/ThreadMember;
 	public fun getShard ()I
 }
 
-public final class dev/kord/core/event/channel/thread/ThreadMembersUpdateEvent : dev/kord/core/event/Event, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/cache/data/ThreadMembersUpdateEventData;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/cache/data/ThreadMembersUpdateEventData;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/channel/thread/ThreadMembersUpdateEvent : dev/kord/core/event/Event {
+	public fun <init> (Ldev/kord/core/cache/data/ThreadMembersUpdateEventData;Ldev/kord/core/Kord;I)V
 	public final fun getAddedMembers ()Ljava/util/List;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public final fun getData ()Ldev/kord/core/cache/data/ThreadMembersUpdateEventData;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
@@ -10843,25 +10741,19 @@ public final class dev/kord/core/event/channel/thread/ThreadUpdateEvent$DefaultI
 	public static fun getKord (Ldev/kord/core/event/channel/thread/ThreadUpdateEvent;)Ldev/kord/core/Kord;
 }
 
-public final class dev/kord/core/event/channel/thread/UnknownChannelThreadCreateEvent : dev/kord/core/event/channel/thread/ThreadChannelCreateEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/channel/thread/ThreadChannel;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/channel/thread/ThreadChannel;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/channel/thread/UnknownChannelThreadCreateEvent : dev/kord/core/event/channel/thread/ThreadChannelCreateEvent {
+	public fun <init> (Ldev/kord/core/entity/channel/thread/ThreadChannel;I)V
 	public synthetic fun getChannel ()Ldev/kord/core/entity/channel/Channel;
 	public fun getChannel ()Ldev/kord/core/entity/channel/thread/ThreadChannel;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/kord/core/event/channel/thread/UnknownChannelThreadDeleteEvent : dev/kord/core/event/channel/thread/ThreadChannelDeleteEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/channel/thread/DeletedThreadChannel;Ldev/kord/core/entity/channel/thread/ThreadChannel;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/channel/thread/DeletedThreadChannel;Ldev/kord/core/entity/channel/thread/ThreadChannel;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/channel/thread/UnknownChannelThreadDeleteEvent : dev/kord/core/event/channel/thread/ThreadChannelDeleteEvent {
+	public fun <init> (Ldev/kord/core/entity/channel/thread/DeletedThreadChannel;Ldev/kord/core/entity/channel/thread/ThreadChannel;I)V
 	public fun getChannel ()Ldev/kord/core/entity/channel/thread/DeletedThreadChannel;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getOld ()Ldev/kord/core/entity/channel/thread/ThreadChannel;
@@ -10869,13 +10761,10 @@ public final class dev/kord/core/event/channel/thread/UnknownChannelThreadDelete
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/kord/core/event/channel/thread/UnknownChannelThreadUpdateEvent : dev/kord/core/event/channel/thread/ThreadUpdateEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/channel/thread/ThreadChannel;Ldev/kord/core/entity/channel/thread/ThreadChannel;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/channel/thread/ThreadChannel;Ldev/kord/core/entity/channel/thread/ThreadChannel;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/channel/thread/UnknownChannelThreadUpdateEvent : dev/kord/core/event/channel/thread/ThreadUpdateEvent {
+	public fun <init> (Ldev/kord/core/entity/channel/thread/ThreadChannel;Ldev/kord/core/entity/channel/thread/ThreadChannel;I)V
 	public synthetic fun getChannel ()Ldev/kord/core/entity/channel/Channel;
 	public fun getChannel ()Ldev/kord/core/entity/channel/thread/ThreadChannel;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public synthetic fun getOld ()Ldev/kord/core/entity/channel/Channel;
@@ -10884,11 +10773,8 @@ public final class dev/kord/core/event/channel/thread/UnknownChannelThreadUpdate
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/kord/core/event/gateway/ConnectEvent : dev/kord/core/event/gateway/GatewayEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+public final class dev/kord/core/event/gateway/ConnectEvent : dev/kord/core/event/gateway/GatewayEvent {
+	public fun <init> (Ldev/kord/core/Kord;I)V
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
 }
@@ -10896,83 +10782,59 @@ public final class dev/kord/core/event/gateway/ConnectEvent : dev/kord/core/even
 public abstract class dev/kord/core/event/gateway/DisconnectEvent : dev/kord/core/event/gateway/GatewayEvent {
 }
 
-public final class dev/kord/core/event/gateway/DisconnectEvent$DetachEvent : dev/kord/core/event/gateway/DisconnectEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+public final class dev/kord/core/event/gateway/DisconnectEvent$DetachEvent : dev/kord/core/event/gateway/DisconnectEvent {
+	public fun <init> (Ldev/kord/core/Kord;I)V
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/kord/core/event/gateway/DisconnectEvent$DiscordCloseEvent : dev/kord/core/event/gateway/DisconnectEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/Kord;ILdev/kord/gateway/GatewayCloseCode;ZLkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/Kord;ILdev/kord/gateway/GatewayCloseCode;ZLkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/gateway/DisconnectEvent$DiscordCloseEvent : dev/kord/core/event/gateway/DisconnectEvent {
+	public fun <init> (Ldev/kord/core/Kord;ILdev/kord/gateway/GatewayCloseCode;Z)V
 	public final fun getCloseCode ()Ldev/kord/gateway/GatewayCloseCode;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getRecoverable ()Z
 	public fun getShard ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/kord/core/event/gateway/DisconnectEvent$ReconnectingEvent : dev/kord/core/event/gateway/DisconnectEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+public final class dev/kord/core/event/gateway/DisconnectEvent$ReconnectingEvent : dev/kord/core/event/gateway/DisconnectEvent {
+	public fun <init> (Ldev/kord/core/Kord;I)V
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/kord/core/event/gateway/DisconnectEvent$RetryLimitReachedEvent : dev/kord/core/event/gateway/DisconnectEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+public final class dev/kord/core/event/gateway/DisconnectEvent$RetryLimitReachedEvent : dev/kord/core/event/gateway/DisconnectEvent {
+	public fun <init> (Ldev/kord/core/Kord;I)V
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/kord/core/event/gateway/DisconnectEvent$SessionReset : dev/kord/core/event/gateway/DisconnectEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+public final class dev/kord/core/event/gateway/DisconnectEvent$SessionReset : dev/kord/core/event/gateway/DisconnectEvent {
+	public fun <init> (Ldev/kord/core/Kord;I)V
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/kord/core/event/gateway/DisconnectEvent$TimeoutEvent : dev/kord/core/event/gateway/DisconnectEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+public final class dev/kord/core/event/gateway/DisconnectEvent$TimeoutEvent : dev/kord/core/event/gateway/DisconnectEvent {
+	public fun <init> (Ldev/kord/core/Kord;I)V
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/kord/core/event/gateway/DisconnectEvent$UserCloseEvent : dev/kord/core/event/gateway/DisconnectEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+public final class dev/kord/core/event/gateway/DisconnectEvent$UserCloseEvent : dev/kord/core/event/gateway/DisconnectEvent {
+	public fun <init> (Ldev/kord/core/Kord;I)V
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/kord/core/event/gateway/DisconnectEvent$ZombieConnectionEvent : dev/kord/core/event/gateway/DisconnectEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+public final class dev/kord/core/event/gateway/DisconnectEvent$ZombieConnectionEvent : dev/kord/core/event/gateway/DisconnectEvent {
+	public fun <init> (Ldev/kord/core/Kord;I)V
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
 	public fun toString ()Ljava/lang/String;
@@ -10982,11 +10844,9 @@ public abstract class dev/kord/core/event/gateway/GatewayEvent : dev/kord/core/e
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 }
 
-public final class dev/kord/core/event/gateway/ReadyEvent : dev/kord/core/event/gateway/GatewayEvent, dev/kord/core/entity/Strategizable, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (ILjava/util/Set;Ldev/kord/core/entity/User;Ljava/lang/String;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (ILjava/util/Set;Ldev/kord/core/entity/User;Ljava/lang/String;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+public final class dev/kord/core/event/gateway/ReadyEvent : dev/kord/core/event/gateway/GatewayEvent, dev/kord/core/entity/Strategizable {
+	public fun <init> (ILjava/util/Set;Ldev/kord/core/entity/User;Ljava/lang/String;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;)V
+	public synthetic fun <init> (ILjava/util/Set;Ldev/kord/core/entity/User;Ljava/lang/String;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getGatewayVersion ()I
 	public final fun getGuildIds ()Ljava/util/Set;
 	public final fun getGuilds ()Ljava/util/Set;
@@ -11001,23 +10861,18 @@ public final class dev/kord/core/event/gateway/ReadyEvent : dev/kord/core/event/
 	public fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/event/gateway/ReadyEvent;
 }
 
-public final class dev/kord/core/event/gateway/ResumedEvent : dev/kord/core/event/gateway/GatewayEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+public final class dev/kord/core/event/gateway/ResumedEvent : dev/kord/core/event/gateway/GatewayEvent {
+	public fun <init> (Ldev/kord/core/Kord;I)V
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/kord/core/event/guild/BanAddEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/User;Ldev/kord/common/entity/Snowflake;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/User;Ldev/kord/common/entity/Snowflake;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/guild/BanAddEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event {
+	public fun <init> (Ldev/kord/core/entity/User;Ldev/kord/common/entity/Snowflake;ILdev/kord/core/supplier/EntitySupplier;)V
+	public synthetic fun <init> (Ldev/kord/core/entity/User;Ldev/kord/common/entity/Snowflake;ILdev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getBan (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getBanOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -11032,11 +10887,9 @@ public final class dev/kord/core/event/guild/BanAddEvent : dev/kord/core/entity/
 	public fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/event/guild/BanAddEvent;
 }
 
-public final class dev/kord/core/event/guild/BanRemoveEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/User;Ldev/kord/common/entity/Snowflake;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/User;Ldev/kord/common/entity/Snowflake;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+public final class dev/kord/core/event/guild/BanRemoveEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event {
+	public fun <init> (Ldev/kord/core/entity/User;Ldev/kord/common/entity/Snowflake;ILdev/kord/core/supplier/EntitySupplier;)V
+	public synthetic fun <init> (Ldev/kord/core/entity/User;Ldev/kord/common/entity/Snowflake;ILdev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -11051,11 +10904,9 @@ public final class dev/kord/core/event/guild/BanRemoveEvent : dev/kord/core/enti
 	public fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/event/guild/BanRemoveEvent;
 }
 
-public final class dev/kord/core/event/guild/EmojisUpdateEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/util/Set;Ljava/util/Set;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/util/Set;Ljava/util/Set;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+public final class dev/kord/core/event/guild/EmojisUpdateEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event {
+	public fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/util/Set;Ljava/util/Set;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;)V
+	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/util/Set;Ljava/util/Set;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getEmojis ()Ljava/util/Set;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
@@ -11071,11 +10922,8 @@ public final class dev/kord/core/event/guild/EmojisUpdateEvent : dev/kord/core/e
 	public fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/event/guild/EmojisUpdateEvent;
 }
 
-public final class dev/kord/core/event/guild/GuildCreateEvent : dev/kord/core/event/Event, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/Guild;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/Guild;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+public final class dev/kord/core/event/guild/GuildCreateEvent : dev/kord/core/event/Event {
+	public fun <init> (Ldev/kord/core/entity/Guild;I)V
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/entity/Guild;
 	public fun getKord ()Ldev/kord/core/Kord;
@@ -11083,11 +10931,8 @@ public final class dev/kord/core/event/guild/GuildCreateEvent : dev/kord/core/ev
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/kord/core/event/guild/GuildDeleteEvent : dev/kord/core/event/Event, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;ZLdev/kord/core/entity/Guild;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;ZLdev/kord/core/entity/Guild;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+public final class dev/kord/core/event/guild/GuildDeleteEvent : dev/kord/core/event/Event {
+	public fun <init> (Ldev/kord/common/entity/Snowflake;ZLdev/kord/core/entity/Guild;Ldev/kord/core/Kord;I)V
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/entity/Guild;
 	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
@@ -11097,21 +10942,18 @@ public final class dev/kord/core/event/guild/GuildDeleteEvent : dev/kord/core/ev
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/kord/core/event/guild/GuildScheduledEventCreateEvent : dev/kord/core/event/guild/GuildScheduledEventEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/GuildScheduledEvent;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/GuildScheduledEvent;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/guild/GuildScheduledEventCreateEvent : dev/kord/core/event/guild/GuildScheduledEventEvent {
+	public fun <init> (Ldev/kord/core/entity/GuildScheduledEvent;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;)V
+	public synthetic fun <init> (Ldev/kord/core/entity/GuildScheduledEvent;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ldev/kord/core/entity/GuildScheduledEvent;
 	public final fun component2 ()Ldev/kord/core/Kord;
 	public final fun component3 ()I
 	public final fun component4 ()Ldev/kord/core/supplier/EntitySupplier;
-	public final fun component5 ()Lkotlinx/coroutines/CoroutineScope;
-	public final fun copy (Ldev/kord/core/entity/GuildScheduledEvent;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;)Ldev/kord/core/event/guild/GuildScheduledEventCreateEvent;
-	public static synthetic fun copy$default (Ldev/kord/core/event/guild/GuildScheduledEventCreateEvent;Ldev/kord/core/entity/GuildScheduledEvent;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;ILjava/lang/Object;)Ldev/kord/core/event/guild/GuildScheduledEventCreateEvent;
+	public final fun copy (Ldev/kord/core/entity/GuildScheduledEvent;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;)Ldev/kord/core/event/guild/GuildScheduledEventCreateEvent;
+	public static synthetic fun copy$default (Ldev/kord/core/event/guild/GuildScheduledEventCreateEvent;Ldev/kord/core/entity/GuildScheduledEvent;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;ILjava/lang/Object;)Ldev/kord/core/event/guild/GuildScheduledEventCreateEvent;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChannelId ()Ldev/kord/common/entity/Snowflake;
 	public fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getGuildId ()Ldev/kord/common/entity/Snowflake;
@@ -11128,21 +10970,18 @@ public final class dev/kord/core/event/guild/GuildScheduledEventCreateEvent : de
 	public synthetic fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/event/guild/GuildScheduledEventEvent;
 }
 
-public final class dev/kord/core/event/guild/GuildScheduledEventDeleteEvent : dev/kord/core/event/guild/GuildScheduledEventEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/GuildScheduledEvent;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/GuildScheduledEvent;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/guild/GuildScheduledEventDeleteEvent : dev/kord/core/event/guild/GuildScheduledEventEvent {
+	public fun <init> (Ldev/kord/core/entity/GuildScheduledEvent;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;)V
+	public synthetic fun <init> (Ldev/kord/core/entity/GuildScheduledEvent;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ldev/kord/core/entity/GuildScheduledEvent;
 	public final fun component2 ()Ldev/kord/core/Kord;
 	public final fun component3 ()I
 	public final fun component4 ()Ldev/kord/core/supplier/EntitySupplier;
-	public final fun component5 ()Lkotlinx/coroutines/CoroutineScope;
-	public final fun copy (Ldev/kord/core/entity/GuildScheduledEvent;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;)Ldev/kord/core/event/guild/GuildScheduledEventDeleteEvent;
-	public static synthetic fun copy$default (Ldev/kord/core/event/guild/GuildScheduledEventDeleteEvent;Ldev/kord/core/entity/GuildScheduledEvent;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;ILjava/lang/Object;)Ldev/kord/core/event/guild/GuildScheduledEventDeleteEvent;
+	public final fun copy (Ldev/kord/core/entity/GuildScheduledEvent;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;)Ldev/kord/core/event/guild/GuildScheduledEventDeleteEvent;
+	public static synthetic fun copy$default (Ldev/kord/core/event/guild/GuildScheduledEventDeleteEvent;Ldev/kord/core/entity/GuildScheduledEvent;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;ILjava/lang/Object;)Ldev/kord/core/event/guild/GuildScheduledEventDeleteEvent;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChannelId ()Ldev/kord/common/entity/Snowflake;
 	public fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getGuildId ()Ldev/kord/common/entity/Snowflake;
@@ -11159,7 +10998,7 @@ public final class dev/kord/core/event/guild/GuildScheduledEventDeleteEvent : de
 	public synthetic fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/event/guild/GuildScheduledEventEvent;
 }
 
-public abstract interface class dev/kord/core/event/guild/GuildScheduledEventEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event, kotlinx/coroutines/CoroutineScope {
+public abstract interface class dev/kord/core/event/guild/GuildScheduledEventEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event {
 	public abstract fun getChannelId ()Ldev/kord/common/entity/Snowflake;
 	public abstract fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -11180,22 +11019,19 @@ public final class dev/kord/core/event/guild/GuildScheduledEventEvent$DefaultImp
 	public static fun getScheduledEventId (Ldev/kord/core/event/guild/GuildScheduledEventEvent;)Ldev/kord/common/entity/Snowflake;
 }
 
-public final class dev/kord/core/event/guild/GuildScheduledEventUpdateEvent : dev/kord/core/event/guild/GuildScheduledEventEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/GuildScheduledEvent;Ldev/kord/core/entity/GuildScheduledEvent;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/GuildScheduledEvent;Ldev/kord/core/entity/GuildScheduledEvent;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/guild/GuildScheduledEventUpdateEvent : dev/kord/core/event/guild/GuildScheduledEventEvent {
+	public fun <init> (Ldev/kord/core/entity/GuildScheduledEvent;Ldev/kord/core/entity/GuildScheduledEvent;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;)V
+	public synthetic fun <init> (Ldev/kord/core/entity/GuildScheduledEvent;Ldev/kord/core/entity/GuildScheduledEvent;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ldev/kord/core/entity/GuildScheduledEvent;
 	public final fun component2 ()Ldev/kord/core/entity/GuildScheduledEvent;
 	public final fun component3 ()Ldev/kord/core/Kord;
 	public final fun component4 ()I
 	public final fun component5 ()Ldev/kord/core/supplier/EntitySupplier;
-	public final fun component6 ()Lkotlinx/coroutines/CoroutineScope;
-	public final fun copy (Ldev/kord/core/entity/GuildScheduledEvent;Ldev/kord/core/entity/GuildScheduledEvent;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;)Ldev/kord/core/event/guild/GuildScheduledEventUpdateEvent;
-	public static synthetic fun copy$default (Ldev/kord/core/event/guild/GuildScheduledEventUpdateEvent;Ldev/kord/core/entity/GuildScheduledEvent;Ldev/kord/core/entity/GuildScheduledEvent;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;ILjava/lang/Object;)Ldev/kord/core/event/guild/GuildScheduledEventUpdateEvent;
+	public final fun copy (Ldev/kord/core/entity/GuildScheduledEvent;Ldev/kord/core/entity/GuildScheduledEvent;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;)Ldev/kord/core/event/guild/GuildScheduledEventUpdateEvent;
+	public static synthetic fun copy$default (Ldev/kord/core/event/guild/GuildScheduledEventUpdateEvent;Ldev/kord/core/entity/GuildScheduledEvent;Ldev/kord/core/entity/GuildScheduledEvent;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;ILjava/lang/Object;)Ldev/kord/core/event/guild/GuildScheduledEventUpdateEvent;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChannelId ()Ldev/kord/common/entity/Snowflake;
 	public fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getGuildId ()Ldev/kord/common/entity/Snowflake;
@@ -11213,21 +11049,18 @@ public final class dev/kord/core/event/guild/GuildScheduledEventUpdateEvent : de
 	public fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/event/guild/GuildScheduledEventUpdateEvent;
 }
 
-public final class dev/kord/core/event/guild/GuildScheduledEventUserAddEvent : dev/kord/core/event/guild/GuildScheduledEventUserEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/guild/GuildScheduledEventUserAddEvent : dev/kord/core/event/guild/GuildScheduledEventUserEvent {
+	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;)V
+	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
 	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
 	public final fun component3 ()Ldev/kord/common/entity/Snowflake;
 	public final fun component4 ()Ldev/kord/core/Kord;
 	public final fun component5 ()I
 	public final fun component6 ()Ldev/kord/core/supplier/EntitySupplier;
-	public final fun component7 ()Lkotlinx/coroutines/CoroutineScope;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;)Ldev/kord/core/event/guild/GuildScheduledEventUserAddEvent;
-	public static synthetic fun copy$default (Ldev/kord/core/event/guild/GuildScheduledEventUserAddEvent;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;ILjava/lang/Object;)Ldev/kord/core/event/guild/GuildScheduledEventUserAddEvent;
+	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;)Ldev/kord/core/event/guild/GuildScheduledEventUserAddEvent;
+	public static synthetic fun copy$default (Ldev/kord/core/event/guild/GuildScheduledEventUserAddEvent;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;ILjava/lang/Object;)Ldev/kord/core/event/guild/GuildScheduledEventUserAddEvent;
 	public fun equals (Ljava/lang/Object;)Z
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getEvent (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getEventOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
@@ -11250,7 +11083,7 @@ public final class dev/kord/core/event/guild/GuildScheduledEventUserAddEvent : d
 	public synthetic fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/event/guild/GuildScheduledEventUserEvent;
 }
 
-public abstract interface class dev/kord/core/event/guild/GuildScheduledEventUserEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event, kotlinx/coroutines/CoroutineScope {
+public abstract interface class dev/kord/core/event/guild/GuildScheduledEventUserEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event {
 	public abstract fun getEvent (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getEventOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -11277,21 +11110,18 @@ public final class dev/kord/core/event/guild/GuildScheduledEventUserEvent$Defaul
 	public static fun getUserOrNull (Ldev/kord/core/event/guild/GuildScheduledEventUserEvent;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public final class dev/kord/core/event/guild/GuildScheduledEventUserRemoveEvent : dev/kord/core/event/guild/GuildScheduledEventUserEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/guild/GuildScheduledEventUserRemoveEvent : dev/kord/core/event/guild/GuildScheduledEventUserEvent {
+	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;)V
+	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
 	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
 	public final fun component3 ()Ldev/kord/common/entity/Snowflake;
 	public final fun component4 ()Ldev/kord/core/Kord;
 	public final fun component5 ()I
 	public final fun component6 ()Ldev/kord/core/supplier/EntitySupplier;
-	public final fun component7 ()Lkotlinx/coroutines/CoroutineScope;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;)Ldev/kord/core/event/guild/GuildScheduledEventUserRemoveEvent;
-	public static synthetic fun copy$default (Ldev/kord/core/event/guild/GuildScheduledEventUserRemoveEvent;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;ILjava/lang/Object;)Ldev/kord/core/event/guild/GuildScheduledEventUserRemoveEvent;
+	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;)Ldev/kord/core/event/guild/GuildScheduledEventUserRemoveEvent;
+	public static synthetic fun copy$default (Ldev/kord/core/event/guild/GuildScheduledEventUserRemoveEvent;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;ILjava/lang/Object;)Ldev/kord/core/event/guild/GuildScheduledEventUserRemoveEvent;
 	public fun equals (Ljava/lang/Object;)Z
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getEvent (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getEventOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
@@ -11314,11 +11144,8 @@ public final class dev/kord/core/event/guild/GuildScheduledEventUserRemoveEvent 
 	public fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/event/guild/GuildScheduledEventUserRemoveEvent;
 }
 
-public final class dev/kord/core/event/guild/GuildUpdateEvent : dev/kord/core/event/Event, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/Guild;Ldev/kord/core/entity/Guild;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/Guild;Ldev/kord/core/entity/Guild;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+public final class dev/kord/core/event/guild/GuildUpdateEvent : dev/kord/core/event/Event {
+	public fun <init> (Ldev/kord/core/entity/Guild;Ldev/kord/core/entity/Guild;I)V
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/entity/Guild;
 	public fun getKord ()Ldev/kord/core/Kord;
@@ -11327,11 +11154,9 @@ public final class dev/kord/core/event/guild/GuildUpdateEvent : dev/kord/core/ev
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/kord/core/event/guild/IntegrationsUpdateEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+public final class dev/kord/core/event/guild/IntegrationsUpdateEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event {
+	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;)V
+	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -11345,9 +11170,9 @@ public final class dev/kord/core/event/guild/IntegrationsUpdateEvent : dev/kord/
 	public fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/event/guild/IntegrationsUpdateEvent;
 }
 
-public final class dev/kord/core/event/guild/InviteCreateEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/cache/data/InviteCreateData;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/cache/data/InviteCreateData;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/guild/InviteCreateEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event {
+	public fun <init> (Ldev/kord/core/cache/data/InviteCreateData;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;)V
+	public synthetic fun <init> (Ldev/kord/core/cache/data/InviteCreateData;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun delete (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun delete$default (Ldev/kord/core/event/guild/InviteCreateEvent;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun getChannel ()Ldev/kord/core/behavior/channel/ChannelBehavior;
@@ -11355,8 +11180,6 @@ public final class dev/kord/core/event/guild/InviteCreateEvent : dev/kord/core/e
 	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
 	public final fun getChannelOrNUll (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getCode ()Ljava/lang/String;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public final fun getCreatedAt ()Lkotlinx/datetime/Instant;
 	public final fun getData ()Ldev/kord/core/cache/data/InviteCreateData;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
@@ -11390,16 +11213,14 @@ public final class dev/kord/core/event/guild/InviteCreateEvent : dev/kord/core/e
 	public fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/event/guild/InviteCreateEvent;
 }
 
-public final class dev/kord/core/event/guild/InviteDeleteEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/cache/data/InviteDeleteData;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/cache/data/InviteDeleteData;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/guild/InviteDeleteEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event {
+	public fun <init> (Ldev/kord/core/cache/data/InviteDeleteData;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;)V
+	public synthetic fun <init> (Ldev/kord/core/cache/data/InviteDeleteData;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getChannel ()Ldev/kord/core/behavior/channel/ChannelBehavior;
 	public final fun getChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
 	public final fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getCode ()Ljava/lang/String;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public final fun getData ()Ldev/kord/core/cache/data/InviteDeleteData;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
@@ -11414,11 +11235,9 @@ public final class dev/kord/core/event/guild/InviteDeleteEvent : dev/kord/core/e
 	public fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/event/guild/InviteDeleteEvent;
 }
 
-public final class dev/kord/core/event/guild/MemberJoinEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/Member;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/Member;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+public final class dev/kord/core/event/guild/MemberJoinEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event {
+	public fun <init> (Ldev/kord/core/entity/Member;ILdev/kord/core/supplier/EntitySupplier;)V
+	public synthetic fun <init> (Ldev/kord/core/entity/Member;ILdev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -11433,11 +11252,8 @@ public final class dev/kord/core/event/guild/MemberJoinEvent : dev/kord/core/ent
 	public fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/event/guild/MemberJoinEvent;
 }
 
-public final class dev/kord/core/event/guild/MemberLeaveEvent : dev/kord/core/event/Event, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/User;Ldev/kord/core/entity/Member;Ldev/kord/common/entity/Snowflake;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/User;Ldev/kord/core/entity/Member;Ldev/kord/common/entity/Snowflake;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+public final class dev/kord/core/event/guild/MemberLeaveEvent : dev/kord/core/event/Event {
+	public fun <init> (Ldev/kord/core/entity/User;Ldev/kord/core/entity/Member;Ldev/kord/common/entity/Snowflake;I)V
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -11450,11 +11266,9 @@ public final class dev/kord/core/event/guild/MemberLeaveEvent : dev/kord/core/ev
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/kord/core/event/guild/MemberUpdateEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/Member;Ldev/kord/core/entity/Member;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/Member;Ldev/kord/core/entity/Member;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+public final class dev/kord/core/event/guild/MemberUpdateEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event {
+	public fun <init> (Ldev/kord/core/entity/Member;Ldev/kord/core/entity/Member;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;)V
+	public synthetic fun <init> (Ldev/kord/core/entity/Member;Ldev/kord/core/entity/Member;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final synthetic fun getCurrentNickName ()Ljava/lang/String;
 	public static fun getCurrentNickName$delegate (Ldev/kord/core/event/guild/MemberUpdateEvent;)Ljava/lang/Object;
 	public final synthetic fun getCurrentRoleIds ()Ljava/util/Set;
@@ -11484,13 +11298,11 @@ public final class dev/kord/core/event/guild/MemberUpdateEvent : dev/kord/core/e
 	public fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/event/guild/MemberUpdateEvent;
 }
 
-public final class dev/kord/core/event/guild/MembersChunkEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/cache/data/MembersChunkData;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/cache/data/MembersChunkData;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/guild/MembersChunkEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event {
+	public fun <init> (Ldev/kord/core/cache/data/MembersChunkData;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;)V
+	public synthetic fun <init> (Ldev/kord/core/cache/data/MembersChunkData;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getChunkCount ()I
 	public final fun getChunkIndex ()I
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public final fun getData ()Ldev/kord/core/cache/data/MembersChunkData;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
@@ -11509,11 +11321,9 @@ public final class dev/kord/core/event/guild/MembersChunkEvent : dev/kord/core/e
 	public fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/event/guild/MembersChunkEvent;
 }
 
-public final class dev/kord/core/event/guild/VoiceServerUpdateEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+public final class dev/kord/core/event/guild/VoiceServerUpdateEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event {
+	public fun <init> (Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;)V
+	public synthetic fun <init> (Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getEndpoint ()Ljava/lang/String;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
@@ -11529,15 +11339,13 @@ public final class dev/kord/core/event/guild/VoiceServerUpdateEvent : dev/kord/c
 	public fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/event/guild/VoiceServerUpdateEvent;
 }
 
-public final class dev/kord/core/event/guild/WebhookUpdateEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/guild/WebhookUpdateEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event {
+	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;)V
+	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getChannel ()Ldev/kord/core/behavior/channel/TopGuildMessageChannelBehavior;
 	public final fun getChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
 	public final fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -11583,11 +11391,8 @@ public final class dev/kord/core/event/interaction/ApplicationCommandInteraction
 	public static fun getGateway (Ldev/kord/core/event/interaction/ApplicationCommandInteractionCreateEvent;)Ldev/kord/gateway/Gateway;
 }
 
-public final class dev/kord/core/event/interaction/ApplicationCommandPermissionsUpdateEvent : dev/kord/core/event/Event, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/application/ApplicationCommandPermissions;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/application/ApplicationCommandPermissions;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+public final class dev/kord/core/event/interaction/ApplicationCommandPermissionsUpdateEvent : dev/kord/core/event/Event {
+	public fun <init> (Ldev/kord/core/entity/application/ApplicationCommandPermissions;Ldev/kord/core/Kord;I)V
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getPermissions ()Ldev/kord/core/entity/application/ApplicationCommandPermissions;
@@ -11618,25 +11423,19 @@ public final class dev/kord/core/event/interaction/ButtonInteractionCreateEvent$
 	public static fun getGateway (Ldev/kord/core/event/interaction/ButtonInteractionCreateEvent;)Ldev/kord/gateway/Gateway;
 }
 
-public final class dev/kord/core/event/interaction/ChatInputCommandCreateEvent : dev/kord/core/event/interaction/ApplicationCommandCreateEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/application/GuildChatInputCommand;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/application/GuildChatInputCommand;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/interaction/ChatInputCommandCreateEvent : dev/kord/core/event/interaction/ApplicationCommandCreateEvent {
+	public fun <init> (Ldev/kord/core/entity/application/GuildChatInputCommand;Ldev/kord/core/Kord;I)V
 	public synthetic fun getCommand ()Ldev/kord/core/entity/application/GuildApplicationCommand;
 	public fun getCommand ()Ldev/kord/core/entity/application/GuildChatInputCommand;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
 }
 
-public final class dev/kord/core/event/interaction/ChatInputCommandDeleteEvent : dev/kord/core/event/interaction/ApplicationCommandDeleteEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/application/GuildChatInputCommand;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/application/GuildChatInputCommand;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/interaction/ChatInputCommandDeleteEvent : dev/kord/core/event/interaction/ApplicationCommandDeleteEvent {
+	public fun <init> (Ldev/kord/core/entity/application/GuildChatInputCommand;Ldev/kord/core/Kord;I)V
 	public synthetic fun getCommand ()Ldev/kord/core/entity/application/GuildApplicationCommand;
 	public fun getCommand ()Ldev/kord/core/entity/application/GuildChatInputCommand;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
@@ -11650,13 +11449,10 @@ public final class dev/kord/core/event/interaction/ChatInputCommandInteractionCr
 	public static fun getGateway (Ldev/kord/core/event/interaction/ChatInputCommandInteractionCreateEvent;)Ldev/kord/gateway/Gateway;
 }
 
-public final class dev/kord/core/event/interaction/ChatInputCommandUpdateEvent : dev/kord/core/event/interaction/ApplicationCommandUpdateEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/application/GuildChatInputCommand;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/application/GuildChatInputCommand;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/interaction/ChatInputCommandUpdateEvent : dev/kord/core/event/interaction/ApplicationCommandUpdateEvent {
+	public fun <init> (Ldev/kord/core/entity/application/GuildChatInputCommand;Ldev/kord/core/Kord;I)V
 	public synthetic fun getCommand ()Ldev/kord/core/entity/application/GuildApplicationCommand;
 	public fun getCommand ()Ldev/kord/core/entity/application/GuildChatInputCommand;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
@@ -11686,11 +11482,8 @@ public final class dev/kord/core/event/interaction/GlobalApplicationCommandInter
 	public static fun getGateway (Ldev/kord/core/event/interaction/GlobalApplicationCommandInteractionCreateEvent;)Ldev/kord/gateway/Gateway;
 }
 
-public final class dev/kord/core/event/interaction/GlobalAutoCompleteInteractionCreateEvent : dev/kord/core/event/interaction/AutoCompleteInteractionCreateEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/Kord;ILdev/kord/core/entity/interaction/GlobalAutoCompleteInteraction;Lkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/Kord;ILdev/kord/core/entity/interaction/GlobalAutoCompleteInteraction;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+public final class dev/kord/core/event/interaction/GlobalAutoCompleteInteractionCreateEvent : dev/kord/core/event/interaction/AutoCompleteInteractionCreateEvent {
+	public fun <init> (Ldev/kord/core/Kord;ILdev/kord/core/entity/interaction/GlobalAutoCompleteInteraction;)V
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public synthetic fun getInteraction ()Ldev/kord/core/entity/interaction/AutoCompleteInteraction;
 	public synthetic fun getInteraction ()Ldev/kord/core/entity/interaction/DataInteraction;
@@ -11700,11 +11493,8 @@ public final class dev/kord/core/event/interaction/GlobalAutoCompleteInteraction
 	public fun getShard ()I
 }
 
-public final class dev/kord/core/event/interaction/GlobalButtonInteractionCreateEvent : dev/kord/core/event/interaction/ButtonInteractionCreateEvent, dev/kord/core/event/interaction/GlobalComponentInteractionCreateEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/interaction/GlobalButtonInteraction;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/interaction/GlobalButtonInteraction;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+public final class dev/kord/core/event/interaction/GlobalButtonInteractionCreateEvent : dev/kord/core/event/interaction/ButtonInteractionCreateEvent, dev/kord/core/event/interaction/GlobalComponentInteractionCreateEvent {
+	public fun <init> (Ldev/kord/core/entity/interaction/GlobalButtonInteraction;Ldev/kord/core/Kord;I)V
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public synthetic fun getInteraction ()Ldev/kord/core/entity/interaction/ActionInteraction;
 	public synthetic fun getInteraction ()Ldev/kord/core/entity/interaction/ButtonInteraction;
@@ -11716,11 +11506,8 @@ public final class dev/kord/core/event/interaction/GlobalButtonInteractionCreate
 	public fun getShard ()I
 }
 
-public final class dev/kord/core/event/interaction/GlobalChatInputCommandInteractionCreateEvent : dev/kord/core/event/interaction/ChatInputCommandInteractionCreateEvent, dev/kord/core/event/interaction/GlobalApplicationCommandInteractionCreateEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/interaction/GlobalChatInputCommandInteraction;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/interaction/GlobalChatInputCommandInteraction;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+public final class dev/kord/core/event/interaction/GlobalChatInputCommandInteractionCreateEvent : dev/kord/core/event/interaction/ChatInputCommandInteractionCreateEvent, dev/kord/core/event/interaction/GlobalApplicationCommandInteractionCreateEvent {
+	public fun <init> (Ldev/kord/core/entity/interaction/GlobalChatInputCommandInteraction;Ldev/kord/core/Kord;I)V
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public synthetic fun getInteraction ()Ldev/kord/core/entity/interaction/ActionInteraction;
 	public synthetic fun getInteraction ()Ldev/kord/core/entity/interaction/ApplicationCommandInteraction;
@@ -11740,11 +11527,8 @@ public final class dev/kord/core/event/interaction/GlobalComponentInteractionCre
 	public static fun getGateway (Ldev/kord/core/event/interaction/GlobalComponentInteractionCreateEvent;)Ldev/kord/gateway/Gateway;
 }
 
-public final class dev/kord/core/event/interaction/GlobalMessageCommandInteractionCreateEvent : dev/kord/core/event/interaction/GlobalApplicationCommandInteractionCreateEvent, dev/kord/core/event/interaction/MessageCommandInteractionCreateEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/interaction/GlobalMessageCommandInteraction;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/interaction/GlobalMessageCommandInteraction;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+public final class dev/kord/core/event/interaction/GlobalMessageCommandInteractionCreateEvent : dev/kord/core/event/interaction/GlobalApplicationCommandInteractionCreateEvent, dev/kord/core/event/interaction/MessageCommandInteractionCreateEvent {
+	public fun <init> (Ldev/kord/core/entity/interaction/GlobalMessageCommandInteraction;Ldev/kord/core/Kord;I)V
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public synthetic fun getInteraction ()Ldev/kord/core/entity/interaction/ActionInteraction;
 	public synthetic fun getInteraction ()Ldev/kord/core/entity/interaction/ApplicationCommandInteraction;
@@ -11756,11 +11540,8 @@ public final class dev/kord/core/event/interaction/GlobalMessageCommandInteracti
 	public fun getShard ()I
 }
 
-public final class dev/kord/core/event/interaction/GlobalModalSubmitInteractionCreateEvent : dev/kord/core/event/interaction/ModalSubmitInteractionCreateEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/interaction/GlobalModalSubmitInteraction;ILdev/kord/core/Kord;Lkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/interaction/GlobalModalSubmitInteraction;ILdev/kord/core/Kord;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+public final class dev/kord/core/event/interaction/GlobalModalSubmitInteractionCreateEvent : dev/kord/core/event/interaction/ModalSubmitInteractionCreateEvent {
+	public fun <init> (Ldev/kord/core/entity/interaction/GlobalModalSubmitInteraction;ILdev/kord/core/Kord;)V
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public synthetic fun getInteraction ()Ldev/kord/core/entity/interaction/ActionInteraction;
 	public fun getInteraction ()Ldev/kord/core/entity/interaction/GlobalModalSubmitInteraction;
@@ -11770,11 +11551,8 @@ public final class dev/kord/core/event/interaction/GlobalModalSubmitInteractionC
 	public fun getShard ()I
 }
 
-public final class dev/kord/core/event/interaction/GlobalSelectMenuInteractionCreateEvent : dev/kord/core/event/interaction/GlobalComponentInteractionCreateEvent, dev/kord/core/event/interaction/SelectMenuInteractionCreateEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/interaction/GlobalSelectMenuInteraction;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/interaction/GlobalSelectMenuInteraction;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+public final class dev/kord/core/event/interaction/GlobalSelectMenuInteractionCreateEvent : dev/kord/core/event/interaction/GlobalComponentInteractionCreateEvent, dev/kord/core/event/interaction/SelectMenuInteractionCreateEvent {
+	public fun <init> (Ldev/kord/core/entity/interaction/GlobalSelectMenuInteraction;Ldev/kord/core/Kord;I)V
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public synthetic fun getInteraction ()Ldev/kord/core/entity/interaction/ActionInteraction;
 	public synthetic fun getInteraction ()Ldev/kord/core/entity/interaction/ComponentInteraction;
@@ -11786,11 +11564,8 @@ public final class dev/kord/core/event/interaction/GlobalSelectMenuInteractionCr
 	public fun getShard ()I
 }
 
-public final class dev/kord/core/event/interaction/GlobalUserCommandInteractionCreateEvent : dev/kord/core/event/interaction/GlobalApplicationCommandInteractionCreateEvent, dev/kord/core/event/interaction/UserCommandInteractionCreateEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/interaction/GlobalUserCommandInteraction;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/interaction/GlobalUserCommandInteraction;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+public final class dev/kord/core/event/interaction/GlobalUserCommandInteractionCreateEvent : dev/kord/core/event/interaction/GlobalApplicationCommandInteractionCreateEvent, dev/kord/core/event/interaction/UserCommandInteractionCreateEvent {
+	public fun <init> (Ldev/kord/core/entity/interaction/GlobalUserCommandInteraction;Ldev/kord/core/Kord;I)V
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public synthetic fun getInteraction ()Ldev/kord/core/entity/interaction/ActionInteraction;
 	public synthetic fun getInteraction ()Ldev/kord/core/entity/interaction/ApplicationCommandInteraction;
@@ -11810,11 +11585,8 @@ public final class dev/kord/core/event/interaction/GuildApplicationCommandIntera
 	public static fun getGateway (Ldev/kord/core/event/interaction/GuildApplicationCommandInteractionCreateEvent;)Ldev/kord/gateway/Gateway;
 }
 
-public final class dev/kord/core/event/interaction/GuildAutoCompleteInteractionCreateEvent : dev/kord/core/event/interaction/AutoCompleteInteractionCreateEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/Kord;ILdev/kord/core/entity/interaction/GuildAutoCompleteInteraction;Lkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/Kord;ILdev/kord/core/entity/interaction/GuildAutoCompleteInteraction;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+public final class dev/kord/core/event/interaction/GuildAutoCompleteInteractionCreateEvent : dev/kord/core/event/interaction/AutoCompleteInteractionCreateEvent {
+	public fun <init> (Ldev/kord/core/Kord;ILdev/kord/core/entity/interaction/GuildAutoCompleteInteraction;)V
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public synthetic fun getInteraction ()Ldev/kord/core/entity/interaction/AutoCompleteInteraction;
 	public synthetic fun getInteraction ()Ldev/kord/core/entity/interaction/DataInteraction;
@@ -11824,11 +11596,8 @@ public final class dev/kord/core/event/interaction/GuildAutoCompleteInteractionC
 	public fun getShard ()I
 }
 
-public final class dev/kord/core/event/interaction/GuildButtonInteractionCreateEvent : dev/kord/core/event/interaction/ButtonInteractionCreateEvent, dev/kord/core/event/interaction/GuildComponentInteractionCreateEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/interaction/GuildButtonInteraction;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/interaction/GuildButtonInteraction;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+public final class dev/kord/core/event/interaction/GuildButtonInteractionCreateEvent : dev/kord/core/event/interaction/ButtonInteractionCreateEvent, dev/kord/core/event/interaction/GuildComponentInteractionCreateEvent {
+	public fun <init> (Ldev/kord/core/entity/interaction/GuildButtonInteraction;Ldev/kord/core/Kord;I)V
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public synthetic fun getInteraction ()Ldev/kord/core/entity/interaction/ActionInteraction;
 	public synthetic fun getInteraction ()Ldev/kord/core/entity/interaction/ButtonInteraction;
@@ -11840,11 +11609,8 @@ public final class dev/kord/core/event/interaction/GuildButtonInteractionCreateE
 	public fun getShard ()I
 }
 
-public final class dev/kord/core/event/interaction/GuildChatInputCommandInteractionCreateEvent : dev/kord/core/event/interaction/ChatInputCommandInteractionCreateEvent, dev/kord/core/event/interaction/GuildApplicationCommandInteractionCreateEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/interaction/GuildChatInputCommandInteraction;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/interaction/GuildChatInputCommandInteraction;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+public final class dev/kord/core/event/interaction/GuildChatInputCommandInteractionCreateEvent : dev/kord/core/event/interaction/ChatInputCommandInteractionCreateEvent, dev/kord/core/event/interaction/GuildApplicationCommandInteractionCreateEvent {
+	public fun <init> (Ldev/kord/core/entity/interaction/GuildChatInputCommandInteraction;Ldev/kord/core/Kord;I)V
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public synthetic fun getInteraction ()Ldev/kord/core/entity/interaction/ActionInteraction;
 	public synthetic fun getInteraction ()Ldev/kord/core/entity/interaction/ApplicationCommandInteraction;
@@ -11864,11 +11630,8 @@ public final class dev/kord/core/event/interaction/GuildComponentInteractionCrea
 	public static fun getGateway (Ldev/kord/core/event/interaction/GuildComponentInteractionCreateEvent;)Ldev/kord/gateway/Gateway;
 }
 
-public final class dev/kord/core/event/interaction/GuildMessageCommandInteractionCreateEvent : dev/kord/core/event/interaction/GuildApplicationCommandInteractionCreateEvent, dev/kord/core/event/interaction/MessageCommandInteractionCreateEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/interaction/GuildMessageCommandInteraction;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/interaction/GuildMessageCommandInteraction;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+public final class dev/kord/core/event/interaction/GuildMessageCommandInteractionCreateEvent : dev/kord/core/event/interaction/GuildApplicationCommandInteractionCreateEvent, dev/kord/core/event/interaction/MessageCommandInteractionCreateEvent {
+	public fun <init> (Ldev/kord/core/entity/interaction/GuildMessageCommandInteraction;Ldev/kord/core/Kord;I)V
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public synthetic fun getInteraction ()Ldev/kord/core/entity/interaction/ActionInteraction;
 	public synthetic fun getInteraction ()Ldev/kord/core/entity/interaction/ApplicationCommandInteraction;
@@ -11880,11 +11643,8 @@ public final class dev/kord/core/event/interaction/GuildMessageCommandInteractio
 	public fun getShard ()I
 }
 
-public final class dev/kord/core/event/interaction/GuildModalSubmitInteractionCreateEvent : dev/kord/core/event/interaction/ModalSubmitInteractionCreateEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/interaction/GuildModalSubmitInteraction;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/interaction/GuildModalSubmitInteraction;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+public final class dev/kord/core/event/interaction/GuildModalSubmitInteractionCreateEvent : dev/kord/core/event/interaction/ModalSubmitInteractionCreateEvent {
+	public fun <init> (Ldev/kord/core/entity/interaction/GuildModalSubmitInteraction;Ldev/kord/core/Kord;I)V
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public synthetic fun getInteraction ()Ldev/kord/core/entity/interaction/ActionInteraction;
 	public fun getInteraction ()Ldev/kord/core/entity/interaction/GuildModalSubmitInteraction;
@@ -11894,11 +11654,8 @@ public final class dev/kord/core/event/interaction/GuildModalSubmitInteractionCr
 	public fun getShard ()I
 }
 
-public final class dev/kord/core/event/interaction/GuildSelectMenuInteractionCreateEvent : dev/kord/core/event/interaction/GuildComponentInteractionCreateEvent, dev/kord/core/event/interaction/SelectMenuInteractionCreateEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/interaction/GuildSelectMenuInteraction;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/interaction/GuildSelectMenuInteraction;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+public final class dev/kord/core/event/interaction/GuildSelectMenuInteractionCreateEvent : dev/kord/core/event/interaction/GuildComponentInteractionCreateEvent, dev/kord/core/event/interaction/SelectMenuInteractionCreateEvent {
+	public fun <init> (Ldev/kord/core/entity/interaction/GuildSelectMenuInteraction;Ldev/kord/core/Kord;I)V
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public synthetic fun getInteraction ()Ldev/kord/core/entity/interaction/ActionInteraction;
 	public synthetic fun getInteraction ()Ldev/kord/core/entity/interaction/ComponentInteraction;
@@ -11910,11 +11667,8 @@ public final class dev/kord/core/event/interaction/GuildSelectMenuInteractionCre
 	public fun getShard ()I
 }
 
-public final class dev/kord/core/event/interaction/GuildUserCommandInteractionCreateEvent : dev/kord/core/event/interaction/GuildApplicationCommandInteractionCreateEvent, dev/kord/core/event/interaction/UserCommandInteractionCreateEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/interaction/GuildUserCommandInteraction;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/interaction/GuildUserCommandInteraction;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+public final class dev/kord/core/event/interaction/GuildUserCommandInteractionCreateEvent : dev/kord/core/event/interaction/GuildApplicationCommandInteractionCreateEvent, dev/kord/core/event/interaction/UserCommandInteractionCreateEvent {
+	public fun <init> (Ldev/kord/core/entity/interaction/GuildUserCommandInteraction;Ldev/kord/core/Kord;I)V
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public synthetic fun getInteraction ()Ldev/kord/core/entity/interaction/ActionInteraction;
 	public synthetic fun getInteraction ()Ldev/kord/core/entity/interaction/ApplicationCommandInteraction;
@@ -11934,25 +11688,19 @@ public final class dev/kord/core/event/interaction/InteractionCreateEvent$Defaul
 	public static fun getGateway (Ldev/kord/core/event/interaction/InteractionCreateEvent;)Ldev/kord/gateway/Gateway;
 }
 
-public final class dev/kord/core/event/interaction/MessageCommandCreateEvent : dev/kord/core/event/interaction/ApplicationCommandCreateEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/application/GuildMessageCommand;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/application/GuildMessageCommand;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/interaction/MessageCommandCreateEvent : dev/kord/core/event/interaction/ApplicationCommandCreateEvent {
+	public fun <init> (Ldev/kord/core/entity/application/GuildMessageCommand;Ldev/kord/core/Kord;I)V
 	public synthetic fun getCommand ()Ldev/kord/core/entity/application/GuildApplicationCommand;
 	public fun getCommand ()Ldev/kord/core/entity/application/GuildMessageCommand;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
 }
 
-public final class dev/kord/core/event/interaction/MessageCommandDeleteEvent : dev/kord/core/event/interaction/ApplicationCommandDeleteEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/application/GuildMessageCommand;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/application/GuildMessageCommand;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/interaction/MessageCommandDeleteEvent : dev/kord/core/event/interaction/ApplicationCommandDeleteEvent {
+	public fun <init> (Ldev/kord/core/entity/application/GuildMessageCommand;Ldev/kord/core/Kord;I)V
 	public synthetic fun getCommand ()Ldev/kord/core/entity/application/GuildApplicationCommand;
 	public fun getCommand ()Ldev/kord/core/entity/application/GuildMessageCommand;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
@@ -11966,13 +11714,10 @@ public final class dev/kord/core/event/interaction/MessageCommandInteractionCrea
 	public static fun getGateway (Ldev/kord/core/event/interaction/MessageCommandInteractionCreateEvent;)Ldev/kord/gateway/Gateway;
 }
 
-public final class dev/kord/core/event/interaction/MessageCommandUpdateEvent : dev/kord/core/event/interaction/ApplicationCommandUpdateEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/application/GuildMessageCommand;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/application/GuildMessageCommand;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/interaction/MessageCommandUpdateEvent : dev/kord/core/event/interaction/ApplicationCommandUpdateEvent {
+	public fun <init> (Ldev/kord/core/entity/application/GuildMessageCommand;Ldev/kord/core/Kord;I)V
 	public synthetic fun getCommand ()Ldev/kord/core/entity/application/GuildApplicationCommand;
 	public fun getCommand ()Ldev/kord/core/entity/application/GuildMessageCommand;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
@@ -11994,61 +11739,46 @@ public final class dev/kord/core/event/interaction/SelectMenuInteractionCreateEv
 	public static fun getGateway (Ldev/kord/core/event/interaction/SelectMenuInteractionCreateEvent;)Ldev/kord/gateway/Gateway;
 }
 
-public final class dev/kord/core/event/interaction/UnknownApplicationCommandCreateEvent : dev/kord/core/event/interaction/ApplicationCommandCreateEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/application/UnknownGuildApplicationCommand;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/application/UnknownGuildApplicationCommand;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/interaction/UnknownApplicationCommandCreateEvent : dev/kord/core/event/interaction/ApplicationCommandCreateEvent {
+	public fun <init> (Ldev/kord/core/entity/application/UnknownGuildApplicationCommand;Ldev/kord/core/Kord;I)V
 	public synthetic fun getCommand ()Ldev/kord/core/entity/application/GuildApplicationCommand;
 	public fun getCommand ()Ldev/kord/core/entity/application/UnknownGuildApplicationCommand;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
 }
 
-public final class dev/kord/core/event/interaction/UnknownApplicationCommandDeleteEvent : dev/kord/core/event/interaction/ApplicationCommandDeleteEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/application/UnknownGuildApplicationCommand;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/application/UnknownGuildApplicationCommand;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/interaction/UnknownApplicationCommandDeleteEvent : dev/kord/core/event/interaction/ApplicationCommandDeleteEvent {
+	public fun <init> (Ldev/kord/core/entity/application/UnknownGuildApplicationCommand;Ldev/kord/core/Kord;I)V
 	public synthetic fun getCommand ()Ldev/kord/core/entity/application/GuildApplicationCommand;
 	public fun getCommand ()Ldev/kord/core/entity/application/UnknownGuildApplicationCommand;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
 }
 
-public final class dev/kord/core/event/interaction/UnknownApplicationCommandUpdateEvent : dev/kord/core/event/interaction/ApplicationCommandUpdateEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/application/UnknownGuildApplicationCommand;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/application/UnknownGuildApplicationCommand;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/interaction/UnknownApplicationCommandUpdateEvent : dev/kord/core/event/interaction/ApplicationCommandUpdateEvent {
+	public fun <init> (Ldev/kord/core/entity/application/UnknownGuildApplicationCommand;Ldev/kord/core/Kord;I)V
 	public synthetic fun getCommand ()Ldev/kord/core/entity/application/GuildApplicationCommand;
 	public fun getCommand ()Ldev/kord/core/entity/application/UnknownGuildApplicationCommand;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
 }
 
-public final class dev/kord/core/event/interaction/UserCommandCreateEvent : dev/kord/core/event/interaction/ApplicationCommandCreateEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/application/GuildUserCommand;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/application/GuildUserCommand;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/interaction/UserCommandCreateEvent : dev/kord/core/event/interaction/ApplicationCommandCreateEvent {
+	public fun <init> (Ldev/kord/core/entity/application/GuildUserCommand;Ldev/kord/core/Kord;I)V
 	public synthetic fun getCommand ()Ldev/kord/core/entity/application/GuildApplicationCommand;
 	public fun getCommand ()Ldev/kord/core/entity/application/GuildUserCommand;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
 }
 
-public final class dev/kord/core/event/interaction/UserCommandDeleteEvent : dev/kord/core/event/interaction/ApplicationCommandDeleteEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/application/GuildUserCommand;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/application/GuildUserCommand;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/interaction/UserCommandDeleteEvent : dev/kord/core/event/interaction/ApplicationCommandDeleteEvent {
+	public fun <init> (Ldev/kord/core/entity/application/GuildUserCommand;Ldev/kord/core/Kord;I)V
 	public synthetic fun getCommand ()Ldev/kord/core/entity/application/GuildApplicationCommand;
 	public fun getCommand ()Ldev/kord/core/entity/application/GuildUserCommand;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
@@ -12062,27 +11792,22 @@ public final class dev/kord/core/event/interaction/UserCommandInteractionCreateE
 	public static fun getGateway (Ldev/kord/core/event/interaction/UserCommandInteractionCreateEvent;)Ldev/kord/gateway/Gateway;
 }
 
-public final class dev/kord/core/event/interaction/UserCommandUpdateEvent : dev/kord/core/event/interaction/ApplicationCommandUpdateEvent, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/application/GuildUserCommand;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/application/GuildUserCommand;Ldev/kord/core/Kord;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/interaction/UserCommandUpdateEvent : dev/kord/core/event/interaction/ApplicationCommandUpdateEvent {
+	public fun <init> (Ldev/kord/core/entity/application/GuildUserCommand;Ldev/kord/core/Kord;I)V
 	public synthetic fun getCommand ()Ldev/kord/core/entity/application/GuildApplicationCommand;
 	public fun getCommand ()Ldev/kord/core/entity/application/GuildUserCommand;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
 }
 
-public final class dev/kord/core/event/message/MessageBulkDeleteEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ljava/util/Set;Ljava/util/Set;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ljava/util/Set;Ljava/util/Set;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/message/MessageBulkDeleteEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event {
+	public fun <init> (Ljava/util/Set;Ljava/util/Set;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;)V
+	public synthetic fun <init> (Ljava/util/Set;Ljava/util/Set;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getChannel ()Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public final fun getChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
 	public final fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -12097,11 +11822,9 @@ public final class dev/kord/core/event/message/MessageBulkDeleteEvent : dev/kord
 	public fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/event/message/MessageBulkDeleteEvent;
 }
 
-public final class dev/kord/core/event/message/MessageCreateEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/Message;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/entity/Member;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/Message;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/entity/Member;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+public final class dev/kord/core/event/message/MessageCreateEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event {
+	public fun <init> (Ldev/kord/core/entity/Message;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/entity/Member;ILdev/kord/core/supplier/EntitySupplier;)V
+	public synthetic fun <init> (Ldev/kord/core/entity/Message;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/entity/Member;ILdev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
@@ -12115,15 +11838,13 @@ public final class dev/kord/core/event/message/MessageCreateEvent : dev/kord/cor
 	public fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/event/message/MessageCreateEvent;
 }
 
-public final class dev/kord/core/event/message/MessageDeleteEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/entity/Message;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/entity/Message;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/message/MessageDeleteEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event {
+	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/entity/Message;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;)V
+	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/entity/Message;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getChannel ()Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public final fun getChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
 	public final fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -12138,13 +11859,11 @@ public final class dev/kord/core/event/message/MessageDeleteEvent : dev/kord/cor
 	public fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/event/message/MessageDeleteEvent;
 }
 
-public final class dev/kord/core/event/message/MessageUpdateEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordPartialMessage;Ldev/kord/core/entity/Message;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordPartialMessage;Ldev/kord/core/entity/Message;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/message/MessageUpdateEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event {
+	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordPartialMessage;Ldev/kord/core/entity/Message;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;)V
+	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordPartialMessage;Ldev/kord/core/entity/Message;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getChannel ()Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getMessage ()Ldev/kord/core/behavior/MessageBehavior;
@@ -12160,15 +11879,13 @@ public final class dev/kord/core/event/message/MessageUpdateEvent : dev/kord/cor
 	public fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/event/message/MessageUpdateEvent;
 }
 
-public final class dev/kord/core/event/message/ReactionAddEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/entity/ReactionEmoji;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/entity/ReactionEmoji;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/message/ReactionAddEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event {
+	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/entity/ReactionEmoji;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;)V
+	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/entity/ReactionEmoji;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getChannel ()Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public final fun getChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
 	public final fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public final fun getEmoji ()Ldev/kord/core/entity/ReactionEmoji;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
@@ -12192,15 +11909,13 @@ public final class dev/kord/core/event/message/ReactionAddEvent : dev/kord/core/
 	public fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/event/message/ReactionAddEvent;
 }
 
-public final class dev/kord/core/event/message/ReactionRemoveAllEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/message/ReactionRemoveAllEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event {
+	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;)V
+	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getChannel ()Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public final fun getChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
 	public final fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -12217,15 +11932,13 @@ public final class dev/kord/core/event/message/ReactionRemoveAllEvent : dev/kord
 	public fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/event/message/ReactionRemoveAllEvent;
 }
 
-public final class dev/kord/core/event/message/ReactionRemoveEmojiEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/cache/data/ReactionRemoveEmojiData;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/cache/data/ReactionRemoveEmojiData;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/message/ReactionRemoveEmojiEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event {
+	public fun <init> (Ldev/kord/core/cache/data/ReactionRemoveEmojiData;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;)V
+	public synthetic fun <init> (Ldev/kord/core/cache/data/ReactionRemoveEmojiData;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getChannel ()Ldev/kord/core/behavior/channel/GuildMessageChannelBehavior;
 	public final fun getChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
 	public final fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public final fun getData ()Ldev/kord/core/cache/data/ReactionRemoveEmojiData;
 	public final fun getEmoji ()Ldev/kord/core/entity/ReactionEmoji;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
@@ -12245,15 +11958,13 @@ public final class dev/kord/core/event/message/ReactionRemoveEmojiEvent : dev/ko
 	public fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/event/message/ReactionRemoveAllEvent;
 }
 
-public final class dev/kord/core/event/message/ReactionRemoveEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/entity/ReactionEmoji;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/entity/ReactionEmoji;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/kord/core/event/message/ReactionRemoveEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event {
+	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/entity/ReactionEmoji;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;)V
+	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/entity/ReactionEmoji;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getChannel ()Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public final fun getChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
 	public final fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public final fun getEmoji ()Ldev/kord/core/entity/ReactionEmoji;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
@@ -12277,11 +11988,9 @@ public final class dev/kord/core/event/message/ReactionRemoveEvent : dev/kord/co
 	public fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/event/message/ReactionRemoveEvent;
 }
 
-public final class dev/kord/core/event/role/RoleCreateEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/Role;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/Role;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+public final class dev/kord/core/event/role/RoleCreateEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event {
+	public fun <init> (Ldev/kord/core/entity/Role;ILdev/kord/core/supplier/EntitySupplier;)V
+	public synthetic fun <init> (Ldev/kord/core/entity/Role;ILdev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -12296,11 +12005,9 @@ public final class dev/kord/core/event/role/RoleCreateEvent : dev/kord/core/enti
 	public fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/event/role/RoleCreateEvent;
 }
 
-public final class dev/kord/core/event/role/RoleDeleteEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/entity/Role;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/entity/Role;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+public final class dev/kord/core/event/role/RoleDeleteEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event {
+	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/entity/Role;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;)V
+	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/entity/Role;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -12316,11 +12023,9 @@ public final class dev/kord/core/event/role/RoleDeleteEvent : dev/kord/core/enti
 	public fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/event/role/RoleDeleteEvent;
 }
 
-public final class dev/kord/core/event/role/RoleUpdateEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/Role;Ldev/kord/core/entity/Role;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/Role;Ldev/kord/core/entity/Role;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+public final class dev/kord/core/event/role/RoleUpdateEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event {
+	public fun <init> (Ldev/kord/core/entity/Role;Ldev/kord/core/entity/Role;ILdev/kord/core/supplier/EntitySupplier;)V
+	public synthetic fun <init> (Ldev/kord/core/entity/Role;Ldev/kord/core/entity/Role;ILdev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -12336,11 +12041,9 @@ public final class dev/kord/core/event/role/RoleUpdateEvent : dev/kord/core/enti
 	public fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/event/role/RoleUpdateEvent;
 }
 
-public final class dev/kord/core/event/user/PresenceUpdateEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/User;Ldev/kord/common/entity/DiscordPresenceUser;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/entity/Presence;Ldev/kord/core/entity/Presence;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/User;Ldev/kord/common/entity/DiscordPresenceUser;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/entity/Presence;Ldev/kord/core/entity/Presence;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+public final class dev/kord/core/event/user/PresenceUpdateEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event {
+	public fun <init> (Ldev/kord/core/entity/User;Ldev/kord/common/entity/DiscordPresenceUser;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/entity/Presence;Ldev/kord/core/entity/Presence;ILdev/kord/core/supplier/EntitySupplier;)V
+	public synthetic fun <init> (Ldev/kord/core/entity/User;Ldev/kord/common/entity/DiscordPresenceUser;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/entity/Presence;Ldev/kord/core/entity/Presence;ILdev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -12363,11 +12066,8 @@ public final class dev/kord/core/event/user/PresenceUpdateEvent : dev/kord/core/
 	public fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/event/user/PresenceUpdateEvent;
 }
 
-public final class dev/kord/core/event/user/UserUpdateEvent : dev/kord/core/event/Event, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/User;Ldev/kord/core/entity/User;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/User;Ldev/kord/core/entity/User;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+public final class dev/kord/core/event/user/UserUpdateEvent : dev/kord/core/event/Event {
+	public fun <init> (Ldev/kord/core/entity/User;Ldev/kord/core/entity/User;I)V
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getOld ()Ldev/kord/core/entity/User;
@@ -12376,11 +12076,8 @@ public final class dev/kord/core/event/user/UserUpdateEvent : dev/kord/core/even
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/kord/core/event/user/VoiceStateUpdateEvent : dev/kord/core/event/Event, kotlinx/coroutines/CoroutineScope {
-	public fun <init> (Ldev/kord/core/entity/VoiceState;Ldev/kord/core/entity/VoiceState;ILkotlinx/coroutines/CoroutineScope;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/VoiceState;Ldev/kord/core/entity/VoiceState;ILkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+public final class dev/kord/core/event/user/VoiceStateUpdateEvent : dev/kord/core/event/Event {
+	public fun <init> (Ldev/kord/core/entity/VoiceState;Ldev/kord/core/entity/VoiceState;I)V
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getOld ()Ldev/kord/core/entity/VoiceState;
@@ -12491,12 +12188,11 @@ public final class dev/kord/core/gateway/ShardEvent {
 public abstract class dev/kord/core/gateway/handler/BaseGatewayEventHandler {
 	public fun <init> (Ldev/kord/cache/api/DataCache;)V
 	protected final fun getCache ()Ldev/kord/cache/api/DataCache;
-	public abstract fun handle (Ldev/kord/gateway/Event;ILdev/kord/core/Kord;Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun handle (Ldev/kord/gateway/Event;ILdev/kord/core/Kord;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class dev/kord/core/gateway/handler/DefaultGatewayEventInterceptor : dev/kord/core/gateway/handler/GatewayEventInterceptor {
-	public fun <init> (Ldev/kord/cache/api/DataCache;Lkotlin/jvm/functions/Function2;)V
-	public synthetic fun <init> (Ldev/kord/cache/api/DataCache;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ldev/kord/cache/api/DataCache;)V
 	public fun handle (Ldev/kord/core/gateway/ShardEvent;Ldev/kord/core/Kord;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -12506,18 +12202,18 @@ public abstract interface class dev/kord/core/gateway/handler/GatewayEventInterc
 
 public final class dev/kord/core/gateway/handler/InteractionEventHandler : dev/kord/core/gateway/handler/BaseGatewayEventHandler {
 	public fun <init> (Ldev/kord/cache/api/DataCache;)V
-	public fun handle (Ldev/kord/gateway/Event;ILdev/kord/core/Kord;Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun handle (Ldev/kord/gateway/Event;ILdev/kord/core/Kord;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class dev/kord/core/gateway/handler/ThreadEventHandler : dev/kord/core/gateway/handler/BaseGatewayEventHandler {
 	public fun <init> (Ldev/kord/cache/api/DataCache;)V
-	public fun handle (Ldev/kord/gateway/Event;ILdev/kord/core/Kord;Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun handle (Ldev/kord/gateway/ThreadCreate;ILdev/kord/core/Kord;Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun handle (Ldev/kord/gateway/ThreadDelete;ILdev/kord/core/Kord;Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun handle (Ldev/kord/gateway/ThreadListSync;ILdev/kord/core/Kord;Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun handle (Ldev/kord/gateway/ThreadMemberUpdate;ILdev/kord/core/Kord;Lkotlinx/coroutines/CoroutineScope;)Ldev/kord/core/event/Event;
-	public final fun handle (Ldev/kord/gateway/ThreadMembersUpdate;ILdev/kord/core/Kord;Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun handle (Ldev/kord/gateway/ThreadUpdate;ILdev/kord/core/Kord;Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun handle (Ldev/kord/gateway/Event;ILdev/kord/core/Kord;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun handle (Ldev/kord/gateway/ThreadCreate;ILdev/kord/core/Kord;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun handle (Ldev/kord/gateway/ThreadDelete;ILdev/kord/core/Kord;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun handle (Ldev/kord/gateway/ThreadListSync;ILdev/kord/core/Kord;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun handle (Ldev/kord/gateway/ThreadMemberUpdate;ILdev/kord/core/Kord;)Ldev/kord/core/event/channel/thread/ThreadMemberUpdateEvent;
+	public final fun handle (Ldev/kord/gateway/ThreadMembersUpdate;ILdev/kord/core/Kord;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun handle (Ldev/kord/gateway/ThreadUpdate;ILdev/kord/core/Kord;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract class dev/kord/core/live/AbstractLiveKordEntity : dev/kord/core/live/LiveKordEntity, kotlinx/coroutines/CoroutineScope {

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -1,40 +1,3 @@
-public final class cache/data/MessageInteractionData {
-	public static final field Companion Lcache/data/MessageInteractionData$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/InteractionType;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/InteractionType;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
-	public final fun component2 ()Ldev/kord/common/entity/InteractionType;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Ldev/kord/common/entity/Snowflake;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/InteractionType;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;)Lcache/data/MessageInteractionData;
-	public static synthetic fun copy$default (Lcache/data/MessageInteractionData;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/InteractionType;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;ILjava/lang/Object;)Lcache/data/MessageInteractionData;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
-	public final fun getName ()Ljava/lang/String;
-	public final fun getType ()Ldev/kord/common/entity/InteractionType;
-	public final fun getUser ()Ldev/kord/common/entity/Snowflake;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lcache/data/MessageInteractionData;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
-}
-
-public final class cache/data/MessageInteractionData$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
-	public static final field INSTANCE Lcache/data/MessageInteractionData$$serializer;
-	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
-	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
-	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcache/data/MessageInteractionData;
-	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
-	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
-	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcache/data/MessageInteractionData;)V
-	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
-}
-
-public final class cache/data/MessageInteractionData$Companion {
-	public final fun from (Ldev/kord/common/entity/DiscordMessageInteraction;)Lcache/data/MessageInteractionData;
-	public final fun serializer ()Lkotlinx/serialization/KSerializer;
-}
-
 public final class dev/kord/core/ClientResources {
 	public fun <init> (Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/gateway/builder/Shards;Lio/ktor/client/HttpClient;Ldev/kord/core/supplier/EntitySupplyStrategy;)V
 	public final fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
@@ -319,7 +282,7 @@ public abstract interface class dev/kord/core/behavior/GuildBehavior : dev/kord/
 	public abstract fun getWidgetOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun kick (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun leave (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun modifySelfNickname (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract synthetic fun modifySelfNickname (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun prune (ILjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun requestMembers (Ldev/kord/gateway/RequestGuildMembers;)Lkotlinx/coroutines/flow/Flow;
 	public abstract fun unban (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -392,7 +355,7 @@ public final class dev/kord/core/behavior/GuildBehavior$DefaultImpls {
 	public static fun kick (Ldev/kord/core/behavior/GuildBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun kick$default (Ldev/kord/core/behavior/GuildBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static fun leave (Ldev/kord/core/behavior/GuildBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun modifySelfNickname (Ldev/kord/core/behavior/GuildBehavior;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun modifySelfNickname (Ldev/kord/core/behavior/GuildBehavior;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun modifySelfNickname$default (Ldev/kord/core/behavior/GuildBehavior;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static fun prune (Ldev/kord/core/behavior/GuildBehavior;ILjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun prune$default (Ldev/kord/core/behavior/GuildBehavior;ILjava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
@@ -405,7 +368,7 @@ public final class dev/kord/core/behavior/GuildBehavior$DefaultImpls {
 public final class dev/kord/core/behavior/GuildBehaviorKt {
 	public static final fun GuildBehavior (Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/GuildBehavior;
 	public static synthetic fun GuildBehavior$default (Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;ILjava/lang/Object;)Ldev/kord/core/behavior/GuildBehavior;
-	public static final fun addRole (Ldev/kord/core/behavior/GuildBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final synthetic fun addRole (Ldev/kord/core/behavior/GuildBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun addRole$default (Ldev/kord/core/behavior/GuildBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun ban (Ldev/kord/core/behavior/GuildBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun createApplicationCommands (Ldev/kord/core/behavior/GuildBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -650,7 +613,7 @@ public final class dev/kord/core/behavior/MessageBehaviorKt {
 	public static final fun edit (Ldev/kord/core/behavior/MessageBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun edit (Ldev/kord/core/behavior/MessageBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun edit$default (Ldev/kord/core/behavior/MessageBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static final fun editWebhookMessage (Ldev/kord/core/behavior/MessageBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final synthetic fun editWebhookMessage (Ldev/kord/core/behavior/MessageBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun reply (Ldev/kord/core/behavior/MessageBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -1565,8 +1528,8 @@ public final class dev/kord/core/behavior/channel/threads/ThreadParentChannelBeh
 }
 
 public abstract interface class dev/kord/core/behavior/interaction/ActionInteractionBehavior : dev/kord/core/behavior/interaction/InteractionBehavior {
-	public abstract fun acknowledgeEphemeral (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun acknowledgePublic (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract synthetic fun acknowledgeEphemeral (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract synthetic fun acknowledgePublic (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun deferEphemeralMessage (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun deferEphemeralResponse (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun deferEphemeralResponseUnsafe (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -1579,8 +1542,8 @@ public abstract interface class dev/kord/core/behavior/interaction/ActionInterac
 }
 
 public final class dev/kord/core/behavior/interaction/ActionInteractionBehavior$DefaultImpls {
-	public static fun acknowledgeEphemeral (Ldev/kord/core/behavior/interaction/ActionInteractionBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun acknowledgePublic (Ldev/kord/core/behavior/interaction/ActionInteractionBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun acknowledgeEphemeral (Ldev/kord/core/behavior/interaction/ActionInteractionBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun acknowledgePublic (Ldev/kord/core/behavior/interaction/ActionInteractionBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun compareTo (Ldev/kord/core/behavior/interaction/ActionInteractionBehavior;Ldev/kord/core/entity/Entity;)I
 	public static fun deferEphemeralMessage (Ldev/kord/core/behavior/interaction/ActionInteractionBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun deferEphemeralResponse (Ldev/kord/core/behavior/interaction/ActionInteractionBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -1608,8 +1571,8 @@ public abstract interface class dev/kord/core/behavior/interaction/ApplicationCo
 }
 
 public final class dev/kord/core/behavior/interaction/ApplicationCommandInteractionBehavior$DefaultImpls {
-	public static fun acknowledgeEphemeral (Ldev/kord/core/behavior/interaction/ApplicationCommandInteractionBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun acknowledgePublic (Ldev/kord/core/behavior/interaction/ApplicationCommandInteractionBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun acknowledgeEphemeral (Ldev/kord/core/behavior/interaction/ApplicationCommandInteractionBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun acknowledgePublic (Ldev/kord/core/behavior/interaction/ApplicationCommandInteractionBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun compareTo (Ldev/kord/core/behavior/interaction/ApplicationCommandInteractionBehavior;Ldev/kord/core/entity/Entity;)I
 	public static fun deferEphemeralMessage (Ldev/kord/core/behavior/interaction/ApplicationCommandInteractionBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun deferEphemeralResponse (Ldev/kord/core/behavior/interaction/ApplicationCommandInteractionBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -1651,9 +1614,9 @@ public abstract interface class dev/kord/core/behavior/interaction/ComponentInte
 }
 
 public final class dev/kord/core/behavior/interaction/ComponentInteractionBehavior$DefaultImpls {
-	public static fun acknowledgeEphemeral (Ldev/kord/core/behavior/interaction/ComponentInteractionBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun acknowledgeEphemeral (Ldev/kord/core/behavior/interaction/ComponentInteractionBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun acknowledgeEphemeralDeferredMessageUpdate (Ldev/kord/core/behavior/interaction/ComponentInteractionBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun acknowledgePublic (Ldev/kord/core/behavior/interaction/ComponentInteractionBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun acknowledgePublic (Ldev/kord/core/behavior/interaction/ComponentInteractionBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun acknowledgePublicDeferredMessageUpdate (Ldev/kord/core/behavior/interaction/ComponentInteractionBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun compareTo (Ldev/kord/core/behavior/interaction/ComponentInteractionBehavior;Ldev/kord/core/entity/Entity;)I
 	public static fun deferEphemeralMessage (Ldev/kord/core/behavior/interaction/ComponentInteractionBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -1709,7 +1672,7 @@ public abstract interface class dev/kord/core/behavior/interaction/GuildInteract
 	public abstract fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public abstract fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getGuildBehavior ()Ldev/kord/core/behavior/GuildBehavior;
+	public abstract synthetic fun getGuildBehavior ()Ldev/kord/core/behavior/GuildBehavior;
 	public abstract fun getGuildId ()Ldev/kord/common/entity/Snowflake;
 	public abstract fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/interaction/GuildInteractionBehavior;
@@ -1722,7 +1685,7 @@ public final class dev/kord/core/behavior/interaction/GuildInteractionBehavior$D
 	public static fun getChannelOrNull (Ldev/kord/core/behavior/interaction/GuildInteractionBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getGuild (Ldev/kord/core/behavior/interaction/GuildInteractionBehavior;)Ldev/kord/core/behavior/GuildBehavior;
 	public static fun getGuild (Ldev/kord/core/behavior/interaction/GuildInteractionBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getGuildBehavior (Ldev/kord/core/behavior/interaction/GuildInteractionBehavior;)Ldev/kord/core/behavior/GuildBehavior;
+	public static synthetic fun getGuildBehavior (Ldev/kord/core/behavior/interaction/GuildInteractionBehavior;)Ldev/kord/core/behavior/GuildBehavior;
 	public static fun getGuildOrNull (Ldev/kord/core/behavior/interaction/GuildInteractionBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun withStrategy (Ldev/kord/core/behavior/interaction/GuildInteractionBehavior;Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/interaction/GuildInteractionBehavior;
 }
@@ -1754,8 +1717,8 @@ public abstract interface class dev/kord/core/behavior/interaction/ModalParentIn
 }
 
 public final class dev/kord/core/behavior/interaction/ModalParentInteractionBehavior$DefaultImpls {
-	public static fun acknowledgeEphemeral (Ldev/kord/core/behavior/interaction/ModalParentInteractionBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun acknowledgePublic (Ldev/kord/core/behavior/interaction/ModalParentInteractionBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun acknowledgeEphemeral (Ldev/kord/core/behavior/interaction/ModalParentInteractionBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun acknowledgePublic (Ldev/kord/core/behavior/interaction/ModalParentInteractionBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun compareTo (Ldev/kord/core/behavior/interaction/ModalParentInteractionBehavior;Ldev/kord/core/entity/Entity;)I
 	public static fun deferEphemeralMessage (Ldev/kord/core/behavior/interaction/ModalParentInteractionBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun deferEphemeralResponse (Ldev/kord/core/behavior/interaction/ModalParentInteractionBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -1943,8 +1906,8 @@ public final class dev/kord/core/behavior/interaction/response/InteractionRespon
 }
 
 public final class dev/kord/core/behavior/interaction/response/InteractionResponseBehaviorKt {
-	public static final fun followUp (Ldev/kord/core/behavior/interaction/response/InteractionResponseBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun followUpEphemeral (Ldev/kord/core/behavior/interaction/response/InteractionResponseBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final synthetic fun followUp (Ldev/kord/core/behavior/interaction/response/InteractionResponseBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final synthetic fun followUpEphemeral (Ldev/kord/core/behavior/interaction/response/InteractionResponseBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class dev/kord/core/behavior/interaction/response/MessageInteractionResponseBehavior : dev/kord/core/behavior/interaction/response/FollowupPermittingInteractionResponseBehavior {
@@ -4135,6 +4098,43 @@ public final class dev/kord/core/cache/data/MessageDataKt {
 	public static final fun toData (Ldev/kord/common/entity/DiscordMessage;)Ldev/kord/core/cache/data/MessageData;
 }
 
+public final class dev/kord/core/cache/data/MessageInteractionData {
+	public static final field Companion Ldev/kord/core/cache/data/MessageInteractionData$Companion;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/InteractionType;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/InteractionType;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;)V
+	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component2 ()Ldev/kord/common/entity/InteractionType;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ldev/kord/common/entity/Snowflake;
+	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/InteractionType;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/cache/data/MessageInteractionData;
+	public static synthetic fun copy$default (Ldev/kord/core/cache/data/MessageInteractionData;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/InteractionType;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;ILjava/lang/Object;)Ldev/kord/core/cache/data/MessageInteractionData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getType ()Ldev/kord/common/entity/InteractionType;
+	public final fun getUser ()Ldev/kord/common/entity/Snowflake;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Ldev/kord/core/cache/data/MessageInteractionData;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class dev/kord/core/cache/data/MessageInteractionData$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Ldev/kord/core/cache/data/MessageInteractionData$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/kord/core/cache/data/MessageInteractionData;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ldev/kord/core/cache/data/MessageInteractionData;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/kord/core/cache/data/MessageInteractionData$Companion {
+	public final fun from (Ldev/kord/common/entity/DiscordMessageInteraction;)Ldev/kord/core/cache/data/MessageInteractionData;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class dev/kord/core/cache/data/MessageReferenceData {
 	public static final field Companion Ldev/kord/core/cache/data/MessageReferenceData$Companion;
 	public fun <init> ()V
@@ -5446,7 +5446,7 @@ public final class dev/kord/core/entity/Activity {
 	public final fun getSecrets ()Ldev/kord/core/entity/Activity$Secrets;
 	public final fun getStart ()Lkotlinx/datetime/Instant;
 	public final fun getState ()Ljava/lang/String;
-	public final fun getStop ()Lkotlinx/datetime/Instant;
+	public final synthetic fun getStop ()Lkotlinx/datetime/Instant;
 	public static fun getStop$delegate (Ldev/kord/core/entity/Activity;)Ljava/lang/Object;
 	public final fun getType ()Ldev/kord/common/entity/ActivityType;
 	public final fun getUrl ()Ljava/lang/String;
@@ -5506,7 +5506,7 @@ public final class dev/kord/core/entity/Application : dev/kord/core/entity/BaseA
 	public synthetic fun <init> (Ldev/kord/core/cache/data/ApplicationData;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getData ()Ldev/kord/core/cache/data/ApplicationData;
 	public synthetic fun getData ()Ldev/kord/core/cache/data/BaseApplicationData;
-	public final fun getOwner (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final synthetic fun getOwner (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getRequireCodeGrant ()Z
 	public final fun getTeam ()Ldev/kord/core/entity/Team;
 	public final fun getTeamId ()Ldev/kord/common/entity/Snowflake;
@@ -5851,10 +5851,10 @@ public final class dev/kord/core/entity/Guild : dev/kord/core/behavior/GuildBeha
 	public final fun getDiscoverySplash (Ldev/kord/rest/Image$Format;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getDiscoverySplashHash ()Ljava/lang/String;
 	public final fun getDiscoverySplashUrl (Ldev/kord/rest/Image$Format;)Ljava/lang/String;
-	public final fun getEmbedChannel ()Ldev/kord/core/behavior/channel/TopGuildChannelBehavior;
+	public final synthetic fun getEmbedChannel ()Ldev/kord/core/behavior/channel/TopGuildChannelBehavior;
 	public final fun getEmbedChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getEmbedChannel$delegate (Ldev/kord/core/entity/Guild;)Ljava/lang/Object;
-	public final fun getEmbedChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final synthetic fun getEmbedChannelId ()Ldev/kord/common/entity/Snowflake;
 	public static fun getEmbedChannelId$delegate (Ldev/kord/core/entity/Guild;)Ljava/lang/Object;
 	public final fun getEmoji (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getEmojiIds ()Ljava/util/Set;
@@ -5951,7 +5951,7 @@ public final class dev/kord/core/entity/Guild : dev/kord/core/behavior/GuildBeha
 	public final fun isWidgetEnabled ()Z
 	public fun kick (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun leave (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun modifySelfNickname (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun modifySelfNickname (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun prune (ILjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun requestMembers (Ldev/kord/gateway/RequestGuildMembers;)Lkotlinx/coroutines/flow/Flow;
 	public fun toString ()Ljava/lang/String;
@@ -6172,7 +6172,7 @@ public class dev/kord/core/entity/Invite : dev/kord/core/KordObject, dev/kord/co
 	public final fun getApproximateMemberCount ()Ljava/lang/Integer;
 	public final fun getApproximatePresenceCount ()Ljava/lang/Integer;
 	public final fun getChannel ()Ldev/kord/core/behavior/channel/ChannelBehavior;
-	public final fun getChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final synthetic fun getChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
 	public final fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getCode ()Ljava/lang/String;
@@ -6180,7 +6180,7 @@ public class dev/kord/core/entity/Invite : dev/kord/core/KordObject, dev/kord/co
 	public final fun getExpiresAt ()Lkotlinx/datetime/Instant;
 	public final fun getGuildScheduledEvent ()Ldev/kord/core/entity/GuildScheduledEvent;
 	public final fun getInviter ()Ldev/kord/core/behavior/UserBehavior;
-	public final fun getInviter (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final synthetic fun getInviter (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getInviterId ()Ldev/kord/common/entity/Snowflake;
 	public final fun getInviterOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getKord ()Ldev/kord/core/Kord;
@@ -6189,7 +6189,7 @@ public class dev/kord/core/entity/Invite : dev/kord/core/KordObject, dev/kord/co
 	public final fun getTargetApplication ()Ldev/kord/core/entity/PartialApplication;
 	public final fun getTargetType ()Ldev/kord/common/entity/InviteTargetType;
 	public final fun getTargetUser ()Ldev/kord/core/behavior/UserBehavior;
-	public final fun getTargetUser (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final synthetic fun getTargetUser (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getTargetUserId ()Ldev/kord/common/entity/Snowflake;
 	public final fun getTargetUserOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getTargetUserType ()Ldev/kord/common/entity/TargetUserType;
@@ -6336,11 +6336,11 @@ public final class dev/kord/core/entity/Message : dev/kord/core/behavior/Message
 }
 
 public final class dev/kord/core/entity/Message$Interaction : dev/kord/core/entity/KordEntity, dev/kord/core/entity/Strategizable {
-	public fun <init> (Lcache/data/MessageInteractionData;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)V
-	public synthetic fun <init> (Lcache/data/MessageInteractionData;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ldev/kord/core/cache/data/MessageInteractionData;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)V
+	public synthetic fun <init> (Ldev/kord/core/cache/data/MessageInteractionData;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun compareTo (Ldev/kord/core/entity/Entity;)I
 	public synthetic fun compareTo (Ljava/lang/Object;)I
-	public final fun getData ()Lcache/data/MessageInteractionData;
+	public final fun getData ()Ldev/kord/core/cache/data/MessageInteractionData;
 	public fun getId ()Ldev/kord/common/entity/Snowflake;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getName ()Ljava/lang/String;
@@ -6460,7 +6460,7 @@ public final class dev/kord/core/entity/PartialGuild : dev/kord/core/behavior/Gu
 	public fun hashCode ()I
 	public fun kick (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun leave (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun modifySelfNickname (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun modifySelfNickname (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun prune (ILjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun requestMembers (Ldev/kord/gateway/RequestGuildMembers;)Lkotlinx/coroutines/flow/Flow;
 	public fun toString ()Ljava/lang/String;
@@ -6518,11 +6518,11 @@ public final class dev/kord/core/entity/Presence : dev/kord/core/KordObject, dev
 	public final fun getActivities ()Ljava/util/List;
 	public final fun getClientStatus ()Ldev/kord/core/entity/ClientStatus;
 	public final fun getData ()Ldev/kord/core/cache/data/PresenceData;
-	public final fun getGame ()Ldev/kord/core/entity/Activity;
+	public final synthetic fun getGame ()Ldev/kord/core/entity/Activity;
 	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
 	public fun getKord ()Ldev/kord/core/Kord;
-	public final fun getRoleIds ()Ljava/util/Set;
-	public final fun getRoles ()Lkotlinx/coroutines/flow/Flow;
+	public final synthetic fun getRoleIds ()Ljava/util/Set;
+	public final synthetic fun getRoles ()Lkotlinx/coroutines/flow/Flow;
 	public final fun getStatus ()Ldev/kord/common/entity/PresenceStatus;
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
 	public final fun getUser (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -6810,12 +6810,12 @@ public class dev/kord/core/entity/User : dev/kord/core/behavior/UserBehavior {
 	public final fun getDiscriminator ()Ljava/lang/String;
 	public fun getDmChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getDmChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getFlags ()Ldev/kord/common/entity/UserFlags;
+	public final synthetic fun getFlags ()Ldev/kord/common/entity/UserFlags;
 	public static fun getFlags$delegate (Ldev/kord/core/entity/User;)Ljava/lang/Object;
 	public fun getId ()Ldev/kord/common/entity/Snowflake;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getMention ()Ljava/lang/String;
-	public final fun getPremiumType ()Ldev/kord/common/entity/UserPremium;
+	public final synthetic fun getPremiumType ()Ldev/kord/common/entity/UserPremium;
 	public final fun getPublicFlags ()Ldev/kord/common/entity/UserFlags;
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
 	public final fun getTag ()Ljava/lang/String;
@@ -6857,7 +6857,7 @@ public final class dev/kord/core/entity/User$Avatar : dev/kord/core/KordObject {
 public final class dev/kord/core/entity/VoiceState : dev/kord/core/KordObject, dev/kord/core/entity/Strategizable {
 	public fun <init> (Ldev/kord/core/cache/data/VoiceStateData;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)V
 	public synthetic fun <init> (Ldev/kord/core/cache/data/VoiceStateData;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final synthetic fun getChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
 	public final fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getData ()Ldev/kord/core/cache/data/VoiceStateData;
@@ -6875,7 +6875,7 @@ public final class dev/kord/core/entity/VoiceState : dev/kord/core/KordObject, d
 	public final fun isMuted ()Z
 	public final fun isSelfDeafened ()Z
 	public final fun isSelfMuted ()Z
-	public final fun isSelfSteaming ()Z
+	public final synthetic fun isSelfSteaming ()Z
 	public final fun isSelfStreaming ()Z
 	public final fun isSelfVideo ()Z
 	public final fun isSuppressed ()Z
@@ -6905,7 +6905,7 @@ public final class dev/kord/core/entity/Webhook : dev/kord/core/behavior/Webhook
 	public final fun getCreatorId ()Ldev/kord/common/entity/Snowflake;
 	public final fun getData ()Ldev/kord/core/cache/data/WebhookData;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
-	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final synthetic fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
 	public final fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getId ()Ldev/kord/common/entity/Snowflake;
@@ -7281,11 +7281,6 @@ public final class dev/kord/core/entity/channel/CategorizableChannel$DefaultImpl
 	public static fun getType (Ldev/kord/core/entity/channel/CategorizableChannel;)Ldev/kord/common/entity/ChannelType;
 }
 
-public final class dev/kord/core/entity/channel/CategorizableChannelKt {
-	public static final synthetic fun createInvite (Ldev/kord/core/entity/channel/CategorizableChannel;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun createInvite$default (Ldev/kord/core/entity/channel/CategorizableChannel;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-}
-
 public final class dev/kord/core/entity/channel/Category : dev/kord/core/behavior/channel/CategoryBehavior, dev/kord/core/entity/channel/TopGuildChannel {
 	public fun <init> (Ldev/kord/core/cache/data/ChannelData;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)V
 	public synthetic fun <init> (Ldev/kord/core/cache/data/ChannelData;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -7379,7 +7374,7 @@ public final class dev/kord/core/entity/channel/DmChannel : dev/kord/core/entity
 	public fun getLastMessage ()Ldev/kord/core/behavior/MessageBehavior;
 	public fun getLastMessage (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getLastMessageId ()Ldev/kord/common/entity/Snowflake;
-	public fun getLastPinTimeStamp ()Lkotlinx/datetime/Instant;
+	public synthetic fun getLastPinTimeStamp ()Lkotlinx/datetime/Instant;
 	public fun getLastPinTimestamp ()Lkotlinx/datetime/Instant;
 	public fun getMention ()Ljava/lang/String;
 	public fun getMessage (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -7452,7 +7447,7 @@ public final class dev/kord/core/entity/channel/GuildMessageChannel$DefaultImpls
 	public static fun getLastMessage (Ldev/kord/core/entity/channel/GuildMessageChannel;)Ldev/kord/core/behavior/MessageBehavior;
 	public static fun getLastMessage (Ldev/kord/core/entity/channel/GuildMessageChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getLastMessageId (Ldev/kord/core/entity/channel/GuildMessageChannel;)Ldev/kord/common/entity/Snowflake;
-	public static fun getLastPinTimeStamp (Ldev/kord/core/entity/channel/GuildMessageChannel;)Lkotlinx/datetime/Instant;
+	public static synthetic fun getLastPinTimeStamp (Ldev/kord/core/entity/channel/GuildMessageChannel;)Lkotlinx/datetime/Instant;
 	public static fun getLastPinTimestamp (Ldev/kord/core/entity/channel/GuildMessageChannel;)Lkotlinx/datetime/Instant;
 	public static fun getMention (Ldev/kord/core/entity/channel/GuildMessageChannel;)Ljava/lang/String;
 	public static fun getMessage (Ldev/kord/core/entity/channel/GuildMessageChannel;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -7473,7 +7468,7 @@ public abstract interface class dev/kord/core/entity/channel/MessageChannel : de
 	public abstract fun getLastMessage ()Ldev/kord/core/behavior/MessageBehavior;
 	public abstract fun getLastMessage (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getLastMessageId ()Ldev/kord/common/entity/Snowflake;
-	public abstract fun getLastPinTimeStamp ()Lkotlinx/datetime/Instant;
+	public abstract synthetic fun getLastPinTimeStamp ()Lkotlinx/datetime/Instant;
 	public abstract fun getLastPinTimestamp ()Lkotlinx/datetime/Instant;
 	public abstract fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/entity/channel/MessageChannel;
 }
@@ -7491,7 +7486,7 @@ public final class dev/kord/core/entity/channel/MessageChannel$DefaultImpls {
 	public static fun getLastMessage (Ldev/kord/core/entity/channel/MessageChannel;)Ldev/kord/core/behavior/MessageBehavior;
 	public static fun getLastMessage (Ldev/kord/core/entity/channel/MessageChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getLastMessageId (Ldev/kord/core/entity/channel/MessageChannel;)Ldev/kord/common/entity/Snowflake;
-	public static fun getLastPinTimeStamp (Ldev/kord/core/entity/channel/MessageChannel;)Lkotlinx/datetime/Instant;
+	public static synthetic fun getLastPinTimeStamp (Ldev/kord/core/entity/channel/MessageChannel;)Lkotlinx/datetime/Instant;
 	public static fun getLastPinTimestamp (Ldev/kord/core/entity/channel/MessageChannel;)Lkotlinx/datetime/Instant;
 	public static fun getMention (Ldev/kord/core/entity/channel/MessageChannel;)Ljava/lang/String;
 	public static fun getMessage (Ldev/kord/core/entity/channel/MessageChannel;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -7538,7 +7533,7 @@ public final class dev/kord/core/entity/channel/NewsChannel : dev/kord/core/beha
 	public fun getLastMessage ()Ldev/kord/core/behavior/MessageBehavior;
 	public fun getLastMessage (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getLastMessageId ()Ldev/kord/common/entity/Snowflake;
-	public fun getLastPinTimeStamp ()Lkotlinx/datetime/Instant;
+	public synthetic fun getLastPinTimeStamp ()Lkotlinx/datetime/Instant;
 	public fun getLastPinTimestamp ()Lkotlinx/datetime/Instant;
 	public fun getMention ()Ljava/lang/String;
 	public fun getMessage (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -7748,7 +7743,7 @@ public final class dev/kord/core/entity/channel/TextChannel : dev/kord/core/beha
 	public fun getLastMessage ()Ldev/kord/core/behavior/MessageBehavior;
 	public fun getLastMessage (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getLastMessageId ()Ldev/kord/common/entity/Snowflake;
-	public fun getLastPinTimeStamp ()Lkotlinx/datetime/Instant;
+	public synthetic fun getLastPinTimeStamp ()Lkotlinx/datetime/Instant;
 	public fun getLastPinTimestamp ()Lkotlinx/datetime/Instant;
 	public fun getMention ()Ljava/lang/String;
 	public fun getMessage (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -7829,7 +7824,7 @@ public final class dev/kord/core/entity/channel/ThreadParentChannel$DefaultImpls
 	public static fun getLastMessage (Ldev/kord/core/entity/channel/ThreadParentChannel;)Ldev/kord/core/behavior/MessageBehavior;
 	public static fun getLastMessage (Ldev/kord/core/entity/channel/ThreadParentChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getLastMessageId (Ldev/kord/core/entity/channel/ThreadParentChannel;)Ldev/kord/common/entity/Snowflake;
-	public static fun getLastPinTimeStamp (Ldev/kord/core/entity/channel/ThreadParentChannel;)Lkotlinx/datetime/Instant;
+	public static synthetic fun getLastPinTimeStamp (Ldev/kord/core/entity/channel/ThreadParentChannel;)Lkotlinx/datetime/Instant;
 	public static fun getLastPinTimestamp (Ldev/kord/core/entity/channel/ThreadParentChannel;)Lkotlinx/datetime/Instant;
 	public static fun getMention (Ldev/kord/core/entity/channel/ThreadParentChannel;)Ljava/lang/String;
 	public static fun getMessage (Ldev/kord/core/entity/channel/ThreadParentChannel;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -7916,7 +7911,7 @@ public final class dev/kord/core/entity/channel/TopGuildMessageChannel$DefaultIm
 	public static fun getLastMessage (Ldev/kord/core/entity/channel/TopGuildMessageChannel;)Ldev/kord/core/behavior/MessageBehavior;
 	public static fun getLastMessage (Ldev/kord/core/entity/channel/TopGuildMessageChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getLastMessageId (Ldev/kord/core/entity/channel/TopGuildMessageChannel;)Ldev/kord/common/entity/Snowflake;
-	public static fun getLastPinTimeStamp (Ldev/kord/core/entity/channel/TopGuildMessageChannel;)Lkotlinx/datetime/Instant;
+	public static synthetic fun getLastPinTimeStamp (Ldev/kord/core/entity/channel/TopGuildMessageChannel;)Lkotlinx/datetime/Instant;
 	public static fun getLastPinTimestamp (Ldev/kord/core/entity/channel/TopGuildMessageChannel;)Lkotlinx/datetime/Instant;
 	public static fun getMention (Ldev/kord/core/entity/channel/TopGuildMessageChannel;)Ljava/lang/String;
 	public static fun getMessage (Ldev/kord/core/entity/channel/TopGuildMessageChannel;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -7970,7 +7965,7 @@ public final class dev/kord/core/entity/channel/VoiceChannel : dev/kord/core/beh
 	public fun getLastMessage ()Ldev/kord/core/behavior/MessageBehavior;
 	public fun getLastMessage (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getLastMessageId ()Ldev/kord/common/entity/Snowflake;
-	public fun getLastPinTimeStamp ()Lkotlinx/datetime/Instant;
+	public synthetic fun getLastPinTimeStamp ()Lkotlinx/datetime/Instant;
 	public fun getLastPinTimestamp ()Lkotlinx/datetime/Instant;
 	public fun getMention ()Ljava/lang/String;
 	public fun getMessage (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -8076,7 +8071,7 @@ public final class dev/kord/core/entity/channel/thread/NewsChannelThread : dev/k
 	public fun deleteMessage (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun fetchChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun fetchChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getArchiveTimeStamp ()Lkotlinx/datetime/Instant;
+	public synthetic fun getArchiveTimeStamp ()Lkotlinx/datetime/Instant;
 	public fun getArchiveTimestamp ()Lkotlinx/datetime/Instant;
 	public fun getAutoArchiveDuration ()Ldev/kord/common/entity/ArchiveDuration;
 	public fun getCreateTimestamp ()Lkotlinx/datetime/Instant;
@@ -8091,7 +8086,7 @@ public final class dev/kord/core/entity/channel/thread/NewsChannelThread : dev/k
 	public fun getLastMessage ()Ldev/kord/core/behavior/MessageBehavior;
 	public fun getLastMessage (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getLastMessageId ()Ldev/kord/common/entity/Snowflake;
-	public fun getLastPinTimeStamp ()Lkotlinx/datetime/Instant;
+	public synthetic fun getLastPinTimeStamp ()Lkotlinx/datetime/Instant;
 	public fun getLastPinTimestamp ()Lkotlinx/datetime/Instant;
 	public fun getMember ()Ldev/kord/core/entity/channel/thread/ThreadMember;
 	public fun getMemberCount ()Ldev/kord/common/entity/optional/OptionalInt;
@@ -8152,7 +8147,7 @@ public final class dev/kord/core/entity/channel/thread/TextChannelThread : dev/k
 	public fun deleteMessage (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun fetchChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun fetchChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getArchiveTimeStamp ()Lkotlinx/datetime/Instant;
+	public synthetic fun getArchiveTimeStamp ()Lkotlinx/datetime/Instant;
 	public fun getArchiveTimestamp ()Lkotlinx/datetime/Instant;
 	public fun getAutoArchiveDuration ()Ldev/kord/common/entity/ArchiveDuration;
 	public fun getCreateTimestamp ()Lkotlinx/datetime/Instant;
@@ -8167,7 +8162,7 @@ public final class dev/kord/core/entity/channel/thread/TextChannelThread : dev/k
 	public fun getLastMessage ()Ldev/kord/core/behavior/MessageBehavior;
 	public fun getLastMessage (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getLastMessageId ()Ldev/kord/common/entity/Snowflake;
-	public fun getLastPinTimeStamp ()Lkotlinx/datetime/Instant;
+	public synthetic fun getLastPinTimeStamp ()Lkotlinx/datetime/Instant;
 	public fun getLastPinTimestamp ()Lkotlinx/datetime/Instant;
 	public fun getMember ()Ldev/kord/core/entity/channel/thread/ThreadMember;
 	public fun getMemberCount ()Ldev/kord/common/entity/optional/OptionalInt;
@@ -8217,7 +8212,7 @@ public final class dev/kord/core/entity/channel/thread/TextChannelThread : dev/k
 }
 
 public abstract interface class dev/kord/core/entity/channel/thread/ThreadChannel : dev/kord/core/behavior/channel/threads/ThreadChannelBehavior, dev/kord/core/entity/channel/GuildMessageChannel {
-	public abstract fun getArchiveTimeStamp ()Lkotlinx/datetime/Instant;
+	public abstract synthetic fun getArchiveTimeStamp ()Lkotlinx/datetime/Instant;
 	public abstract fun getArchiveTimestamp ()Lkotlinx/datetime/Instant;
 	public abstract fun getAutoArchiveDuration ()Ldev/kord/common/entity/ArchiveDuration;
 	public abstract fun getCreateTimestamp ()Lkotlinx/datetime/Instant;
@@ -8246,7 +8241,7 @@ public final class dev/kord/core/entity/channel/thread/ThreadChannel$DefaultImpl
 	public static fun deleteMessage (Ldev/kord/core/entity/channel/thread/ThreadChannel;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun fetchChannel (Ldev/kord/core/entity/channel/thread/ThreadChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun fetchChannelOrNull (Ldev/kord/core/entity/channel/thread/ThreadChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getArchiveTimeStamp (Ldev/kord/core/entity/channel/thread/ThreadChannel;)Lkotlinx/datetime/Instant;
+	public static synthetic fun getArchiveTimeStamp (Ldev/kord/core/entity/channel/thread/ThreadChannel;)Lkotlinx/datetime/Instant;
 	public static fun getArchiveTimestamp (Ldev/kord/core/entity/channel/thread/ThreadChannel;)Lkotlinx/datetime/Instant;
 	public static fun getAutoArchiveDuration (Ldev/kord/core/entity/channel/thread/ThreadChannel;)Ldev/kord/common/entity/ArchiveDuration;
 	public static fun getCreateTimestamp (Ldev/kord/core/entity/channel/thread/ThreadChannel;)Lkotlinx/datetime/Instant;
@@ -8259,7 +8254,7 @@ public final class dev/kord/core/entity/channel/thread/ThreadChannel$DefaultImpl
 	public static fun getLastMessage (Ldev/kord/core/entity/channel/thread/ThreadChannel;)Ldev/kord/core/behavior/MessageBehavior;
 	public static fun getLastMessage (Ldev/kord/core/entity/channel/thread/ThreadChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getLastMessageId (Ldev/kord/core/entity/channel/thread/ThreadChannel;)Ldev/kord/common/entity/Snowflake;
-	public static fun getLastPinTimeStamp (Ldev/kord/core/entity/channel/thread/ThreadChannel;)Lkotlinx/datetime/Instant;
+	public static synthetic fun getLastPinTimeStamp (Ldev/kord/core/entity/channel/thread/ThreadChannel;)Lkotlinx/datetime/Instant;
 	public static fun getLastPinTimestamp (Ldev/kord/core/entity/channel/thread/ThreadChannel;)Lkotlinx/datetime/Instant;
 	public static fun getMember (Ldev/kord/core/entity/channel/thread/ThreadChannel;)Ldev/kord/core/entity/channel/thread/ThreadMember;
 	public static fun getMemberCount (Ldev/kord/core/entity/channel/thread/ThreadChannel;)Ldev/kord/common/entity/optional/OptionalInt;
@@ -8423,8 +8418,8 @@ public abstract interface class dev/kord/core/entity/interaction/ActionInteracti
 }
 
 public final class dev/kord/core/entity/interaction/ActionInteraction$DefaultImpls {
-	public static fun acknowledgeEphemeral (Ldev/kord/core/entity/interaction/ActionInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun acknowledgePublic (Ldev/kord/core/entity/interaction/ActionInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun acknowledgeEphemeral (Ldev/kord/core/entity/interaction/ActionInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun acknowledgePublic (Ldev/kord/core/entity/interaction/ActionInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun compareTo (Ldev/kord/core/entity/interaction/ActionInteraction;Ldev/kord/core/entity/Entity;)I
 	public static fun deferEphemeralMessage (Ldev/kord/core/entity/interaction/ActionInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun deferEphemeralResponse (Ldev/kord/core/entity/interaction/ActionInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -8457,8 +8452,8 @@ public abstract interface class dev/kord/core/entity/interaction/ApplicationComm
 }
 
 public final class dev/kord/core/entity/interaction/ApplicationCommandInteraction$DefaultImpls {
-	public static fun acknowledgeEphemeral (Ldev/kord/core/entity/interaction/ApplicationCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun acknowledgePublic (Ldev/kord/core/entity/interaction/ApplicationCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun acknowledgeEphemeral (Ldev/kord/core/entity/interaction/ApplicationCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun acknowledgePublic (Ldev/kord/core/entity/interaction/ApplicationCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun compareTo (Ldev/kord/core/entity/interaction/ApplicationCommandInteraction;Ldev/kord/core/entity/Entity;)I
 	public static fun deferEphemeralMessage (Ldev/kord/core/entity/interaction/ApplicationCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun deferEphemeralResponse (Ldev/kord/core/entity/interaction/ApplicationCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -8540,9 +8535,9 @@ public abstract interface class dev/kord/core/entity/interaction/ButtonInteracti
 }
 
 public final class dev/kord/core/entity/interaction/ButtonInteraction$DefaultImpls {
-	public static fun acknowledgeEphemeral (Ldev/kord/core/entity/interaction/ButtonInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun acknowledgeEphemeral (Ldev/kord/core/entity/interaction/ButtonInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun acknowledgeEphemeralDeferredMessageUpdate (Ldev/kord/core/entity/interaction/ButtonInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun acknowledgePublic (Ldev/kord/core/entity/interaction/ButtonInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun acknowledgePublic (Ldev/kord/core/entity/interaction/ButtonInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun acknowledgePublicDeferredMessageUpdate (Ldev/kord/core/entity/interaction/ButtonInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun compareTo (Ldev/kord/core/entity/interaction/ButtonInteraction;Ldev/kord/core/entity/Entity;)I
 	public static fun deferEphemeralMessage (Ldev/kord/core/entity/interaction/ButtonInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -8588,8 +8583,8 @@ public abstract interface class dev/kord/core/entity/interaction/ChatInputComman
 }
 
 public final class dev/kord/core/entity/interaction/ChatInputCommandInteraction$DefaultImpls {
-	public static fun acknowledgeEphemeral (Ldev/kord/core/entity/interaction/ChatInputCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun acknowledgePublic (Ldev/kord/core/entity/interaction/ChatInputCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun acknowledgeEphemeral (Ldev/kord/core/entity/interaction/ChatInputCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun acknowledgePublic (Ldev/kord/core/entity/interaction/ChatInputCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun compareTo (Ldev/kord/core/entity/interaction/ChatInputCommandInteraction;Ldev/kord/core/entity/Entity;)I
 	public static fun deferEphemeralMessage (Ldev/kord/core/entity/interaction/ChatInputCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun deferEphemeralResponse (Ldev/kord/core/entity/interaction/ChatInputCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -8627,9 +8622,9 @@ public abstract interface class dev/kord/core/entity/interaction/ComponentIntera
 }
 
 public final class dev/kord/core/entity/interaction/ComponentInteraction$DefaultImpls {
-	public static fun acknowledgeEphemeral (Ldev/kord/core/entity/interaction/ComponentInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun acknowledgeEphemeral (Ldev/kord/core/entity/interaction/ComponentInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun acknowledgeEphemeralDeferredMessageUpdate (Ldev/kord/core/entity/interaction/ComponentInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun acknowledgePublic (Ldev/kord/core/entity/interaction/ComponentInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun acknowledgePublic (Ldev/kord/core/entity/interaction/ComponentInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun acknowledgePublicDeferredMessageUpdate (Ldev/kord/core/entity/interaction/ComponentInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun compareTo (Ldev/kord/core/entity/interaction/ComponentInteraction;Ldev/kord/core/entity/Entity;)I
 	public static fun deferEphemeralMessage (Ldev/kord/core/entity/interaction/ComponentInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -8687,8 +8682,8 @@ public abstract interface class dev/kord/core/entity/interaction/GlobalApplicati
 }
 
 public final class dev/kord/core/entity/interaction/GlobalApplicationCommandInteraction$DefaultImpls {
-	public static fun acknowledgeEphemeral (Ldev/kord/core/entity/interaction/GlobalApplicationCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun acknowledgePublic (Ldev/kord/core/entity/interaction/GlobalApplicationCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun acknowledgeEphemeral (Ldev/kord/core/entity/interaction/GlobalApplicationCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun acknowledgePublic (Ldev/kord/core/entity/interaction/GlobalApplicationCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun compareTo (Ldev/kord/core/entity/interaction/GlobalApplicationCommandInteraction;Ldev/kord/core/entity/Entity;)I
 	public static fun deferEphemeralMessage (Ldev/kord/core/entity/interaction/GlobalApplicationCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun deferEphemeralResponse (Ldev/kord/core/entity/interaction/GlobalApplicationCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -8757,9 +8752,9 @@ public final class dev/kord/core/entity/interaction/GlobalAutoCompleteInteractio
 
 public final class dev/kord/core/entity/interaction/GlobalButtonInteraction : dev/kord/core/entity/interaction/ButtonInteraction, dev/kord/core/entity/interaction/GlobalComponentInteraction {
 	public fun <init> (Ldev/kord/core/cache/data/InteractionData;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)V
-	public fun acknowledgeEphemeral (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun acknowledgeEphemeral (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun acknowledgeEphemeralDeferredMessageUpdate (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun acknowledgePublic (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun acknowledgePublic (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun acknowledgePublicDeferredMessageUpdate (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun compareTo (Ldev/kord/core/entity/Entity;)I
 	public synthetic fun compareTo (Ljava/lang/Object;)I
@@ -8813,8 +8808,8 @@ public final class dev/kord/core/entity/interaction/GlobalButtonInteraction : de
 
 public final class dev/kord/core/entity/interaction/GlobalChatInputCommandInteraction : dev/kord/core/entity/interaction/ChatInputCommandInteraction, dev/kord/core/entity/interaction/GlobalApplicationCommandInteraction {
 	public fun <init> (Ldev/kord/core/cache/data/InteractionData;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)V
-	public fun acknowledgeEphemeral (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun acknowledgePublic (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun acknowledgeEphemeral (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun acknowledgePublic (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun compareTo (Ldev/kord/core/entity/Entity;)I
 	public synthetic fun compareTo (Ljava/lang/Object;)I
 	public fun deferEphemeralMessage (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -8869,9 +8864,9 @@ public abstract interface class dev/kord/core/entity/interaction/GlobalComponent
 }
 
 public final class dev/kord/core/entity/interaction/GlobalComponentInteraction$DefaultImpls {
-	public static fun acknowledgeEphemeral (Ldev/kord/core/entity/interaction/GlobalComponentInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun acknowledgeEphemeral (Ldev/kord/core/entity/interaction/GlobalComponentInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun acknowledgeEphemeralDeferredMessageUpdate (Ldev/kord/core/entity/interaction/GlobalComponentInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun acknowledgePublic (Ldev/kord/core/entity/interaction/GlobalComponentInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun acknowledgePublic (Ldev/kord/core/entity/interaction/GlobalComponentInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun acknowledgePublicDeferredMessageUpdate (Ldev/kord/core/entity/interaction/GlobalComponentInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun compareTo (Ldev/kord/core/entity/interaction/GlobalComponentInteraction;Ldev/kord/core/entity/Entity;)I
 	public static fun deferEphemeralMessage (Ldev/kord/core/entity/interaction/GlobalComponentInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -8924,8 +8919,8 @@ public final class dev/kord/core/entity/interaction/GlobalInteraction$DefaultImp
 
 public final class dev/kord/core/entity/interaction/GlobalMessageCommandInteraction : dev/kord/core/entity/interaction/GlobalApplicationCommandInteraction, dev/kord/core/entity/interaction/MessageCommandInteraction {
 	public fun <init> (Ldev/kord/core/cache/data/InteractionData;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)V
-	public fun acknowledgeEphemeral (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun acknowledgePublic (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun acknowledgeEphemeral (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun acknowledgePublic (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun compareTo (Ldev/kord/core/entity/Entity;)I
 	public synthetic fun compareTo (Ljava/lang/Object;)I
 	public fun deferEphemeralMessage (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -8956,7 +8951,7 @@ public final class dev/kord/core/entity/interaction/GlobalMessageCommandInteract
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
 	public fun getTarget ()Ldev/kord/core/behavior/MessageBehavior;
 	public fun getTarget (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getTargetBehavior ()Ldev/kord/core/behavior/MessageBehavior;
+	public synthetic fun getTargetBehavior ()Ldev/kord/core/behavior/MessageBehavior;
 	public fun getTargetId ()Ldev/kord/common/entity/Snowflake;
 	public fun getTargetOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getToken ()Ljava/lang/String;
@@ -8983,9 +8978,9 @@ public final class dev/kord/core/entity/interaction/GlobalMessageCommandInteract
 public final class dev/kord/core/entity/interaction/GlobalModalSubmitInteraction : dev/kord/core/entity/interaction/GlobalInteraction, dev/kord/core/entity/interaction/ModalSubmitInteraction {
 	public fun <init> (Ldev/kord/core/cache/data/InteractionData;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)V
 	public synthetic fun <init> (Ldev/kord/core/cache/data/InteractionData;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun acknowledgeEphemeral (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun acknowledgeEphemeral (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun acknowledgeEphemeralDeferredMessageUpdate (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun acknowledgePublic (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun acknowledgePublic (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun acknowledgePublicDeferredMessageUpdate (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun compareTo (Ldev/kord/core/entity/Entity;)I
 	public synthetic fun compareTo (Ljava/lang/Object;)I
@@ -9035,9 +9030,9 @@ public final class dev/kord/core/entity/interaction/GlobalModalSubmitInteraction
 
 public final class dev/kord/core/entity/interaction/GlobalSelectMenuInteraction : dev/kord/core/entity/interaction/GlobalComponentInteraction, dev/kord/core/entity/interaction/SelectMenuInteraction {
 	public fun <init> (Ldev/kord/core/cache/data/InteractionData;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)V
-	public fun acknowledgeEphemeral (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun acknowledgeEphemeral (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun acknowledgeEphemeralDeferredMessageUpdate (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun acknowledgePublic (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun acknowledgePublic (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun acknowledgePublicDeferredMessageUpdate (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun compareTo (Ldev/kord/core/entity/Entity;)I
 	public synthetic fun compareTo (Ljava/lang/Object;)I
@@ -9092,8 +9087,8 @@ public final class dev/kord/core/entity/interaction/GlobalSelectMenuInteraction 
 
 public final class dev/kord/core/entity/interaction/GlobalUserCommandInteraction : dev/kord/core/entity/interaction/GlobalApplicationCommandInteraction, dev/kord/core/entity/interaction/UserCommandInteraction {
 	public fun <init> (Ldev/kord/core/cache/data/InteractionData;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)V
-	public fun acknowledgeEphemeral (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun acknowledgePublic (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun acknowledgeEphemeral (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun acknowledgePublic (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun compareTo (Ldev/kord/core/entity/Entity;)I
 	public synthetic fun compareTo (Ljava/lang/Object;)I
 	public fun deferEphemeralMessage (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -9123,7 +9118,7 @@ public final class dev/kord/core/entity/interaction/GlobalUserCommandInteraction
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
 	public fun getTarget ()Ldev/kord/core/behavior/UserBehavior;
 	public fun getTarget (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getTargetBehavior ()Ldev/kord/core/behavior/UserBehavior;
+	public synthetic fun getTargetBehavior ()Ldev/kord/core/behavior/UserBehavior;
 	public fun getTargetId ()Ldev/kord/common/entity/Snowflake;
 	public fun getTargetOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getToken ()Ljava/lang/String;
@@ -9175,8 +9170,8 @@ public abstract interface class dev/kord/core/entity/interaction/GuildApplicatio
 }
 
 public final class dev/kord/core/entity/interaction/GuildApplicationCommandInteraction$DefaultImpls {
-	public static fun acknowledgeEphemeral (Ldev/kord/core/entity/interaction/GuildApplicationCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun acknowledgePublic (Ldev/kord/core/entity/interaction/GuildApplicationCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun acknowledgeEphemeral (Ldev/kord/core/entity/interaction/GuildApplicationCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun acknowledgePublic (Ldev/kord/core/entity/interaction/GuildApplicationCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun compareTo (Ldev/kord/core/entity/interaction/GuildApplicationCommandInteraction;Ldev/kord/core/entity/Entity;)I
 	public static fun deferEphemeralMessage (Ldev/kord/core/entity/interaction/GuildApplicationCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun deferEphemeralResponse (Ldev/kord/core/entity/interaction/GuildApplicationCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -9192,7 +9187,7 @@ public final class dev/kord/core/entity/interaction/GuildApplicationCommandInter
 	public static fun getChannelOrNull (Ldev/kord/core/entity/interaction/GuildApplicationCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getGuild (Ldev/kord/core/entity/interaction/GuildApplicationCommandInteraction;)Ldev/kord/core/behavior/GuildBehavior;
 	public static fun getGuild (Ldev/kord/core/entity/interaction/GuildApplicationCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getGuildBehavior (Ldev/kord/core/entity/interaction/GuildApplicationCommandInteraction;)Ldev/kord/core/behavior/GuildBehavior;
+	public static synthetic fun getGuildBehavior (Ldev/kord/core/entity/interaction/GuildApplicationCommandInteraction;)Ldev/kord/core/behavior/GuildBehavior;
 	public static fun getGuildId (Ldev/kord/core/entity/interaction/GuildApplicationCommandInteraction;)Ldev/kord/common/entity/Snowflake;
 	public static fun getGuildLocale (Ldev/kord/core/entity/interaction/GuildApplicationCommandInteraction;)Ldev/kord/common/Locale;
 	public static fun getGuildOrNull (Ldev/kord/core/entity/interaction/GuildApplicationCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -9231,7 +9226,7 @@ public final class dev/kord/core/entity/interaction/GuildAutoCompleteInteraction
 	public fun getFocusedOption ()Ldev/kord/core/entity/interaction/StringOptionValue;
 	public fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildBehavior ()Ldev/kord/core/behavior/GuildBehavior;
+	public synthetic fun getGuildBehavior ()Ldev/kord/core/behavior/GuildBehavior;
 	public fun getGuildId ()Ldev/kord/common/entity/Snowflake;
 	public fun getGuildLocale ()Ldev/kord/common/Locale;
 	public fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -9261,9 +9256,9 @@ public final class dev/kord/core/entity/interaction/GuildAutoCompleteInteraction
 
 public final class dev/kord/core/entity/interaction/GuildButtonInteraction : dev/kord/core/entity/interaction/ButtonInteraction, dev/kord/core/entity/interaction/GuildComponentInteraction {
 	public fun <init> (Ldev/kord/core/cache/data/InteractionData;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)V
-	public fun acknowledgeEphemeral (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun acknowledgeEphemeral (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun acknowledgeEphemeralDeferredMessageUpdate (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun acknowledgePublic (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun acknowledgePublic (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun acknowledgePublicDeferredMessageUpdate (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun compareTo (Ldev/kord/core/entity/Entity;)I
 	public synthetic fun compareTo (Ljava/lang/Object;)I
@@ -9290,7 +9285,7 @@ public final class dev/kord/core/entity/interaction/GuildButtonInteraction : dev
 	public fun getData ()Ldev/kord/core/cache/data/InteractionData;
 	public fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildBehavior ()Ldev/kord/core/behavior/GuildBehavior;
+	public synthetic fun getGuildBehavior ()Ldev/kord/core/behavior/GuildBehavior;
 	public fun getGuildId ()Ldev/kord/common/entity/Snowflake;
 	public fun getGuildLocale ()Ldev/kord/common/Locale;
 	public fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -9326,8 +9321,8 @@ public final class dev/kord/core/entity/interaction/GuildButtonInteraction : dev
 
 public final class dev/kord/core/entity/interaction/GuildChatInputCommandInteraction : dev/kord/core/entity/interaction/ChatInputCommandInteraction, dev/kord/core/entity/interaction/GuildApplicationCommandInteraction {
 	public fun <init> (Ldev/kord/core/cache/data/InteractionData;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)V
-	public fun acknowledgeEphemeral (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun acknowledgePublic (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun acknowledgeEphemeral (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun acknowledgePublic (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun compareTo (Ldev/kord/core/entity/Entity;)I
 	public synthetic fun compareTo (Ljava/lang/Object;)I
 	public fun deferEphemeralMessage (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -9348,7 +9343,7 @@ public final class dev/kord/core/entity/interaction/GuildChatInputCommandInterac
 	public fun getData ()Ldev/kord/core/cache/data/InteractionData;
 	public fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildBehavior ()Ldev/kord/core/behavior/GuildBehavior;
+	public synthetic fun getGuildBehavior ()Ldev/kord/core/behavior/GuildBehavior;
 	public fun getGuildId ()Ldev/kord/common/entity/Snowflake;
 	public fun getGuildLocale ()Ldev/kord/common/Locale;
 	public fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -9391,9 +9386,9 @@ public abstract interface class dev/kord/core/entity/interaction/GuildComponentI
 }
 
 public final class dev/kord/core/entity/interaction/GuildComponentInteraction$DefaultImpls {
-	public static fun acknowledgeEphemeral (Ldev/kord/core/entity/interaction/GuildComponentInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun acknowledgeEphemeral (Ldev/kord/core/entity/interaction/GuildComponentInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun acknowledgeEphemeralDeferredMessageUpdate (Ldev/kord/core/entity/interaction/GuildComponentInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun acknowledgePublic (Ldev/kord/core/entity/interaction/GuildComponentInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun acknowledgePublic (Ldev/kord/core/entity/interaction/GuildComponentInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun acknowledgePublicDeferredMessageUpdate (Ldev/kord/core/entity/interaction/GuildComponentInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun compareTo (Ldev/kord/core/entity/interaction/GuildComponentInteraction;Ldev/kord/core/entity/Entity;)I
 	public static fun deferEphemeralMessage (Ldev/kord/core/entity/interaction/GuildComponentInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -9414,7 +9409,7 @@ public final class dev/kord/core/entity/interaction/GuildComponentInteraction$De
 	public static fun getComponentType (Ldev/kord/core/entity/interaction/GuildComponentInteraction;)Ldev/kord/common/entity/ComponentType;
 	public static fun getGuild (Ldev/kord/core/entity/interaction/GuildComponentInteraction;)Ldev/kord/core/behavior/GuildBehavior;
 	public static fun getGuild (Ldev/kord/core/entity/interaction/GuildComponentInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getGuildBehavior (Ldev/kord/core/entity/interaction/GuildComponentInteraction;)Ldev/kord/core/behavior/GuildBehavior;
+	public static synthetic fun getGuildBehavior (Ldev/kord/core/entity/interaction/GuildComponentInteraction;)Ldev/kord/core/behavior/GuildBehavior;
 	public static fun getGuildId (Ldev/kord/core/entity/interaction/GuildComponentInteraction;)Ldev/kord/common/entity/Snowflake;
 	public static fun getGuildLocale (Ldev/kord/core/entity/interaction/GuildComponentInteraction;)Ldev/kord/common/Locale;
 	public static fun getGuildOrNull (Ldev/kord/core/entity/interaction/GuildComponentInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -9448,7 +9443,7 @@ public final class dev/kord/core/entity/interaction/GuildInteraction$DefaultImpl
 	public static fun getChannelOrNull (Ldev/kord/core/entity/interaction/GuildInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getGuild (Ldev/kord/core/entity/interaction/GuildInteraction;)Ldev/kord/core/behavior/GuildBehavior;
 	public static fun getGuild (Ldev/kord/core/entity/interaction/GuildInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getGuildBehavior (Ldev/kord/core/entity/interaction/GuildInteraction;)Ldev/kord/core/behavior/GuildBehavior;
+	public static synthetic fun getGuildBehavior (Ldev/kord/core/entity/interaction/GuildInteraction;)Ldev/kord/core/behavior/GuildBehavior;
 	public static fun getGuildId (Ldev/kord/core/entity/interaction/GuildInteraction;)Ldev/kord/common/entity/Snowflake;
 	public static fun getGuildLocale (Ldev/kord/core/entity/interaction/GuildInteraction;)Ldev/kord/common/Locale;
 	public static fun getGuildOrNull (Ldev/kord/core/entity/interaction/GuildInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -9463,8 +9458,8 @@ public final class dev/kord/core/entity/interaction/GuildInteraction$DefaultImpl
 
 public final class dev/kord/core/entity/interaction/GuildMessageCommandInteraction : dev/kord/core/entity/interaction/GuildApplicationCommandInteraction, dev/kord/core/entity/interaction/MessageCommandInteraction {
 	public fun <init> (Ldev/kord/core/cache/data/InteractionData;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)V
-	public fun acknowledgeEphemeral (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun acknowledgePublic (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun acknowledgeEphemeral (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun acknowledgePublic (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun compareTo (Ldev/kord/core/entity/Entity;)I
 	public synthetic fun compareTo (Ljava/lang/Object;)I
 	public fun deferEphemeralMessage (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -9484,7 +9479,7 @@ public final class dev/kord/core/entity/interaction/GuildMessageCommandInteracti
 	public fun getData ()Ldev/kord/core/cache/data/InteractionData;
 	public fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildBehavior ()Ldev/kord/core/behavior/GuildBehavior;
+	public synthetic fun getGuildBehavior ()Ldev/kord/core/behavior/GuildBehavior;
 	public fun getGuildId ()Ldev/kord/common/entity/Snowflake;
 	public fun getGuildLocale ()Ldev/kord/common/Locale;
 	public fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -9503,7 +9498,7 @@ public final class dev/kord/core/entity/interaction/GuildMessageCommandInteracti
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
 	public fun getTarget ()Ldev/kord/core/behavior/MessageBehavior;
 	public fun getTarget (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getTargetBehavior ()Ldev/kord/core/behavior/MessageBehavior;
+	public synthetic fun getTargetBehavior ()Ldev/kord/core/behavior/MessageBehavior;
 	public fun getTargetId ()Ldev/kord/common/entity/Snowflake;
 	public fun getTargetOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getToken ()Ljava/lang/String;
@@ -9531,9 +9526,9 @@ public final class dev/kord/core/entity/interaction/GuildMessageCommandInteracti
 public final class dev/kord/core/entity/interaction/GuildModalSubmitInteraction : dev/kord/core/entity/interaction/GuildInteraction, dev/kord/core/entity/interaction/ModalSubmitInteraction {
 	public fun <init> (Ldev/kord/core/cache/data/InteractionData;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)V
 	public synthetic fun <init> (Ldev/kord/core/cache/data/InteractionData;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun acknowledgeEphemeral (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun acknowledgeEphemeral (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun acknowledgeEphemeralDeferredMessageUpdate (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun acknowledgePublic (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun acknowledgePublic (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun acknowledgePublicDeferredMessageUpdate (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun compareTo (Ldev/kord/core/entity/Entity;)I
 	public synthetic fun compareTo (Ljava/lang/Object;)I
@@ -9557,7 +9552,7 @@ public final class dev/kord/core/entity/interaction/GuildModalSubmitInteraction 
 	public fun getData ()Ldev/kord/core/cache/data/InteractionData;
 	public fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildBehavior ()Ldev/kord/core/behavior/GuildBehavior;
+	public synthetic fun getGuildBehavior ()Ldev/kord/core/behavior/GuildBehavior;
 	public fun getGuildId ()Ldev/kord/common/entity/Snowflake;
 	public fun getGuildLocale ()Ldev/kord/common/Locale;
 	public fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -9592,9 +9587,9 @@ public final class dev/kord/core/entity/interaction/GuildModalSubmitInteraction 
 
 public final class dev/kord/core/entity/interaction/GuildSelectMenuInteraction : dev/kord/core/entity/interaction/GuildComponentInteraction, dev/kord/core/entity/interaction/SelectMenuInteraction {
 	public fun <init> (Ldev/kord/core/cache/data/InteractionData;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)V
-	public fun acknowledgeEphemeral (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun acknowledgeEphemeral (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun acknowledgeEphemeralDeferredMessageUpdate (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun acknowledgePublic (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun acknowledgePublic (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun acknowledgePublicDeferredMessageUpdate (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun compareTo (Ldev/kord/core/entity/Entity;)I
 	public synthetic fun compareTo (Ljava/lang/Object;)I
@@ -9621,7 +9616,7 @@ public final class dev/kord/core/entity/interaction/GuildSelectMenuInteraction :
 	public fun getData ()Ldev/kord/core/cache/data/InteractionData;
 	public fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildBehavior ()Ldev/kord/core/behavior/GuildBehavior;
+	public synthetic fun getGuildBehavior ()Ldev/kord/core/behavior/GuildBehavior;
 	public fun getGuildId ()Ldev/kord/common/entity/Snowflake;
 	public fun getGuildLocale ()Ldev/kord/common/Locale;
 	public fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -9658,8 +9653,8 @@ public final class dev/kord/core/entity/interaction/GuildSelectMenuInteraction :
 
 public final class dev/kord/core/entity/interaction/GuildUserCommandInteraction : dev/kord/core/entity/interaction/GuildApplicationCommandInteraction, dev/kord/core/entity/interaction/UserCommandInteraction {
 	public fun <init> (Ldev/kord/core/cache/data/InteractionData;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)V
-	public fun acknowledgeEphemeral (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun acknowledgePublic (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun acknowledgeEphemeral (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun acknowledgePublic (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun compareTo (Ldev/kord/core/entity/Entity;)I
 	public synthetic fun compareTo (Ljava/lang/Object;)I
 	public fun deferEphemeralMessage (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -9679,7 +9674,7 @@ public final class dev/kord/core/entity/interaction/GuildUserCommandInteraction 
 	public fun getData ()Ldev/kord/core/cache/data/InteractionData;
 	public fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildBehavior ()Ldev/kord/core/behavior/GuildBehavior;
+	public synthetic fun getGuildBehavior ()Ldev/kord/core/behavior/GuildBehavior;
 	public fun getGuildId ()Ldev/kord/common/entity/Snowflake;
 	public fun getGuildLocale ()Ldev/kord/common/Locale;
 	public fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -9697,7 +9692,7 @@ public final class dev/kord/core/entity/interaction/GuildUserCommandInteraction 
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
 	public fun getTarget ()Ldev/kord/core/behavior/UserBehavior;
 	public fun getTarget (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getTargetBehavior ()Ldev/kord/core/behavior/UserBehavior;
+	public synthetic fun getTargetBehavior ()Ldev/kord/core/behavior/UserBehavior;
 	public fun getTargetId ()Ldev/kord/common/entity/Snowflake;
 	public fun getTargetOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getToken ()Ljava/lang/String;
@@ -9825,15 +9820,15 @@ public abstract interface class dev/kord/core/entity/interaction/MessageCommandI
 	public abstract fun getMessages ()Ljava/util/Map;
 	public abstract fun getTarget ()Ldev/kord/core/behavior/MessageBehavior;
 	public abstract fun getTarget (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getTargetBehavior ()Ldev/kord/core/behavior/MessageBehavior;
+	public abstract synthetic fun getTargetBehavior ()Ldev/kord/core/behavior/MessageBehavior;
 	public abstract fun getTargetId ()Ldev/kord/common/entity/Snowflake;
 	public abstract fun getTargetOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/entity/interaction/MessageCommandInteraction;
 }
 
 public final class dev/kord/core/entity/interaction/MessageCommandInteraction$DefaultImpls {
-	public static fun acknowledgeEphemeral (Ldev/kord/core/entity/interaction/MessageCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun acknowledgePublic (Ldev/kord/core/entity/interaction/MessageCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun acknowledgeEphemeral (Ldev/kord/core/entity/interaction/MessageCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun acknowledgePublic (Ldev/kord/core/entity/interaction/MessageCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun compareTo (Ldev/kord/core/entity/interaction/MessageCommandInteraction;Ldev/kord/core/entity/Entity;)I
 	public static fun deferEphemeralMessage (Ldev/kord/core/entity/interaction/MessageCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun deferEphemeralResponse (Ldev/kord/core/entity/interaction/MessageCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -9859,7 +9854,7 @@ public final class dev/kord/core/entity/interaction/MessageCommandInteraction$De
 	public static fun getResolvedObjects (Ldev/kord/core/entity/interaction/MessageCommandInteraction;)Ldev/kord/core/entity/interaction/ResolvedObjects;
 	public static fun getTarget (Ldev/kord/core/entity/interaction/MessageCommandInteraction;)Ldev/kord/core/behavior/MessageBehavior;
 	public static fun getTarget (Ldev/kord/core/entity/interaction/MessageCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getTargetBehavior (Ldev/kord/core/entity/interaction/MessageCommandInteraction;)Ldev/kord/core/behavior/MessageBehavior;
+	public static synthetic fun getTargetBehavior (Ldev/kord/core/entity/interaction/MessageCommandInteraction;)Ldev/kord/core/behavior/MessageBehavior;
 	public static fun getTargetId (Ldev/kord/core/entity/interaction/MessageCommandInteraction;)Ldev/kord/common/entity/Snowflake;
 	public static fun getTargetOrNull (Ldev/kord/core/entity/interaction/MessageCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getToken (Ldev/kord/core/entity/interaction/MessageCommandInteraction;)Ljava/lang/String;
@@ -9876,9 +9871,9 @@ public abstract interface class dev/kord/core/entity/interaction/ModalSubmitInte
 }
 
 public final class dev/kord/core/entity/interaction/ModalSubmitInteraction$DefaultImpls {
-	public static fun acknowledgeEphemeral (Ldev/kord/core/entity/interaction/ModalSubmitInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun acknowledgeEphemeral (Ldev/kord/core/entity/interaction/ModalSubmitInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun acknowledgeEphemeralDeferredMessageUpdate (Ldev/kord/core/entity/interaction/ModalSubmitInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun acknowledgePublic (Ldev/kord/core/entity/interaction/ModalSubmitInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun acknowledgePublic (Ldev/kord/core/entity/interaction/ModalSubmitInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun acknowledgePublicDeferredMessageUpdate (Ldev/kord/core/entity/interaction/ModalSubmitInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun compareTo (Ldev/kord/core/entity/interaction/ModalSubmitInteraction;Ldev/kord/core/entity/Entity;)I
 	public static fun deferEphemeralMessage (Ldev/kord/core/entity/interaction/ModalSubmitInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -9985,9 +9980,9 @@ public abstract interface class dev/kord/core/entity/interaction/SelectMenuInter
 }
 
 public final class dev/kord/core/entity/interaction/SelectMenuInteraction$DefaultImpls {
-	public static fun acknowledgeEphemeral (Ldev/kord/core/entity/interaction/SelectMenuInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun acknowledgeEphemeral (Ldev/kord/core/entity/interaction/SelectMenuInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun acknowledgeEphemeralDeferredMessageUpdate (Ldev/kord/core/entity/interaction/SelectMenuInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun acknowledgePublic (Ldev/kord/core/entity/interaction/SelectMenuInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun acknowledgePublic (Ldev/kord/core/entity/interaction/SelectMenuInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun acknowledgePublicDeferredMessageUpdate (Ldev/kord/core/entity/interaction/SelectMenuInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun compareTo (Ldev/kord/core/entity/interaction/SelectMenuInteraction;Ldev/kord/core/entity/Entity;)I
 	public static fun deferEphemeralMessage (Ldev/kord/core/entity/interaction/SelectMenuInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -10050,7 +10045,7 @@ public final class dev/kord/core/entity/interaction/SubCommand : dev/kord/core/e
 public abstract interface class dev/kord/core/entity/interaction/UserCommandInteraction : dev/kord/core/entity/interaction/ApplicationCommandInteraction {
 	public abstract fun getTarget ()Ldev/kord/core/behavior/UserBehavior;
 	public abstract fun getTarget (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getTargetBehavior ()Ldev/kord/core/behavior/UserBehavior;
+	public abstract synthetic fun getTargetBehavior ()Ldev/kord/core/behavior/UserBehavior;
 	public abstract fun getTargetId ()Ldev/kord/common/entity/Snowflake;
 	public abstract fun getTargetOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getUsers ()Ljava/util/Map;
@@ -10058,8 +10053,8 @@ public abstract interface class dev/kord/core/entity/interaction/UserCommandInte
 }
 
 public final class dev/kord/core/entity/interaction/UserCommandInteraction$DefaultImpls {
-	public static fun acknowledgeEphemeral (Ldev/kord/core/entity/interaction/UserCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun acknowledgePublic (Ldev/kord/core/entity/interaction/UserCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun acknowledgeEphemeral (Ldev/kord/core/entity/interaction/UserCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun acknowledgePublic (Ldev/kord/core/entity/interaction/UserCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun compareTo (Ldev/kord/core/entity/interaction/UserCommandInteraction;Ldev/kord/core/entity/Entity;)I
 	public static fun deferEphemeralMessage (Ldev/kord/core/entity/interaction/UserCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun deferEphemeralResponse (Ldev/kord/core/entity/interaction/UserCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -10084,7 +10079,7 @@ public final class dev/kord/core/entity/interaction/UserCommandInteraction$Defau
 	public static fun getResolvedObjects (Ldev/kord/core/entity/interaction/UserCommandInteraction;)Ldev/kord/core/entity/interaction/ResolvedObjects;
 	public static fun getTarget (Ldev/kord/core/entity/interaction/UserCommandInteraction;)Ldev/kord/core/behavior/UserBehavior;
 	public static fun getTarget (Ldev/kord/core/entity/interaction/UserCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getTargetBehavior (Ldev/kord/core/entity/interaction/UserCommandInteraction;)Ldev/kord/core/behavior/UserBehavior;
+	public static synthetic fun getTargetBehavior (Ldev/kord/core/entity/interaction/UserCommandInteraction;)Ldev/kord/core/behavior/UserBehavior;
 	public static fun getTargetId (Ldev/kord/core/entity/interaction/UserCommandInteraction;)Ldev/kord/common/entity/Snowflake;
 	public static fun getTargetOrNull (Ldev/kord/core/entity/interaction/UserCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getToken (Ldev/kord/core/entity/interaction/UserCommandInteraction;)Ljava/lang/String;
@@ -11366,12 +11361,12 @@ public final class dev/kord/core/event/guild/InviteCreateEvent : dev/kord/core/e
 	public final fun getData ()Ldev/kord/core/cache/data/InviteCreateData;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
-	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final synthetic fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
 	public final fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getInviter ()Ldev/kord/core/behavior/UserBehavior;
-	public final fun getInviter (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getInviterAsMember (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final synthetic fun getInviter (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final synthetic fun getInviterAsMember (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getInviterAsMemberOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getInviterId ()Ldev/kord/common/entity/Snowflake;
 	public final fun getInviterMember ()Ldev/kord/core/behavior/MemberBehavior;
@@ -11408,7 +11403,7 @@ public final class dev/kord/core/event/guild/InviteDeleteEvent : dev/kord/core/e
 	public final fun getData ()Ldev/kord/core/cache/data/InviteDeleteData;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
-	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final synthetic fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
 	public final fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getKord ()Ldev/kord/core/Kord;
@@ -11460,11 +11455,11 @@ public final class dev/kord/core/event/guild/MemberUpdateEvent : dev/kord/core/e
 	public synthetic fun <init> (Ldev/kord/core/entity/Member;Ldev/kord/core/entity/Member;Ldev/kord/core/Kord;ILdev/kord/core/supplier/EntitySupplier;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
 	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
-	public final fun getCurrentNickName ()Ljava/lang/String;
+	public final synthetic fun getCurrentNickName ()Ljava/lang/String;
 	public static fun getCurrentNickName$delegate (Ldev/kord/core/event/guild/MemberUpdateEvent;)Ljava/lang/Object;
-	public final fun getCurrentRoleIds ()Ljava/util/Set;
+	public final synthetic fun getCurrentRoleIds ()Ljava/util/Set;
 	public static fun getCurrentRoleIds$delegate (Ldev/kord/core/event/guild/MemberUpdateEvent;)Ljava/lang/Object;
-	public final fun getCurrentRoles ()Lkotlinx/coroutines/flow/Flow;
+	public final synthetic fun getCurrentRoles ()Lkotlinx/coroutines/flow/Flow;
 	public static fun getCurrentRoles$delegate (Ldev/kord/core/event/guild/MemberUpdateEvent;)Ljava/lang/Object;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
@@ -11473,16 +11468,16 @@ public final class dev/kord/core/event/guild/MemberUpdateEvent : dev/kord/core/e
 	public final fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getMember ()Ldev/kord/core/entity/Member;
-	public final fun getMember (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getMemberId ()Ldev/kord/common/entity/Snowflake;
+	public final synthetic fun getMember (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final synthetic fun getMemberId ()Ldev/kord/common/entity/Snowflake;
 	public static fun getMemberId$delegate (Ldev/kord/core/event/guild/MemberUpdateEvent;)Ljava/lang/Object;
-	public final fun getMemberOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final synthetic fun getMemberOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getOld ()Ldev/kord/core/entity/Member;
-	public final fun getPremiumSince ()Lkotlinx/datetime/Instant;
+	public final synthetic fun getPremiumSince ()Lkotlinx/datetime/Instant;
 	public static fun getPremiumSince$delegate (Ldev/kord/core/event/guild/MemberUpdateEvent;)Ljava/lang/Object;
 	public fun getShard ()I
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
-	public final fun getUser ()Ldev/kord/core/entity/User;
+	public final synthetic fun getUser ()Ldev/kord/core/entity/User;
 	public static fun getUser$delegate (Ldev/kord/core/event/guild/MemberUpdateEvent;)Ljava/lang/Object;
 	public fun toString ()Ljava/lang/String;
 	public synthetic fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/entity/Strategizable;
@@ -12565,7 +12560,7 @@ public final class dev/kord/core/live/LiveGuildKt {
 	public static synthetic fun onEmojisUpdate$default (Ldev/kord/core/live/LiveGuild;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
 	public static final fun onGuildCreate (Ldev/kord/core/live/LiveGuild;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onGuildCreate$default (Ldev/kord/core/live/LiveGuild;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
-	public static final fun onGuildDelete (Ldev/kord/core/live/LiveGuild;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
+	public static final synthetic fun onGuildDelete (Ldev/kord/core/live/LiveGuild;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onGuildDelete$default (Ldev/kord/core/live/LiveGuild;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
 	public static final fun onGuildUpdate (Ldev/kord/core/live/LiveGuild;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onGuildUpdate$default (Ldev/kord/core/live/LiveGuild;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
@@ -12631,13 +12626,13 @@ public final class dev/kord/core/live/LiveMemberKt {
 	public static final fun live (Ldev/kord/core/entity/Member;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;)Ldev/kord/core/live/LiveMember;
 	public static synthetic fun live$default (Ldev/kord/core/entity/Member;Lkotlinx/coroutines/CoroutineScope;ILjava/lang/Object;)Ldev/kord/core/live/LiveMember;
 	public static synthetic fun live$default (Ldev/kord/core/entity/Member;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/kord/core/live/LiveMember;
-	public static final fun onBanAdd (Ldev/kord/core/live/LiveMember;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
+	public static final synthetic fun onBanAdd (Ldev/kord/core/live/LiveMember;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onBanAdd$default (Ldev/kord/core/live/LiveMember;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
-	public static final fun onGuildDelete (Ldev/kord/core/live/channel/LiveGuildChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
+	public static final synthetic fun onGuildDelete (Ldev/kord/core/live/channel/LiveGuildChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onGuildDelete$default (Ldev/kord/core/live/channel/LiveGuildChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
-	public static final fun onLeave (Ldev/kord/core/live/LiveMember;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
+	public static final synthetic fun onLeave (Ldev/kord/core/live/LiveMember;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onLeave$default (Ldev/kord/core/live/LiveMember;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
-	public static final fun onShutdown (Ldev/kord/core/live/channel/LiveGuildChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
+	public static final synthetic fun onShutdown (Ldev/kord/core/live/channel/LiveGuildChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onShutdown$default (Ldev/kord/core/live/channel/LiveGuildChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
 	public static final fun onUpdate (Ldev/kord/core/live/LiveMember;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onUpdate$default (Ldev/kord/core/live/LiveMember;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
@@ -12656,15 +12651,15 @@ public final class dev/kord/core/live/LiveMessageKt {
 	public static final fun live (Ldev/kord/core/entity/Message;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun live$default (Ldev/kord/core/entity/Message;Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun live$default (Ldev/kord/core/entity/Message;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static final fun onBulkDelete (Ldev/kord/core/live/LiveMessage;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
+	public static final synthetic fun onBulkDelete (Ldev/kord/core/live/LiveMessage;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onBulkDelete$default (Ldev/kord/core/live/LiveMessage;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
-	public static final fun onChannelDelete (Ldev/kord/core/live/LiveMessage;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
+	public static final synthetic fun onChannelDelete (Ldev/kord/core/live/LiveMessage;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onChannelDelete$default (Ldev/kord/core/live/LiveMessage;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
-	public static final fun onCreate (Ldev/kord/core/live/LiveMessage;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
+	public static final synthetic fun onCreate (Ldev/kord/core/live/LiveMessage;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onCreate$default (Ldev/kord/core/live/LiveMessage;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
-	public static final fun onGuildDelete (Ldev/kord/core/live/LiveMessage;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
+	public static final synthetic fun onGuildDelete (Ldev/kord/core/live/LiveMessage;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onGuildDelete$default (Ldev/kord/core/live/LiveMessage;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
-	public static final fun onOnlyDelete (Ldev/kord/core/live/LiveMessage;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
+	public static final synthetic fun onOnlyDelete (Ldev/kord/core/live/LiveMessage;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onOnlyDelete$default (Ldev/kord/core/live/LiveMessage;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
 	public static final fun onReactionAdd (Ldev/kord/core/live/LiveMessage;Ldev/kord/core/entity/ReactionEmoji;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static final fun onReactionAdd (Ldev/kord/core/live/LiveMessage;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
@@ -12676,7 +12671,7 @@ public final class dev/kord/core/live/LiveMessageKt {
 	public static synthetic fun onReactionRemove$default (Ldev/kord/core/live/LiveMessage;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
 	public static final fun onReactionRemoveAll (Ldev/kord/core/live/LiveMessage;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onReactionRemoveAll$default (Ldev/kord/core/live/LiveMessage;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
-	public static final fun onShutdown (Ldev/kord/core/live/LiveMessage;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
+	public static final synthetic fun onShutdown (Ldev/kord/core/live/LiveMessage;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onShutdown$default (Ldev/kord/core/live/LiveMessage;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
 	public static final fun onUpdate (Ldev/kord/core/live/LiveMessage;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onUpdate$default (Ldev/kord/core/live/LiveMessage;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
@@ -12694,11 +12689,11 @@ public final class dev/kord/core/live/LiveRoleKt {
 	public static final fun live (Ldev/kord/core/entity/Role;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;)Ldev/kord/core/live/LiveRole;
 	public static synthetic fun live$default (Ldev/kord/core/entity/Role;Lkotlinx/coroutines/CoroutineScope;ILjava/lang/Object;)Ldev/kord/core/live/LiveRole;
 	public static synthetic fun live$default (Ldev/kord/core/entity/Role;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/kord/core/live/LiveRole;
-	public static final fun onDelete (Ldev/kord/core/live/LiveRole;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
+	public static final synthetic fun onDelete (Ldev/kord/core/live/LiveRole;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onDelete$default (Ldev/kord/core/live/LiveRole;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
-	public static final fun onGuildDelete (Ldev/kord/core/live/LiveRole;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
+	public static final synthetic fun onGuildDelete (Ldev/kord/core/live/LiveRole;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onGuildDelete$default (Ldev/kord/core/live/LiveRole;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
-	public static final fun onShutdown (Ldev/kord/core/live/LiveRole;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
+	public static final synthetic fun onShutdown (Ldev/kord/core/live/LiveRole;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onShutdown$default (Ldev/kord/core/live/LiveRole;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
 	public static final fun onUpdate (Ldev/kord/core/live/LiveRole;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onUpdate$default (Ldev/kord/core/live/LiveRole;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
@@ -12733,13 +12728,13 @@ public final class dev/kord/core/live/channel/LiveCategoryKt {
 	public static final fun live (Ldev/kord/core/entity/channel/Category;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;)Ldev/kord/core/live/channel/LiveCategory;
 	public static synthetic fun live$default (Ldev/kord/core/entity/channel/Category;Lkotlinx/coroutines/CoroutineScope;ILjava/lang/Object;)Ldev/kord/core/live/channel/LiveCategory;
 	public static synthetic fun live$default (Ldev/kord/core/entity/channel/Category;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/kord/core/live/channel/LiveCategory;
-	public static final fun onCreate (Ldev/kord/core/live/channel/LiveCategory;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
+	public static final synthetic fun onCreate (Ldev/kord/core/live/channel/LiveCategory;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onCreate$default (Ldev/kord/core/live/channel/LiveCategory;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
-	public static final fun onDelete (Ldev/kord/core/live/channel/LiveCategory;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
+	public static final synthetic fun onDelete (Ldev/kord/core/live/channel/LiveCategory;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onDelete$default (Ldev/kord/core/live/channel/LiveCategory;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
-	public static final fun onGuildDelete (Ldev/kord/core/live/channel/LiveCategory;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
+	public static final synthetic fun onGuildDelete (Ldev/kord/core/live/channel/LiveCategory;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onGuildDelete$default (Ldev/kord/core/live/channel/LiveCategory;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
-	public static final fun onShutDown (Ldev/kord/core/live/channel/LiveCategory;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
+	public static final synthetic fun onShutDown (Ldev/kord/core/live/channel/LiveCategory;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onShutDown$default (Ldev/kord/core/live/channel/LiveCategory;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
 	public static final fun onUpdate (Ldev/kord/core/live/channel/LiveCategory;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onUpdate$default (Ldev/kord/core/live/channel/LiveCategory;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
@@ -12757,13 +12752,13 @@ public final class dev/kord/core/live/channel/LiveChannelKt {
 	public static final fun live (Ldev/kord/core/entity/channel/Channel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;)Ldev/kord/core/live/channel/LiveChannel;
 	public static synthetic fun live$default (Ldev/kord/core/entity/channel/Channel;Lkotlinx/coroutines/CoroutineScope;ILjava/lang/Object;)Ldev/kord/core/live/channel/LiveChannel;
 	public static synthetic fun live$default (Ldev/kord/core/entity/channel/Channel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/kord/core/live/channel/LiveChannel;
-	public static final fun onChannelCreate (Ldev/kord/core/live/channel/LiveChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
+	public static final synthetic fun onChannelCreate (Ldev/kord/core/live/channel/LiveChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onChannelCreate$default (Ldev/kord/core/live/channel/LiveChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
-	public static final fun onChannelDelete (Ldev/kord/core/live/channel/LiveChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
+	public static final synthetic fun onChannelDelete (Ldev/kord/core/live/channel/LiveChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onChannelDelete$default (Ldev/kord/core/live/channel/LiveChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
 	public static final fun onChannelUpdate (Ldev/kord/core/live/channel/LiveChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onChannelUpdate$default (Ldev/kord/core/live/channel/LiveChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
-	public static final fun onGuildCreate (Ldev/kord/core/live/channel/LiveChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
+	public static final synthetic fun onGuildCreate (Ldev/kord/core/live/channel/LiveChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onGuildCreate$default (Ldev/kord/core/live/channel/LiveChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
 	public static final fun onGuildUpdate (Ldev/kord/core/live/channel/LiveChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onGuildUpdate$default (Ldev/kord/core/live/channel/LiveChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
@@ -12800,13 +12795,13 @@ public final class dev/kord/core/live/channel/LiveDmChannelKt {
 	public static final fun live (Ldev/kord/core/entity/channel/DmChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;)Ldev/kord/core/live/channel/LiveDmChannel;
 	public static synthetic fun live$default (Ldev/kord/core/entity/channel/DmChannel;Lkotlinx/coroutines/CoroutineScope;ILjava/lang/Object;)Ldev/kord/core/live/channel/LiveDmChannel;
 	public static synthetic fun live$default (Ldev/kord/core/entity/channel/DmChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/kord/core/live/channel/LiveDmChannel;
-	public static final fun onCreate (Ldev/kord/core/live/channel/LiveDmChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
+	public static final synthetic fun onCreate (Ldev/kord/core/live/channel/LiveDmChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onCreate$default (Ldev/kord/core/live/channel/LiveDmChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
-	public static final fun onDelete (Ldev/kord/core/live/channel/LiveDmChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
+	public static final synthetic fun onDelete (Ldev/kord/core/live/channel/LiveDmChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onDelete$default (Ldev/kord/core/live/channel/LiveDmChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
-	public static final fun onGuildDelete (Ldev/kord/core/live/channel/LiveDmChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
+	public static final synthetic fun onGuildDelete (Ldev/kord/core/live/channel/LiveDmChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onGuildDelete$default (Ldev/kord/core/live/channel/LiveDmChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
-	public static final fun onShutDown (Ldev/kord/core/live/channel/LiveDmChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
+	public static final synthetic fun onShutDown (Ldev/kord/core/live/channel/LiveDmChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onShutDown$default (Ldev/kord/core/live/channel/LiveDmChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
 	public static final fun onUpdate (Ldev/kord/core/live/channel/LiveDmChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onUpdate$default (Ldev/kord/core/live/channel/LiveDmChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
@@ -12825,13 +12820,13 @@ public final class dev/kord/core/live/channel/LiveGuildChannelKt {
 	public static final fun live (Ldev/kord/core/entity/channel/TopGuildChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;)Ldev/kord/core/live/channel/LiveGuildChannel;
 	public static synthetic fun live$default (Ldev/kord/core/entity/channel/TopGuildChannel;Lkotlinx/coroutines/CoroutineScope;ILjava/lang/Object;)Ldev/kord/core/live/channel/LiveGuildChannel;
 	public static synthetic fun live$default (Ldev/kord/core/entity/channel/TopGuildChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/kord/core/live/channel/LiveGuildChannel;
-	public static final fun onCreate (Ldev/kord/core/live/channel/LiveGuildChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
+	public static final synthetic fun onCreate (Ldev/kord/core/live/channel/LiveGuildChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onCreate$default (Ldev/kord/core/live/channel/LiveGuildChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
-	public static final fun onDelete (Ldev/kord/core/live/channel/LiveGuildChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
+	public static final synthetic fun onDelete (Ldev/kord/core/live/channel/LiveGuildChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onDelete$default (Ldev/kord/core/live/channel/LiveGuildChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
-	public static final fun onGuildDelete (Ldev/kord/core/live/channel/LiveGuildChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
+	public static final synthetic fun onGuildDelete (Ldev/kord/core/live/channel/LiveGuildChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onGuildDelete$default (Ldev/kord/core/live/channel/LiveGuildChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
-	public static final fun onShutDown (Ldev/kord/core/live/channel/LiveGuildChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
+	public static final synthetic fun onShutDown (Ldev/kord/core/live/channel/LiveGuildChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onShutDown$default (Ldev/kord/core/live/channel/LiveGuildChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
 	public static final fun onUpdate (Ldev/kord/core/live/channel/LiveGuildChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onUpdate$default (Ldev/kord/core/live/channel/LiveGuildChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
@@ -12850,13 +12845,13 @@ public final class dev/kord/core/live/channel/LiveGuildMessageChannelKt {
 	public static final fun live (Ldev/kord/core/entity/channel/TopGuildMessageChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;)Ldev/kord/core/live/channel/LiveGuildMessageChannel;
 	public static synthetic fun live$default (Ldev/kord/core/entity/channel/TopGuildMessageChannel;Lkotlinx/coroutines/CoroutineScope;ILjava/lang/Object;)Ldev/kord/core/live/channel/LiveGuildMessageChannel;
 	public static synthetic fun live$default (Ldev/kord/core/entity/channel/TopGuildMessageChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/kord/core/live/channel/LiveGuildMessageChannel;
-	public static final fun onChannelDelete (Ldev/kord/core/live/channel/LiveGuildMessageChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
+	public static final synthetic fun onChannelDelete (Ldev/kord/core/live/channel/LiveGuildMessageChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onChannelDelete$default (Ldev/kord/core/live/channel/LiveGuildMessageChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
-	public static final fun onCreate (Ldev/kord/core/live/channel/LiveGuildMessageChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
+	public static final synthetic fun onCreate (Ldev/kord/core/live/channel/LiveGuildMessageChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onCreate$default (Ldev/kord/core/live/channel/LiveGuildMessageChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
-	public static final fun onDelete (Ldev/kord/core/live/channel/LiveGuildMessageChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
+	public static final synthetic fun onDelete (Ldev/kord/core/live/channel/LiveGuildMessageChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onDelete$default (Ldev/kord/core/live/channel/LiveGuildMessageChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
-	public static final fun onShutDown (Ldev/kord/core/live/channel/LiveGuildMessageChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
+	public static final synthetic fun onShutDown (Ldev/kord/core/live/channel/LiveGuildMessageChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onShutDown$default (Ldev/kord/core/live/channel/LiveGuildMessageChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
 	public static final fun onUpdate (Ldev/kord/core/live/channel/LiveGuildMessageChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onUpdate$default (Ldev/kord/core/live/channel/LiveGuildMessageChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
@@ -12875,13 +12870,13 @@ public final class dev/kord/core/live/channel/LiveVoiceChannelKt {
 	public static final fun live (Ldev/kord/core/entity/channel/VoiceChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;)Ldev/kord/core/live/channel/LiveVoiceChannel;
 	public static synthetic fun live$default (Ldev/kord/core/entity/channel/VoiceChannel;Lkotlinx/coroutines/CoroutineScope;ILjava/lang/Object;)Ldev/kord/core/live/channel/LiveVoiceChannel;
 	public static synthetic fun live$default (Ldev/kord/core/entity/channel/VoiceChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/kord/core/live/channel/LiveVoiceChannel;
-	public static final fun onCreate (Ldev/kord/core/live/channel/LiveVoiceChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
+	public static final synthetic fun onCreate (Ldev/kord/core/live/channel/LiveVoiceChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onCreate$default (Ldev/kord/core/live/channel/LiveVoiceChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
-	public static final fun onDelete (Ldev/kord/core/live/channel/LiveVoiceChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
+	public static final synthetic fun onDelete (Ldev/kord/core/live/channel/LiveVoiceChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onDelete$default (Ldev/kord/core/live/channel/LiveVoiceChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
-	public static final fun onGuildDelete (Ldev/kord/core/live/channel/LiveVoiceChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
+	public static final synthetic fun onGuildDelete (Ldev/kord/core/live/channel/LiveVoiceChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onGuildDelete$default (Ldev/kord/core/live/channel/LiveVoiceChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
-	public static final fun onShutDown (Ldev/kord/core/live/channel/LiveVoiceChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
+	public static final synthetic fun onShutDown (Ldev/kord/core/live/channel/LiveVoiceChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onShutDown$default (Ldev/kord/core/live/channel/LiveVoiceChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
 	public static final fun onUpdate (Ldev/kord/core/live/channel/LiveVoiceChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
 	public static synthetic fun onUpdate$default (Ldev/kord/core/live/channel/LiveVoiceChannel;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
@@ -13229,7 +13224,7 @@ public final class dev/kord/core/supplier/RestEntitySupplier : dev/kord/core/sup
 
 public final class dev/kord/core/supplier/StoreEntitySupplier : dev/kord/core/supplier/EntitySupplier {
 	public fun <init> (Ldev/kord/core/supplier/EntitySupplier;Ldev/kord/cache/api/DataCache;)V
-	public fun <init> (Ldev/kord/core/supplier/EntitySupplier;Ldev/kord/cache/api/DataCache;Ldev/kord/core/Kord;)V
+	public synthetic fun <init> (Ldev/kord/core/supplier/EntitySupplier;Ldev/kord/cache/api/DataCache;Ldev/kord/core/Kord;)V
 	public fun getActiveThreads (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
 	public fun getApplicationCommandPermissions (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getApplicationCommandPermissionsOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/rest/api/rest.api
+++ b/rest/api/rest.api
@@ -1889,6 +1889,7 @@ public final class dev/kord/rest/json/JsonErrorCode : java/lang/Enum {
 	public static final field AlreadyCrossposted Ldev/kord/rest/json/JsonErrorCode;
 	public static final field AnnouncementRateLimit Ldev/kord/rest/json/JsonErrorCode;
 	public static final field ApplicationCommandNameExists Ldev/kord/rest/json/JsonErrorCode;
+	public static final field ApplicationNotAvailable Ldev/kord/rest/json/JsonErrorCode;
 	public static final field BeforeValueBeforeThreadCreate Ldev/kord/rest/json/JsonErrorCode;
 	public static final field BitrateTooHigh Ldev/kord/rest/json/JsonErrorCode;
 	public static final field BotsEndpoint Ldev/kord/rest/json/JsonErrorCode;
@@ -1911,8 +1912,10 @@ public final class dev/kord/rest/json/JsonErrorCode : java/lang/Enum {
 	public static final field ChannelWriteRateLimit Ldev/kord/rest/json/JsonErrorCode;
 	public static final field CommunityServerChannelMustBeTextChannel Ldev/kord/rest/json/JsonErrorCode;
 	public static final field Companion Ldev/kord/rest/json/JsonErrorCode$Companion;
+	public static final field ConnectionRevoked Ldev/kord/rest/json/JsonErrorCode;
 	public static final field DisallowedName Ldev/kord/rest/json/JsonErrorCode;
 	public static final field FailedToCreateStage Ldev/kord/rest/json/JsonErrorCode;
+	public static final field FailedToResizeAssetBelowMaximumSize Ldev/kord/rest/json/JsonErrorCode;
 	public static final field FileTooLarge Ldev/kord/rest/json/JsonErrorCode;
 	public static final field General Ldev/kord/rest/json/JsonErrorCode;
 	public static final field GiftRequiresPaymentSource Ldev/kord/rest/json/JsonErrorCode;
@@ -1946,8 +1949,10 @@ public final class dev/kord/rest/json/JsonErrorCode : java/lang/Enum {
 	public static final field MaxActiveAnnouncementThreads Ldev/kord/rest/json/JsonErrorCode;
 	public static final field MaxActiveThreads Ldev/kord/rest/json/JsonErrorCode;
 	public static final field MaxAnimatedEmojis Ldev/kord/rest/json/JsonErrorCode;
+	public static final field MaxApplicationCommands Ldev/kord/rest/json/JsonErrorCode;
 	public static final field MaxAttachments Ldev/kord/rest/json/JsonErrorCode;
 	public static final field MaxBanFetches Ldev/kord/rest/json/JsonErrorCode;
+	public static final field MaxDailyApplicationCommandCreates Ldev/kord/rest/json/JsonErrorCode;
 	public static final field MaxEmojis Ldev/kord/rest/json/JsonErrorCode;
 	public static final field MaxFriends Ldev/kord/rest/json/JsonErrorCode;
 	public static final field MaxGuildChannels Ldev/kord/rest/json/JsonErrorCode;
@@ -1972,6 +1977,7 @@ public final class dev/kord/rest/json/JsonErrorCode : java/lang/Enum {
 	public static final field MaxUncompletedGuildScheduledEvents Ldev/kord/rest/json/JsonErrorCode;
 	public static final field MaxWebhooks Ldev/kord/rest/json/JsonErrorCode;
 	public static final field MessageAlreadyHasThread Ldev/kord/rest/json/JsonErrorCode;
+	public static final field MessageBlockedByAutomaticModeration Ldev/kord/rest/json/JsonErrorCode;
 	public static final field MissingAccess Ldev/kord/rest/json/JsonErrorCode;
 	public static final field MissingOAuthScope Ldev/kord/rest/json/JsonErrorCode;
 	public static final field NoUsersWithDiscordTag Ldev/kord/rest/json/JsonErrorCode;
@@ -1982,6 +1988,7 @@ public final class dev/kord/rest/json/JsonErrorCode : java/lang/Enum {
 	public static final field OnlyOwner Ldev/kord/rest/json/JsonErrorCode;
 	public static final field OperationOnAchievedThread Ldev/kord/rest/json/JsonErrorCode;
 	public static final field OperationOnArchivedThread Ldev/kord/rest/json/JsonErrorCode;
+	public static final field OwnershipCannotBeTransferredToBot Ldev/kord/rest/json/JsonErrorCode;
 	public static final field PermissionLack Ldev/kord/rest/json/JsonErrorCode;
 	public static final field ProvidedMessageCountInsufficient Ldev/kord/rest/json/JsonErrorCode;
 	public static final field RasterizedImagesInLotties Ldev/kord/rest/json/JsonErrorCode;
@@ -1998,6 +2005,7 @@ public final class dev/kord/rest/json/JsonErrorCode : java/lang/Enum {
 	public static final field StickerPermissionLack Ldev/kord/rest/json/JsonErrorCode;
 	public static final field TemporarilyDisabled Ldev/kord/rest/json/JsonErrorCode;
 	public static final field TheadLocked Ldev/kord/rest/json/JsonErrorCode;
+	public static final field TitleBlockedByAutomaticModeration Ldev/kord/rest/json/JsonErrorCode;
 	public static final field TooFastDM Ldev/kord/rest/json/JsonErrorCode;
 	public static final field TooLongNote Ldev/kord/rest/json/JsonErrorCode;
 	public static final field Unauthorized Ldev/kord/rest/json/JsonErrorCode;
@@ -2041,6 +2049,7 @@ public final class dev/kord/rest/json/JsonErrorCode : java/lang/Enum {
 	public static final field UnknownStoreListing Ldev/kord/rest/json/JsonErrorCode;
 	public static final field UnknownStream Ldev/kord/rest/json/JsonErrorCode;
 	public static final field UnknownToken Ldev/kord/rest/json/JsonErrorCode;
+	public static final field UnknownUpload Ldev/kord/rest/json/JsonErrorCode;
 	public static final field UnknownUser Ldev/kord/rest/json/JsonErrorCode;
 	public static final field UnknownVoiceState Ldev/kord/rest/json/JsonErrorCode;
 	public static final field UnknownWebhook Ldev/kord/rest/json/JsonErrorCode;
@@ -2520,7 +2529,7 @@ public final class dev/kord/rest/json/request/CurrentVoiceStateModifyRequest {
 	public static synthetic fun copy$default (Ldev/kord/rest/json/request/CurrentVoiceStateModifyRequest;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/rest/json/request/CurrentVoiceStateModifyRequest;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
-	public final fun getRequestToSpeakTimeStamp ()Ldev/kord/common/entity/optional/Optional;
+	public final synthetic fun getRequestToSpeakTimeStamp ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getRequestToSpeakTimestamp ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getSuppress ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public fun hashCode ()I
@@ -3460,7 +3469,7 @@ public final class dev/kord/rest/json/request/GuildRoleCreateRequest {
 	public final fun getMentionable ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun getName ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getPermissions ()Ldev/kord/common/entity/optional/Optional;
-	public final fun getSeparate ()Ldev/kord/common/entity/optional/OptionalBoolean;
+	public final synthetic fun getSeparate ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun getUnicodeEmoji ()Ldev/kord/common/entity/optional/Optional;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -3505,7 +3514,7 @@ public final class dev/kord/rest/json/request/GuildRoleModifyRequest {
 	public final fun getMentionable ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun getName ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getPermissions ()Ldev/kord/common/entity/optional/Optional;
-	public final fun getSeparate ()Ldev/kord/common/entity/optional/OptionalBoolean;
+	public final synthetic fun getSeparate ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun getUnicodeEmoji ()Ldev/kord/common/entity/optional/Optional;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -5424,7 +5433,7 @@ public final class dev/kord/rest/request/RequestBuilder {
 	public final fun getBaseUrl ()Ljava/lang/String;
 	public final fun getKeys ()Ljava/util/Map;
 	public final fun getRoute ()Ldev/kord/rest/route/Route;
-	public final fun header (Ljava/lang/String;Ljava/lang/String;)V
+	public final synthetic fun header (Ljava/lang/String;Ljava/lang/String;)V
 	public final fun parameter (Ljava/lang/String;Ldev/kord/common/entity/Snowflake;)V
 	public final fun parameter (Ljava/lang/String;Ljava/lang/Object;)V
 	public final fun set (Ljava/util/Map;Ldev/kord/rest/route/Route$Key;Ldev/kord/common/entity/Snowflake;)V
@@ -6446,7 +6455,7 @@ public final class dev/kord/rest/service/GuildService : dev/kord/rest/service/Re
 	public final fun getGuildBans (Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/route/Position$BeforeOrAfter;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getGuildBans$default (Ldev/kord/rest/service/GuildService;Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/route/Position$BeforeOrAfter;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun getGuildChannels (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildEmbed (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final synthetic fun getGuildEmbed (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getGuildIntegrations (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getGuildInvites (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getGuildMember (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -6477,7 +6486,7 @@ public final class dev/kord/rest/service/GuildService : dev/kord/rest/service/Re
 	public final fun modifyCurrentVoiceState (Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/CurrentVoiceStateModifyRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun modifyGuild (Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun modifyGuildChannelPosition (Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun modifyGuildEmbed (Ldev/kord/common/entity/Snowflake;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final synthetic fun modifyGuildEmbed (Ldev/kord/common/entity/Snowflake;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun modifyGuildIntegration (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun modifyGuildMFALevel (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/MFALevel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun modifyGuildMember (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -6540,7 +6549,7 @@ public final class dev/kord/rest/service/InteractionService : dev/kord/rest/serv
 	public final fun createModalInteractionResponse (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/DiscordModal;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun createModalInteractionResponse (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun createNumberAutoCompleteInteractionResponse (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun createPublicInteractionResponse (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final synthetic fun createPublicInteractionResponse (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun createPublicInteractionResponse$default (Ldev/kord/rest/service/InteractionService;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun createStringAutoCompleteInteractionResponse (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun deferMessage (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -51,7 +51,7 @@ fun VersionCatalogBuilder.kotlinx() {
 }
 
 fun VersionCatalogBuilder.ktor() {
-    val ktor = version("ktor", "2.0.3")
+    val ktor = version("ktor", "2.1.0")
 
     library("ktor-client-json", "io.ktor", "ktor-serialization-kotlinx-json").versionRef(ktor)
     library("ktor-client-content-negotiation", "io.ktor", "ktor-client-content-negotiation").versionRef(ktor)
@@ -69,19 +69,19 @@ fun VersionCatalogBuilder.ktor() {
 }
 
 fun VersionCatalogBuilder.common() {
-    version("kotlinx-coroutines", "1.6.3")
+    version("kotlinx-coroutines", "1.6.4")
     library("kotlinx-serialization", "org.jetbrains.kotlinx", "kotlinx-serialization-json").version("1.3.3")
     library("kotlinx-coroutines", "org.jetbrains.kotlinx", "kotlinx-coroutines-core").versionRef("kotlinx-coroutines")
-    library("kotlinx-atomicfu", "org.jetbrains.kotlinx", "atomicfu").version("0.18.2")
+    library("kotlinx-atomicfu", "org.jetbrains.kotlinx", "atomicfu").version("0.18.3")
     library("kotlin-logging", "io.github.microutils", "kotlin-logging").version("2.1.23")
 
     bundle("common", listOf("kotlinx-serialization", "kotlinx-coroutines", "kotlinx-atomicfu", "kotlin-logging"))
 }
 
 fun VersionCatalogBuilder.tests() {
-    val junit5 = version("junit5", "5.8.2")
+    val junit5 = version("junit5", "5.9.0")
 
-    library("mockk", "io.mockk", "mockk").version("1.12.4")
+    library("mockk", "io.mockk", "mockk").version("1.12.5")
     library("kotlinx-coroutines-test", "org.jetbrains.kotlinx", "kotlinx-coroutines-test").versionRef("kotlinx-coroutines")
     library("junit-jupiter-api", "org.junit.jupiter", "junit-jupiter-api").versionRef(junit5)
 

--- a/voice/api/voice.api
+++ b/voice/api/voice.api
@@ -289,7 +289,7 @@ public final class dev/kord/voice/SpeakingFlags$Companion {
 }
 
 public final class dev/kord/voice/VoiceConnection {
-	public fun <init> (Ldev/kord/voice/VoiceConnectionData;Ldev/kord/gateway/Gateway;Ldev/kord/voice/gateway/VoiceGateway;Ldev/kord/voice/udp/VoiceUdpSocket;Ldev/kord/voice/gateway/VoiceGatewayConfiguration;Ldev/kord/voice/streams/Streams;Ldev/kord/voice/AudioProvider;Ldev/kord/voice/FrameInterceptor;Ldev/kord/voice/udp/AudioFrameSender;Ldev/kord/voice/encryption/strategies/NonceStrategy;)V
+	public synthetic fun <init> (Ldev/kord/voice/VoiceConnectionData;Ldev/kord/gateway/Gateway;Ldev/kord/voice/gateway/VoiceGateway;Ldev/kord/voice/udp/VoiceUdpSocket;Ldev/kord/voice/gateway/VoiceGatewayConfiguration;Ldev/kord/voice/streams/Streams;Ldev/kord/voice/AudioProvider;Ldev/kord/voice/FrameInterceptor;Ldev/kord/voice/udp/AudioFrameSender;Ldev/kord/voice/encryption/strategies/NonceStrategy;JLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun connect (Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun connect$default (Ldev/kord/voice/VoiceConnection;Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun disconnect (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -305,6 +305,8 @@ public final class dev/kord/voice/VoiceConnection {
 	public final fun getVoiceGateway ()Ldev/kord/voice/gateway/VoiceGateway;
 	public final fun getVoiceGatewayConfiguration ()Ldev/kord/voice/gateway/VoiceGatewayConfiguration;
 	public final fun leave (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun move (Ldev/kord/common/entity/Snowflake;ZZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun move$default (Ldev/kord/voice/VoiceConnection;Ldev/kord/common/entity/Snowflake;ZZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun setVoiceGatewayConfiguration (Ldev/kord/voice/gateway/VoiceGatewayConfiguration;)V
 	public final fun shutdown (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
@@ -317,6 +319,7 @@ public final class dev/kord/voice/VoiceConnectionBuilder {
 	public final fun getAudioProvider ()Ldev/kord/voice/AudioProvider;
 	public final fun getAudioSender ()Ldev/kord/voice/udp/AudioFrameSender;
 	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getConnectionDetachDuration-UwyO8pc ()J
 	public final fun getFrameInterceptor ()Ldev/kord/voice/FrameInterceptor;
 	public final fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
@@ -331,6 +334,7 @@ public final class dev/kord/voice/VoiceConnectionBuilder {
 	public final fun setAudioProvider (Ldev/kord/voice/AudioProvider;)V
 	public final fun setAudioSender (Ldev/kord/voice/udp/AudioFrameSender;)V
 	public final fun setChannelId (Ldev/kord/common/entity/Snowflake;)V
+	public final fun setConnectionDetachDuration-LRDsOJo (J)V
 	public final fun setFrameInterceptor (Ldev/kord/voice/FrameInterceptor;)V
 	public final fun setGateway (Ldev/kord/gateway/Gateway;)V
 	public final fun setGuildId (Ldev/kord/common/entity/Snowflake;)V


### PR DESCRIPTION
- Binary compatibility validator 0.10.1 -> 0.11.0
- AtomicFU 0.18.2 -> 0.18.3
- Ktor 2.0.3 -> 2.1.0
- kotlinx.coroutines 1.6.3 -> 1.6.4
- JUnit 5 5.8.2 -> 5.9.0
- MockK 1.12.4 -> 1.12.5
- Change workflow for binary compatibility validator like recommended [here](https://github.com/Kotlin/binary-compatibility-validator#workflow).
We will now always have to run `apiDump` when we change public API, otherwise tests will fail. This will keep the diff in `.api` files in the same commit as the actual changes. It ensures we are aware that we changed something and will prevent unwanted breaking changes by mistake. (Previously, we only dumped API before a release, so it was hard to track which commits changed which part of the API.)
This is also the normal way the validator is used by other libs (kxser, kxcoro, ...) so new contributors that worked with it before will not have to use it differently than they are used to.
(This PR also updates api dumps to let tests pass.)



