### PR TITLE
Fix default avatar URL not working

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -6401,8 +6401,7 @@ public final class dev/kord/core/entity/GuildWidget : dev/kord/core/KordObject, 
 }
 
 public abstract class dev/kord/core/entity/Icon : dev/kord/core/KordObject {
-	public synthetic fun <init> (ZLdev/kord/rest/route/CdnUrl;Ldev/kord/core/Kord;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getAnimated ()Z
+	public synthetic fun <init> (Ldev/kord/rest/Image$Format;Ldev/kord/rest/route/CdnUrl;Ldev/kord/core/Kord;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getCdnUrl ()Ldev/kord/rest/route/CdnUrl;
 	public final fun getFormat ()Ldev/kord/rest/Image$Format;
 	public final fun getImage (Ldev/kord/rest/Image$Format;Ldev/kord/rest/Image$Size;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -6401,7 +6401,7 @@ public final class dev/kord/core/entity/GuildWidget : dev/kord/core/KordObject, 
 }
 
 public abstract class dev/kord/core/entity/Icon : dev/kord/core/KordObject {
-	public synthetic fun <init> (Ldev/kord/rest/Image$Format;Ldev/kord/rest/route/CdnUrl;Ldev/kord/core/Kord;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ldev/kord/rest/Image$Format;ZLdev/kord/rest/route/CdnUrl;Ldev/kord/core/Kord;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAnimated ()Z
 	public final fun getCdnUrl ()Ldev/kord/rest/route/CdnUrl;
 	public final fun getFormat ()Ldev/kord/rest/Image$Format;

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -6402,6 +6402,7 @@ public final class dev/kord/core/entity/GuildWidget : dev/kord/core/KordObject, 
 
 public abstract class dev/kord/core/entity/Icon : dev/kord/core/KordObject {
 	public synthetic fun <init> (Ldev/kord/rest/Image$Format;Ldev/kord/rest/route/CdnUrl;Ldev/kord/core/Kord;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getAnimated ()Z
 	public final fun getCdnUrl ()Ldev/kord/rest/route/CdnUrl;
 	public final fun getFormat ()Ldev/kord/rest/Image$Format;
 	public final fun getImage (Ldev/kord/rest/Image$Format;Ldev/kord/rest/Image$Size;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/core/src/main/kotlin/entity/Icon.kt
+++ b/core/src/main/kotlin/entity/Icon.kt
@@ -7,14 +7,12 @@ import dev.kord.rest.Image
 import dev.kord.rest.route.CdnUrl
 import dev.kord.rest.route.DiscordCdn
 
-public sealed class Icon(public val animated: Boolean, public val cdnUrl: CdnUrl, override val kord: Kord) :
+public sealed class Icon(
+    public val format: Image.Format,
+    public val cdnUrl: CdnUrl,
+    override val kord: Kord
+) :
     KordObject {
-
-    public val format: Image.Format
-        get() = when {
-            animated -> Image.Format.GIF
-            else -> Image.Format.WEBP
-        }
 
     public val url: String
         get() = cdnUrl.toUrl {
@@ -40,22 +38,22 @@ public sealed class Icon(public val animated: Boolean, public val cdnUrl: CdnUrl
         })
 
     override fun toString(): String {
-        return "Icon(type=${javaClass.name},animated=$animated,cdnUrl=$cdnUrl,kord=$kord)"
+        return "Icon(type=${javaClass.name},format=$format,cdnUrl=$cdnUrl,kord=$kord)"
     }
 
     public class EmojiIcon(animated: Boolean, emojiId: Snowflake, kord: Kord) :
-        Icon(animated, DiscordCdn.emoji(emojiId), kord)
+        Icon(if (animated) Image.Format.GIF else Image.Format.WEBP, DiscordCdn.emoji(emojiId), kord)
 
     public class DefaultUserAvatar(discriminator: Int, kord: Kord) :
-        Icon(false, DiscordCdn.defaultAvatar(discriminator), kord)
+        Icon(Image.Format.PNG /* Discord Default Avatars only support PNG */, DiscordCdn.defaultAvatar(discriminator), kord)
 
     public class UserAvatar(userId: Snowflake, avatarHash: String, kord: Kord) :
-        Icon(avatarHash.startsWith("a_"), DiscordCdn.userAvatar(userId, avatarHash), kord)
+        Icon(if (avatarHash.startsWith("a_")) Image.Format.GIF else Image.Format.WEBP, DiscordCdn.userAvatar(userId, avatarHash), kord)
 
     public class MemberAvatar(guildId: Snowflake, userId: Snowflake, avatarHash: String, kord: Kord) :
-        Icon(avatarHash.startsWith("a_"), DiscordCdn.memberAvatar(guildId, userId, avatarHash), kord)
+        Icon(if (avatarHash.startsWith("a_")) Image.Format.GIF else Image.Format.WEBP, DiscordCdn.memberAvatar(guildId, userId, avatarHash), kord)
 
     public class RoleIcon(roleId: Snowflake, iconHash: String, kord: Kord) :
-        Icon(iconHash.startsWith("a_"), DiscordCdn.roleIcon(roleId, iconHash), kord)
+        Icon(if (iconHash.startsWith("a_")) Image.Format.GIF else Image.Format.WEBP, DiscordCdn.roleIcon(roleId, iconHash), kord)
 
 }

--- a/core/src/main/kotlin/entity/Icon.kt
+++ b/core/src/main/kotlin/entity/Icon.kt
@@ -9,12 +9,10 @@ import dev.kord.rest.route.DiscordCdn
 
 public sealed class Icon(
     public val format: Image.Format,
+    public val animated: Boolean,
     public val cdnUrl: CdnUrl,
     override val kord: Kord
 ) : KordObject {
-    public val animated: Boolean
-        get() = format == Image.Format.GIF
-
     public val url: String
         get() = cdnUrl.toUrl {
             this.format = this@Icon.format
@@ -43,18 +41,18 @@ public sealed class Icon(
     }
 
     public class EmojiIcon(animated: Boolean, emojiId: Snowflake, kord: Kord) :
-        Icon(if (animated) Image.Format.GIF else Image.Format.WEBP, DiscordCdn.emoji(emojiId), kord)
+        Icon(if (animated) Image.Format.GIF else Image.Format.WEBP, animated, DiscordCdn.emoji(emojiId), kord)
 
     public class DefaultUserAvatar(discriminator: Int, kord: Kord) :
-        Icon(Image.Format.PNG /* Discord Default Avatars only support PNG */, DiscordCdn.defaultAvatar(discriminator), kord)
+        Icon(Image.Format.PNG /* Discord Default Avatars only support PNG */, false, DiscordCdn.defaultAvatar(discriminator), kord)
 
     public class UserAvatar(userId: Snowflake, avatarHash: String, kord: Kord) :
-        Icon(if (avatarHash.startsWith("a_")) Image.Format.GIF else Image.Format.WEBP, DiscordCdn.userAvatar(userId, avatarHash), kord)
+        Icon(if (avatarHash.startsWith("a_")) Image.Format.GIF else Image.Format.WEBP, avatarHash.startsWith("a_"), DiscordCdn.userAvatar(userId, avatarHash), kord)
 
     public class MemberAvatar(guildId: Snowflake, userId: Snowflake, avatarHash: String, kord: Kord) :
-        Icon(if (avatarHash.startsWith("a_")) Image.Format.GIF else Image.Format.WEBP, DiscordCdn.memberAvatar(guildId, userId, avatarHash), kord)
+        Icon(if (avatarHash.startsWith("a_")) Image.Format.GIF else Image.Format.WEBP, avatarHash.startsWith("a_"), DiscordCdn.memberAvatar(guildId, userId, avatarHash), kord)
 
     public class RoleIcon(roleId: Snowflake, iconHash: String, kord: Kord) :
-        Icon(if (iconHash.startsWith("a_")) Image.Format.GIF else Image.Format.WEBP, DiscordCdn.roleIcon(roleId, iconHash), kord)
+        Icon(if (iconHash.startsWith("a_")) Image.Format.GIF else Image.Format.WEBP, iconHash.startsWith("a_"), DiscordCdn.roleIcon(roleId, iconHash), kord)
 
 }

--- a/core/src/main/kotlin/entity/Icon.kt
+++ b/core/src/main/kotlin/entity/Icon.kt
@@ -37,7 +37,7 @@ public sealed class Icon(
         })
 
     override fun toString(): String {
-        return "Icon(type=${javaClass.name},format=$format,cdnUrl=$cdnUrl,kord=$kord)"
+        return "Icon(type=${javaClass.name},format=$format,animated=$animated,cdnUrl=$cdnUrl,kord=$kord)"
     }
 
     public class EmojiIcon(animated: Boolean, emojiId: Snowflake, kord: Kord) :

--- a/core/src/main/kotlin/entity/Icon.kt
+++ b/core/src/main/kotlin/entity/Icon.kt
@@ -12,6 +12,8 @@ public sealed class Icon(
     public val cdnUrl: CdnUrl,
     override val kord: Kord
 ) : KordObject {
+    public val animated: Boolean
+        get() = format == Image.Format.GIF
 
     public val url: String
         get() = cdnUrl.toUrl {

--- a/core/src/main/kotlin/entity/Icon.kt
+++ b/core/src/main/kotlin/entity/Icon.kt
@@ -11,8 +11,7 @@ public sealed class Icon(
     public val format: Image.Format,
     public val cdnUrl: CdnUrl,
     override val kord: Kord
-) :
-    KordObject {
+) : KordObject {
 
     public val url: String
         get() = cdnUrl.toUrl {


### PR DESCRIPTION
This PR changes that now the format must be provided when initializing the `Icon` class, instead of relying on the `animated` property.

Fixes #689