### PR TITLE
Add support for initializing a gateway connection with resume session data

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -2174,6 +2174,8 @@ public final class dev/kord/core/cache/CachingGateway : dev/kord/cache/api/DataC
 	public fun send (Ldev/kord/gateway/Command;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun start (Ldev/kord/gateway/GatewayConfiguration;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun stop (Ldev/kord/gateway/WebSocketCloseReason;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun stopAndInvalidateSession (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun stopForResume (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -2038,6 +2038,11 @@ public final class dev/kord/core/behavior/interaction/response/InteractionRespon
 	public static fun getFollowupMessageOrNull (Ldev/kord/core/behavior/interaction/response/InteractionResponseBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public final class dev/kord/core/behavior/interaction/response/InteractionResponseBehaviorKt {
+	public static final synthetic fun followUp (Ldev/kord/core/behavior/interaction/response/InteractionResponseBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final synthetic fun followUpEphemeral (Ldev/kord/core/behavior/interaction/response/InteractionResponseBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public abstract interface class dev/kord/core/behavior/interaction/response/MessageInteractionResponseBehavior : dev/kord/core/behavior/interaction/response/FollowupPermittingInteractionResponseBehavior {
 	public abstract fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/interaction/response/MessageInteractionResponseBehavior;
 }
@@ -2170,9 +2175,10 @@ public final class dev/kord/core/cache/CachingGateway : dev/kord/cache/api/DataC
 	public fun register (Ldev/kord/cache/api/data/DataDescription;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun register (Ljava/lang/Iterable;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun register ([Ldev/kord/cache/api/data/DataDescription;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun resume (Ldev/kord/gateway/GatewayResumeConfiguration;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun send (Ldev/kord/gateway/Command;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun start (Ldev/kord/gateway/GatewayConfiguration;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun stop (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun stop (Ldev/kord/gateway/WebSocketCloseReason;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -2038,6 +2038,11 @@ public final class dev/kord/core/behavior/interaction/response/InteractionRespon
 	public static fun getFollowupMessageOrNull (Ldev/kord/core/behavior/interaction/response/InteractionResponseBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public final class dev/kord/core/behavior/interaction/response/InteractionResponseBehaviorKt {
+	public static final synthetic fun followUp (Ldev/kord/core/behavior/interaction/response/InteractionResponseBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final synthetic fun followUpEphemeral (Ldev/kord/core/behavior/interaction/response/InteractionResponseBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public abstract interface class dev/kord/core/behavior/interaction/response/MessageInteractionResponseBehavior : dev/kord/core/behavior/interaction/response/FollowupPermittingInteractionResponseBehavior {
 	public abstract fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/interaction/response/MessageInteractionResponseBehavior;
 }
@@ -2174,8 +2179,7 @@ public final class dev/kord/core/cache/CachingGateway : dev/kord/cache/api/DataC
 	public fun send (Ldev/kord/gateway/Command;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun start (Ldev/kord/gateway/GatewayConfiguration;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun stop (Ldev/kord/gateway/WebSocketCloseReason;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun stopAndInvalidateSession (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun stopForResume (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun stop (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -2038,11 +2038,6 @@ public final class dev/kord/core/behavior/interaction/response/InteractionRespon
 	public static fun getFollowupMessageOrNull (Ldev/kord/core/behavior/interaction/response/InteractionResponseBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public final class dev/kord/core/behavior/interaction/response/InteractionResponseBehaviorKt {
-	public static final synthetic fun followUp (Ldev/kord/core/behavior/interaction/response/InteractionResponseBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final synthetic fun followUpEphemeral (Ldev/kord/core/behavior/interaction/response/InteractionResponseBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
 public abstract interface class dev/kord/core/behavior/interaction/response/MessageInteractionResponseBehavior : dev/kord/core/behavior/interaction/response/FollowupPermittingInteractionResponseBehavior {
 	public abstract fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/interaction/response/MessageInteractionResponseBehavior;
 }

--- a/core/src/test/kotlin/gateway/MasterGatewayTest.kt
+++ b/core/src/test/kotlin/gateway/MasterGatewayTest.kt
@@ -73,7 +73,7 @@ internal class DefaultMasterGatewayTest {
 
         override suspend fun start(configuration: GatewayConfiguration) {}
 
-        override suspend fun stop(closeReason: WebSocketCloseReason): GatewaySession? { return null }
+        override suspend fun stop(closeReason: WebSocketCloseReason): GatewayResumeConfiguration { error("Can't stop this!") }
 
         override suspend fun resume(configuration: GatewayResumeConfiguration) {}
     }

--- a/core/src/test/kotlin/gateway/MasterGatewayTest.kt
+++ b/core/src/test/kotlin/gateway/MasterGatewayTest.kt
@@ -1,10 +1,7 @@
 package gateway
 
 import dev.kord.core.gateway.DefaultMasterGateway
-import dev.kord.gateway.Command
-import dev.kord.gateway.Event
-import dev.kord.gateway.Gateway
-import dev.kord.gateway.GatewayConfiguration
+import dev.kord.gateway.*
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -76,8 +73,9 @@ internal class DefaultMasterGatewayTest {
 
         override suspend fun start(configuration: GatewayConfiguration) {}
 
-        override suspend fun stop() {}
+        override suspend fun stop(closeReason: WebSocketCloseReason) {}
 
+        override suspend fun resume(configuration: GatewayResumeConfiguration) {}
     }
 
 }

--- a/core/src/test/kotlin/gateway/MasterGatewayTest.kt
+++ b/core/src/test/kotlin/gateway/MasterGatewayTest.kt
@@ -73,7 +73,7 @@ internal class DefaultMasterGatewayTest {
 
         override suspend fun start(configuration: GatewayConfiguration) {}
 
-        override suspend fun stop(closeReason: WebSocketCloseReason) {}
+        override suspend fun stop(closeReason: WebSocketCloseReason): GatewaySession? { return null }
 
         override suspend fun resume(configuration: GatewayResumeConfiguration) {}
     }

--- a/core/src/test/kotlin/live/AbstractLiveEntityTest.kt
+++ b/core/src/test/kotlin/live/AbstractLiveEntityTest.kt
@@ -50,7 +50,7 @@ abstract class AbstractLiveEntityTest<LIVE : AbstractLiveKordEntity> {
 
         override suspend fun start(configuration: GatewayConfiguration) {}
 
-        override suspend fun stop(closeReason: WebSocketCloseReason) {}
+        override suspend fun stop(closeReason: WebSocketCloseReason): GatewaySession? { return null }
 
         override suspend fun resume(configuration: GatewayResumeConfiguration) {}
     }

--- a/core/src/test/kotlin/live/AbstractLiveEntityTest.kt
+++ b/core/src/test/kotlin/live/AbstractLiveEntityTest.kt
@@ -50,7 +50,7 @@ abstract class AbstractLiveEntityTest<LIVE : AbstractLiveKordEntity> {
 
         override suspend fun start(configuration: GatewayConfiguration) {}
 
-        override suspend fun stop(closeReason: WebSocketCloseReason): GatewaySession? { return null }
+        override suspend fun stop(closeReason: WebSocketCloseReason): GatewayResumeConfiguration { error("Can't stop this!") }
 
         override suspend fun resume(configuration: GatewayResumeConfiguration) {}
     }

--- a/core/src/test/kotlin/live/AbstractLiveEntityTest.kt
+++ b/core/src/test/kotlin/live/AbstractLiveEntityTest.kt
@@ -8,10 +8,7 @@ import dev.kord.core.gateway.DefaultMasterGateway
 import dev.kord.core.gateway.handler.DefaultGatewayEventInterceptor
 import dev.kord.core.live.AbstractLiveKordEntity
 import dev.kord.core.supplier.EntitySupplyStrategy
-import dev.kord.gateway.Command
-import dev.kord.gateway.Event
-import dev.kord.gateway.Gateway
-import dev.kord.gateway.GatewayConfiguration
+import dev.kord.gateway.*
 import dev.kord.gateway.builder.Shards
 import dev.kord.rest.request.KtorRequestHandler
 import dev.kord.rest.service.RestClient
@@ -53,7 +50,9 @@ abstract class AbstractLiveEntityTest<LIVE : AbstractLiveKordEntity> {
 
         override suspend fun start(configuration: GatewayConfiguration) {}
 
-        override suspend fun stop() {}
+        override suspend fun stop(closeReason: WebSocketCloseReason) {}
+
+        override suspend fun resume(configuration: GatewayResumeConfiguration) {}
     }
 
     class CounterAtomicLatch(count: Int) {

--- a/core/src/test/kotlin/performance/KordEventDropTest.kt
+++ b/core/src/test/kotlin/performance/KordEventDropTest.kt
@@ -48,7 +48,7 @@ class KordEventDropTest {
 
         override suspend fun start(configuration: GatewayConfiguration) {}
 
-        override suspend fun stop(closeReason: WebSocketCloseReason) {}
+        override suspend fun stop(closeReason: WebSocketCloseReason): GatewaySession? { return null }
 
         override suspend fun resume(configuration: GatewayResumeConfiguration) {}
     }

--- a/core/src/test/kotlin/performance/KordEventDropTest.kt
+++ b/core/src/test/kotlin/performance/KordEventDropTest.kt
@@ -48,7 +48,9 @@ class KordEventDropTest {
 
         override suspend fun start(configuration: GatewayConfiguration) {}
 
-        override suspend fun stop() {}
+        override suspend fun stop(closeReason: WebSocketCloseReason) {}
+
+        override suspend fun resume(configuration: GatewayResumeConfiguration) {}
     }
 
     val kord = Kord(

--- a/core/src/test/kotlin/performance/KordEventDropTest.kt
+++ b/core/src/test/kotlin/performance/KordEventDropTest.kt
@@ -48,7 +48,7 @@ class KordEventDropTest {
 
         override suspend fun start(configuration: GatewayConfiguration) {}
 
-        override suspend fun stop(closeReason: WebSocketCloseReason): GatewaySession? { return null }
+        override suspend fun stop(closeReason: WebSocketCloseReason): GatewayResumeConfiguration { error("Can't stop this!") }
 
         override suspend fun resume(configuration: GatewayResumeConfiguration) {}
     }

--- a/core/src/test/kotlin/regression/CacheMissRegression.kt
+++ b/core/src/test/kotlin/regression/CacheMissRegression.kt
@@ -69,8 +69,9 @@ object FakeGateway : Gateway {
         deferred.await()
     }
 
-    override suspend fun stop(closeReason: WebSocketCloseReason) {
+    override suspend fun stop(closeReason: WebSocketCloseReason): GatewaySession? {
         deferred.complete(Unit)
+        return null
     }
 
     override suspend fun resume(configuration: GatewayResumeConfiguration) {

--- a/core/src/test/kotlin/regression/CacheMissRegression.kt
+++ b/core/src/test/kotlin/regression/CacheMissRegression.kt
@@ -13,10 +13,7 @@ import dev.kord.core.cache.registerKordData
 import dev.kord.core.gateway.DefaultMasterGateway
 import dev.kord.core.gateway.handler.DefaultGatewayEventInterceptor
 import dev.kord.core.supplier.EntitySupplyStrategy
-import dev.kord.gateway.Command
-import dev.kord.gateway.Event
-import dev.kord.gateway.Gateway
-import dev.kord.gateway.GatewayConfiguration
+import dev.kord.gateway.*
 import dev.kord.gateway.builder.Shards
 import dev.kord.rest.request.JsonRequest
 import dev.kord.rest.request.MultipartRequest
@@ -72,8 +69,12 @@ object FakeGateway : Gateway {
         deferred.await()
     }
 
-    override suspend fun stop() {
+    override suspend fun stop(closeReason: WebSocketCloseReason) {
         deferred.complete(Unit)
+    }
+
+    override suspend fun resume(configuration: GatewayResumeConfiguration) {
+        deferred.await()
     }
 
     override val coroutineContext: CoroutineContext = SupervisorJob() + EmptyCoroutineContext

--- a/core/src/test/kotlin/regression/CacheMissRegression.kt
+++ b/core/src/test/kotlin/regression/CacheMissRegression.kt
@@ -69,9 +69,9 @@ object FakeGateway : Gateway {
         deferred.await()
     }
 
-    override suspend fun stop(closeReason: WebSocketCloseReason): GatewaySession? {
+    override suspend fun stop(closeReason: WebSocketCloseReason): GatewayResumeConfiguration {
         deferred.complete(Unit)
-        return null
+        error("Can't stop this!")
     }
 
     override suspend fun resume(configuration: GatewayResumeConfiguration) {

--- a/gateway/api/gateway.api
+++ b/gateway/api/gateway.api
@@ -219,6 +219,8 @@ public final class dev/kord/gateway/DefaultGateway : dev/kord/gateway/Gateway {
 	public fun send (Ldev/kord/gateway/Command;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun start (Ldev/kord/gateway/GatewayConfiguration;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun stop (Ldev/kord/gateway/WebSocketCloseReason;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun stopAndInvalidateSession (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun stopForResume (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class dev/kord/gateway/DefaultGateway$Companion {
@@ -657,6 +659,8 @@ public abstract interface class dev/kord/gateway/Gateway : kotlinx/coroutines/Co
 	public abstract fun send (Ldev/kord/gateway/Command;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun start (Ldev/kord/gateway/GatewayConfiguration;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun stop (Ldev/kord/gateway/WebSocketCloseReason;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun stopAndInvalidateSession (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun stopForResume (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class dev/kord/gateway/Gateway$Companion {
@@ -665,6 +669,8 @@ public final class dev/kord/gateway/Gateway$Companion {
 
 public final class dev/kord/gateway/Gateway$DefaultImpls {
 	public static synthetic fun stop$default (Ldev/kord/gateway/Gateway;Ldev/kord/gateway/WebSocketCloseReason;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static fun stopAndInvalidateSession (Ldev/kord/gateway/Gateway;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun stopForResume (Ldev/kord/gateway/Gateway;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class dev/kord/gateway/GatewayCloseCode : java/lang/Enum {

--- a/gateway/api/gateway.api
+++ b/gateway/api/gateway.api
@@ -219,8 +219,7 @@ public final class dev/kord/gateway/DefaultGateway : dev/kord/gateway/Gateway {
 	public fun send (Ldev/kord/gateway/Command;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun start (Ldev/kord/gateway/GatewayConfiguration;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun stop (Ldev/kord/gateway/WebSocketCloseReason;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun stopAndInvalidateSession (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun stopForResume (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun stop (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class dev/kord/gateway/DefaultGateway$Companion {
@@ -659,8 +658,7 @@ public abstract interface class dev/kord/gateway/Gateway : kotlinx/coroutines/Co
 	public abstract fun send (Ldev/kord/gateway/Command;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun start (Ldev/kord/gateway/GatewayConfiguration;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun stop (Ldev/kord/gateway/WebSocketCloseReason;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun stopAndInvalidateSession (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun stopForResume (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract synthetic fun stop (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class dev/kord/gateway/Gateway$Companion {
@@ -668,9 +666,8 @@ public final class dev/kord/gateway/Gateway$Companion {
 }
 
 public final class dev/kord/gateway/Gateway$DefaultImpls {
+	public static synthetic fun stop (Ldev/kord/gateway/Gateway;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun stop$default (Ldev/kord/gateway/Gateway;Ldev/kord/gateway/WebSocketCloseReason;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static fun stopAndInvalidateSession (Ldev/kord/gateway/Gateway;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun stopForResume (Ldev/kord/gateway/Gateway;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class dev/kord/gateway/GatewayCloseCode : java/lang/Enum {
@@ -762,6 +759,8 @@ public final class dev/kord/gateway/GatewayKt {
 	public static synthetic fun resume$default (Ldev/kord/gateway/Gateway;Ljava/lang/String;Ldev/kord/gateway/GatewaySession;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun start (Ldev/kord/gateway/Gateway;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun start$default (Ldev/kord/gateway/Gateway;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun stopAndInvalidateSession (Ldev/kord/gateway/Gateway;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun stopForResume (Ldev/kord/gateway/Gateway;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class dev/kord/gateway/GatewayResumeConfiguration {

--- a/gateway/api/gateway.api
+++ b/gateway/api/gateway.api
@@ -1698,19 +1698,6 @@ public final class dev/kord/gateway/RequestGuildMembers$Nonce {
 	public final fun new ()Ljava/lang/String;
 }
 
-public final class dev/kord/gateway/ResumeSession {
-	public fun <init> (Ldev/kord/gateway/Session;I)V
-	public final fun component1 ()Ldev/kord/gateway/Session;
-	public final fun component2 ()I
-	public final fun copy (Ldev/kord/gateway/Session;I)Ldev/kord/gateway/ResumeSession;
-	public static synthetic fun copy$default (Ldev/kord/gateway/ResumeSession;Ldev/kord/gateway/Session;IILjava/lang/Object;)Ldev/kord/gateway/ResumeSession;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getSequenceId ()I
-	public final fun getSession ()Ldev/kord/gateway/Session;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
 public final class dev/kord/gateway/Resumed : dev/kord/gateway/DispatchEvent {
 	public static final field Companion Ldev/kord/gateway/Resumed$Companion;
 	public synthetic fun <init> (ILjava/lang/Integer;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
@@ -1739,19 +1726,6 @@ public final class dev/kord/gateway/Resumed$$serializer : kotlinx/serialization/
 
 public final class dev/kord/gateway/Resumed$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
-}
-
-public final class dev/kord/gateway/Session {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Ldev/kord/gateway/Session;
-	public static synthetic fun copy$default (Ldev/kord/gateway/Session;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ldev/kord/gateway/Session;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getResumeGatewayUrl ()Ljava/lang/String;
-	public final fun getSessionId ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
 }
 
 public final class dev/kord/gateway/ThreadCreate : dev/kord/gateway/DispatchEvent {

--- a/gateway/api/gateway.api
+++ b/gateway/api/gateway.api
@@ -215,9 +215,10 @@ public final class dev/kord/gateway/DefaultGateway : dev/kord/gateway/Gateway {
 	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
 	public fun getEvents ()Lkotlinx/coroutines/flow/SharedFlow;
 	public fun getPing ()Lkotlinx/coroutines/flow/StateFlow;
+	public fun resume (Ldev/kord/gateway/GatewayResumeConfiguration;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun send (Ldev/kord/gateway/Command;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun start (Ldev/kord/gateway/GatewayConfiguration;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun stop (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun stop (Ldev/kord/gateway/WebSocketCloseReason;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class dev/kord/gateway/DefaultGateway$Companion {
@@ -652,13 +653,18 @@ public abstract interface class dev/kord/gateway/Gateway : kotlinx/coroutines/Co
 	public abstract fun detach (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getEvents ()Lkotlinx/coroutines/flow/SharedFlow;
 	public abstract fun getPing ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun resume (Ldev/kord/gateway/GatewayResumeConfiguration;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun send (Ldev/kord/gateway/Command;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun start (Ldev/kord/gateway/GatewayConfiguration;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun stop (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun stop (Ldev/kord/gateway/WebSocketCloseReason;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class dev/kord/gateway/Gateway$Companion {
 	public final fun none ()Ldev/kord/gateway/Gateway;
+}
+
+public final class dev/kord/gateway/Gateway$DefaultImpls {
+	public static synthetic fun stop$default (Ldev/kord/gateway/Gateway;Ldev/kord/gateway/WebSocketCloseReason;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class dev/kord/gateway/GatewayCloseCode : java/lang/Enum {
@@ -682,6 +688,8 @@ public final class dev/kord/gateway/GatewayCloseCode : java/lang/Enum {
 }
 
 public final class dev/kord/gateway/GatewayConfiguration {
+	public static final field Companion Ldev/kord/gateway/GatewayConfiguration$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/DiscordShard;Ldev/kord/common/entity/optional/Optional;ILdev/kord/gateway/Intents;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/DiscordShard;Ldev/kord/common/entity/optional/Optional;ILdev/kord/gateway/Intents;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/DiscordShard;Ldev/kord/common/entity/optional/Optional;ILdev/kord/gateway/Intents;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -701,6 +709,23 @@ public final class dev/kord/gateway/GatewayConfiguration {
 	public final fun getToken ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Ldev/kord/gateway/GatewayConfiguration;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class dev/kord/gateway/GatewayConfiguration$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Ldev/kord/gateway/GatewayConfiguration$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/kord/gateway/GatewayConfiguration;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ldev/kord/gateway/GatewayConfiguration;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/kord/gateway/GatewayConfiguration$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class dev/kord/gateway/GatewayConfigurationBuilder {
@@ -727,8 +752,46 @@ public final class dev/kord/gateway/GatewayKt {
 	public static final fun requestGuildMembers (Ldev/kord/gateway/Gateway;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun requestGuildMembers (Ldev/kord/gateway/Gateway;Ldev/kord/gateway/RequestGuildMembers;)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun requestGuildMembers$default (Ldev/kord/gateway/Gateway;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun resume (Ldev/kord/gateway/Gateway;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun resume$default (Ldev/kord/gateway/Gateway;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun start (Ldev/kord/gateway/Gateway;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun start$default (Ldev/kord/gateway/Gateway;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class dev/kord/gateway/GatewayResumeConfiguration {
+	public static final field Companion Ldev/kord/gateway/GatewayResumeConfiguration$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;ILdev/kord/gateway/GatewayConfiguration;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;ILdev/kord/gateway/GatewayConfiguration;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()I
+	public final fun component4 ()Ldev/kord/gateway/GatewayConfiguration;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;ILdev/kord/gateway/GatewayConfiguration;)Ldev/kord/gateway/GatewayResumeConfiguration;
+	public static synthetic fun copy$default (Ldev/kord/gateway/GatewayResumeConfiguration;Ljava/lang/String;Ljava/lang/String;ILdev/kord/gateway/GatewayConfiguration;ILjava/lang/Object;)Ldev/kord/gateway/GatewayResumeConfiguration;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getResumeUrl ()Ljava/lang/String;
+	public final fun getSequence ()I
+	public final fun getSessionId ()Ljava/lang/String;
+	public final fun getStartConfiguration ()Ldev/kord/gateway/GatewayConfiguration;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Ldev/kord/gateway/GatewayResumeConfiguration;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class dev/kord/gateway/GatewayResumeConfiguration$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Ldev/kord/gateway/GatewayResumeConfiguration$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/kord/gateway/GatewayResumeConfiguration;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ldev/kord/gateway/GatewayResumeConfiguration;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/kord/gateway/GatewayResumeConfiguration$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class dev/kord/gateway/GuildBanAdd : dev/kord/gateway/DispatchEvent {
@@ -1605,6 +1668,19 @@ public final class dev/kord/gateway/RequestGuildMembers$Nonce {
 	public final fun new ()Ljava/lang/String;
 }
 
+public final class dev/kord/gateway/ResumeSession {
+	public fun <init> (Ldev/kord/gateway/Session;I)V
+	public final fun component1 ()Ldev/kord/gateway/Session;
+	public final fun component2 ()I
+	public final fun copy (Ldev/kord/gateway/Session;I)Ldev/kord/gateway/ResumeSession;
+	public static synthetic fun copy$default (Ldev/kord/gateway/ResumeSession;Ldev/kord/gateway/Session;IILjava/lang/Object;)Ldev/kord/gateway/ResumeSession;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSequenceId ()I
+	public final fun getSession ()Ldev/kord/gateway/Session;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class dev/kord/gateway/Resumed : dev/kord/gateway/DispatchEvent {
 	public static final field Companion Ldev/kord/gateway/Resumed$Companion;
 	public synthetic fun <init> (ILjava/lang/Integer;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
@@ -1633,6 +1709,19 @@ public final class dev/kord/gateway/Resumed$$serializer : kotlinx/serialization/
 
 public final class dev/kord/gateway/Resumed$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/kord/gateway/Session {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Ldev/kord/gateway/Session;
+	public static synthetic fun copy$default (Ldev/kord/gateway/Session;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ldev/kord/gateway/Session;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getResumeGatewayUrl ()Ljava/lang/String;
+	public final fun getSessionId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class dev/kord/gateway/ThreadCreate : dev/kord/gateway/DispatchEvent {
@@ -1842,6 +1931,19 @@ public final class dev/kord/gateway/VoiceStateUpdate : dev/kord/gateway/Dispatch
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getSequence ()Ljava/lang/Integer;
 	public final fun getVoiceState ()Ldev/kord/common/entity/DiscordVoiceState;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/kord/gateway/WebSocketCloseReason {
+	public fun <init> (SLjava/lang/String;)V
+	public final fun component1 ()S
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (SLjava/lang/String;)Ldev/kord/gateway/WebSocketCloseReason;
+	public static synthetic fun copy$default (Ldev/kord/gateway/WebSocketCloseReason;SLjava/lang/String;ILjava/lang/Object;)Ldev/kord/gateway/WebSocketCloseReason;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCode ()S
+	public final fun getMessage ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/gateway/api/gateway.api
+++ b/gateway/api/gateway.api
@@ -752,26 +752,22 @@ public final class dev/kord/gateway/GatewayKt {
 	public static final fun requestGuildMembers (Ldev/kord/gateway/Gateway;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun requestGuildMembers (Ldev/kord/gateway/Gateway;Ldev/kord/gateway/RequestGuildMembers;)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun requestGuildMembers$default (Ldev/kord/gateway/Gateway;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
-	public static final fun resume (Ldev/kord/gateway/Gateway;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun resume$default (Ldev/kord/gateway/Gateway;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun resume (Ldev/kord/gateway/Gateway;Ljava/lang/String;Ldev/kord/gateway/GatewaySession;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun resume$default (Ldev/kord/gateway/Gateway;Ljava/lang/String;Ldev/kord/gateway/GatewaySession;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun start (Ldev/kord/gateway/Gateway;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun start$default (Ldev/kord/gateway/Gateway;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class dev/kord/gateway/GatewayResumeConfiguration {
 	public static final field Companion Ldev/kord/gateway/GatewayResumeConfiguration$Companion;
-	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;ILdev/kord/gateway/GatewayConfiguration;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;ILdev/kord/gateway/GatewayConfiguration;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()I
-	public final fun component4 ()Ldev/kord/gateway/GatewayConfiguration;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;ILdev/kord/gateway/GatewayConfiguration;)Ldev/kord/gateway/GatewayResumeConfiguration;
-	public static synthetic fun copy$default (Ldev/kord/gateway/GatewayResumeConfiguration;Ljava/lang/String;Ljava/lang/String;ILdev/kord/gateway/GatewayConfiguration;ILjava/lang/Object;)Ldev/kord/gateway/GatewayResumeConfiguration;
+	public synthetic fun <init> (ILdev/kord/gateway/GatewaySession;Ldev/kord/gateway/GatewayConfiguration;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ldev/kord/gateway/GatewaySession;Ldev/kord/gateway/GatewayConfiguration;)V
+	public final fun component1 ()Ldev/kord/gateway/GatewaySession;
+	public final fun component2 ()Ldev/kord/gateway/GatewayConfiguration;
+	public final fun copy (Ldev/kord/gateway/GatewaySession;Ldev/kord/gateway/GatewayConfiguration;)Ldev/kord/gateway/GatewayResumeConfiguration;
+	public static synthetic fun copy$default (Ldev/kord/gateway/GatewayResumeConfiguration;Ldev/kord/gateway/GatewaySession;Ldev/kord/gateway/GatewayConfiguration;ILjava/lang/Object;)Ldev/kord/gateway/GatewayResumeConfiguration;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getResumeUrl ()Ljava/lang/String;
-	public final fun getSequence ()I
-	public final fun getSessionId ()Ljava/lang/String;
+	public final fun getSession ()Ldev/kord/gateway/GatewaySession;
 	public final fun getStartConfiguration ()Ldev/kord/gateway/GatewayConfiguration;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -791,6 +787,40 @@ public final class dev/kord/gateway/GatewayResumeConfiguration$$serializer : kot
 }
 
 public final class dev/kord/gateway/GatewayResumeConfiguration$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/kord/gateway/GatewaySession {
+	public static final field Companion Ldev/kord/gateway/GatewaySession$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;ILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;I)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()I
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;I)Ldev/kord/gateway/GatewaySession;
+	public static synthetic fun copy$default (Ldev/kord/gateway/GatewaySession;Ljava/lang/String;Ljava/lang/String;IILjava/lang/Object;)Ldev/kord/gateway/GatewaySession;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getResumeUrl ()Ljava/lang/String;
+	public final fun getSequence ()I
+	public final fun getSessionId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Ldev/kord/gateway/GatewaySession;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class dev/kord/gateway/GatewaySession$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Ldev/kord/gateway/GatewaySession$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/kord/gateway/GatewaySession;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ldev/kord/gateway/GatewaySession;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/kord/gateway/GatewaySession$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 

--- a/gateway/src/main/kotlin/DefaultGateway.kt
+++ b/gateway/src/main/kotlin/DefaultGateway.kt
@@ -85,10 +85,10 @@ public class DefaultGateway(private val data: DefaultGatewayData) : Gateway {
     }
 
     private val stateMutex = Mutex()
+    private val initialUrl = Url(data.url)
     private val sequence = Sequence()
 
     init {
-        val initialUrl = Url(data.url)
         compression = initialUrl.parameters.contains("compress", "zlib-stream")
 
         SequenceHandler(events, sequence)
@@ -112,7 +112,12 @@ public class DefaultGateway(private val data: DefaultGatewayData) : Gateway {
         if (session != null) {
             sequence.value = session.sequence
             handshakeHandler.resumeContext.update {
-                HandshakeHandler.ResumeContext(session.sessionId, Url(session.resumeUrl))
+                HandshakeHandler.ResumeContext(
+                    session.sessionId,
+                    URLBuilder(initialUrl)
+                        .apply { parameters.appendMissing(initialUrl.parameters) }
+                        .build()
+                )
             }
         }
 

--- a/gateway/src/main/kotlin/DefaultGateway.kt
+++ b/gateway/src/main/kotlin/DefaultGateway.kt
@@ -114,7 +114,7 @@ public class DefaultGateway(private val data: DefaultGatewayData) : Gateway {
             handshakeHandler.resumeContext.update {
                 HandshakeHandler.ResumeContext(
                     session.sessionId,
-                    URLBuilder(initialUrl)
+                    URLBuilder(session.resumeUrl)
                         .apply { parameters.appendMissing(initialUrl.parameters) }
                         .build()
                 )

--- a/gateway/src/main/kotlin/DefaultGateway.kt
+++ b/gateway/src/main/kotlin/DefaultGateway.kt
@@ -99,8 +99,7 @@ public class DefaultGateway(private val data: DefaultGatewayData) : Gateway {
         InvalidSessionHandler(events) { restart(it) }
     }
 
-    //running on default dispatchers because ktor does *not* like running on an EmptyCoroutineContext from main
-    override suspend fun start(configuration: GatewayConfiguration): Unit = withContext(Dispatchers.Default) {
+    override suspend fun start(configuration: GatewayConfiguration) {
         resetState(configuration)
 
         startAndHandleGatewayConnection()
@@ -124,7 +123,7 @@ public class DefaultGateway(private val data: DefaultGatewayData) : Gateway {
         startAndHandleGatewayConnection()
     }
 
-    private suspend fun startAndHandleGatewayConnection() {
+    private suspend fun startAndHandleGatewayConnection() = withContext(data.dispatcher) {
         while (data.reconnectRetry.hasNext && state.value is State.Running) {
             try {
                 val url = handshakeHandler.gatewayUrl

--- a/gateway/src/main/kotlin/Gateway.kt
+++ b/gateway/src/main/kotlin/Gateway.kt
@@ -91,6 +91,24 @@ public interface Gateway : CoroutineScope {
      */
     public suspend fun stop(closeReason: WebSocketCloseReason = WebSocketCloseReason(1000, "leaving")): GatewayResumeConfiguration
 
+    /**
+     * Closes the Gateway with code 1012, suspending until the underlying webSocket is closed.
+     *
+     * The session won't be invalidated, and you will be able to [resume] the gateway session. The session will be invalidated by Discord after a few minutes.
+     *
+     * @return the gateway session information, if there was any successful identify before closing the connection.
+     */
+    public suspend fun stopForResume(): GatewayResumeConfiguration = stop(WebSocketCloseReason(1012, "service restart"))
+
+    /**
+     * Closes the Gateway with code 1000, suspending until the underlying webSocket is closed.
+     *
+     * The session will be invalidated, and you won't be able to [resume] it. The bot will appear offline in the member list.
+     *
+     * @return the gateway session information, if there was any successful identify before closing the connection.
+     */
+    public suspend fun stopAndInvalidateSession(): GatewayResumeConfiguration = stop(WebSocketCloseReason(1000, "leaving"))
+
     public companion object {
         private object None : Gateway {
 

--- a/gateway/src/main/kotlin/Gateway.kt
+++ b/gateway/src/main/kotlin/Gateway.kt
@@ -89,7 +89,7 @@ public interface Gateway : CoroutineScope {
      * @param closeReason the close reason that will be used when stopping the WebSocket connection.
      * @return the gateway session information, if there was any successful identify before closing the connection.
      */
-    public suspend fun stop(closeReason: WebSocketCloseReason = WebSocketCloseReason(1000, "leaving")): GatewaySession?
+    public suspend fun stop(closeReason: WebSocketCloseReason = WebSocketCloseReason(1000, "leaving")): GatewayResumeConfiguration
 
     public companion object {
         private object None : Gateway {
@@ -108,7 +108,7 @@ public interface Gateway : CoroutineScope {
 
             override suspend fun resume(configuration: GatewayResumeConfiguration) {}
 
-            override suspend fun stop(closeReason: WebSocketCloseReason): GatewaySession? { return null }
+            override suspend fun stop(closeReason: WebSocketCloseReason): GatewayResumeConfiguration { error("Can't stop this!") }
 
             override suspend fun detach() {
                 (this as CoroutineScope).cancel()

--- a/gateway/src/main/kotlin/Gateway.kt
+++ b/gateway/src/main/kotlin/Gateway.kt
@@ -80,6 +80,11 @@ public interface Gateway : CoroutineScope {
      */
     public suspend fun detach()
 
+    @Deprecated("Binary compatibility", level = DeprecationLevel.HIDDEN)
+    public suspend fun stop() {
+        stop(WebSocketCloseReason(1000, "leaving"))
+    }
+
     /**
      * Closes the Gateway, suspending until the underlying WebSocket is closed.
      *

--- a/gateway/src/main/kotlin/Gateway.kt
+++ b/gateway/src/main/kotlin/Gateway.kt
@@ -54,7 +54,7 @@ public interface Gateway : CoroutineScope {
     /**
      * Starts a reconnecting gateway connection with the given [configuration].
      *
-     * After connecting, a resume request will be sent and the session will be resumed if the session is valid.
+     * After connecting, a [Resume] request will be sent and the session will be resumed if the session is valid.
      * If the session was invalidated, an identify request will be sent and a session will be created.
      * If you want to start a new session, use [start].
      *

--- a/gateway/src/main/kotlin/Gateway.kt
+++ b/gateway/src/main/kotlin/Gateway.kt
@@ -156,7 +156,7 @@ public suspend inline fun Gateway.editPresence(builder: PresenceBuilder.() -> Un
 /**
  * Starts a reconnecting gateway connection with the given parameters.
  *
- * After connecting, an identify request will be sent and a session will be created.
+ * After connecting, an [Identify] request will be sent and a session will be created.
  * If you want to resume an already started session, use [resume].
  *
  * This function will suspend until the lifecycle of the gateway has ended.

--- a/gateway/src/main/kotlin/Gateway.kt
+++ b/gateway/src/main/kotlin/Gateway.kt
@@ -99,24 +99,6 @@ public interface Gateway : CoroutineScope {
      */
     public suspend fun stop(closeReason: WebSocketCloseReason = WebSocketCloseReason(1000, "leaving")): GatewayResumeConfiguration
 
-    /**
-     * Closes the Gateway with code 1012, suspending until the underlying webSocket is closed.
-     *
-     * The session won't be invalidated, and you will be able to [resume] the gateway session. The session will be invalidated by Discord after a few minutes.
-     *
-     * @return the gateway session information, if there was any successful identify before closing the connection.
-     */
-    public suspend fun stopForResume(): GatewayResumeConfiguration = stop(WebSocketCloseReason(1012, "service restart"))
-
-    /**
-     * Closes the Gateway with code 1000, suspending until the underlying webSocket is closed.
-     *
-     * The session will be invalidated, and you won't be able to [resume] it. The bot will appear offline in the member list.
-     *
-     * @return the gateway session information, if there was any successful identify before closing the connection.
-     */
-    public suspend fun stopAndInvalidateSession(): GatewayResumeConfiguration = stop(WebSocketCloseReason(1000, "leaving"))
-
     public companion object {
         private object None : Gateway {
 
@@ -160,6 +142,25 @@ public suspend inline fun Gateway.editPresence(builder: PresenceBuilder.() -> Un
     val status = PresenceBuilder().apply(builder).toUpdateStatus()
     send(status)
 }
+
+/**
+ * Closes the Gateway with code 1012, suspending until the underlying webSocket is closed.
+ *
+ * The session won't be invalidated, and you will be able to [resume] the gateway session. The session will be invalidated by Discord after a few minutes.
+ *
+ * @return the gateway session information, if there was any successful identify before closing the connection.
+ */
+public suspend fun Gateway.stopForResume(): GatewayResumeConfiguration = stop(WebSocketCloseReason(1012, "service restart"))
+
+/**
+ * Closes the Gateway with code 1000, suspending until the underlying webSocket is closed.
+ *
+ * The session will be invalidated, and you won't be able to [resume] it. The bot will appear offline in the member list.
+ *
+ * @return the gateway session information, if there was any successful identify before closing the connection.
+ */
+public suspend fun Gateway.stopAndInvalidateSession(): GatewayResumeConfiguration = stop(WebSocketCloseReason(1000, "leaving"))
+
 
 /**
  * Starts a reconnecting gateway connection with the given parameters.

--- a/gateway/src/main/kotlin/Gateway.kt
+++ b/gateway/src/main/kotlin/Gateway.kt
@@ -81,13 +81,16 @@ public interface Gateway : CoroutineScope {
     public suspend fun detach()
 
     /**
-     * Closes the Gateway, suspending until the underlying webSocket is closed.
+     * Closes the Gateway, suspending until the underlying WebSocket is closed.
      *
-     * By default, the current gateway session will be closed. If you want to keep the session alive to reconnect later,
-     * change the [closeReason] to use a different [WebSocketCloseReason.code] that isn't 1000 or 1001.
+     * By default, the current gateway session will be closed. If you want to keep the session alive to [resume] later,
+     * change the [closeReason] to use a different [WebSocketCloseReason.code] that isn't `1000` or `1001`.
      *
-     * @param closeReason the close reason that will be used when stopping the WebSocket connection.
-     * @return the gateway session information, if there was any successful identify before closing the connection.
+     * Returns a [GatewayResumeConfiguration] that can be passed to [resume] later. The
+     * [session][GatewayResumeConfiguration.session] will be non-null if there was any successful [Identify]
+     * request before closing the connection.
+     *
+     * @param closeReason the close reason that will be used when closing the WebSocket connection.
      */
     public suspend fun stop(closeReason: WebSocketCloseReason = WebSocketCloseReason(1000, "leaving")): GatewayResumeConfiguration
 

--- a/gateway/src/main/kotlin/Gateway.kt
+++ b/gateway/src/main/kotlin/Gateway.kt
@@ -42,7 +42,7 @@ public interface Gateway : CoroutineScope {
     /**
      * Starts a reconnecting gateway connection with the given [configuration].
      *
-     * After connecting, an identify request will be sent and a session will be created.
+     * After connecting, an [Identify] request will be sent and a session will be created.
      * If you want to resume an already started session, use [resume].
      *
      * This function will suspend until the lifecycle of the gateway has ended.

--- a/gateway/src/main/kotlin/GatewayConfiguration.kt
+++ b/gateway/src/main/kotlin/GatewayConfiguration.kt
@@ -67,3 +67,9 @@ public class GatewayConfigurationBuilder(
         intents
     )
 }
+
+@Serializable
+public data class GatewayResumeConfiguration(
+    val session: GatewaySession?,
+    val startConfiguration: GatewayConfiguration
+)

--- a/gateway/src/main/kotlin/GatewayConfiguration.kt
+++ b/gateway/src/main/kotlin/GatewayConfiguration.kt
@@ -5,9 +5,11 @@ import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.coerceToMissing
 import dev.kord.common.entity.optional.optional
 import dev.kord.gateway.builder.PresenceBuilder
+import kotlinx.serialization.Serializable
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
+@Serializable
 public data class GatewayConfiguration(
     val token: String,
     val name: String,

--- a/gateway/src/main/kotlin/GatewayResumeConfiguration.kt
+++ b/gateway/src/main/kotlin/GatewayResumeConfiguration.kt
@@ -4,8 +4,6 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 public data class GatewayResumeConfiguration(
-    val sessionId: String,
-    val resumeUrl: String,
-    val sequence: Int,
+    val session: GatewaySession,
     val startConfiguration: GatewayConfiguration
 )

--- a/gateway/src/main/kotlin/GatewayResumeConfiguration.kt
+++ b/gateway/src/main/kotlin/GatewayResumeConfiguration.kt
@@ -4,6 +4,6 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 public data class GatewayResumeConfiguration(
-    val session: GatewaySession,
+    val session: GatewaySession?,
     val startConfiguration: GatewayConfiguration
 )

--- a/gateway/src/main/kotlin/GatewayResumeConfiguration.kt
+++ b/gateway/src/main/kotlin/GatewayResumeConfiguration.kt
@@ -1,9 +1,0 @@
-package dev.kord.gateway
-
-import kotlinx.serialization.Serializable
-
-@Serializable
-public data class GatewayResumeConfiguration(
-    val session: GatewaySession?,
-    val startConfiguration: GatewayConfiguration
-)

--- a/gateway/src/main/kotlin/GatewayResumeConfiguration.kt
+++ b/gateway/src/main/kotlin/GatewayResumeConfiguration.kt
@@ -1,0 +1,11 @@
+package dev.kord.gateway
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+public data class GatewayResumeConfiguration(
+    val sessionId: String,
+    val resumeUrl: String,
+    val sequence: Int,
+    val startConfiguration: GatewayConfiguration
+)

--- a/gateway/src/main/kotlin/GatewaySession.kt
+++ b/gateway/src/main/kotlin/GatewaySession.kt
@@ -1,0 +1,10 @@
+package dev.kord.gateway
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+public data class GatewaySession(
+    val sessionId: String,
+    val resumeUrl: String,
+    val sequence: Int
+)

--- a/gateway/src/main/kotlin/handler/HandshakeHandler.kt
+++ b/gateway/src/main/kotlin/handler/HandshakeHandler.kt
@@ -34,11 +34,7 @@ internal class HandshakeHandler(
     override fun start() {
         on<Hello> {
             reconnectRetry.reset() // connected and read without problems, resetting retry counter
-            
-            val resumeContext = resumeContext.value
-            if (resumeContext != null) {
-                send(Resume(configuration.token, resumeContext.sessionId, sequence.value ?: 0))
-            } else identifyRateLimiter.consume {
+            identifyRateLimiter.consume {
                 send(resumeOrIdentify)
             }
         }

--- a/gateway/src/main/kotlin/handler/HandshakeHandler.kt
+++ b/gateway/src/main/kotlin/handler/HandshakeHandler.kt
@@ -20,9 +20,9 @@ internal class HandshakeHandler(
     lateinit var configuration: GatewayConfiguration
 
     // see https://discord.com/developers/docs/topics/gateway#resuming
-    private class ResumeContext(val sessionId: String, val resumeUrl: Url)
+    internal class ResumeContext(val sessionId: String, val resumeUrl: Url)
 
-    private val resumeContext = atomic<ResumeContext?>(initial = null)
+    internal val resumeContext = atomic<ResumeContext?>(initial = null)
     val gatewayUrl get() = resumeContext.value?.resumeUrl ?: initialUrl
 
     private val resumeOrIdentify

--- a/gateway/src/main/kotlin/handler/HandshakeHandler.kt
+++ b/gateway/src/main/kotlin/handler/HandshakeHandler.kt
@@ -34,7 +34,11 @@ internal class HandshakeHandler(
     override fun start() {
         on<Hello> {
             reconnectRetry.reset() // connected and read without problems, resetting retry counter
-            identifyRateLimiter.consume {
+            
+            val resumeContext = resumeContext.value
+            if (resumeContext != null) {
+                send(Resume(configuration.token, resumeContext.sessionId, sequence.value ?: 0))
+            } else identifyRateLimiter.consume {
                 send(resumeOrIdentify)
             }
         }


### PR DESCRIPTION
Adds support for `resume_gateway_url`, the `resumeGatewayUrl` parameter is a `(String) -> (String)` instead of a `String` because the `resume_gateway_url` varies between sessions, so the user may want to override the gateway resume URL on a case by case basis (idk who would want to do that tho lmao)

This PR also adds support for initializing a gateway connection with resume session data, this allows you to store your session data somewhere (example: in a file) and, after restarting your bot, you can resume the session instead of reidentifying.

This is VERY useful for large bots, because you can have (almost) zero downtime without consuming `IDENTIFY`.

Here's an example of how it works:
```kotlin
suspend fun main() {
    val gateway = DefaultGateway {}

    var sessionId: String? = null
    var resumeGatewayUrl: String? = null
    var sequenceId: Int? = null

    gateway.events
        .filterIsInstance<Ready>()
        .onEach {
            sessionId = it.data.sessionId
            resumeGatewayUrl = it.data.resumeGatewayUrl
        }
        .launchIn(gateway)

    gateway.events
        .filterIsInstance<DispatchEvent>()
        .onEach {
            sequenceId = it.sequence
        }
        .launchIn(gateway)

    gateway.events
        .filterIsInstance<MessageCreate>()
        .filter { it.message.content.startsWith("!!reconnect") }
        .onEach {
            println("Stopping gateway connection...")
            gateway.stop(CloseReason.Codes.SERVICE_RESTART.code) // Using code 1000 (which is what Kord uses) cancels the current session, using service restart doesn't!
            println("Restarting gateway session $sessionId, using $resumeGatewayUrl and seq number $sequenceId")
            gateway.start("BotTokenHereYay") {
                resumeSession = ResumeSession(Session(sessionId!!, "$resumeGatewayUrl/?v=${KordConfiguration.GATEWAY_VERSION}&encoding=json&compress=zlib-stream"), sequenceId!!)

                @OptIn(PrivilegedIntent::class)
                intents = Intents.all
            }
        }
        .launchIn(gateway)

    gateway.start("BotTokenHereYay") {
        @OptIn(PrivilegedIntent::class)
        intents = Intents.all
    }

    awaitCancellation()
}
```

The API dump has a bunch of random stuff, idk why