### PR TITLE
Kord enum updates

### DIFF
--- a/common/api/common.api
+++ b/common/api/common.api
@@ -202,8 +202,9 @@ public final class dev/kord/common/entity/ActivityFlags$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class dev/kord/common/entity/ActivityType : java/lang/Enum {
+public abstract class dev/kord/common/entity/ActivityType {
 	public static final field ActivityTypeSerializer Ldev/kord/common/entity/ActivityType$ActivityTypeSerializer;
+	public static final field Companion Ldev/kord/common/entity/ActivityType$Companion;
 	public static final field Competing Ldev/kord/common/entity/ActivityType;
 	public static final field Custom Ldev/kord/common/entity/ActivityType;
 	public static final field Game Ldev/kord/common/entity/ActivityType;
@@ -211,18 +212,58 @@ public final class dev/kord/common/entity/ActivityType : java/lang/Enum {
 	public static final field Streaming Ldev/kord/common/entity/ActivityType;
 	public static final field Unknown Ldev/kord/common/entity/ActivityType;
 	public static final field Watching Ldev/kord/common/entity/ActivityType;
+	public synthetic fun <init> (ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun equals (Ljava/lang/Object;)Z
 	public final fun getCode ()I
+	public final fun hashCode ()I
+	public final fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Ldev/kord/common/entity/ActivityType;
 	public static fun values ()[Ldev/kord/common/entity/ActivityType;
 }
 
 public final class dev/kord/common/entity/ActivityType$ActivityTypeSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Ldev/kord/common/entity/ActivityType$ActivityTypeSerializer;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/kord/common/entity/ActivityType;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ldev/kord/common/entity/ActivityType;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/kord/common/entity/ActivityType$Companion {
+	public final fun getEntries ()Ljava/util/List;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+	public fun valueOf (Ljava/lang/String;)Ldev/kord/common/entity/ActivityType;
+	public fun values ()[Ldev/kord/common/entity/ActivityType;
+}
+
+public final class dev/kord/common/entity/ActivityType$Competing : dev/kord/common/entity/ActivityType {
+	public static final field INSTANCE Ldev/kord/common/entity/ActivityType$Competing;
+}
+
+public final class dev/kord/common/entity/ActivityType$Custom : dev/kord/common/entity/ActivityType {
+	public static final field INSTANCE Ldev/kord/common/entity/ActivityType$Custom;
+}
+
+public final class dev/kord/common/entity/ActivityType$Game : dev/kord/common/entity/ActivityType {
+	public static final field INSTANCE Ldev/kord/common/entity/ActivityType$Game;
+}
+
+public final class dev/kord/common/entity/ActivityType$Listening : dev/kord/common/entity/ActivityType {
+	public static final field INSTANCE Ldev/kord/common/entity/ActivityType$Listening;
+}
+
+public final class dev/kord/common/entity/ActivityType$Streaming : dev/kord/common/entity/ActivityType {
+	public static final field INSTANCE Ldev/kord/common/entity/ActivityType$Streaming;
+}
+
+public final class dev/kord/common/entity/ActivityType$Unknown : dev/kord/common/entity/ActivityType {
+	public fun <init> (I)V
+}
+
+public final class dev/kord/common/entity/ActivityType$Watching : dev/kord/common/entity/ActivityType {
+	public static final field INSTANCE Ldev/kord/common/entity/ActivityType$Watching;
 }
 
 public final class dev/kord/common/entity/AllRemovedMessageReactions {

--- a/common/api/common.api
+++ b/common/api/common.api
@@ -603,10 +603,14 @@ public final class dev/kord/common/entity/ApplicationFlags$Companion {
 public abstract class dev/kord/common/entity/ArchiveDuration {
 	public static final field Companion Ldev/kord/common/entity/ArchiveDuration$Companion;
 	public synthetic fun <init> (JLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun equals (Ljava/lang/Object;)Z
 	public final fun getDuration-UwyO8pc ()J
+	public final fun hashCode ()I
+	public final fun toString ()Ljava/lang/String;
 }
 
 public final class dev/kord/common/entity/ArchiveDuration$Companion {
+	public final fun getEntries ()Ljava/util/List;
 	public final fun getValues ()Ljava/util/Set;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }

--- a/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/AllowedMentionType.kt
+++ b/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/AllowedMentionType.kt
@@ -72,9 +72,9 @@ public sealed class AllowedMentionType(
 
         public override fun deserialize(decoder: Decoder) =
                 when (val value = decoder.decodeString()) {
-            "everyone" -> EveryoneMentions
             "roles" -> RoleMentions
             "users" -> UserMentions
+            "everyone" -> EveryoneMentions
             else -> Unknown(value)
         }
     }
@@ -85,9 +85,9 @@ public sealed class AllowedMentionType(
          */
         public val entries: List<AllowedMentionType> by lazy(mode = PUBLICATION) {
             listOf(
-                EveryoneMentions,
                 RoleMentions,
                 UserMentions,
+                EveryoneMentions,
             )
         }
 

--- a/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/AllowedMentionType.kt
+++ b/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/AllowedMentionType.kt
@@ -19,6 +19,10 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
+/**
+ * See [AllowedMentionType]s in the
+ * [Discord Developer Documentation](https://discord.com/developers/docs/resources/channel#allowed-mentions-object-allowed-mention-types).
+ */
 @Serializable(with = AllowedMentionType.Serializer::class)
 public sealed class AllowedMentionType(
     /**

--- a/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/ApplicationCommandOptionType.kt
+++ b/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/ApplicationCommandOptionType.kt
@@ -17,6 +17,10 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
+/**
+ * See [ApplicationCommandOptionType]s in the
+ * [Discord Developer Documentation](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-type).
+ */
 @Serializable(with = ApplicationCommandOptionType.Serializer::class)
 public sealed class ApplicationCommandOptionType(
     /**

--- a/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/ApplicationCommandPermissionType.kt
+++ b/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/ApplicationCommandPermissionType.kt
@@ -19,6 +19,10 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
+/**
+ * See [ApplicationCommandPermissionType]s in the
+ * [Discord Developer Documentation](https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-application-command-permission-type).
+ */
 @Serializable(with = ApplicationCommandPermissionType.Serializer::class)
 public sealed class ApplicationCommandPermissionType(
     /**

--- a/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/ApplicationCommandType.kt
+++ b/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/ApplicationCommandType.kt
@@ -19,6 +19,10 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
+/**
+ * See [ApplicationCommandType]s in the
+ * [Discord Developer Documentation](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-types).
+ */
 @Serializable(with = ApplicationCommandType.Serializer::class)
 public sealed class ApplicationCommandType(
     /**

--- a/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/AuditLogEvent.kt
+++ b/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/AuditLogEvent.kt
@@ -19,6 +19,10 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
+/**
+ * See [AuditLogEvent]s in the
+ * [Discord Developer Documentation](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
+ */
 @Serializable(with = AuditLogEvent.Serializer::class)
 public sealed class AuditLogEvent(
     /**

--- a/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/AutoModerationActionType.kt
+++ b/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/AutoModerationActionType.kt
@@ -21,6 +21,9 @@ import kotlinx.serialization.encoding.Encoder
 
 /**
  * The type of action.
+ *
+ * See [AutoModerationActionType]s in the
+ * [Discord Developer Documentation](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-action-object-action-types).
  */
 @Serializable(with = AutoModerationActionType.Serializer::class)
 public sealed class AutoModerationActionType(

--- a/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/AutoModerationRuleEventType.kt
+++ b/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/AutoModerationRuleEventType.kt
@@ -21,6 +21,9 @@ import kotlinx.serialization.encoding.Encoder
 
 /**
  * Indicates in what event context a rule should be checked.
+ *
+ * See [AutoModerationRuleEventType]s in the
+ * [Discord Developer Documentation](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-event-types).
  */
 @Serializable(with = AutoModerationRuleEventType.Serializer::class)
 public sealed class AutoModerationRuleEventType(

--- a/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/AutoModerationRuleKeywordPresetType.kt
+++ b/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/AutoModerationRuleKeywordPresetType.kt
@@ -21,6 +21,9 @@ import kotlinx.serialization.encoding.Encoder
 
 /**
  * An internally pre-defined wordset which will be searched for in content.
+ *
+ * See [AutoModerationRuleKeywordPresetType]s in the
+ * [Discord Developer Documentation](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-keyword-preset-types).
  */
 @Serializable(with = AutoModerationRuleKeywordPresetType.Serializer::class)
 public sealed class AutoModerationRuleKeywordPresetType(

--- a/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/AutoModerationRuleTriggerType.kt
+++ b/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/AutoModerationRuleTriggerType.kt
@@ -21,6 +21,9 @@ import kotlinx.serialization.encoding.Encoder
 
 /**
  * Characterizes the type of content which can trigger the rule.
+ *
+ * See [AutoModerationRuleTriggerType]s in the
+ * [Discord Developer Documentation](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-trigger-types).
  */
 @Serializable(with = AutoModerationRuleTriggerType.Serializer::class)
 public sealed class AutoModerationRuleTriggerType(

--- a/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/ButtonStyle.kt
+++ b/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/ButtonStyle.kt
@@ -26,8 +26,8 @@ import kotlinx.serialization.encoding.Encoder
 /**
  * Style of a [button][dev.kord.common.entity.ComponentType.Button].
  *
- * A preview of the different styles can be found
- * [here](https://discord.com/developers/docs/interactions/message-components#button-object-button-styles).
+ * See [ButtonStyle]s in the
+ * [Discord Developer Documentation](https://discord.com/developers/docs/interactions/message-components#button-object-button-styles).
  */
 @Serializable(with = ButtonStyle.NewSerializer::class)
 public sealed class ButtonStyle(

--- a/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/ChannelType.kt
+++ b/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/ChannelType.kt
@@ -21,6 +21,10 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
+/**
+ * See [ChannelType]s in the
+ * [Discord Developer Documentation](https://discord.com/developers/docs/resources/channel#channel-object-channel-types).
+ */
 @Serializable(with = ChannelType.Serializer::class)
 public sealed class ChannelType(
     /**

--- a/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/ComponentType.kt
+++ b/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/ComponentType.kt
@@ -23,6 +23,10 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
+/**
+ * See [ComponentType]s in the
+ * [Discord Developer Documentation](https://discord.com/developers/docs/interactions/message-components#component-object-component-types).
+ */
 @Serializable(with = ComponentType.NewSerializer::class)
 public sealed class ComponentType(
     /**

--- a/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/DefaultMessageNotificationLevel.kt
+++ b/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/DefaultMessageNotificationLevel.kt
@@ -19,6 +19,10 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
+/**
+ * See [DefaultMessageNotificationLevel]s in the
+ * [Discord Developer Documentation](https://discord.com/developers/docs/resources/guild#guild-object-default-message-notification-level).
+ */
 @Serializable(with = DefaultMessageNotificationLevel.Serializer::class)
 public sealed class DefaultMessageNotificationLevel(
     /**

--- a/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/DiscordConnectionVisibility.kt
+++ b/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/DiscordConnectionVisibility.kt
@@ -19,6 +19,10 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
+/**
+ * See [DiscordConnectionVisibility]s in the
+ * [Discord Developer Documentation](https://discord.com/developers/docs/resources/user#connection-object-visibility-types).
+ */
 @Serializable(with = DiscordConnectionVisibility.Serializer::class)
 public sealed class DiscordConnectionVisibility(
     /**

--- a/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/EmbedType.kt
+++ b/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/EmbedType.kt
@@ -86,12 +86,12 @@ public sealed class EmbedType(
 
         public override fun deserialize(decoder: Decoder) =
                 when (val value = decoder.decodeString()) {
-            "article" -> Article
-            "gifv" -> Gifv
-            "image" -> Image
-            "link" -> Link
             "rich" -> Rich
+            "image" -> Image
             "video" -> Video
+            "gifv" -> Gifv
+            "article" -> Article
+            "link" -> Link
             else -> Unknown(value)
         }
     }
@@ -102,12 +102,12 @@ public sealed class EmbedType(
          */
         public val entries: List<EmbedType> by lazy(mode = PUBLICATION) {
             listOf(
-                Article,
-                Gifv,
-                Image,
-                Link,
                 Rich,
+                Image,
                 Video,
+                Gifv,
+                Article,
+                Link,
             )
         }
 

--- a/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/EmbedType.kt
+++ b/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/EmbedType.kt
@@ -19,6 +19,10 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
+/**
+ * See [EmbedType]s in the
+ * [Discord Developer Documentation](https://discord.com/developers/docs/resources/channel#embed-object-embed-types).
+ */
 @Serializable(with = EmbedType.Serializer::class)
 public sealed class EmbedType(
     /**

--- a/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/ExplicitContentFilter.kt
+++ b/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/ExplicitContentFilter.kt
@@ -19,6 +19,10 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
+/**
+ * See [ExplicitContentFilter]s in the
+ * [Discord Developer Documentation](https://discord.com/developers/docs/resources/guild#guild-object-explicit-content-filter-level).
+ */
 @Serializable(with = ExplicitContentFilter.Serializer::class)
 public sealed class ExplicitContentFilter(
     /**

--- a/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/GuildFeature.kt
+++ b/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/GuildFeature.kt
@@ -168,17 +168,6 @@ public sealed class GuildFeature(
     public object Commerce : GuildFeature("COMMERCE")
 
     /**
-     * Guild has access to the three-day archive time for threads
-     *
-     * @suppress.
-     */
-    @Deprecated(
-        level = DeprecationLevel.ERROR,
-        message = "Thread archive durations are no longer boost locked.",
-    )
-    public object ThreeDayThreadArchive : GuildFeature("THREE_DAY_THREAD_ARCHIVE")
-
-    /**
      * Guild has access to the seven day archive time for threads.
      *
      * @suppress
@@ -188,6 +177,17 @@ public sealed class GuildFeature(
         message = "Thread archive durations are no longer boost locked.",
     )
     public object SevenDayThreadArchive : GuildFeature("SEVEN_DAY_THREAD_ARCHIVE")
+
+    /**
+     * Guild has access to the three-day archive time for threads.
+     *
+     * @suppress
+     */
+    @Deprecated(
+        level = DeprecationLevel.ERROR,
+        message = "Thread archive durations are no longer boost locked.",
+    )
+    public object ThreeDayThreadArchive : GuildFeature("THREE_DAY_THREAD_ARCHIVE")
 
     internal object Serializer : KSerializer<GuildFeature> {
         public override val descriptor: SerialDescriptor =

--- a/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/GuildFeature.kt
+++ b/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/GuildFeature.kt
@@ -21,6 +21,10 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
+/**
+ * See [GuildFeature]s in the
+ * [Discord Developer Documentation](https://discord.com/developers/docs/resources/guild#guild-object-guild-features).
+ */
 @Serializable(with = GuildFeature.Serializer::class)
 public sealed class GuildFeature(
     /**

--- a/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/GuildScheduledEventPrivacyLevel.kt
+++ b/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/GuildScheduledEventPrivacyLevel.kt
@@ -19,6 +19,10 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
+/**
+ * See [GuildScheduledEventPrivacyLevel]s in the
+ * [Discord Developer Documentation](https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-privacy-level).
+ */
 @Serializable(with = GuildScheduledEventPrivacyLevel.Serializer::class)
 public sealed class GuildScheduledEventPrivacyLevel(
     /**

--- a/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/GuildScheduledEventStatus.kt
+++ b/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/GuildScheduledEventStatus.kt
@@ -23,6 +23,10 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
+/**
+ * See [GuildScheduledEventStatus]s in the
+ * [Discord Developer Documentation](https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-status).
+ */
 @Serializable(with = GuildScheduledEventStatus.NewSerializer::class)
 public sealed class GuildScheduledEventStatus(
     /**

--- a/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/IntegrationExpireBehavior.kt
+++ b/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/IntegrationExpireBehavior.kt
@@ -23,6 +23,10 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
+/**
+ * See [IntegrationExpireBehavior]s in the
+ * [Discord Developer Documentation](https://discord.com/developers/docs/resources/guild#integration-object-integration-expire-behaviors).
+ */
 @Serializable(with = IntegrationExpireBehavior.NewSerializer::class)
 public sealed class IntegrationExpireBehavior(
     /**

--- a/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/InteractionResponseType.kt
+++ b/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/InteractionResponseType.kt
@@ -19,6 +19,10 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
+/**
+ * See [InteractionResponseType]s in the
+ * [Discord Developer Documentation](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-interaction-callback-type).
+ */
 @Serializable(with = InteractionResponseType.Serializer::class)
 public sealed class InteractionResponseType(
     /**

--- a/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/InteractionType.kt
+++ b/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/InteractionType.kt
@@ -19,6 +19,10 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
+/**
+ * See [InteractionType]s in the
+ * [Discord Developer Documentation](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-type).
+ */
 @Serializable(with = InteractionType.Serializer::class)
 public sealed class InteractionType(
     /**

--- a/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/InviteTargetType.kt
+++ b/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/InviteTargetType.kt
@@ -19,6 +19,10 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
+/**
+ * See [InviteTargetType]s in the
+ * [Discord Developer Documentation](https://discord.com/developers/docs/resources/invite#invite-object-invite-target-types).
+ */
 @Serializable(with = InviteTargetType.Serializer::class)
 public sealed class InviteTargetType(
     /**

--- a/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/MFALevel.kt
+++ b/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/MFALevel.kt
@@ -19,6 +19,10 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
+/**
+ * See [MFALevel]s in the
+ * [Discord Developer Documentation](https://discord.com/developers/docs/resources/guild#guild-object-mfa-level).
+ */
 @Serializable(with = MFALevel.Serializer::class)
 public sealed class MFALevel(
     /**

--- a/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/MessageActivityType.kt
+++ b/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/MessageActivityType.kt
@@ -19,6 +19,10 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
+/**
+ * See [MessageActivityType]s in the
+ * [Discord Developer Documentation](https://discord.com/developers/docs/resources/channel#message-object-message-activity-types).
+ */
 @Serializable(with = MessageActivityType.Serializer::class)
 public sealed class MessageActivityType(
     /**

--- a/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/MessageStickerType.kt
+++ b/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/MessageStickerType.kt
@@ -22,6 +22,10 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
+/**
+ * See [MessageStickerType]s in the
+ * [Discord Developer Documentation](https://discord.com/developers/docs/resources/sticker#sticker-object-sticker-format-types).
+ */
 @Serializable(with = MessageStickerType.Serializer::class)
 public sealed class MessageStickerType(
     /**

--- a/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/MessageType.kt
+++ b/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/MessageType.kt
@@ -23,6 +23,10 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
+/**
+ * See [MessageType]s in the
+ * [Discord Developer Documentation](https://discord.com/developers/docs/resources/channel#message-object-message-types).
+ */
 @Serializable(with = MessageType.Serializer::class)
 public sealed class MessageType(
     /**

--- a/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/NsfwLevel.kt
+++ b/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/NsfwLevel.kt
@@ -19,6 +19,10 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
+/**
+ * See [NsfwLevel]s in the
+ * [Discord Developer Documentation](https://discord.com/developers/docs/resources/guild#guild-object-guild-nsfw-level).
+ */
 @Serializable(with = NsfwLevel.Serializer::class)
 public sealed class NsfwLevel(
     /**

--- a/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/OverwriteType.kt
+++ b/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/OverwriteType.kt
@@ -19,6 +19,10 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
+/**
+ * See [OverwriteType]s in the
+ * [Discord Developer Documentation](https://discord.com/developers/docs/resources/channel#overwrite-object-overwrite-structure).
+ */
 @Serializable(with = OverwriteType.Serializer::class)
 public sealed class OverwriteType(
     /**

--- a/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/PremiumTier.kt
+++ b/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/PremiumTier.kt
@@ -19,6 +19,10 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
+/**
+ * See [PremiumTier]s in the
+ * [Discord Developer Documentation](https://discord.com/developers/docs/resources/guild#guild-object-premium-tier).
+ */
 @Serializable(with = PremiumTier.Serializer::class)
 public sealed class PremiumTier(
     /**

--- a/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/PresenceStatus.kt
+++ b/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/PresenceStatus.kt
@@ -86,11 +86,11 @@ public sealed class PresenceStatus(
 
         public override fun deserialize(decoder: Decoder) =
                 when (val value = decoder.decodeString()) {
+            "online" -> Online
             "dnd" -> DoNotDisturb
             "idle" -> Idle
             "invisible" -> Invisible
             "offline" -> Offline
-            "online" -> Online
             else -> Unknown(value)
         }
     }
@@ -115,11 +115,11 @@ public sealed class PresenceStatus(
          */
         public val entries: List<PresenceStatus> by lazy(mode = PUBLICATION) {
             listOf(
+                Online,
                 DoNotDisturb,
                 Idle,
                 Invisible,
                 Offline,
-                Online,
             )
         }
 

--- a/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/PresenceStatus.kt
+++ b/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/PresenceStatus.kt
@@ -23,6 +23,10 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
+/**
+ * See [PresenceStatus]s in the
+ * [Discord Developer Documentation](https://discord.com/developers/docs/topics/gateway-events#update-presence-status-types).
+ */
 @Serializable(with = PresenceStatus.Serializer::class)
 public sealed class PresenceStatus(
     /**

--- a/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/ScheduledEntityType.kt
+++ b/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/ScheduledEntityType.kt
@@ -23,6 +23,10 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
+/**
+ * See [ScheduledEntityType]s in the
+ * [Discord Developer Documentation](https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-entity-types).
+ */
 @Serializable(with = ScheduledEntityType.NewSerializer::class)
 public sealed class ScheduledEntityType(
     /**

--- a/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/StageInstancePrivacyLevel.kt
+++ b/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/StageInstancePrivacyLevel.kt
@@ -23,6 +23,10 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
+/**
+ * See [StageInstancePrivacyLevel]s in the
+ * [Discord Developer Documentation](https://discord.com/developers/docs/resources/stage-instance#stage-instance-object-privacy-level).
+ */
 @Serializable(with = StageInstancePrivacyLevel.NewSerializer::class)
 public sealed class StageInstancePrivacyLevel(
     /**

--- a/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/TeamMembershipState.kt
+++ b/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/TeamMembershipState.kt
@@ -23,6 +23,10 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
+/**
+ * See [TeamMembershipState]s in the
+ * [Discord Developer Documentation](https://discord.com/developers/docs/topics/teams#data-models-membership-state-enum).
+ */
 @Serializable(with = TeamMembershipState.Serializer::class)
 public sealed class TeamMembershipState(
     /**

--- a/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/TextInputStyle.kt
+++ b/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/TextInputStyle.kt
@@ -21,6 +21,9 @@ import kotlinx.serialization.encoding.Encoder
 
 /**
  * Style of a [text input][dev.kord.common.entity.ComponentType.TextInput].
+ *
+ * See [TextInputStyle]s in the
+ * [Discord Developer Documentation](https://discord.com/developers/docs/interactions/message-components#text-inputs-text-input-styles).
  */
 @Serializable(with = TextInputStyle.Serializer::class)
 public sealed class TextInputStyle(

--- a/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/UserPremium.kt
+++ b/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/UserPremium.kt
@@ -21,6 +21,9 @@ import kotlinx.serialization.encoding.Encoder
 
 /**
  * Premium types denote the level of premium a user has.
+ *
+ * See [UserPremium]s in the
+ * [Discord Developer Documentation](https://discord.com/developers/docs/resources/user#user-object-premium-types).
  */
 @Serializable(with = UserPremium.Serializer::class)
 public sealed class UserPremium(

--- a/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/VerificationLevel.kt
+++ b/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/VerificationLevel.kt
@@ -19,6 +19,10 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
+/**
+ * See [VerificationLevel]s in the
+ * [Discord Developer Documentation](https://discord.com/developers/docs/resources/guild#guild-object-verification-level).
+ */
 @Serializable(with = VerificationLevel.Serializer::class)
 public sealed class VerificationLevel(
     /**

--- a/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/VideoQualityMode.kt
+++ b/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/VideoQualityMode.kt
@@ -19,6 +19,10 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
+/**
+ * See [VideoQualityMode]s in the
+ * [Discord Developer Documentation](https://discord.com/developers/docs/resources/channel#channel-object-video-quality-modes).
+ */
 @Serializable(with = VideoQualityMode.Serializer::class)
 public sealed class VideoQualityMode(
     /**

--- a/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/WebhookType.kt
+++ b/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/WebhookType.kt
@@ -19,6 +19,10 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
+/**
+ * See [WebhookType]s in the
+ * [Discord Developer Documentation](https://discord.com/developers/docs/resources/webhook#webhook-object-webhook-types).
+ */
 @Serializable(with = WebhookType.Serializer::class)
 public sealed class WebhookType(
     /**

--- a/common/src/main/kotlin/entity/AuditLog.kt
+++ b/common/src/main/kotlin/entity/AuditLog.kt
@@ -1,5 +1,6 @@
 @file:GenerateKordEnum(
     name = "AuditLogEvent", valueType = INT,
+    docUrl = "https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events",
     entries = [
         Entry("GuildUpdate", intValue = 1, kDoc = "Server settings were updated."),
         Entry("ChannelCreate", intValue = 10, kDoc = "Channel was created."),

--- a/common/src/main/kotlin/entity/AutoModeration.kt
+++ b/common/src/main/kotlin/entity/AutoModeration.kt
@@ -1,6 +1,7 @@
 @file:GenerateKordEnum(
     name = "AutoModerationRuleTriggerType", valueType = INT,
     kDoc = "Characterizes the type of content which can trigger the rule.",
+    docUrl = "https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-trigger-types",
     entries = [
         Entry("Keyword", intValue = 1, kDoc = "Check if content contains words from a user defined list of keywords."),
         Entry("Spam", intValue = 3, kDoc = "Check if content represents generic spam."),
@@ -15,6 +16,7 @@
 @file:GenerateKordEnum(
     name = "AutoModerationRuleKeywordPresetType", valueType = INT,
     kDoc = "An internally pre-defined wordset which will be searched for in content.",
+    docUrl = "https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-keyword-preset-types",
     entries = [
         Entry("Profanity", intValue = 1, kDoc = "Words that may be considered forms of swearing or cursing."),
         Entry("SexualContent", intValue = 2, kDoc = "Words that refer to sexually explicit behavior or activity."),
@@ -25,6 +27,7 @@
 @file:GenerateKordEnum(
     name = "AutoModerationRuleEventType", valueType = INT,
     kDoc = "Indicates in what event context a rule should be checked.",
+    docUrl = "https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-event-types",
     entries = [
         Entry("MessageSend", intValue = 1, kDoc = "When a member sends or edits a message in the guild."),
     ],
@@ -33,6 +36,7 @@
 @file:GenerateKordEnum(
     name = "AutoModerationActionType", valueType = INT,
     kDoc = "The type of action.",
+    docUrl = "https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-action-object-action-types",
     entries = [
         Entry("BlockMessage", intValue = 1, kDoc = "Blocks the content of a message according to the rule."),
         Entry("SendAlertMessage", intValue = 2, kDoc = "Logs user content to a specified channel."),

--- a/common/src/main/kotlin/entity/DiscordActivity.kt
+++ b/common/src/main/kotlin/entity/DiscordActivity.kt
@@ -11,6 +11,9 @@ import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
+import kotlin.DeprecationLevel.HIDDEN
+import kotlin.DeprecationLevel.WARNING
+import kotlin.LazyThreadSafetyMode.PUBLICATION
 
 @Serializable
 public data class DiscordBotActivity(
@@ -131,29 +134,115 @@ public data class DiscordActivitySecrets(
     val match: Optional<String> = Optional.Missing()
 )
 
-@Serializable(with = ActivityType.ActivityTypeSerializer::class)
-public enum class ActivityType(public val code: Int) {
-    /** The default code for unknown values. */
-    Unknown(Int.MIN_VALUE),
-    Game(0),
-    Streaming(1),
-    Listening(2),
-    Watching(3),
-    Custom(4),
-    Competing(5);
 
-    public companion object ActivityTypeSerializer : KSerializer<ActivityType> {
-        override val descriptor: SerialDescriptor
-            get() = PrimitiveSerialDescriptor("op", PrimitiveKind.INT)
+// TODO replace with the following annotation once the deprecation cycle for enum artifacts is done
+// @file:GenerateKordEnum(
+//     name = "ActivityType", valueType = INT, valueName = "code",
+//     deprecatedSerializerName = "ActivityTypeSerializer",
+//     docUrl = "https://discord.com/developers/docs/topics/gateway-events#activity-object-activity-types",
+//     entries = [
+//         Entry("Game", intValue = 0),
+//         Entry("Streaming", intValue = 1),
+//         Entry("Listening", intValue = 2),
+//         Entry("Watching", intValue = 3),
+//         Entry("Custom", intValue = 4),
+//         Entry("Competing", intValue = 5),
+//     ],
+// )
+@Serializable(with = ActivityType.Serializer::class)
+public sealed class ActivityType(public val code: Int) {
+    final override fun equals(other: Any?): Boolean =
+        this === other || (other is ActivityType && this.code == other.code)
 
-        override fun deserialize(decoder: Decoder): ActivityType {
-            val code = decoder.decodeInt()
-            return values().firstOrNull { it.code == code } ?: Unknown
-        }
+    final override fun hashCode(): Int = code.hashCode()
+    final override fun toString(): String = "ActivityType.${this::class.simpleName}(code=$code)"
 
-        override fun serialize(encoder: Encoder, value: ActivityType) {
-            encoder.encodeInt(value.code)
+    public class Unknown(code: Int) : ActivityType(code)
+    public object Game : ActivityType(0)
+    public object Streaming : ActivityType(1)
+    public object Listening : ActivityType(2)
+    public object Watching : ActivityType(3)
+    public object Custom : ActivityType(4)
+    public object Competing : ActivityType(5)
+
+    internal object Serializer : KSerializer<ActivityType> {
+        override val descriptor = PrimitiveSerialDescriptor("dev.kord.common.entity.ActivityType", PrimitiveKind.INT)
+        override fun serialize(encoder: Encoder, value: ActivityType) = encoder.encodeInt(value.code)
+        override fun deserialize(decoder: Decoder) = when (val code = decoder.decodeInt()) {
+            0 -> Game
+            1 -> Streaming
+            2 -> Listening
+            3 -> Watching
+            4 -> Custom
+            5 -> Competing
+            else -> Unknown(code)
         }
     }
 
+    public companion object {
+        public val entries: List<ActivityType> by lazy(mode = PUBLICATION) {
+            listOf(Game, Streaming, Listening, Watching, Custom, Competing)
+        }
+
+
+        // enum artifacts
+
+        private val UNKNOWN = Unknown(Int.MIN_VALUE) // like old enum entry `Unknown`
+
+        // @formatter:off
+        @Deprecated("Binary compatibility", level = HIDDEN) @JvmField public val Unknown: ActivityType = UNKNOWN
+        @Deprecated("Binary compatibility", level = HIDDEN) @JvmField public val Game: ActivityType = Game
+        @Deprecated("Binary compatibility", level = HIDDEN) @JvmField public val Streaming: ActivityType = Streaming
+        @Deprecated("Binary compatibility", level = HIDDEN) @JvmField public val Listening: ActivityType = Listening
+        @Deprecated("Binary compatibility", level = HIDDEN) @JvmField public val Watching: ActivityType = Watching
+        @Deprecated("Binary compatibility", level = HIDDEN) @JvmField public val Custom: ActivityType = Custom
+        @Deprecated("Binary compatibility", level = HIDDEN) @JvmField public val Competing: ActivityType = Competing
+        // @formatter:on
+
+        /** @suppress */
+        @Suppress("NON_FINAL_MEMBER_IN_OBJECT")
+        @Deprecated("ActivityType is no longer an enum class. Deprecated without replacement.", level = WARNING)
+        @JvmStatic
+        public open fun valueOf(name: String): ActivityType = when (name) {
+            "Unknown" -> UNKNOWN
+            "Game" -> Game
+            "Streaming" -> Streaming
+            "Listening" -> Listening
+            "Watching" -> Watching
+            "Custom" -> Custom
+            "Competing" -> Competing
+            else -> throw IllegalArgumentException(name)
+        }
+
+        /** @suppress */
+        @Suppress("NON_FINAL_MEMBER_IN_OBJECT")
+        @Deprecated(
+            "ActivityType is no longer an enum class.",
+            ReplaceWith("ActivityType.entries.toTypedArray()", "dev.kord.common.entity.ActivityType"),
+            level = WARNING,
+        )
+        @JvmStatic
+        public open fun values(): Array<ActivityType> =
+            arrayOf(UNKNOWN, Game, Streaming, Listening, Watching, Custom, Competing)
+
+
+        @Suppress("DEPRECATION")
+        @Deprecated("Binary compatibility", level = HIDDEN)
+        @JvmField
+        public val ActivityTypeSerializer: ActivityTypeSerializer = ActivityTypeSerializer
+    }
+
+    @Deprecated(
+        "Use 'ActivityType.serializer()' instead.",
+        ReplaceWith("ActivityType.serializer()", "dev.kord.common.entity.ActivityType"),
+        level = WARNING,
+    )
+    public object ActivityTypeSerializer : KSerializer<ActivityType> by Serializer {
+        @Deprecated(
+            "Use 'ActivityType.serializer()' instead.",
+            ReplaceWith("ActivityType.serializer()", "dev.kord.common.entity.ActivityType"),
+            level = WARNING,
+        )
+        public fun serializer(): KSerializer<ActivityType> = this
+    }
 }

--- a/common/src/main/kotlin/entity/DiscordChannel.kt
+++ b/common/src/main/kotlin/entity/DiscordChannel.kt
@@ -1,5 +1,6 @@
 @file:GenerateKordEnum(
     name = "ChannelType", valueType = INT,
+    docUrl = "https://discord.com/developers/docs/resources/channel#channel-object-channel-types",
     entries = [
         Entry("GuildText", intValue = 0, kDoc = "A text channel within a server."),
         Entry("DM", intValue = 1, kDoc = "A direct message between users."),
@@ -48,6 +49,7 @@
 
 @file:GenerateKordEnum(
     name = "VideoQualityMode", valueType = INT,
+    docUrl = "https://discord.com/developers/docs/resources/channel#channel-object-video-quality-modes",
     entries = [
         Entry("Auto", intValue = 1, kDoc = "Discord chooses the quality for optimal performance."),
         Entry("Full", intValue = 2, kDoc = "720p."),
@@ -56,6 +58,7 @@
 
 @file:GenerateKordEnum(
     name = "OverwriteType", valueType = INT,
+    docUrl = "https://discord.com/developers/docs/resources/channel#overwrite-object-overwrite-structure",
     entries = [Entry("Role", intValue = 0), Entry("Member", intValue = 1)],
 )
 

--- a/common/src/main/kotlin/entity/DiscordChannel.kt
+++ b/common/src/main/kotlin/entity/DiscordChannel.kt
@@ -174,6 +174,8 @@ public data class DiscordThreadMetadata(
     val createTimestamp: Optional<Instant?> = Optional.Missing(),
 )
 
+// this should actually be generated with @file:GenerateKordEnum,
+// but it's not worth adding support for Duration just for this class
 @Serializable(with = ArchiveDuration.NewSerializer::class)
 public sealed class ArchiveDuration(
     /** The raw [Duration] used by Discord. */

--- a/common/src/main/kotlin/entity/DiscordChannel.kt
+++ b/common/src/main/kotlin/entity/DiscordChannel.kt
@@ -77,10 +77,11 @@ import kotlinx.datetime.Instant
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlin.DeprecationLevel.HIDDEN
+import kotlin.DeprecationLevel.WARNING
+import kotlin.LazyThreadSafetyMode.PUBLICATION
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 
@@ -173,35 +174,55 @@ public data class DiscordThreadMetadata(
     val createTimestamp: Optional<Instant?> = Optional.Missing(),
 )
 
-@Serializable(with = ArchiveDuration.Serializer::class)
-public sealed class ArchiveDuration(public val duration: Duration) {
+@Serializable(with = ArchiveDuration.NewSerializer::class)
+public sealed class ArchiveDuration(
+    /** The raw [Duration] used by Discord. */
+    public val duration: Duration,
+) {
+    final override fun equals(other: Any?): Boolean =
+        this === other || (other is ArchiveDuration && this.duration == other.duration)
+
+    final override fun hashCode(): Int = duration.hashCode()
+    final override fun toString(): String = "ArchiveDuration.${this::class.simpleName}(duration=$duration)"
+
+    /**
+     * An unknown [ArchiveDuration].
+     *
+     * This is used as a fallback for [ArchiveDuration]s that haven't been added to Kord yet.
+     */
     public class Unknown(duration: Duration) : ArchiveDuration(duration)
     public object Hour : ArchiveDuration(60.minutes)
     public object Day : ArchiveDuration(1440.minutes)
     public object ThreeDays : ArchiveDuration(4320.minutes)
     public object Week : ArchiveDuration(10080.minutes)
 
-    public object Serializer : KSerializer<ArchiveDuration> {
+    internal object NewSerializer : KSerializer<ArchiveDuration> {
+        override val descriptor get() = DurationInMinutesSerializer.descriptor
 
-        override val descriptor: SerialDescriptor get() = DurationInMinutesSerializer.descriptor
+        override fun serialize(encoder: Encoder, value: ArchiveDuration) =
+            encoder.encodeSerializableValue(DurationInMinutesSerializer, value.duration)
 
         override fun deserialize(decoder: Decoder): ArchiveDuration {
-            val value = decoder.decodeSerializableValue(DurationInMinutesSerializer)
-            return values.firstOrNull { it.duration == value } ?: Unknown(value)
-        }
-
-        override fun serialize(encoder: Encoder, value: ArchiveDuration) {
-            encoder.encodeSerializableValue(DurationInMinutesSerializer, value.duration)
+            val duration = decoder.decodeSerializableValue(DurationInMinutesSerializer)
+            return entries.firstOrNull { it.duration == duration } ?: Unknown(duration)
         }
     }
 
     public companion object {
-        public val values: Set<ArchiveDuration>
-            get() = setOf(
-                Hour,
-                Day,
-                ThreeDays,
-                Week,
-            )
+        /** A [List] of all known [ArchiveDuration]s. */
+        public val entries: List<ArchiveDuration> by lazy(mode = PUBLICATION) {
+            listOf(Hour, Day, ThreeDays, Week)
+        }
+
+        @Deprecated("Renamed to 'entries'.", ReplaceWith("this.entries"), level = WARNING)
+        public val values: Set<ArchiveDuration> get() = entries.toSet()
     }
+
+    @Deprecated(
+        "Use 'ArchiveDuration.serializer()' instead.",
+        ReplaceWith("ArchiveDuration.serializer()", "dev.kord.common.entity.ArchiveDuration"),
+        level = WARNING,
+    )
+    // TODO rename internal `NewSerializer` to `Serializer` when this is removed
+    public object Serializer : KSerializer<ArchiveDuration> by NewSerializer
 }

--- a/common/src/main/kotlin/entity/DiscordComponent.kt
+++ b/common/src/main/kotlin/entity/DiscordComponent.kt
@@ -1,6 +1,7 @@
 @file:GenerateKordEnum(
     name = "ComponentType", valueType = INT,
     deprecatedSerializerName = "Serializer",
+    docUrl = "https://discord.com/developers/docs/interactions/message-components#component-object-component-types",
     entries = [
         Entry("ActionRow", intValue = 1, kDoc = "A container for other components."),
         Entry("Button", intValue = 2, kDoc = "A button object."),
@@ -12,9 +13,8 @@
 @file:GenerateKordEnum(
     name = "ButtonStyle", valueType = INT,
     deprecatedSerializerName = "Serializer",
-    kDoc = "Style of a [button][dev.kord.common.entity.ComponentType.Button].\n\nA preview of the different styles " +
-            "can be found [here]" +
-            "(https://discord.com/developers/docs/interactions/message-components#button-object-button-styles).",
+    kDoc = "Style of a [button][dev.kord.common.entity.ComponentType.Button].",
+    docUrl = "https://discord.com/developers/docs/interactions/message-components#button-object-button-styles",
     entries = [
         Entry("Primary", intValue = 1, kDoc = "Blurple."),
         Entry("Secondary", intValue = 2, kDoc = "Grey."),
@@ -27,6 +27,7 @@
 @file:GenerateKordEnum(
     name = "TextInputStyle", valueType = INT,
     kDoc = "Style of a [text·input][dev.kord.common.entity.ComponentType.TextInput].",
+    docUrl = "https://discord.com/developers/docs/interactions/message-components#text-inputs-text-input-styles",
     entries = [
         Entry("Short", intValue = 1, kDoc = "A single-line input."),
         Entry("Paragraph", intValue = 2, kDoc = "A multi-line input."),

--- a/common/src/main/kotlin/entity/DiscordConnection.kt
+++ b/common/src/main/kotlin/entity/DiscordConnection.kt
@@ -1,5 +1,6 @@
 @file:GenerateKordEnum(
     name = "DiscordConnectionVisibility", valueType = INT,
+    docUrl = "https://discord.com/developers/docs/resources/user#connection-object-visibility-types",
     entries = [
         Entry("None", intValue = 0, kDoc = "Invisible to everyone except the user themselves."),
         Entry("Everyone", intValue = 1, kDoc = "Visible to everyone."),

--- a/common/src/main/kotlin/entity/DiscordGuild.kt
+++ b/common/src/main/kotlin/entity/DiscordGuild.kt
@@ -131,13 +131,13 @@
             deprecationLevel = ERROR,
         ),
         Entry(
-            "ThreeDayThreadArchive", stringValue = "THREE_DAY_THREAD_ARCHIVE",
-            kDoc = "Guild has access to the three-day archive time for threads\n\n@suppress.",
+            "SevenDayThreadArchive", stringValue = "SEVEN_DAY_THREAD_ARCHIVE",
+            kDoc = "Guild has access to the seven day archive time for threads.\n\n@suppress",
             deprecationMessage = "Thread archive durations are no longer boost locked.", deprecationLevel = ERROR,
         ),
         Entry(
-            "SevenDayThreadArchive", stringValue = "SEVEN_DAY_THREAD_ARCHIVE",
-            kDoc = "Guild has access to the seven day archive time for threads.\n\n@suppress",
+            "ThreeDayThreadArchive", stringValue = "THREE_DAY_THREAD_ARCHIVE",
+            kDoc = "Guild has access to the three-day archive time for threads.\n\n@suppress",
             deprecationMessage = "Thread archive durations are no longer boost locked.", deprecationLevel = ERROR,
         ),
     ],

--- a/common/src/main/kotlin/entity/DiscordGuild.kt
+++ b/common/src/main/kotlin/entity/DiscordGuild.kt
@@ -1,5 +1,6 @@
 @file:GenerateKordEnum(
     name = "DefaultMessageNotificationLevel", valueType = INT,
+    docUrl = "https://discord.com/developers/docs/resources/guild#guild-object-default-message-notification-level",
     entries = [
         Entry("AllMessages", intValue = 0, kDoc = "Members will receive notifications for all messages by default."),
         Entry(
@@ -11,6 +12,7 @@
 
 @file:GenerateKordEnum(
     name = "ExplicitContentFilter", valueType = INT,
+    docUrl = "https://discord.com/developers/docs/resources/guild#guild-object-explicit-content-filter-level",
     entries = [
         Entry("Disabled", intValue = 0, kDoc = "Media content will not be scanned."),
         Entry(
@@ -23,6 +25,7 @@
 
 @file:GenerateKordEnum(
     name = "MFALevel", valueType = INT,
+    docUrl = "https://discord.com/developers/docs/resources/guild#guild-object-mfa-level",
     entries = [
         Entry("None", intValue = 0, kDoc = "Guild has no MFA/2FA requirement for moderation actions."),
         Entry("Elevated", intValue = 1, kDoc = "Guild has a 2FA requirement for moderation actions."),
@@ -31,6 +34,7 @@
 
 @file:GenerateKordEnum(
     name = "VerificationLevel", valueType = INT,
+    docUrl = "https://discord.com/developers/docs/resources/guild#guild-object-verification-level",
     entries = [
         Entry("None", intValue = 0, kDoc = "Unrestricted."),
         Entry("Low", intValue = 1, kDoc = "Must have verified email on account."),
@@ -42,6 +46,7 @@
 
 @file:GenerateKordEnum(
     name = "NsfwLevel", valueType = INT,
+    docUrl = "https://discord.com/developers/docs/resources/guild#guild-object-guild-nsfw-level",
     entries = [
         Entry("Default", intValue = 0),
         Entry("Explicit", intValue = 1),
@@ -52,6 +57,7 @@
 
 @file:GenerateKordEnum(
     name = "PremiumTier", valueType = INT,
+    docUrl = "https://discord.com/developers/docs/resources/guild#guild-object-premium-tier",
     entries = [
         Entry("None", intValue = 0, kDoc = "Guild has not unlocked any Server Boost perks."),
         Entry("One", intValue = 1, kDoc = "Guild has unlocked Server Boost level 1 perks."),
@@ -62,6 +68,7 @@
 
 @file:GenerateKordEnum(
     name = "GuildFeature", valueType = STRING,
+    docUrl = "https://discord.com/developers/docs/resources/guild#guild-object-guild-features",
     entries = [
         Entry(
             "AnimatedBanner", stringValue = "ANIMATED_BANNER",

--- a/common/src/main/kotlin/entity/DiscordGuildScheduledEvent.kt
+++ b/common/src/main/kotlin/entity/DiscordGuildScheduledEvent.kt
@@ -1,11 +1,13 @@
 @file:GenerateKordEnum(
     name = "GuildScheduledEventPrivacyLevel", valueType = INT,
+    docUrl = "https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-privacy-level",
     entries = [Entry("GuildOnly", intValue = 2, kDoc = "The scheduled event is only accessible to guild members.")],
 )
 
 @file:GenerateKordEnum(
     name = "ScheduledEntityType", valueType = INT,
     deprecatedSerializerName = "Serializer",
+    docUrl = "https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-entity-types",
     entries = [
         Entry("StageInstance", intValue = 1),
         Entry("Voice", intValue = 2),
@@ -16,6 +18,7 @@
 @file:GenerateKordEnum(
     name = "GuildScheduledEventStatus", valueType = INT,
     deprecatedSerializerName = "Serializer",
+    docUrl = "https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-status",
     entries = [
         Entry("Scheduled", intValue = 1),
         Entry("Active", intValue = 2),

--- a/common/src/main/kotlin/entity/DiscordIntegration.kt
+++ b/common/src/main/kotlin/entity/DiscordIntegration.kt
@@ -1,6 +1,7 @@
 @file:GenerateKordEnum(
     name = "IntegrationExpireBehavior", valueType = INT,
     deprecatedSerializerName = "Serializer",
+    docUrl = "https://discord.com/developers/docs/resources/guild#integration-object-integration-expire-behaviors",
     entries = [
         Entry("RemoveRole", intValue = 0),
         Entry("Kick", intValue = 1),

--- a/common/src/main/kotlin/entity/DiscordInvite.kt
+++ b/common/src/main/kotlin/entity/DiscordInvite.kt
@@ -1,5 +1,6 @@
 @file:GenerateKordEnum(
     name = "InviteTargetType", valueType = INT,
+    docUrl = "https://discord.com/developers/docs/resources/invite#invite-object-invite-target-types",
     entries = [
         Entry("Stream", intValue = 1),
         Entry("EmbeddedApplication", intValue = 2),

--- a/common/src/main/kotlin/entity/DiscordMessage.kt
+++ b/common/src/main/kotlin/entity/DiscordMessage.kt
@@ -2,6 +2,7 @@
     name = "MessageType", valueType = INT, valueName = "code",
     // had `public val values: Set<MessageType>` in companion before -> replace with `entries`
     valuesPropertyName = "values", valuesPropertyType = SET,
+    docUrl = "https://discord.com/developers/docs/resources/channel#message-object-message-types",
     entries = [
         Entry("Default", intValue = 0),
         Entry("RecipientAdd", intValue = 1),
@@ -59,6 +60,7 @@
 
 @file:GenerateKordEnum(
     name = "MessageActivityType", valueType = INT,
+    docUrl = "https://discord.com/developers/docs/resources/channel#message-object-message-activity-types",
     entries = [
         Entry("Join", intValue = 1),
         Entry("Spectate", intValue = 2),
@@ -69,6 +71,7 @@
 
 @file:GenerateKordEnum(
     name = "EmbedType", valueType = STRING,
+    docUrl = "https://discord.com/developers/docs/resources/channel#embed-object-embed-types",
     entries = [
         Entry("Rich", stringValue = "rich", kDoc = "Generic embed rendered from embed attributes."),
         Entry("Image", stringValue = "image", kDoc = "Image embed."),
@@ -81,6 +84,7 @@
 
 @file:GenerateKordEnum(
     name = "AllowedMentionType", valueType = STRING,
+    docUrl = "https://discord.com/developers/docs/resources/channel#allowed-mentions-object-allowed-mention-types",
     entries = [
         Entry("RoleMentions", stringValue = "roles", kDoc = "Controls role mentions."),
         Entry("UserMentions", stringValue = "users", kDoc = "Controls user mentions"),
@@ -92,6 +96,7 @@
     name = "MessageStickerType", valueType = INT,
     // had `public val values: Set<MessageStickerType>` in companion before -> replace with `entries`
     valuesPropertyName = "values", valuesPropertyType = SET,
+    docUrl = "https://discord.com/developers/docs/resources/sticker#sticker-object-sticker-format-types",
     entries = [
         Entry("PNG", intValue = 1),
         Entry("APNG", intValue = 2),

--- a/common/src/main/kotlin/entity/DiscordStageInstance.kt
+++ b/common/src/main/kotlin/entity/DiscordStageInstance.kt
@@ -1,6 +1,7 @@
 @file:GenerateKordEnum(
     name = "StageInstancePrivacyLevel", valueType = INT,
     deprecatedSerializerName = "Serializer",
+    docUrl = "https://discord.com/developers/docs/resources/stage-instance#stage-instance-object-privacy-level",
     entries = [
         Entry("GuildOnly", intValue = 2, kDoc = "The Stage instance is visible to only guild members."),
     ],

--- a/common/src/main/kotlin/entity/DiscordUser.kt
+++ b/common/src/main/kotlin/entity/DiscordUser.kt
@@ -1,6 +1,7 @@
 @file:GenerateKordEnum(
     name = "UserPremium", valueType = INT,
     kDoc = "Premium types denote the level of premium a user has.",
+    docUrl = "https://discord.com/developers/docs/resources/user#user-object-premium-types",
     entries = [
         Entry("None", intValue = 0),
         Entry("NitroClassic", intValue = 1),

--- a/common/src/main/kotlin/entity/DiscordWebhook.kt
+++ b/common/src/main/kotlin/entity/DiscordWebhook.kt
@@ -1,5 +1,6 @@
 @file:GenerateKordEnum(
     name = "WebhookType", valueType = INT,
+    docUrl = "https://discord.com/developers/docs/resources/webhook#webhook-object-webhook-types",
     entries = [
         Entry(
             "Incoming", intValue = 1,

--- a/common/src/main/kotlin/entity/Interactions.kt
+++ b/common/src/main/kotlin/entity/Interactions.kt
@@ -1,5 +1,6 @@
 @file:GenerateKordEnum(
     name = "ApplicationCommandType", valueType = INT,
+    docUrl = "https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-types",
     entries = [
         Entry("ChatInput", intValue = 1, kDoc = "A text-based command that shows up when a user types `/`."),
         Entry("User", intValue = 2, kDoc = "A UI-based command that shows up when you right-click or tap on a user."),
@@ -12,6 +13,7 @@
 
 @file:GenerateKordEnum(
     name = "ApplicationCommandOptionType", valueType = INT, valueName = "type",
+    docUrl = "https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-type",
     entries = [
         Entry("SubCommand", intValue = 1),
         Entry("SubCommandGroup", intValue = 2),
@@ -29,6 +31,7 @@
 
 @file:GenerateKordEnum(
     name = "InteractionType", valueType = INT, valueName = "type",
+    docUrl = "https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-type",
     entries = [
         Entry("Ping", intValue = 1),
         Entry("ApplicationCommand", intValue = 2),
@@ -40,6 +43,7 @@
 
 @file:GenerateKordEnum(
     name = "InteractionResponseType", valueType = INT, valueName = "type",
+    docUrl = "https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-interaction-callback-type",
     entries = [
         Entry("Pong", intValue = 1, kDoc = "ACK a [Ping][dev.kord.common.entity.InteractionType.Ping]."),
         Entry("ChannelMessageWithSource", intValue = 4, kDoc = "Respond to an interaction with a message."),
@@ -63,6 +67,7 @@
 
 @file:GenerateKordEnum(
     name = "ApplicationCommandPermissionType", valueType = INT,
+    docUrl = "https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-application-command-permission-type",
     entries = [
         Entry("Role", intValue = 1),
         Entry("User", intValue = 2),

--- a/common/src/main/kotlin/entity/Presence.kt
+++ b/common/src/main/kotlin/entity/Presence.kt
@@ -1,6 +1,7 @@
 @file:GenerateKordEnum(
     name = "PresenceStatus", valueType = STRING,
     deprecatedSerializerName = "StatusSerializer",
+    docUrl = "https://discord.com/developers/docs/topics/gateway-events#update-presence-status-types",
     entries = [
         Entry("Online", stringValue = "online", kDoc = "Online."),
         Entry("DoNotDisturb", stringValue = "dnd", kDoc = "Do Not Disturb."),

--- a/common/src/main/kotlin/entity/Team.kt
+++ b/common/src/main/kotlin/entity/Team.kt
@@ -1,6 +1,7 @@
 @file:GenerateKordEnum(
     name = "TeamMembershipState", valueType = INT,
     deprecatedSerializerName = "TeamMembershipStateSerializer",
+    docUrl = "https://discord.com/developers/docs/topics/teams#data-models-membership-state-enum",
     entries = [
         Entry("Invited", intValue = 1),
         Entry("Accepted", intValue = 2),

--- a/ksp-annotations/src/main/kotlin/GenerateKordEnum.kt
+++ b/ksp-annotations/src/main/kotlin/GenerateKordEnum.kt
@@ -22,6 +22,8 @@ annotation class GenerateKordEnum(
     val entries: Array<Entry>,
     /** KDoc for the kord enum (optional). */
     val kDoc: String = "",
+    /** Url to the Discord Developer Documentation for the kord enum (optional). */
+    val docUrl: String = "",
     /** Name of the value of the kord enum. */
     val valueName: String = "value",
     /** [entries] of the kord enum that are [Deprecated]. [Entry.deprecationMessage] is required for these. */

--- a/ksp-processors/src/main/kotlin/kordenum/KordEnum.kt
+++ b/ksp-processors/src/main/kotlin/kordenum/KordEnum.kt
@@ -18,6 +18,7 @@ import kotlin.DeprecationLevel.*
 internal class KordEnum(
     val name: String,
     val kDoc: String?,
+    val docUrl: String?,
     val valueType: ValueType,
     val valueName: String,
     val entries: List<Entry>,
@@ -52,6 +53,7 @@ internal fun KSAnnotation.toKordEnumOrNull(logger: KSPLogger): KordEnum? {
     val valueType = args[GenerateKordEnum::valueType].toValueType()
     val entries = args[GenerateKordEnum::entries] as List<*>
     val kDoc = args[GenerateKordEnum::kDoc].toKDoc()
+    val docUrl = (args[GenerateKordEnum::docUrl] as String).ifBlank { null }
     val valueName = args[GenerateKordEnum::valueName] as String
     val deprecatedEntries = args[GenerateKordEnum::deprecatedEntries] as List<*>
 
@@ -71,7 +73,7 @@ internal fun KSAnnotation.toKordEnumOrNull(logger: KSPLogger): KordEnum? {
     val deprecatedSerializerName = (args[GenerateKordEnum::deprecatedSerializerName] as String).ifEmpty { null }
 
     return KordEnum(
-        name, kDoc, valueType, valueName,
+        name, kDoc, docUrl, valueType, valueName,
         entries.map { it.toEntryOrNull(valueType, isDeprecated = false, logger) ?: return null },
         deprecatedEntries.map { it.toEntryOrNull(valueType, isDeprecated = true, logger) ?: return null },
 

--- a/ksp-processors/src/main/kotlin/kordenum/KordEnum.kt
+++ b/ksp-processors/src/main/kotlin/kordenum/KordEnum.kt
@@ -14,6 +14,8 @@ import dev.kord.ksp.GenerateKordEnum.ValuesPropertyType.SET
 import dev.kord.ksp.kordenum.KordEnum.Entry
 import kotlin.DeprecationLevel.*
 
+private val NATURAL_ORDER: Comparator<Comparable<*>> = compareBy { it }
+
 /** Mapping of [GenerateKordEnum] that is easier to work with in [KordEnumProcessor]. */
 internal class KordEnum(
     val name: String,
@@ -38,7 +40,9 @@ internal class KordEnum(
         val deprecationMessage: String,
         val replaceWith: ReplaceWith,
         val deprecationLevel: DeprecationLevel,
-    )
+    ) : Comparable<Entry> {
+        override fun compareTo(other: Entry) = with(NATURAL_ORDER) { compare(value, other.value) }
+    }
 }
 
 /**

--- a/ksp-processors/src/main/kotlin/kordenum/KordEnumGeneration.kt
+++ b/ksp-processors/src/main/kotlin/kordenum/KordEnumGeneration.kt
@@ -82,8 +82,9 @@ internal fun KordEnum.generateFileSpec(originatingFile: KSFile): FileSpec {
         // don't keep deprecated entries with a non-deprecated replacement
         val nonDeprecated = entries
         val nonDeprecatedValues = nonDeprecated.map { it.value }
-        val deprecatedToKeep = deprecatedEntries.filter { it.value !in nonDeprecatedValues }.sorted()
+        val deprecatedToKeep = deprecatedEntries.filter { it.value !in nonDeprecatedValues }
 
+        // merge nonDeprecated and deprecatedToKeep, preserving their order
         val (result, taken) = nonDeprecated.fold(emptyList<Entry>() to 0) { (acc, taken), entry ->
             val smallerDeprecated = deprecatedToKeep.drop(taken).takeWhile { it < entry }
             (acc + smallerDeprecated + entry) to (taken + smallerDeprecated.size)

--- a/ksp-processors/src/main/kotlin/kordenum/KordEnumGeneration.kt
+++ b/ksp-processors/src/main/kotlin/kordenum/KordEnumGeneration.kt
@@ -114,7 +114,16 @@ internal fun KordEnum.generateFileSpec(originatingFile: KSFile): FileSpec {
             // for ksp incremental processing
             addOriginatingKSFile(originatingFile)
 
-            kDoc?.let { addKdoc(it) }
+            // KDoc for the kord enum
+            run {
+                val docLink = docUrl?.let { url -> "See [%T]s in the [Discord·Developer·Documentation]($url)." }
+                val combinedKDocFormat = when {
+                    kDoc != null && docLink != null -> "$kDoc\n\n$docLink"
+                    else -> kDoc ?: docLink
+                }
+                combinedKDocFormat?.let { format -> addKdoc(format, enumName) }
+            }
+
             addAnnotation<Serializable> {
                 addMember("with·=·%T.$internalSerializerName::class", enumName)
             }


### PR DESCRIPTION
followup to #686
* turn `ActivityType` into kord enum, it was `enum class` before (it's not yet generated by the processor because of binary compatibility)
* add `GenerateKordEnum.docUrl` that adds a link to Discord's docs in the KDoc of kord enums
* update `ArchiveDuration` to match kord enums (it's not generated by the processor because it's the only class with backing `Duration` value)
* preserve declaration order for non-deprecated kord enum entries (affected `AllowedMentionType`, `EmbedType` and `PresenceStatus`)