### PR TITLE
Update voice state modification

### DIFF
--- a/core/src/main/kotlin/behavior/channel/StageChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/StageChannelBehavior.kt
@@ -62,7 +62,7 @@ public suspend inline fun StageChannelBehavior.createStageInstance(
  */
 public suspend inline fun StageChannelBehavior.editCurrentVoiceState(builder: CurrentVoiceStateModifyBuilder.() -> Unit) {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
-    kord.rest.guild.modifyCurrentVoiceState(guildId, id, builder)
+    kord.rest.guild.modifyCurrentVoiceState(guildId, builder)
 }
 
 /**

--- a/rest/api/rest.api
+++ b/rest/api/rest.api
@@ -812,10 +812,12 @@ public final class dev/kord/rest/builder/component/TextInputBuilder : dev/kord/r
 }
 
 public final class dev/kord/rest/builder/guild/CurrentVoiceStateModifyBuilder : dev/kord/rest/builder/RequestBuilder {
+	public fun <init> ()V
 	public fun <init> (Ldev/kord/common/entity/Snowflake;)V
 	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
 	public final fun getRequestToSpeakTimestamp ()Lkotlinx/datetime/Instant;
 	public final fun getSuppress ()Ljava/lang/Boolean;
+	public final fun setChannelId (Ldev/kord/common/entity/Snowflake;)V
 	public final fun setRequestToSpeakTimestamp (Lkotlinx/datetime/Instant;)V
 	public final fun setSuppress (Ljava/lang/Boolean;)V
 	public fun toRequest ()Ldev/kord/rest/json/request/CurrentVoiceStateModifyRequest;
@@ -979,6 +981,7 @@ public final class dev/kord/rest/builder/guild/VoiceStateModifyBuilder : dev/kor
 	public fun <init> (Ldev/kord/common/entity/Snowflake;)V
 	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
 	public final fun getSuppress ()Ljava/lang/Boolean;
+	public final fun setChannelId (Ldev/kord/common/entity/Snowflake;)V
 	public final fun setSuppress (Ljava/lang/Boolean;)V
 	public fun toRequest ()Ldev/kord/rest/json/request/VoiceStateModifyRequest;
 	public synthetic fun toRequest ()Ljava/lang/Object;
@@ -2848,16 +2851,17 @@ public final class dev/kord/rest/json/request/CurrentUserNicknameModifyRequest$C
 
 public final class dev/kord/rest/json/request/CurrentVoiceStateModifyRequest {
 	public static final field Companion Ldev/kord/rest/json/request/CurrentVoiceStateModifyRequest$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public fun <init> ()V
+	public synthetic fun <init> (ILdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;)V
+	public synthetic fun <init> (Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun component2 ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun component3 ()Ldev/kord/common/entity/optional/Optional;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/rest/json/request/CurrentVoiceStateModifyRequest;
-	public static synthetic fun copy$default (Ldev/kord/rest/json/request/CurrentVoiceStateModifyRequest;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/rest/json/request/CurrentVoiceStateModifyRequest;
+	public final fun copy (Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/rest/json/request/CurrentVoiceStateModifyRequest;
+	public static synthetic fun copy$default (Ldev/kord/rest/json/request/CurrentVoiceStateModifyRequest;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/rest/json/request/CurrentVoiceStateModifyRequest;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final synthetic fun getRequestToSpeakTimeStamp ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getRequestToSpeakTimestamp ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getSuppress ()Ldev/kord/common/entity/optional/OptionalBoolean;
@@ -6887,6 +6891,7 @@ public final class dev/kord/rest/service/GuildServiceKt {
 	public static final fun createTextChannel (Ldev/kord/rest/service/GuildService;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun createVoiceChannel (Ldev/kord/rest/service/GuildService;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun modifyCurrentVoiceState (Ldev/kord/rest/service/GuildService;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun modifyCurrentVoiceState (Ldev/kord/rest/service/GuildService;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun modifyGuildWelcomeScreen (Ldev/kord/rest/service/GuildService;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun modifyScheduledEvent (Ldev/kord/rest/service/GuildService;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun modifyVoiceState (Ldev/kord/rest/service/GuildService;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/rest/src/main/kotlin/builder/guild/VoiceStateModifyBuilder.kt
+++ b/rest/src/main/kotlin/builder/guild/VoiceStateModifyBuilder.kt
@@ -1,55 +1,75 @@
 package dev.kord.rest.builder.guild
 
+import dev.kord.common.annotation.KordDsl
 import dev.kord.common.entity.Snowflake
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
+import dev.kord.common.entity.optional.OptionalSnowflake
 import dev.kord.common.entity.optional.delegate.delegate
 import dev.kord.rest.builder.RequestBuilder
 import dev.kord.rest.json.request.CurrentVoiceStateModifyRequest
 import dev.kord.rest.json.request.VoiceStateModifyRequest
 import kotlinx.datetime.Instant
+import kotlin.DeprecationLevel.WARNING
 
-public class CurrentVoiceStateModifyBuilder(public val channelId: Snowflake) :
-    RequestBuilder<CurrentVoiceStateModifyRequest> {
+@KordDsl
+public class CurrentVoiceStateModifyBuilder() : RequestBuilder<CurrentVoiceStateModifyRequest> {
 
-    private var _requestToSpeakTimestamp: Optional<Instant?> = Optional.Missing()
+    /** @suppress */
+    @Deprecated(
+        "'channelId' is no longer required, use other constructor instead.",
+        ReplaceWith("CurrentVoiceStateModifyBuilder().apply { this@apply.channelId = channelId }"),
+        level = WARNING,
+    )
+    public constructor(channelId: Snowflake) : this() {
+        this.channelId = channelId
+    }
+
+    private var _channelId: OptionalSnowflake = OptionalSnowflake.Missing
+
+    /** The ID of the channel the current user is currently in. */
+    public var channelId: Snowflake? by ::_channelId.delegate()
 
     private var _suppress: OptionalBoolean = OptionalBoolean.Missing
 
+    /** Toggles the current user's suppress state. */
+    public var suppress: Boolean? by ::_suppress.delegate()
+
+    private var _requestToSpeakTimestamp: Optional<Instant?> = Optional.Missing()
+
     /**
-     * Sets the user's request to speak.
+     * Sets the current user's request to speak.
      * The timestamp is used to sort how users appear on the moderators' request list.
      *
      * e.g: A client who requested to speak at 18:00,
      * will appear above a client who requested to speak at 20:00 in the same timezone.
      *
-     * * A date in the past is treated as "now" by Discord.
-     * * A null value removes the request to speak.
+     * - A date in the past is treated as "now" by Discord.
+     * - A null value removes the request to speak.
      */
     public var requestToSpeakTimestamp: Instant? by ::_requestToSpeakTimestamp.delegate()
 
-    /**
-     *  whether this user is muted by the current user.
-     */
-    public var suppress: Boolean? by ::_suppress.delegate()
-
-
-    override fun toRequest(): CurrentVoiceStateModifyRequest {
-        return CurrentVoiceStateModifyRequest(channelId, _suppress, _requestToSpeakTimestamp)
-    }
+    override fun toRequest(): CurrentVoiceStateModifyRequest = CurrentVoiceStateModifyRequest(
+        channelId = _channelId,
+        suppress = _suppress,
+        requestToSpeakTimestamp = _requestToSpeakTimestamp,
+    )
 }
 
 
