### PR TITLE
Fix `with_count` parameter typo

### DIFF
--- a/rest/src/main/kotlin/service/GuildService.kt
+++ b/rest/src/main/kotlin/service/GuildService.kt
@@ -42,7 +42,7 @@ public class GuildService(requestHandler: RequestHandler) : RestService(requestH
      */
     public suspend fun getGuild(guildId: Snowflake, withCounts: Boolean = false): DiscordGuild = call(Route.GuildGet) {
         keys[Route.GuildId] = guildId
-        parameter("with_count", withCounts.toString())
+        parameter("with_counts", withCounts.toString())
     }
 
     /**


### PR DESCRIPTION
The parameter in Discord's docs is `with_counts`