### PR TITLE
Use structured concurrency for `MessageChannelBehavior.withTyping`

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -1216,7 +1216,8 @@ public final class dev/kord/core/behavior/channel/MessageChannelBehaviorKt {
 	public static synthetic fun MessageChannelBehavior$default (Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;ILjava/lang/Object;)Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public static final fun createEmbed (Ldev/kord/core/behavior/channel/MessageChannelBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun createMessage (Ldev/kord/core/behavior/channel/MessageChannelBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun withTyping (Ldev/kord/core/behavior/channel/MessageChannelBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final synthetic fun withTyping (Ldev/kord/core/behavior/channel/MessageChannelBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun withTyping (Ldev/kord/core/behavior/channel/MessageChannelBehavior;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class dev/kord/core/behavior/channel/NewsChannelBehavior : dev/kord/core/behavior/channel/threads/ThreadParentChannelBehavior {


### PR DESCRIPTION
- `launch` concurrent typing job in locally confined `CoroutineScope` (using `coroutineScope {}` builder) instead of more gloabal `Kord` scope
- eliminate potential problems of concurrent modification of local `typing` variable by utilizing cancellation instead (`typingJob.cancel()`)
- guarantee that first typing indicator is triggered before `block` is called by calling `type()` before launching typing job and calling `block()`
- return result of `block`
- no `try { ... } finally { ... }` needed because of `coroutineScope {}` cancellation semantics