### PR TITLE
Add bucket ID to the discovered bucket trace log

### DIFF
--- a/rest/src/main/kotlin/ratelimit/AbstractRateLimiter.kt
+++ b/rest/src/main/kotlin/ratelimit/AbstractRateLimiter.kt
@@ -60,7 +60,7 @@ public abstract class AbstractRateLimiter internal constructor(public val clock:
                 if (key != null) {
                     if (identity.addBucket(key)) {
 
-                        logger.trace { "[DISCOVERED]:[BUCKET]:Bucket discovered for" }
+                        logger.trace { "[DISCOVERED]:[BUCKET]:Bucket discovered for ${key.bucket.id.value}" }
                         buckets[key] = key.bucket
                     }
                 }


### PR DESCRIPTION
I think this was meant to have the discovered bucket ID