### PR TITLE
Update create guild ban endpoint

### DIFF
--- a/rest/api/rest.api
+++ b/rest/api/rest.api
@@ -91,8 +91,10 @@ public final class dev/kord/rest/builder/auditlog/AuditLogGetRequestBuilder : de
 
 public final class dev/kord/rest/builder/ban/BanCreateBuilder : dev/kord/rest/builder/AuditRequestBuilder {
 	public fun <init> ()V
+	public final fun getDeleteMessageDuration-FghU774 ()Lkotlin/time/Duration;
 	public final fun getDeleteMessagesDays ()Ljava/lang/Integer;
 	public fun getReason ()Ljava/lang/String;
+	public final fun setDeleteMessageDuration-BwNAW2A (Lkotlin/time/Duration;)V
 	public final fun setDeleteMessagesDays (Ljava/lang/Integer;)V
 	public fun setReason (Ljava/lang/String;)V
 	public fun toRequest ()Ldev/kord/rest/json/request/GuildBanCreateRequest;
@@ -2988,14 +2990,18 @@ public final class dev/kord/rest/json/request/GroupDMCreateRequest$Companion {
 public final class dev/kord/rest/json/request/GuildBanCreateRequest {
 	public static final field Companion Ldev/kord/rest/json/request/GuildBanCreateRequest$Companion;
 	public fun <init> ()V
-	public synthetic fun <init> (ILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (ILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ldev/kord/common/entity/optional/Optional;)V
+	public synthetic fun <init> (Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;)V
+	public synthetic fun <init> (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component2 ()Ldev/kord/common/entity/optional/OptionalInt;
-	public final fun copy (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;)Ldev/kord/rest/json/request/GuildBanCreateRequest;
-	public static synthetic fun copy$default (Ldev/kord/rest/json/request/GuildBanCreateRequest;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;ILjava/lang/Object;)Ldev/kord/rest/json/request/GuildBanCreateRequest;
+	public final fun component3 ()Ldev/kord/common/entity/optional/Optional;
+	public final fun copy (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/rest/json/request/GuildBanCreateRequest;
+	public static synthetic fun copy$default (Ldev/kord/rest/json/request/GuildBanCreateRequest;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/rest/json/request/GuildBanCreateRequest;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeleteMessageSeconds ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getDeleteMessagesDays ()Ldev/kord/common/entity/optional/OptionalInt;
 	public final fun getReason ()Ldev/kord/common/entity/optional/Optional;
 	public fun hashCode ()I

--- a/rest/src/main/kotlin/builder/ban/BanCreateBuilder.kt
+++ b/rest/src/main/kotlin/builder/ban/BanCreateBuilder.kt
@@ -6,23 +6,31 @@ import dev.kord.common.entity.optional.OptionalInt
 import dev.kord.common.entity.optional.delegate.delegate
 import dev.kord.rest.builder.AuditRequestBuilder
 import dev.kord.rest.json.request.GuildBanCreateRequest
+import kotlin.DeprecationLevel.WARNING
+import kotlin.time.Duration
 
 @KordDsl
 public class BanCreateBuilder : AuditRequestBuilder<GuildBanCreateRequest> {
 
-    private var _reason: Optional<String> = Optional.Missing()
-
-    /**
-     * The reason for banning this member.
-     */
-    override var reason: String? by ::_reason.delegate()
+    override var reason: String? = null
 
     private var _deleteMessagesDays: OptionalInt = OptionalInt.Missing
 
     /**
      * The number of days to delete messages for (0-7).
+     *
+     * @suppress
      */
+    @Deprecated("Use 'deleteMessageDuration' instead.", ReplaceWith("this.deleteMessageDuration"), level = WARNING)
     public var deleteMessagesDays: Int? by ::_deleteMessagesDays.delegate()
 
-    override fun toRequest(): GuildBanCreateRequest = GuildBanCreateRequest(_reason, _deleteMessagesDays)
+    private var _deleteMessageDuration: Optional<Duration> = Optional.Missing()
+
+    /** [Duration] to delete messages for, between 0 and 604800 seconds (7 days). */
+    public var deleteMessageDuration: Duration? by ::_deleteMessageDuration.delegate()
+
+    override fun toRequest(): GuildBanCreateRequest = @Suppress("DEPRECATION") GuildBanCreateRequest(
+        deleteMessagesDays = _deleteMessagesDays,
+        deleteMessageSeconds = _deleteMessageDuration,
+    )
 }

--- a/rest/src/main/kotlin/json/request/GuildRequests.kt
+++ b/rest/src/main/kotlin/json/request/GuildRequests.kt
@@ -17,6 +17,7 @@ import kotlinx.serialization.descriptors.listSerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlin.DeprecationLevel.HIDDEN
+import kotlin.DeprecationLevel.WARNING
 
 @Serializable
 public data class GuildCreateRequest(
@@ -119,11 +120,29 @@ public data class GuildMemberModifyRequest(
 
 
 @Serializable
-public data class GuildBanCreateRequest(
+public data class GuildBanCreateRequest @Deprecated(
+    "'reason' and 'deleteMessageDays' are deprecated, use other constructor instead.",
+    ReplaceWith("GuildBanCreateRequest(deleteMessageSeconds)"),
+    level = WARNING,
+) public constructor(
+    /** @suppress*/
+    @Deprecated("Use 'X-Audit-Log-Reason' header instead.", level = WARNING)
     val reason: Optional<String> = Optional.Missing(),
+    /** @suppress*/
+    @Deprecated("Use 'deleteMessageSeconds' instead.", ReplaceWith("this.deleteMessageSeconds"), level = WARNING)
     @SerialName("delete_message_days")
     val deleteMessagesDays: OptionalInt = OptionalInt.Missing,
-)
+    @SerialName("delete_message_seconds")
+    val deleteMessageSeconds: Optional<DurationInSeconds> = Optional.Missing(),
+) {
+    // use this as primary constructor when other constructor is removed
+    @Suppress("DEPRECATION")
+    public constructor(deleteMessageSeconds: Optional<DurationInSeconds> = Optional.Missing()) : this(
+        reason = Optional.Missing(),
+        deleteMessagesDays = OptionalInt.Missing,
+        deleteMessageSeconds = deleteMessageSeconds,
+    )
+}
 
 @Serializable
 public data class GuildRoleCreateRequest(


### PR DESCRIPTION
- deprecate `GuildBanCreateRequest.reason`, `GuildBanCreateRequest.deleteMessagesDays` and `BanCreateBuilder.deleteMessagesDays`
- don't send `reason` in JSON payload when using `BanCreateBuilder` ([`GuildService.addGuildBan()`](https://github.com/kordlib/kord/blob/dc62be35dd35dbc71e78eb866872816ee8e64509/rest/src/main/kotlin/service/GuildService.kt#L211) already uses `X-Audit-Log-Reason` header)
- add `GuildBanCreateRequest.deleteMessageSeconds` and `BanCreateBuilder.deleteMessageDuration`

see https://github.com/discord/discord-api-docs/pull/5219, merged in https://github.com/discord/discord-api-docs/commit/7e3e3a3de46a909c9a5bc04404f0df9a806e7271