### PR TITLE
Automod updates

### DIFF
--- a/common/api/common.api
+++ b/common/api/common.api
@@ -874,20 +874,26 @@ public final class dev/kord/common/entity/AuditLogChangeKey$WidgetEnabled : dev/
 public final class dev/kord/common/entity/AuditLogEntryOptionalInfo {
 	public static final field Companion Ldev/kord/common/entity/AuditLogEntryOptionalInfo$Companion;
 	public fun <init> ()V
-	public synthetic fun <init> (ILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/optional/Optional;
+	public synthetic fun <init> (ILdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)V
+	public synthetic fun <init> (Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
+	public final fun component10 ()Ldev/kord/common/entity/optional/Optional;
+	public final fun component11 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component2 ()Ldev/kord/common/entity/optional/Optional;
-	public final fun component3 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
-	public final fun component4 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
+	public final fun component3 ()Ldev/kord/common/entity/optional/Optional;
+	public final fun component4 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component5 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component6 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
-	public final fun component7 ()Ldev/kord/common/entity/optional/Optional;
+	public final fun component7 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun component8 ()Ldev/kord/common/entity/optional/Optional;
-	public final fun copy (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/common/entity/AuditLogEntryOptionalInfo;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/AuditLogEntryOptionalInfo;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/common/entity/AuditLogEntryOptionalInfo;
+	public final fun component9 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
+	public final fun copy (Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/common/entity/AuditLogEntryOptionalInfo;
+	public static synthetic fun copy$default (Ldev/kord/common/entity/AuditLogEntryOptionalInfo;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/common/entity/AuditLogEntryOptionalInfo;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getApplicationId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
+	public final fun getAutoModerationRuleName ()Ldev/kord/common/entity/optional/Optional;
+	public final fun getAutoModerationRuleTriggerType ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getChannelId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun getCount ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getDeleteMemberDays ()Ldev/kord/common/entity/optional/Optional;
@@ -934,6 +940,10 @@ public final class dev/kord/common/entity/AuditLogEvent$AutoModerationBlockMessa
 	public static final field INSTANCE Ldev/kord/common/entity/AuditLogEvent$AutoModerationBlockMessage;
 }
 
+public final class dev/kord/common/entity/AuditLogEvent$AutoModerationFlagToChannel : dev/kord/common/entity/AuditLogEvent {
+	public static final field INSTANCE Ldev/kord/common/entity/AuditLogEvent$AutoModerationFlagToChannel;
+}
+
 public final class dev/kord/common/entity/AuditLogEvent$AutoModerationRuleCreate : dev/kord/common/entity/AuditLogEvent {
 	public static final field INSTANCE Ldev/kord/common/entity/AuditLogEvent$AutoModerationRuleCreate;
 }
@@ -944,6 +954,10 @@ public final class dev/kord/common/entity/AuditLogEvent$AutoModerationRuleDelete
 
 public final class dev/kord/common/entity/AuditLogEvent$AutoModerationRuleUpdate : dev/kord/common/entity/AuditLogEvent {
 	public static final field INSTANCE Ldev/kord/common/entity/AuditLogEvent$AutoModerationRuleUpdate;
+}
+
+public final class dev/kord/common/entity/AuditLogEvent$AutoModerationUserCommunicationDisabled : dev/kord/common/entity/AuditLogEvent {
+	public static final field INSTANCE Ldev/kord/common/entity/AuditLogEvent$AutoModerationUserCommunicationDisabled;
 }
 
 public final class dev/kord/common/entity/AuditLogEvent$BotAdd : dev/kord/common/entity/AuditLogEvent {

--- a/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/AuditLogEvent.kt
+++ b/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/AuditLogEvent.kt
@@ -299,9 +299,19 @@ public sealed class AuditLogEvent(
     public object AutoModerationRuleDelete : AuditLogEvent(142)
 
     /**
-     * Message was blocked by AutoMod (according to a rule).
+     * Message was blocked by AutoMod.
      */
     public object AutoModerationBlockMessage : AuditLogEvent(143)
+
+    /**
+     * Message was flagged by AutoMod.
+     */
+    public object AutoModerationFlagToChannel : AuditLogEvent(144)
+
+    /**
+     * Member was timed out by AutoMod.
+     */
+    public object AutoModerationUserCommunicationDisabled : AuditLogEvent(145)
 
     internal object Serializer : KSerializer<AuditLogEvent> {
         public override val descriptor: SerialDescriptor =
@@ -363,6 +373,8 @@ public sealed class AuditLogEvent(
             141 -> AutoModerationRuleUpdate
             142 -> AutoModerationRuleDelete
             143 -> AutoModerationBlockMessage
+            144 -> AutoModerationFlagToChannel
+            145 -> AutoModerationUserCommunicationDisabled
             else -> Unknown(value)
         }
     }
@@ -425,6 +437,8 @@ public sealed class AuditLogEvent(
                 AutoModerationRuleUpdate,
                 AutoModerationRuleDelete,
                 AutoModerationBlockMessage,
+                AutoModerationFlagToChannel,
+                AutoModerationUserCommunicationDisabled,
             )
         }
 

--- a/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/AutoModerationRuleTriggerType.kt
+++ b/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/AutoModerationRuleTriggerType.kt
@@ -63,7 +63,7 @@ public sealed class AutoModerationRuleTriggerType(
     public object KeywordPreset : AutoModerationRuleTriggerType(4)
 
     /**
-     * Check if content contains more mentions than allowed.
+     * Check if content contains more unique mentions than allowed.
      */
     public object MentionSpam : AutoModerationRuleTriggerType(5)
 

--- a/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/AutoModerationRuleTriggerType.kt
+++ b/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/AutoModerationRuleTriggerType.kt
@@ -4,7 +4,6 @@
 
 package dev.kord.common.entity
 
-import dev.kord.common.`annotation`.KordExperimental
 import kotlin.Any
 import kotlin.Boolean
 import kotlin.Int
@@ -55,11 +54,7 @@ public sealed class AutoModerationRuleTriggerType(
 
     /**
      * Check if content represents generic spam.
-     *
-     * This [trigger type][AutoModerationRuleTriggerType] is not yet released, so it cannot be used
-     * in most servers.
      */
-    @KordExperimental
     public object Spam : AutoModerationRuleTriggerType(3)
 
     /**
@@ -69,11 +64,7 @@ public sealed class AutoModerationRuleTriggerType(
 
     /**
      * Check if content contains more mentions than allowed.
-     *
-     * This [trigger type][AutoModerationRuleTriggerType] is not yet released, so it cannot be used
-     * in most servers.
      */
-    @KordExperimental
     public object MentionSpam : AutoModerationRuleTriggerType(5)
 
     internal object Serializer : KSerializer<AutoModerationRuleTriggerType> {

--- a/common/src/main/kotlin/entity/AuditLog.kt
+++ b/common/src/main/kotlin/entity/AuditLog.kt
@@ -52,7 +52,9 @@
         Entry("AutoModerationRuleCreate", intValue = 140, kDoc = "Auto Moderation rule was created."),
         Entry("AutoModerationRuleUpdate", intValue = 141, kDoc = "Auto Moderation rule was updated."),
         Entry("AutoModerationRuleDelete", intValue = 142, kDoc = "Auto Moderation rule was deleted."),
-        Entry("AutoModerationBlockMessage", intValue = 143, kDoc = "Message was blocked by AutoMod (according to a rule)."),
+        Entry("AutoModerationBlockMessage", intValue = 143, kDoc = "Message was blocked by AutoMod."),
+        Entry("AutoModerationFlagToChannel", intValue = 144, kDoc = "Message was flagged by AutoMod."),
+        Entry("AutoModerationUserCommunicationDisabled", intValue = 145, kDoc = "Member was timed out by AutoMod."),
     ],
 )
 
@@ -118,6 +120,12 @@ public data class DiscordAuditLogEntry(
 
 @Serializable
 public data class AuditLogEntryOptionalInfo(
+    @SerialName("application_id")
+    val applicationId: OptionalSnowflake = OptionalSnowflake.Missing,
+    @SerialName("auto_moderation_rule_name")
+    val autoModerationRuleName: Optional<String> = Optional.Missing(),
+    @SerialName("auto_moderation_rule_trigger_type")
+    val autoModerationRuleTriggerType: Optional<String> = Optional.Missing(),
     /*
     Do not trust the docs:
     2020-11-12 field is described as present but is in fact optional

--- a/common/src/main/kotlin/entity/AutoModeration.kt
+++ b/common/src/main/kotlin/entity/AutoModeration.kt
@@ -8,7 +8,7 @@
             "KeywordPreset", intValue = 4,
             kDoc = "Check if content contains words from internal pre-defined wordsets."
         ),
-        Entry("MentionSpam", intValue = 5, kDoc = "Check if content contains more mentions than allowed."),
+        Entry("MentionSpam", intValue = 5, kDoc = "Check if content contains more unique mentions than allowed."),
     ],
 )
 

--- a/common/src/main/kotlin/entity/AutoModeration.kt
+++ b/common/src/main/kotlin/entity/AutoModeration.kt
@@ -3,20 +3,12 @@
     kDoc = "Characterizes the type of content which can trigger the rule.",
     entries = [
         Entry("Keyword", intValue = 1, kDoc = "Check if content contains words from a user defined list of keywords."),
-        Entry(
-            "Spam", intValue = 3, isKordExperimental = true,
-            kDoc = "Check if content represents generic spam.\n\nThis [trigger·type][AutoModerationRuleTriggerType] " +
-                    "is not yet released, so it cannot be used in most servers."
-        ),
+        Entry("Spam", intValue = 3, kDoc = "Check if content represents generic spam."),
         Entry(
             "KeywordPreset", intValue = 4,
             kDoc = "Check if content contains words from internal pre-defined wordsets."
         ),
-        Entry(
-            "MentionSpam", intValue = 5, isKordExperimental = true,
-            kDoc = "Check if content contains more mentions than allowed.\n\nThis [trigger·type][" +
-                    "AutoModerationRuleTriggerType] is not yet released, so it cannot be used in most servers."
-        ),
+        Entry("MentionSpam", intValue = 5, kDoc = "Check if content contains more mentions than allowed."),
     ],
 )
 

--- a/core/src/main/kotlin/Unsafe.kt
+++ b/core/src/main/kotlin/Unsafe.kt
@@ -29,23 +29,23 @@ import kotlin.DeprecationLevel.HIDDEN
 public class Unsafe(private val kord: Kord) {
 
     public fun autoModerationRule(guildId: Snowflake, ruleId: Snowflake): AutoModerationRuleBehavior =
-        AutoModerationRuleBehavior(guildId, ruleId, kord)
+        AutoModerationRuleBehaviorImpl(guildId, ruleId, kord)
 
     public fun keywordAutoModerationRule(guildId: Snowflake, ruleId: Snowflake): KeywordAutoModerationRuleBehavior =
-        KeywordAutoModerationRuleBehavior(guildId, ruleId, kord)
+        KeywordAutoModerationRuleBehaviorImpl(guildId, ruleId, kord)
 
     public fun spamAutoModerationRule(guildId: Snowflake, ruleId: Snowflake): SpamAutoModerationRuleBehavior =
-        SpamAutoModerationRuleBehavior(guildId, ruleId, kord)
+        SpamAutoModerationRuleBehaviorImpl(guildId, ruleId, kord)
 
     public fun keywordPresetAutoModerationRule(
         guildId: Snowflake,
         ruleId: Snowflake,
-    ): KeywordPresetAutoModerationRuleBehavior = KeywordPresetAutoModerationRuleBehavior(guildId, ruleId, kord)
+    ): KeywordPresetAutoModerationRuleBehavior = KeywordPresetAutoModerationRuleBehaviorImpl(guildId, ruleId, kord)
 
     public fun mentionSpamAutoModerationRule(
         guildId: Snowflake,
         ruleId: Snowflake,
-    ): MentionSpamAutoModerationRuleBehavior = MentionSpamAutoModerationRuleBehavior(guildId, ruleId, kord)
+    ): MentionSpamAutoModerationRuleBehavior = MentionSpamAutoModerationRuleBehaviorImpl(guildId, ruleId, kord)
 
     public fun message(channelId: Snowflake, messageId: Snowflake): MessageBehavior =
         MessageBehavior(channelId = channelId, messageId = messageId, kord = kord)

--- a/core/src/main/kotlin/Unsafe.kt
+++ b/core/src/main/kotlin/Unsafe.kt
@@ -34,7 +34,6 @@ public class Unsafe(private val kord: Kord) {
     public fun keywordAutoModerationRule(guildId: Snowflake, ruleId: Snowflake): KeywordAutoModerationRuleBehavior =
         KeywordAutoModerationRuleBehavior(guildId, ruleId, kord)
 
-    @KordExperimental
     public fun spamAutoModerationRule(guildId: Snowflake, ruleId: Snowflake): SpamAutoModerationRuleBehavior =
         SpamAutoModerationRuleBehavior(guildId, ruleId, kord)
 
@@ -43,7 +42,6 @@ public class Unsafe(private val kord: Kord) {
         ruleId: Snowflake,
     ): KeywordPresetAutoModerationRuleBehavior = KeywordPresetAutoModerationRuleBehavior(guildId, ruleId, kord)
 
-    @KordExperimental
     public fun mentionSpamAutoModerationRule(
         guildId: Snowflake,
         ruleId: Snowflake,

--- a/core/src/main/kotlin/behavior/GuildBehavior.kt
+++ b/core/src/main/kotlin/behavior/GuildBehavior.kt
@@ -1156,7 +1156,7 @@ public suspend inline fun GuildBehavior.createKeywordPresetAutoModerationRule(
  *
  * @param name the rule name.
  * @param eventType the rule [event type][AutoModerationRuleEventType].
- * @param mentionLimit total number of mentions (role & user) allowed per message (maximum of 50).
+ * @param mentionLimit total number of unique role and user mentions allowed per message (maximum of 50).
  *
  * @throws RestRequestException if something went wrong during the request.
  */

--- a/core/src/main/kotlin/behavior/GuildBehavior.kt
+++ b/core/src/main/kotlin/behavior/GuildBehavior.kt
@@ -5,8 +5,6 @@ import dev.kord.common.annotation.DeprecatedSinceKord
 import dev.kord.common.annotation.KordExperimental
 import dev.kord.common.entity.*
 import dev.kord.common.entity.AutoModerationRuleEventType.MessageSend
-import dev.kord.common.entity.AutoModerationRuleTriggerType.MentionSpam
-import dev.kord.common.entity.AutoModerationRuleTriggerType.Spam
 import dev.kord.common.entity.Permission.ManageGuild
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.unwrap
@@ -1116,14 +1114,11 @@ public suspend inline fun GuildBehavior.createKeywordAutoModerationRule(
  *
  * This requires the [ManageGuild] permission.
  *
- * The [Spam] trigger type is not yet released, so it cannot be used in most servers.
- *
  * @param name the rule name.
  * @param eventType the rule [event type][AutoModerationRuleEventType].
  *
  * @throws RestRequestException if something went wrong during the request.
  */
-@KordExperimental
 public suspend inline fun GuildBehavior.createSpamAutoModerationRule(
     name: String,
     eventType: AutoModerationRuleEventType = MessageSend,
@@ -1159,15 +1154,12 @@ public suspend inline fun GuildBehavior.createKeywordPresetAutoModerationRule(
  *
  * This requires the [ManageGuild] permission.
  *
- * The [MentionSpam] trigger type is not yet released, so it cannot be used in most servers.
- *
  * @param name the rule name.
  * @param eventType the rule [event type][AutoModerationRuleEventType].
  * @param mentionLimit total number of mentions (role & user) allowed per message (maximum of 50).
  *
  * @throws RestRequestException if something went wrong during the request.
  */
-@KordExperimental
 public suspend inline fun GuildBehavior.createMentionSpamAutoModerationRule(
     name: String,
     eventType: AutoModerationRuleEventType = MessageSend,

--- a/core/src/main/kotlin/behavior/automoderation/AutoModerationRuleBehavior.kt
+++ b/core/src/main/kotlin/behavior/automoderation/AutoModerationRuleBehavior.kt
@@ -1,6 +1,5 @@
 package dev.kord.core.behavior.automoderation
 
-import dev.kord.common.annotation.KordExperimental
 import dev.kord.common.entity.AutoModerationRuleTriggerType
 import dev.kord.common.entity.AutoModerationRuleTriggerType.*
 import dev.kord.common.entity.Permission.ManageGuild
@@ -217,12 +216,7 @@ public suspend inline fun KeywordAutoModerationRuleBehavior.edit(
 }
 
 
-/**
- * The behavior of a [SpamAutoModerationRule].
- *
- * The [Spam] trigger type is not yet released, so it cannot be used in most servers.
- */
-@KordExperimental
+/** The behavior of a [SpamAutoModerationRule]. */
 public interface SpamAutoModerationRuleBehavior : TypedAutoModerationRuleBehavior {
 
     override val triggerType: Spam get() = Spam
@@ -278,11 +272,8 @@ internal fun SpamAutoModerationRuleBehavior(
  *
  * This requires the [ManageGuild] permission.
  *
- * The [Spam] trigger type is not yet released, so it cannot be used in most servers.
- *
  * @throws RestRequestException if something went wrong during the request.
  */
-@KordExperimental
 public suspend inline fun SpamAutoModerationRuleBehavior.edit(
     builder: SpamAutoModerationRuleModifyBuilder.() -> Unit,
 ): SpamAutoModerationRule {
@@ -359,12 +350,7 @@ public suspend inline fun KeywordPresetAutoModerationRuleBehavior.edit(
 }
 
 
-/**
- * The behavior of a [MentionSpamAutoModerationRule].
- *
- * The [MentionSpam] trigger type is not yet released, so it cannot be used in most servers.
- */
-@KordExperimental
+/** The behavior of a [MentionSpamAutoModerationRule]. */
 public interface MentionSpamAutoModerationRuleBehavior : TypedAutoModerationRuleBehavior {
 
     override val triggerType: MentionSpam get() = MentionSpam
@@ -420,11 +406,8 @@ internal fun MentionSpamAutoModerationRuleBehavior(
  *
  * This requires the [ManageGuild] permission.
  *
- * The [MentionSpam] trigger type is not yet released, so it cannot be used in most servers.
- *
  * @throws RestRequestException if something went wrong during the request.
  */
-@KordExperimental
 public suspend inline fun MentionSpamAutoModerationRuleBehavior.edit(
     builder: MentionSpamAutoModerationRuleModifyBuilder.() -> Unit,
 ): MentionSpamAutoModerationRule {

--- a/core/src/main/kotlin/behavior/automoderation/AutoModerationRuleBehavior.kt
+++ b/core/src/main/kotlin/behavior/automoderation/AutoModerationRuleBehavior.kt
@@ -22,7 +22,7 @@ import kotlin.contracts.InvocationKind.EXACTLY_ONCE
 import kotlin.contracts.contract
 
 /** The behavior of an [AutoModerationRule]. */
-public interface AutoModerationRuleBehavior : KordEntity, Strategizable {
+public sealed interface AutoModerationRuleBehavior : KordEntity, Strategizable {
 
     /** The ID of the [Guild] which this rule belongs to. */
     public val guildId: Snowflake
@@ -87,20 +87,16 @@ public interface AutoModerationRuleBehavior : KordEntity, Strategizable {
     override fun toString(): String
 }
 
-internal fun AutoModerationRuleBehavior(
-    guildId: Snowflake,
-    ruleId: Snowflake,
-    kord: Kord,
-    supplier: EntitySupplier = kord.defaultSupplier,
-): AutoModerationRuleBehavior = object : AutoModerationRuleBehavior {
-    override val guildId get() = guildId
-    override val id get() = ruleId
+internal class AutoModerationRuleBehaviorImpl(
+    override val guildId: Snowflake,
+    override val id: Snowflake,
+    override val kord: Kord,
+    override val supplier: EntitySupplier = kord.defaultSupplier,
+) : AutoModerationRuleBehavior {
     override val triggerType get() = null
-    override val kord get() = kord
-    override val supplier get() = supplier
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>) =
-        AutoModerationRuleBehavior(guildId, ruleId, kord, strategy.supply(kord))
+        AutoModerationRuleBehaviorImpl(guildId, id, kord, strategy.supply(kord))
 
     override fun equals(other: Any?) = autoModerationRuleEquals(other)
     override fun hashCode() = autoModerationRuleHashCode()
@@ -141,10 +137,10 @@ internal fun TypedAutoModerationRuleBehavior(
     kord: Kord,
     supplier: EntitySupplier = kord.defaultSupplier,
 ): TypedAutoModerationRuleBehavior = when (triggerType) {
-    Keyword -> KeywordAutoModerationRuleBehavior(guildId, ruleId, kord, supplier)
-    Spam -> SpamAutoModerationRuleBehavior(guildId, ruleId, kord, supplier)
-    KeywordPreset -> KeywordPresetAutoModerationRuleBehavior(guildId, ruleId, kord, supplier)
-    MentionSpam -> MentionSpamAutoModerationRuleBehavior(guildId, ruleId, kord, supplier)
+    Keyword -> KeywordAutoModerationRuleBehaviorImpl(guildId, ruleId, kord, supplier)
+    Spam -> SpamAutoModerationRuleBehaviorImpl(guildId, ruleId, kord, supplier)
+    KeywordPreset -> KeywordPresetAutoModerationRuleBehaviorImpl(guildId, ruleId, kord, supplier)
+    MentionSpam -> MentionSpamAutoModerationRuleBehaviorImpl(guildId, ruleId, kord, supplier)
     is Unknown -> UnknownAutoModerationRuleBehavior(guildId, ruleId, triggerType, kord, supplier)
 }
 
@@ -180,19 +176,14 @@ public interface KeywordAutoModerationRuleBehavior : TypedAutoModerationRuleBeha
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): KeywordAutoModerationRuleBehavior
 }
 
-internal fun KeywordAutoModerationRuleBehavior(
-    guildId: Snowflake,
-    ruleId: Snowflake,
-    kord: Kord,
-    supplier: EntitySupplier = kord.defaultSupplier,
-): KeywordAutoModerationRuleBehavior = object : KeywordAutoModerationRuleBehavior {
-    override val guildId get() = guildId
-    override val id get() = ruleId
-    override val kord get() = kord
-    override val supplier get() = supplier
-
+internal class KeywordAutoModerationRuleBehaviorImpl(
+    override val guildId: Snowflake,
+    override val id: Snowflake,
+    override val kord: Kord,
+    override val supplier: EntitySupplier = kord.defaultSupplier,
+) : KeywordAutoModerationRuleBehavior {
     override fun withStrategy(strategy: EntitySupplyStrategy<*>) =
-        KeywordAutoModerationRuleBehavior(guildId, ruleId, kord, strategy.supply(kord))
+        KeywordAutoModerationRuleBehaviorImpl(guildId, id, kord, strategy.supply(kord))
 
     override fun equals(other: Any?) = autoModerationRuleEquals(other)
     override fun hashCode() = autoModerationRuleHashCode()
@@ -247,24 +238,18 @@ public interface SpamAutoModerationRuleBehavior : TypedAutoModerationRuleBehavio
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): SpamAutoModerationRuleBehavior
 }
 
-internal fun SpamAutoModerationRuleBehavior(
-    guildId: Snowflake,
-    ruleId: Snowflake,
-    kord: Kord,
-    supplier: EntitySupplier = kord.defaultSupplier,
-): SpamAutoModerationRuleBehavior = object : SpamAutoModerationRuleBehavior {
-    override val guildId get() = guildId
-    override val id get() = ruleId
-    override val kord get() = kord
-    override val supplier get() = supplier
-
+internal class SpamAutoModerationRuleBehaviorImpl(
+    override val guildId: Snowflake,
+    override val id: Snowflake,
+    override val kord: Kord,
+    override val supplier: EntitySupplier = kord.defaultSupplier,
+) : SpamAutoModerationRuleBehavior {
     override fun withStrategy(strategy: EntitySupplyStrategy<*>) =
-        SpamAutoModerationRuleBehavior(guildId, ruleId, kord, strategy.supply(kord))
+        SpamAutoModerationRuleBehaviorImpl(guildId, id, kord, strategy.supply(kord))
 
     override fun equals(other: Any?) = autoModerationRuleEquals(other)
     override fun hashCode() = autoModerationRuleHashCode()
-    override fun toString() =
-        "SpamAutoModerationRuleBehavior(guildId=$guildId, id=$id, kord=$kord, supplier=$supplier)"
+    override fun toString() = "SpamAutoModerationRuleBehavior(guildId=$guildId, id=$id, kord=$kord, supplier=$supplier)"
 }
 
 /**
@@ -314,19 +299,14 @@ public interface KeywordPresetAutoModerationRuleBehavior : TypedAutoModerationRu
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): KeywordPresetAutoModerationRuleBehavior
 }
 
-internal fun KeywordPresetAutoModerationRuleBehavior(
-    guildId: Snowflake,
-    ruleId: Snowflake,
-    kord: Kord,
-    supplier: EntitySupplier = kord.defaultSupplier,
-): KeywordPresetAutoModerationRuleBehavior = object : KeywordPresetAutoModerationRuleBehavior {
-    override val guildId get() = guildId
-    override val id get() = ruleId
-    override val kord get() = kord
-    override val supplier get() = supplier
-
+internal class KeywordPresetAutoModerationRuleBehaviorImpl(
+    override val guildId: Snowflake,
+    override val id: Snowflake,
+    override val kord: Kord,
+    override val supplier: EntitySupplier = kord.defaultSupplier,
+) : KeywordPresetAutoModerationRuleBehavior {
     override fun withStrategy(strategy: EntitySupplyStrategy<*>) =
-        KeywordPresetAutoModerationRuleBehavior(guildId, ruleId, kord, strategy.supply(kord))
+        KeywordPresetAutoModerationRuleBehaviorImpl(guildId, id, kord, strategy.supply(kord))
 
     override fun equals(other: Any?) = autoModerationRuleEquals(other)
     override fun hashCode() = autoModerationRuleHashCode()
@@ -381,19 +361,14 @@ public interface MentionSpamAutoModerationRuleBehavior : TypedAutoModerationRule
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): MentionSpamAutoModerationRuleBehavior
 }
 
-internal fun MentionSpamAutoModerationRuleBehavior(
-    guildId: Snowflake,
-    ruleId: Snowflake,
-    kord: Kord,
-    supplier: EntitySupplier = kord.defaultSupplier,
-): MentionSpamAutoModerationRuleBehavior = object : MentionSpamAutoModerationRuleBehavior {
-    override val guildId get() = guildId
-    override val id get() = ruleId
-    override val kord get() = kord
-    override val supplier get() = supplier
-
+internal class MentionSpamAutoModerationRuleBehaviorImpl(
+    override val guildId: Snowflake,
+    override val id: Snowflake,
+    override val kord: Kord,
+    override val supplier: EntitySupplier = kord.defaultSupplier,
+) : MentionSpamAutoModerationRuleBehavior {
     override fun withStrategy(strategy: EntitySupplyStrategy<*>) =
-        MentionSpamAutoModerationRuleBehavior(guildId, ruleId, kord, strategy.supply(kord))
+        MentionSpamAutoModerationRuleBehaviorImpl(guildId, id, kord, strategy.supply(kord))
 
     override fun equals(other: Any?) = autoModerationRuleEquals(other)
     override fun hashCode() = autoModerationRuleHashCode()
@@ -417,22 +392,15 @@ public suspend inline fun MentionSpamAutoModerationRuleBehavior.edit(
 }
 
 
-@Suppress("FunctionName")
-internal fun UnknownAutoModerationRuleBehavior(
-    guildId: Snowflake,
-    ruleId: Snowflake,
-    triggerType: Unknown,
-    kord: Kord,
-    supplier: EntitySupplier,
-): TypedAutoModerationRuleBehavior = object : TypedAutoModerationRuleBehavior {
-    override val guildId get() = guildId
-    override val id get() = ruleId
-    override val triggerType get() = triggerType
-    override val kord get() = kord
-    override val supplier get() = supplier
-
+private class UnknownAutoModerationRuleBehavior(
+    override val guildId: Snowflake,
+    override val id: Snowflake,
+    override val triggerType: Unknown,
+    override val kord: Kord,
+    override val supplier: EntitySupplier,
+) : TypedAutoModerationRuleBehavior {
     override fun withStrategy(strategy: EntitySupplyStrategy<*>) =
-        UnknownAutoModerationRuleBehavior(guildId, ruleId, triggerType, kord, strategy.supply(kord))
+        UnknownAutoModerationRuleBehavior(guildId, id, triggerType, kord, strategy.supply(kord))
 
     override fun equals(other: Any?) = autoModerationRuleEquals(other)
     override fun hashCode() = autoModerationRuleHashCode()

--- a/core/src/main/kotlin/entity/automoderation/AutoModerationRule.kt
+++ b/core/src/main/kotlin/entity/automoderation/AutoModerationRule.kt
@@ -179,7 +179,7 @@ public class MentionSpamAutoModerationRule(data: AutoModerationRuleData, kord: K
     AutoModerationRule(data, kord, supplier, expectedTriggerType = MentionSpam),
     MentionSpamAutoModerationRuleBehavior {
 
-    /** Total number of mentions (role & user) allowed per message. */
+    /** Total number of unique role and user mentions allowed per message. */
     public val mentionLimit: Int get() = data.triggerMetadata.mentionTotalLimit.value!!
 
     override suspend fun asAutoModerationRuleOrNull(): MentionSpamAutoModerationRule = this

--- a/core/src/main/kotlin/entity/automoderation/AutoModerationRule.kt
+++ b/core/src/main/kotlin/entity/automoderation/AutoModerationRule.kt
@@ -1,6 +1,5 @@
 package dev.kord.core.entity.automoderation
 
-import dev.kord.common.annotation.KordExperimental
 import dev.kord.common.entity.AutoModerationRuleEventType
 import dev.kord.common.entity.AutoModerationRuleKeywordPresetType
 import dev.kord.common.entity.AutoModerationRuleTriggerType
@@ -137,12 +136,7 @@ public class KeywordAutoModerationRule(data: AutoModerationRuleData, kord: Kord,
     override fun toString(): String = "KeywordAutoModerationRule(data=$data, kord=$kord, supplier=$supplier)"
 }
 
-/**
- * An [AutoModerationRule] with trigger type [Spam].
- *
- * The [Spam] trigger type is not yet released, so it cannot be used in most servers.
- */
-@KordExperimental
+/** An [AutoModerationRule] with trigger type [Spam]. */
 public class SpamAutoModerationRule(data: AutoModerationRuleData, kord: Kord, supplier: EntitySupplier) :
     AutoModerationRule(data, kord, supplier, expectedTriggerType = Spam),
     SpamAutoModerationRuleBehavior {
@@ -180,12 +174,7 @@ public class KeywordPresetAutoModerationRule(data: AutoModerationRuleData, kord:
     override fun toString(): String = "KeywordPresetAutoModerationRule(data=$data, kord=$kord, supplier=$supplier)"
 }
 
-/**
- * An [AutoModerationRule] with trigger type [MentionSpam].
- *
- * The [MentionSpam] trigger type is not yet released, so it cannot be used in most servers.
- */
-@KordExperimental
+/** An [AutoModerationRule] with trigger type [MentionSpam]. */
 public class MentionSpamAutoModerationRule(data: AutoModerationRuleData, kord: Kord, supplier: EntitySupplier) :
     AutoModerationRule(data, kord, supplier, expectedTriggerType = MentionSpam),
     MentionSpamAutoModerationRuleBehavior {

--- a/rest/src/main/kotlin/builder/automoderation/AutoModerationRuleBuilder.kt
+++ b/rest/src/main/kotlin/builder/automoderation/AutoModerationRuleBuilder.kt
@@ -1,7 +1,6 @@
 package dev.kord.rest.builder.automoderation
 
 import dev.kord.common.annotation.KordDsl
-import dev.kord.common.annotation.KordExperimental
 import dev.kord.common.entity.AutoModerationActionType.*
 import dev.kord.common.entity.AutoModerationRuleEventType
 import dev.kord.common.entity.AutoModerationRuleKeywordPresetType
@@ -195,13 +194,8 @@ public fun KeywordAutoModerationRuleBuilder.anywhereKeyword(keyword: String) {
 }
 
 
-/**
- * An [AutoModerationRuleBuilder] for building rules with trigger type [Spam].
- *
- * The [Spam] trigger type is not yet released, so it cannot be used in most servers.
- */
+/** An [AutoModerationRuleBuilder] for building rules with trigger type [Spam]. */
 @KordDsl
-@KordExperimental
 public sealed interface SpamAutoModerationRuleBuilder : TypedAutoModerationRuleBuilder {
     override val triggerType: Spam get() = Spam
 }
@@ -245,13 +239,8 @@ public fun KeywordPresetAutoModerationRuleBuilder.allowKeyword(keyword: String) 
 }
 
 
-/**
- * An [AutoModerationRuleBuilder] for building rules with trigger type [MentionSpam].
- *
- * The [MentionSpam] trigger type is not yet released, so it cannot be used in most servers.
- */
+/** An [AutoModerationRuleBuilder] for building rules with trigger type [MentionSpam]. */
 @KordDsl
-@KordExperimental
 public sealed interface MentionSpamAutoModerationRuleBuilder : TimeoutAutoModerationRuleBuilder {
 
     override val triggerType: MentionSpam get() = MentionSpam

--- a/rest/src/main/kotlin/builder/automoderation/AutoModerationRuleBuilder.kt
+++ b/rest/src/main/kotlin/builder/automoderation/AutoModerationRuleBuilder.kt
@@ -245,7 +245,7 @@ public sealed interface MentionSpamAutoModerationRuleBuilder : TimeoutAutoModera
 
     override val triggerType: MentionSpam get() = MentionSpam
 
-    /** Total number of mentions (role & user) allowed per message (maximum of 50). */
+    /** Total number of unique role and user mentions allowed per message (maximum of 50). */
     public val mentionLimit: Int?
 
     /**

--- a/rest/src/main/kotlin/builder/automoderation/AutoModerationRuleCreateBuilder.kt
+++ b/rest/src/main/kotlin/builder/automoderation/AutoModerationRuleCreateBuilder.kt
@@ -1,11 +1,8 @@
 package dev.kord.rest.builder.automoderation
 
 import dev.kord.common.annotation.KordDsl
-import dev.kord.common.annotation.KordExperimental
 import dev.kord.common.entity.AutoModerationRuleEventType
 import dev.kord.common.entity.AutoModerationRuleKeywordPresetType
-import dev.kord.common.entity.AutoModerationRuleTriggerType.MentionSpam
-import dev.kord.common.entity.AutoModerationRuleTriggerType.Spam
 import dev.kord.common.entity.DiscordAutoModerationRuleTriggerMetadata
 import dev.kord.common.entity.Snowflake
 import dev.kord.common.entity.optional.*
@@ -79,13 +76,8 @@ public class KeywordAutoModerationRuleCreateBuilder(
         DiscordAutoModerationRuleTriggerMetadata(keywordFilter = keywords.toList().optional()).optional()
 }
 
-/**
- * A [SpamAutoModerationRuleBuilder] for building [AutoModerationRuleCreateRequest]s.
- *
- * The [Spam] trigger type is not yet released, so it cannot be used in most servers.
- */
+/** A [SpamAutoModerationRuleBuilder] for building [AutoModerationRuleCreateRequest]s. */
 @KordDsl
-@KordExperimental
 public class SpamAutoModerationRuleCreateBuilder(
     name: String,
     eventType: AutoModerationRuleEventType,
@@ -115,13 +107,8 @@ public class KeywordPresetAutoModerationRuleCreateBuilder(
         ).optional()
 }
 
-/**
- * A [MentionSpamAutoModerationRuleBuilder] for building [AutoModerationRuleCreateRequest]s.
- *
- * The [MentionSpam] trigger type is not yet released, so it cannot be used in most servers.
- */
+/** A [MentionSpamAutoModerationRuleBuilder] for building [AutoModerationRuleCreateRequest]s. */
 @KordDsl
-@KordExperimental
 public class MentionSpamAutoModerationRuleCreateBuilder(
     name: String,
     eventType: AutoModerationRuleEventType,

--- a/rest/src/main/kotlin/builder/automoderation/AutoModerationRuleModifyBuilder.kt
+++ b/rest/src/main/kotlin/builder/automoderation/AutoModerationRuleModifyBuilder.kt
@@ -1,10 +1,7 @@
 package dev.kord.rest.builder.automoderation
 
 import dev.kord.common.annotation.KordDsl
-import dev.kord.common.annotation.KordExperimental
 import dev.kord.common.entity.*
-import dev.kord.common.entity.AutoModerationRuleTriggerType.MentionSpam
-import dev.kord.common.entity.AutoModerationRuleTriggerType.Spam
 import dev.kord.common.entity.optional.*
 import dev.kord.common.entity.optional.delegate.delegate
 import dev.kord.rest.builder.AuditRequestBuilder
@@ -92,14 +89,9 @@ public class KeywordAutoModerationRuleModifyBuilder :
         _keywords.map { DiscordAutoModerationRuleTriggerMetadata(keywordFilter = it.toList().optional()) }
 }
 
-/**
- * A [SpamAutoModerationRuleBuilder] for building [AutoModerationRuleModifyRequest]s.
- *
- * The [Spam] trigger type is not yet released, so it cannot be used in most servers.
- */
+/** A [SpamAutoModerationRuleBuilder] for building [AutoModerationRuleModifyRequest]s. */
 @Suppress("CanSealedSubClassBeObject") // has state in super class
 @KordDsl
-@KordExperimental
 public class SpamAutoModerationRuleModifyBuilder :
     AutoModerationRuleModifyBuilder(),
     SpamAutoModerationRuleBuilder
@@ -136,13 +128,8 @@ public class KeywordPresetAutoModerationRuleModifyBuilder :
     }
 }
 
-/**
- * A [MentionSpamAutoModerationRuleBuilder] for building [AutoModerationRuleModifyRequest]s.
- *
- * The [MentionSpam] trigger type is not yet released, so it cannot be used in most servers.
- */
+/** A [MentionSpamAutoModerationRuleBuilder] for building [AutoModerationRuleModifyRequest]s. */
 @KordDsl
-@KordExperimental
 public class MentionSpamAutoModerationRuleModifyBuilder :
     AutoModerationRuleModifyBuilder(),
     MentionSpamAutoModerationRuleBuilder {

--- a/rest/src/main/kotlin/service/AutoModerationService.kt
+++ b/rest/src/main/kotlin/service/AutoModerationService.kt
@@ -1,6 +1,5 @@
 package dev.kord.rest.service
 
-import dev.kord.common.annotation.KordExperimental
 import dev.kord.common.entity.AutoModerationRuleEventType
 import dev.kord.common.entity.DiscordAutoModerationRule
 import dev.kord.common.entity.Snowflake
@@ -47,7 +46,6 @@ public class AutoModerationService(requestHandler: RequestHandler) : RestService
         return createAutoModerationRule(guildId, request.toRequest(), request.reason)
     }
 
-    @KordExperimental
     public suspend inline fun createSpamAutoModerationRule(
         guildId: Snowflake,
         name: String,
@@ -70,7 +68,6 @@ public class AutoModerationService(requestHandler: RequestHandler) : RestService
         return createAutoModerationRule(guildId, request.toRequest(), request.reason)
     }
 
-    @KordExperimental
     public suspend inline fun createMentionSpamAutoModerationRule(
         guildId: Snowflake,
         name: String,
@@ -115,7 +112,6 @@ public class AutoModerationService(requestHandler: RequestHandler) : RestService
         return modifyAutoModerationRule(guildId, ruleId, request.toRequest(), request.reason)
     }
 
-    @KordExperimental
     public suspend inline fun modifySpamAutoModerationRule(
         guildId: Snowflake,
         ruleId: Snowflake,
@@ -136,7 +132,6 @@ public class AutoModerationService(requestHandler: RequestHandler) : RestService
         return modifyAutoModerationRule(guildId, ruleId, request.toRequest(), request.reason)
     }
 
-    @KordExperimental
     public suspend inline fun modifyMentionSpamAutoModerationRule(
         guildId: Snowflake,
         ruleId: Snowflake,


### PR DESCRIPTION
* remove `@KordExperimental` from `Spam` and `MentionSpam` types (see https://github.com/discord/discord-api-docs/commit/cc2fddcb3042b2c7e3908d4a9da27b702539af30), effectively reverting https://github.com/kordlib/kord/pull/647/commits/b9ca8c6984377ce322c21702597545e2ace56aec
* update docs for `MentionSpam` type (see https://github.com/discord/discord-api-docs/commit/2f2ea9842ba8d56199ea44a89f28837e00e6a0b1)
* update audit log (see https://github.com/discord/discord-api-docs/commit/9bac5d688467ed1690039cbc71e5d15e6448fffb)
* use named instead of anonymous classes for behavior implementations (this means a little less code and allows sealed hierarchies)