-public class VoiceStateModifyBuilder(public val channelId: Snowflake) : RequestBuilder<VoiceStateModifyRequest> {
+@KordDsl
+public class VoiceStateModifyBuilder(
+    /** The ID of the channel the user is currently in. */
+    public var channelId: Snowflake,
+) : RequestBuilder<VoiceStateModifyRequest> {
 
     private var _suppress: OptionalBoolean = OptionalBoolean.Missing
 
-    /**
-     *  whether this user is muted by the current user.
-     */
+    /** Toggles the user's suppress state. */
     public var suppress: Boolean? by ::_suppress.delegate()
 
-    override fun toRequest(): VoiceStateModifyRequest {
-        return VoiceStateModifyRequest(channelId, _suppress)
-    }
+    override fun toRequest(): VoiceStateModifyRequest = VoiceStateModifyRequest(
+        channelId = channelId,
+        suppress = _suppress,
+    )
 }

--- a/rest/src/main/kotlin/json/request/VoiceStateRequests.kt
+++ b/rest/src/main/kotlin/json/request/VoiceStateRequests.kt
@@ -1,10 +1,7 @@
 package dev.kord.rest.json.request
 
 import dev.kord.common.entity.Snowflake
-import dev.kord.common.entity.optional.Optional
-import dev.kord.common.entity.optional.OptionalBoolean
-import dev.kord.common.entity.optional.coerceToMissing
-import dev.kord.common.entity.optional.map
+import dev.kord.common.entity.optional.*
 import kotlinx.datetime.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -12,7 +9,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class CurrentVoiceStateModifyRequest(
     @SerialName("channel_id")
-    val channelId: Snowflake,
+    val channelId: OptionalSnowflake = OptionalSnowflake.Missing,
     val suppress: OptionalBoolean = OptionalBoolean.Missing,
     @SerialName("request_to_speak_timestamp")
     val requestToSpeakTimestamp: Optional<Instant?> = Optional.Missing(),

--- a/rest/src/main/kotlin/service/GuildService.kt
+++ b/rest/src/main/kotlin/service/GuildService.kt
@@ -21,6 +21,7 @@ import dev.kord.rest.route.Position
 import dev.kord.rest.route.Route
 import kotlinx.datetime.Instant
 import kotlin.DeprecationLevel.HIDDEN
+import kotlin.DeprecationLevel.WARNING
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -594,12 +595,31 @@ public suspend inline fun GuildService.createCategory(
 
 public suspend inline fun GuildService.modifyCurrentVoiceState(
     guildId: Snowflake,
+    builder: CurrentVoiceStateModifyBuilder.() -> Unit,
+) {
+    contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
+    val request = CurrentVoiceStateModifyBuilder().apply(builder).toRequest()
+    modifyCurrentVoiceState(guildId, request)
+}
+
+@Deprecated(
+    "'channelId' is no longer required, use other overload instead.",
+    ReplaceWith(
+        "this.modifyCurrentVoiceState(guildId) {\nthis@modifyCurrentVoiceState.channelId = channelId\nbuilder()\n}"
+    ),
+    level = WARNING,
+)
+public suspend inline fun GuildService.modifyCurrentVoiceState(
+    guildId: Snowflake,
     channelId: Snowflake,
     builder: CurrentVoiceStateModifyBuilder.() -> Unit
 ) {
     contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
-    val modifyBuilder = CurrentVoiceStateModifyBuilder(channelId).apply(builder)
-    modifyCurrentVoiceState(guildId, modifyBuilder.toRequest())
+    val request = CurrentVoiceStateModifyBuilder()
+        .apply { this@apply.channelId = channelId }
+        .apply(builder)
+        .toRequest()
+    modifyCurrentVoiceState(guildId, request)
 }
 
 public suspend inline fun GuildService.modifyVoiceState(


### PR DESCRIPTION
- change type of `CurrentVoiceStateModifyRequest.channelId` from `Snowflake` to `OptionalSnowflake` (see https://github.com/discord/discord-api-docs/pull/5261, merged in https://github.com/discord/discord-api-docs/commit/631b4d4a14ace4c427d432460475d3e5970feb46)
- change type of `CurrentVoiceStateModifyBuilder.channelId` to nullable
- deprecate `CurrentVoiceStateModifyBuilder` constructor that takes `channelId` and replace with no-arg constructor
- deprecate `GuildService.modifyCurrentVoiceState(guildId, channelId, builder)` and add replacement overload without `channelId` parameter
- change `CurrentVoiceStateModifyBuilder.channelId` and `VoiceStateModifyBuilder.channelId` to `var`s instead of `val`s
- add `@KordDsl` to `CurrentVoiceStateModifyBuilder` and `VoiceStateModifyBuilder`