### PR TITLE
Fix gateway events created with "buildJsonObject" failing to be deserialized

### DIFF
--- a/gateway/src/main/kotlin/Event.kt
+++ b/gateway/src/main/kotlin/Event.kt
@@ -67,7 +67,7 @@ public sealed class Event {
                         decodeElementIndex(descriptor)) {//we assume the all fields to be present *before* the data field
                         CompositeDecoder.DECODE_DONE -> break@loop
                         0 -> {
-                            op = OpCode.serializer().deserialize(decoder)
+                            op = decodeSerializableElement(descriptor, index, OpCode.serializer())
                             when (op) {
                                 OpCode.HeartbeatACK -> data = HeartbeatACK
                                 OpCode.Reconnect -> data = Reconnect


### PR DESCRIPTION
```kotlin
fun main() {
    val opCode = Json.decodeFromString(OpCode.OpCodeSerializer, "0")
    println(opCode) // Works

    val event = Json.decodeFromJsonElement(
        Event.DeserializationStrategy,
        buildJsonObject {
            // Imagine that this is has all the required attributs to decode an event, we don't need them here because it fails while trying to decode the OpCode
            put("op", JsonPrimitive(0))
        }
    )

    println(event) // Fails
}
```

```
Exception in thread "main" java.lang.IndexOutOfBoundsException: Index -1 out of bounds for length 0
    at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64)
    at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70)
    at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:266)
    at java.base/java.util.Objects.checkIndex(Objects.java:359)
    at java.base/java.util.ArrayList.remove(ArrayList.java:504)
    at kotlinx.serialization.internal.TaggedDecoder.popTag(Tagged.kt:322)
    at kotlinx.serialization.internal.TaggedDecoder.decodeInt(Tagged.kt:227)
    at dev.kord.gateway.OpCode$OpCodeSerializer.deserialize(OpCode.kt:76)
    at dev.kord.gateway.OpCode$OpCodeSerializer.deserialize(OpCode.kt:71)
    at dev.kord.gateway.Event$DeserializationStrategy.deserialize(Event.kt:70)
    at dev.kord.gateway.Event$DeserializationStrategy.deserialize(Event.kt:49)
    at kotlinx.serialization.json.internal.PolymorphicKt.decodeSerializableValuePolymorphic(Polymorphic.kt:61)
    at kotlinx.serialization.json.internal.AbstractJsonTreeDecoder.decodeSerializableValue(TreeJsonDecoder.kt:52)
    at kotlinx.serialization.json.internal.TreeJsonDecoderKt.readJson(TreeJsonDecoder.kt:25)
    at kotlinx.serialization.json.Json.decodeFromJsonElement(Json.kt:115)
    at net.perfectdreams.loritta.cinnamon.discord.webserver.TestKt.main(Test.kt:23)
    at net.perfectdreams.loritta.cinnamon.discord.webserver.TestKt.main(Test.kt)
```

Weirdly enough, converting the `buildJsonObject` result to a String (which converts it to a JSON String) fixes the decoding issue

```kotlin
    val event = Json.decodeFromString(
        Event.DeserializationStrategy,
        buildJsonObject {
            // Imagine that this is a full event data
            put("op", JsonPrimitive(0))
        }.toString()
    )
```

Then I went and looked into how Events were deserialized, and I noticed that the OpCode deserialization was the only one that called the deserializer directly, instead of letting the `Decoding` deserialize the serializable element.

After changing it, the bug was fixed, yay! :3