### PR TITLE
Deprecate `GuildFeature.Commerce`

### DIFF
--- a/common/src/main/kotlin/entity/DiscordGuild.kt
+++ b/common/src/main/kotlin/entity/DiscordGuild.kt
@@ -208,7 +208,20 @@ public sealed class GuildFeature(public val value: String) {
     /** Guild can enable welcome screen and discovery, and receives community updates */
     public object Community : GuildFeature("COMMUNITY")
 
-    /** Guild has access to use commerce features (i.e. create store channels) */
+    /**
+     * Guild has access to use commerce features (i.e. create store channels)
+     *
+     * @suppress
+     */
+    @Deprecated(
+        """
+        Discord no longer offers the ability to purchase a license to sell PC games on Discord and store channels were
+        removed on March 10, 2022.
+        
+        See https://support-dev.discord.com/hc/en-us/articles/4414590563479 for more information.
+        """,
+        level = DeprecationLevel.ERROR,
+    )
     public object Commerce : GuildFeature("COMMERCE")
 
     /** Guild has access to create news channels */
@@ -270,7 +283,7 @@ public sealed class GuildFeature(public val value: String) {
             "VERIFIED" -> Verified
             "PARTNERED" -> Partnered
             "COMMUNITY" -> Community
-            "COMMERCE" -> Commerce
+            "COMMERCE" -> @Suppress("DEPRECATION_ERROR") Commerce
             "NEWS" -> News
             "DISCOVERABLE" -> Discoverable
             "FEATURABLE" -> Featurable

--- a/common/src/main/kotlin/entity/DiscordGuild.kt
+++ b/common/src/main/kotlin/entity/DiscordGuild.kt
@@ -218,7 +218,8 @@ public sealed class GuildFeature(public val value: String) {
         Discord no longer offers the ability to purchase a license to sell PC games on Discord and store channels were
         removed on March 10, 2022.
         
-        See https://support-dev.discord.com/hc/en-us/articles/4414590563479 for more information.
+        See https://support-dev.discord.com/hc/en-us/articles/6309018858647-Self-serve-Game-Selling-Deprecation for more
+        information.
         """,
         level = DeprecationLevel.ERROR,
     )


### PR DESCRIPTION
Overlooked in #564

see https://github.com/discord/discord-api-docs/pull/5180, merged in https://github.com/discord/discord-api-docs/commit/aa867a1023fb5ffb24297eefb7f345ab3b94c24c