### PR TITLE
Add `ApplicationFlag.ApplicationCommandBadge`

### DIFF
--- a/common/api/common.api
+++ b/common/api/common.api
@@ -467,6 +467,7 @@ public final class dev/kord/common/entity/ApplicationCommandType$User : dev/kord
 }
 
 public final class dev/kord/common/entity/ApplicationFlag : java/lang/Enum {
+	public static final field ApplicationCommandBadge Ldev/kord/common/entity/ApplicationFlag;
 	public static final field Embedded Ldev/kord/common/entity/ApplicationFlag;
 	public static final field GatewayGuildMembers Ldev/kord/common/entity/ApplicationFlag;
 	public static final field GatewayGuildMembersLimited Ldev/kord/common/entity/ApplicationFlag;

--- a/common/src/main/kotlin/entity/DiscordApplication.kt
+++ b/common/src/main/kotlin/entity/DiscordApplication.kt
@@ -155,8 +155,10 @@ public enum class ApplicationFlag(public val code: Int) {
      * Intent required for bots in under 100 servers to receive
      * [message content](https://support-dev.discord.com/hc/en-us/articles/4404772028055), found in Bot Settings.
      */
-    GatewayMessageContentLimited(1 shl 19);
+    GatewayMessageContentLimited(1 shl 19),
 
+    /** Indicates if an app has registered global application commands. */
+    ApplicationCommandBadge(1 shl 23);
 
     public operator fun plus(flag: ApplicationFlag): ApplicationFlags = ApplicationFlags(this.code or flag.code)
 


### PR DESCRIPTION
see https://github.com/discord/discord-api-docs/pull/5222, merged in https://github.com/discord/discord-api-docs/commit/96bd1882cdd1113ce9688a1922ef4952bf1fec90