### PR TITLE
Use GitHub Pages Deploy Action

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -1,10 +1,10 @@
-# This workflow will upload docs to the gh-pages branch whenever something is pushed to 0.8.x.
+# This workflow will build and push docs to the gh-pages branch whenever something is pushed to 0.8.x.
 
 name: Docs
 on:
   push:
     branches:
-      - docs # todo set back to 0.8.x after testing
+      - 0.8.x
 
 jobs:
   update_docs:

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -4,25 +4,28 @@ name: Docs
 on:
   push:
     branches:
-      - 0.8.x
+      - docs # todo set back to 0.8.x after testing
 
 jobs:
-  upload_docs:
-    name: update docs
+  update_docs:
+    name: Update docs
     runs-on: ubuntu-latest
-    env:
-      GRGIT_USER: ${{ secrets.GRGIT_USER }}
-      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
-
     steps:
       - uses: actions/checkout@v2
+
       - name: Set up JDK 8
         uses: actions/setup-java@v1
         with:
           java-version: 8
 
-
-      - name: Publish docs with Gradle
+      - name: Build docs with Gradle
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: --stacktrace --info gitPublishPush
+          arguments: --stacktrace --info dokkaHtmlMultiModule
+
+      - name: Push docs to gh-pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: dokka
+          branch: gh-pages
+          commit-message: Update docs

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -28,4 +28,6 @@ jobs:
         with:
           folder: dokka
           branch: gh-pages
+          git-config-name: GitHub Actions
+          git-config-email: actions@github.com
           commit-message: Update docs

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -10,6 +10,11 @@ jobs:
   update_docs:
     name: Update docs
     runs-on: ubuntu-latest
+
+    env:
+      GITHUB_TAG_NAME: ${{ github.event.release.tag_name }}
+      GITHUB_BRANCH_NAME: ${{ github.ref }}
+
     steps:
       - uses: actions/checkout@v2
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,3 @@
-import org.ajoberstar.gradle.git.publish.GitPublishExtension
 import org.gradle.api.tasks.wrapper.Wrapper.DistributionType.ALL
 
 plugins {
@@ -6,8 +5,6 @@ plugins {
     kotlin("plugin.serialization")
     id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.11.0"
     id("org.jetbrains.dokka")
-
-    id("org.ajoberstar.git-publish") version "3.0.1"
 
     signing
     `maven-publish`
@@ -48,19 +45,4 @@ tasks {
         failOnWarning.set(true)
         outputDirectory.set(dokkaOutputDir)
     }
-
-    gitPublishReset {
-        dependsOn(dokkaHtmlMultiModule)
-    }
-}
-
-configure<GitPublishExtension> {
-    repoUri.set("https://github.com/kordlib/kord.git")
-    branch.set("gh-pages")
-
-    contents {
-        from(project.projectDir.resolve("dokka"))
-    }
-
-    commitMessage.set("Update Docs")
 }

--- a/buildSrc/src/main/kotlin/Projects.kt
+++ b/buildSrc/src/main/kotlin/Projects.kt
@@ -34,6 +34,10 @@ object Library {
     val isRelease: Boolean get() = !isSnapshot && !isUndefined
 
     val isUndefined get() = version == "undefined"
+
+    init {
+        println("(debug print) version from env: $version")
+    }
 }
 
 object Repo {

--- a/buildSrc/src/main/kotlin/Projects.kt
+++ b/buildSrc/src/main/kotlin/Projects.kt
@@ -34,10 +34,6 @@ object Library {
     val isRelease: Boolean get() = !isSnapshot && !isUndefined
 
     val isUndefined get() = version == "undefined"
-
-    init {
-        println("(debug print) version from env: $version")
-    }
 }
 
 object Repo {


### PR DESCRIPTION
This PR replaces the [gradle-git-publish](https://github.com/ajoberstar/gradle-git-publish) plugin with [GitHub Pages Deploy Action](https://github.com/marketplace/actions/deploy-to-github-pages).

Since GitHub Pages Deploy Action uses the always available [`GITHUB_TOKEN`](https://docs.github.com/en/actions/security-guides/automatic-token-authentication), we don't longer need to provide a personal access token for authentication. If this gets merged, the `GRGIT_USER` secret can be removed.
This also fixes the issue that we couldn't upgrade the gradle-git-publish plugin because its newer versions are built for jdk 11 while kord is still using jdk 8.

This was inspired by @DRSchlaubi's [kord-dokka](https://github.com/DRSchlaubi/kord-dokka) repo.