### PR TITLE
Fix REST Module Rate Limiting Issues

### DIFF
--- a/rest/api/rest.api
+++ b/rest/api/rest.api
@@ -5644,6 +5644,21 @@ public final class dev/kord/rest/ratelimit/RequestResponse$GlobalRateLimit : dev
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class dev/kord/rest/ratelimit/RequestResponse$UnknownBucketRateLimit : dev/kord/rest/ratelimit/RequestResponse {
+	public synthetic fun <init> (Ldev/kord/rest/ratelimit/RateLimit;Lkotlinx/datetime/Instant;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ldev/kord/rest/ratelimit/RateLimit;
+	public final fun component2-Ad4v_Ag ()Lkotlinx/datetime/Instant;
+	public final fun copy-K94tdRY (Ldev/kord/rest/ratelimit/RateLimit;Lkotlinx/datetime/Instant;)Ldev/kord/rest/ratelimit/RequestResponse$UnknownBucketRateLimit;
+	public static synthetic fun copy-K94tdRY$default (Ldev/kord/rest/ratelimit/RequestResponse$UnknownBucketRateLimit;Ldev/kord/rest/ratelimit/RateLimit;Lkotlinx/datetime/Instant;ILjava/lang/Object;)Ldev/kord/rest/ratelimit/RequestResponse$UnknownBucketRateLimit;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getBucketKey-JBzVXgM ()Ljava/lang/String;
+	public fun getRateLimit ()Ldev/kord/rest/ratelimit/RateLimit;
+	public synthetic fun getReset-8536Nbg ()Lkotlinx/datetime/Instant;
+	public fun getReset-Ad4v_Ag ()Lkotlinx/datetime/Instant;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract interface class dev/kord/rest/ratelimit/RequestToken {
 	public abstract fun complete (Ldev/kord/rest/ratelimit/RequestResponse;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getCompleted ()Z
@@ -5695,7 +5710,7 @@ public final class dev/kord/rest/request/HttpStatus {
 
 public final class dev/kord/rest/request/HttpUtilsKt {
 	public static final fun auditLogReason (Ldev/kord/rest/request/RequestBuilder;Ljava/lang/String;)V
-	public static final fun channelResetPoint (Lio/ktor/client/statement/HttpResponse;)Lkotlinx/datetime/Instant;
+	public static final fun channelResetPoint (Lio/ktor/client/statement/HttpResponse;Lkotlinx/datetime/Clock;)Lkotlinx/datetime/Instant;
 	public static final fun errorString (Lio/ktor/client/statement/HttpResponse;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun getBucket (Lio/ktor/client/statement/HttpResponse;)Ljava/lang/String;
 	public static final fun getChannelResetPoint (Lio/ktor/client/statement/HttpResponse;)Lkotlinx/datetime/Instant;
@@ -5709,6 +5724,8 @@ public final class dev/kord/rest/request/HttpUtilsKt {
 	public static final fun isRateLimit (Lio/ktor/client/statement/HttpResponse;)Z
 	public static final fun logString (Ldev/kord/rest/request/Request;Ljava/lang/String;)Ljava/lang/String;
 	public static final fun logString (Lio/ktor/client/statement/HttpResponse;Ljava/lang/String;)Ljava/lang/String;
+	public static final fun rateLimitResetPoint (Lio/ktor/client/statement/HttpResponse;)Lkotlinx/datetime/Instant;
+	public static final fun retryAfterResetPoint (Lio/ktor/client/statement/HttpResponse;Lkotlinx/datetime/Clock;)Lkotlinx/datetime/Instant;
 }
 
 public final class dev/kord/rest/request/JsonRequest : dev/kord/rest/request/Request {

--- a/rest/api/rest.api
+++ b/rest/api/rest.api
@@ -5695,7 +5695,7 @@ public final class dev/kord/rest/request/HttpStatus {
 
 public final class dev/kord/rest/request/HttpUtilsKt {
 	public static final fun auditLogReason (Ldev/kord/rest/request/RequestBuilder;Ljava/lang/String;)V
-	public static final fun channelResetPoint (Lio/ktor/client/statement/HttpResponse;Lkotlinx/datetime/Clock;)Lkotlinx/datetime/Instant;
+	public static final fun channelResetPoint (Lio/ktor/client/statement/HttpResponse;)Lkotlinx/datetime/Instant;
 	public static final fun errorString (Lio/ktor/client/statement/HttpResponse;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun getBucket (Lio/ktor/client/statement/HttpResponse;)Ljava/lang/String;
 	public static final fun getChannelResetPoint (Lio/ktor/client/statement/HttpResponse;)Lkotlinx/datetime/Instant;
@@ -5738,7 +5738,7 @@ public final class dev/kord/rest/request/KtorRequestHandler : dev/kord/rest/requ
 public final class dev/kord/rest/request/KtorRequestHandlerKt {
 	public static final fun KtorRequestHandler (Ljava/lang/String;Ldev/kord/rest/ratelimit/RequestRateLimiter;Lkotlinx/datetime/Clock;Lkotlinx/serialization/json/Json;)Ldev/kord/rest/request/KtorRequestHandler;
 	public static synthetic fun KtorRequestHandler$default (Ljava/lang/String;Ldev/kord/rest/ratelimit/RequestRateLimiter;Lkotlinx/datetime/Clock;Lkotlinx/serialization/json/Json;ILjava/lang/Object;)Ldev/kord/rest/request/KtorRequestHandler;
-	public static final fun from (Ldev/kord/rest/ratelimit/RequestResponse$Companion;Lio/ktor/client/statement/HttpResponse;Lkotlinx/datetime/Clock;)Ldev/kord/rest/ratelimit/RequestResponse;
+	public static final fun from (Ldev/kord/rest/ratelimit/RequestResponse$Companion;Lio/ktor/client/statement/HttpResponse;)Ldev/kord/rest/ratelimit/RequestResponse;
 }
 
 public final class dev/kord/rest/request/MultipartRequest : dev/kord/rest/request/Request {

--- a/rest/api/rest.api
+++ b/rest/api/rest.api
@@ -5701,7 +5701,7 @@ public final class dev/kord/rest/request/HttpUtilsKt {
 	public static final fun getChannelResetPoint (Lio/ktor/client/statement/HttpResponse;)Lkotlinx/datetime/Instant;
 	public static final fun getRateLimitRemaining (Lio/ktor/client/statement/HttpResponse;)Ljava/lang/Long;
 	public static final fun getRateLimitTotal (Lio/ktor/client/statement/HttpResponse;)Ljava/lang/Long;
-	public static final fun globalSuspensionPoint (Lio/ktor/client/statement/HttpResponse;Lkotlinx/datetime/Clock;)J
+	public static final fun globalSuspensionPoint (Lio/ktor/client/statement/HttpResponse;Lkotlinx/datetime/Clock;)Lkotlinx/datetime/Instant;
 	public static final fun isChannelRateLimit (Lio/ktor/client/statement/HttpResponse;)Z
 	public static final fun isError (Lio/ktor/client/statement/HttpResponse;)Z
 	public static final fun isErrorWithRateLimit (Lio/ktor/client/statement/HttpResponse;)Z
@@ -5738,7 +5738,7 @@ public final class dev/kord/rest/request/KtorRequestHandler : dev/kord/rest/requ
 public final class dev/kord/rest/request/KtorRequestHandlerKt {
 	public static final fun KtorRequestHandler (Ljava/lang/String;Ldev/kord/rest/ratelimit/RequestRateLimiter;Lkotlinx/datetime/Clock;Lkotlinx/serialization/json/Json;)Ldev/kord/rest/request/KtorRequestHandler;
 	public static synthetic fun KtorRequestHandler$default (Ljava/lang/String;Ldev/kord/rest/ratelimit/RequestRateLimiter;Lkotlinx/datetime/Clock;Lkotlinx/serialization/json/Json;ILjava/lang/Object;)Ldev/kord/rest/request/KtorRequestHandler;
-	public static final fun from (Ldev/kord/rest/ratelimit/RequestResponse$Companion;Lio/ktor/client/statement/HttpResponse;)Ldev/kord/rest/ratelimit/RequestResponse;
+	public static final fun from (Ldev/kord/rest/ratelimit/RequestResponse$Companion;Lio/ktor/client/statement/HttpResponse;Lkotlinx/datetime/Clock;)Ldev/kord/rest/ratelimit/RequestResponse;
 }
 
 public final class dev/kord/rest/request/MultipartRequest : dev/kord/rest/request/Request {

--- a/rest/src/main/kotlin/ratelimit/AbstractRateLimiter.kt
+++ b/rest/src/main/kotlin/ratelimit/AbstractRateLimiter.kt
@@ -51,7 +51,7 @@ public abstract class AbstractRateLimiter internal constructor(public val clock:
 
     internal abstract fun newToken(request: Request<*, *>, buckets: List<Bucket>): RequestToken
 
-    internal abstract inner class AbstractRequestToken(
+    internal abstract class AbstractRequestToken(
         val rateLimiter: AbstractRateLimiter,
         val identity: RequestIdentifier,
         val requestBuckets: List<Bucket>

--- a/rest/src/main/kotlin/ratelimit/AbstractRateLimiter.kt
+++ b/rest/src/main/kotlin/ratelimit/AbstractRateLimiter.kt
@@ -19,7 +19,8 @@ import kotlin.time.Duration.Companion.seconds
 public abstract class AbstractRateLimiter internal constructor(public val clock: Clock) : RequestRateLimiter {
     internal abstract val logger: KLogger
 
-    internal val autoBanRateLimiter = IntervalRateLimiter(limit = 25000, interval = 10.minutes)
+    // https://discord.com/developers/docs/topics/rate-limits#invalid-request-limit-aka-cloudflare-bans
+    internal val autoBanRateLimiter = IntervalRateLimiter(limit = 10_000, interval = 10.minutes)
     internal val globalSuspensionPoint = atomic(Reset(clock.now()))
     internal val routeBuckets = ConcurrentHashMap<RequestIdentifier, ConcurrentHashMap<BucketKey, Bucket>>()
     internal val Request<*, *>.buckets get() = routeBuckets[identifier].orEmpty().values.toList()

--- a/rest/src/main/kotlin/ratelimit/AbstractRateLimiter.kt
+++ b/rest/src/main/kotlin/ratelimit/AbstractRateLimiter.kt
@@ -27,7 +27,7 @@ public abstract class AbstractRateLimiter internal constructor(public val clock:
     internal fun createBucket(identity: RequestIdentifier, response: RequestResponse): Bucket? {
         val key = response.bucketKey ?: return null
 
-        logger.trace { "[DISCOVERED]:[BUCKET]:Bucket discovered for $key" }
+        logger.trace { "[DISCOVERED]:[BUCKET]:Bucket discovered for ${key.value}" }
         val bucket = Bucket(key)
         routeBuckets.getOrPut(identity) { ConcurrentHashMap() }[key] = bucket
         return bucket

--- a/rest/src/main/kotlin/ratelimit/RequestRateLimiter.kt
+++ b/rest/src/main/kotlin/ratelimit/RequestRateLimiter.kt
@@ -110,6 +110,16 @@ public sealed class RequestResponse {
         override val reset: Reset
     ) : RequestResponse()
 
+    /**
+     * The request returned a rate limit error without a bucket key present.
+     */
+    public data class UnknownBucketRateLimit(
+        override val rateLimit: RateLimit?,
+        override val reset: Reset
+    ) : RequestResponse() {
+        override val bucketKey: BucketKey? = null
+    }
+
     public companion object
 
 }

--- a/rest/src/main/kotlin/request/HttpUtils.kt
+++ b/rest/src/main/kotlin/request/HttpUtils.kt
@@ -30,9 +30,9 @@ public val HttpResponse.channelResetPoint: Instant
         return Instant.fromEpochMilliseconds(unixSeconds.times(1000).toLong())
     }
 
-public fun HttpResponse.channelResetPoint(clock: Clock): Instant {
-    val seconds = headers[rateLimitResetAfter]?.toDouble() ?: return clock.now()
-    return clock.now().plus(seconds.seconds)
+public fun HttpResponse.channelResetPoint(): Instant {
+    val seconds = headers[rateLimitResetAfter]?.toDouble() ?: return channelResetPoint
+    return channelResetPoint.plus(seconds.seconds)
 }
 
 public val HttpResponse.isRateLimit: Boolean get() = status.value == 429

--- a/rest/src/main/kotlin/request/HttpUtils.kt
+++ b/rest/src/main/kotlin/request/HttpUtils.kt
@@ -47,9 +47,9 @@ public val HttpResponse.bucket: BucketKey? get() = headers[bucketRateLimitKey]?.
 /**
  * The unix time (in ms) when the global rate limit gets reset.
  */
-public fun HttpResponse.globalSuspensionPoint(clock: Clock): Long {
-    val secondsWait = headers[retryAfterHeader]?.toLong() ?: return clock.now().toEpochMilliseconds()
-    return (secondsWait * 1000) + clock.now().toEpochMilliseconds()
+public fun HttpResponse.globalSuspensionPoint(clock: Clock): Instant? {
+    val secondsWait = headers[retryAfterHeader]?.toLong() ?: return null
+    return clock.now() + secondsWait.seconds
 }
 
 public fun HttpResponse.logString(body: String): String =

--- a/rest/src/main/kotlin/request/HttpUtils.kt
+++ b/rest/src/main/kotlin/request/HttpUtils.kt
@@ -56,7 +56,7 @@ public fun HttpResponse.rateLimitResetPoint(): Instant? {
  * The end time will be based from the current instant from the [clock], plus the retry after seconds.
  */
 public fun HttpResponse.retryAfterResetPoint(clock: Clock): Instant? {
-    val seconds = headers[retryAfterHeader]?.toDouble() ?: return null
+    val seconds = headers[retryAfterHeader]?.toLong() ?: return null
     return clock.now() + seconds.seconds
 }
 
@@ -68,14 +68,6 @@ public val HttpResponse.rateLimitTotal: Long? get() = headers[rateLimit]?.toLong
 public val HttpResponse.rateLimitRemaining: Long? get() = headers[rateLimitRemainingHeader]?.toLongOrNull()
 public val HttpResponse.isChannelRateLimit: Boolean get() = headers[rateLimitRemainingHeader]?.toIntOrNull() == 0
 public val HttpResponse.bucket: BucketKey? get() = headers[bucketRateLimitKey]?.let { BucketKey(it) }
-
-/**
- * The unix time (in ms) when the global rate limit gets reset.
- */
-public fun HttpResponse.globalSuspensionPoint(clock: Clock): Instant? {
-    val secondsWait = headers[retryAfterHeader]?.toLong() ?: return null
-    return clock.now() + secondsWait.seconds
-}
 
 public fun HttpResponse.logString(body: String): String =
     "[RESPONSE]:${status.value}:${call.request.method.value}:${call.request.url} body:$body"

--- a/rest/src/main/kotlin/request/KtorRequestHandler.kt
+++ b/rest/src/main/kotlin/request/KtorRequestHandler.kt
@@ -127,7 +127,7 @@ public fun RequestResponse.Companion.from(response: HttpResponse, clock: Clock):
     return when {
         response.isRateLimit -> when {
             response.isGlobalRateLimit -> RequestResponse.GlobalRateLimit(bucket, rateLimit, reset)
-            bucket != null -> RequestResponse.GlobalRateLimit(bucket, rateLimit, reset)
+            bucket != null -> RequestResponse.BucketRateLimit(bucket, rateLimit, reset)
             // Can be a "You are being blocked from accessing our API temporarily due to exceeding our rate limits frequently" ban.
             // In this case, the request only has a "retry-after" header
             else -> RequestResponse.GlobalRateLimit(null, rateLimit, Reset(response.globalSuspensionPoint(clock) ?: error("Received a 429 request with no Retry-After header!")))

--- a/rest/src/main/kotlin/request/KtorRequestHandler.kt
+++ b/rest/src/main/kotlin/request/KtorRequestHandler.kt
@@ -126,7 +126,7 @@ public fun RequestResponse.Companion.from(response: HttpResponse, clock: Clock):
 
     return when {
         response.isGlobalRateLimit -> RequestResponse.GlobalRateLimit(bucket, rateLimit, reset)
-        response.isRateLimit && bucket != null -> RequestResponse.BucketRateLimit(bucket, rateLimit, Reset(response.globalSuspensionPoint(clock) ?: error("Missing Retry-After header from Global Rate Limit response!")))
+        response.isRateLimit && bucket != null -> RequestResponse.BucketRateLimit(bucket, rateLimit, reset)
         response.isRateLimit -> RequestResponse.UnknownBucketRateLimit(rateLimit, reset)
         response.isError -> RequestResponse.Error
         else -> RequestResponse.Accepted(bucket, rateLimit, reset)

--- a/rest/src/main/kotlin/request/KtorRequestHandler.kt
+++ b/rest/src/main/kotlin/request/KtorRequestHandler.kt
@@ -44,7 +44,7 @@ public class KtorRequestHandler(
             val httpRequest = client.createRequest(request)
             val response = httpRequest.execute()
 
-            it.complete(RequestResponse.from(response, clock))
+            it.complete(RequestResponse.from(response))
 
             response
         }
@@ -114,7 +114,7 @@ public fun KtorRequestHandler(
     return KtorRequestHandler(client, requestRateLimiter, clock, parser, token)
 }
 
-public fun RequestResponse.Companion.from(response: HttpResponse, clock: Clock): RequestResponse {
+public fun RequestResponse.Companion.from(response: HttpResponse): RequestResponse {
     val bucket = response.bucket
     val rateLimit = run {
         val total = Total(response.rateLimitTotal ?: return@run null)
@@ -122,7 +122,7 @@ public fun RequestResponse.Companion.from(response: HttpResponse, clock: Clock):
         RateLimit(total, remaining)
     }
 
-    val reset = Reset(response.channelResetPoint(clock))
+    val reset = Reset(response.channelResetPoint())
 
     return when {
         response.isGlobalRateLimit -> RequestResponse.GlobalRateLimit(bucket, rateLimit, reset)

--- a/rest/src/test/kotlin/ratelimit/AbstractRequestRateLimiterTest.kt
+++ b/rest/src/test/kotlin/ratelimit/AbstractRequestRateLimiterTest.kt
@@ -118,8 +118,8 @@ abstract class AbstractRequestRateLimiterTest {
         val rateLimiter = newRequestRateLimiter(clock)
 
         rateLimiter.sendRequest(clock, 1, 1, rateLimit = RateLimit.exhausted)
-        rateLimiter.sendRequest(clock, 2, 1, rateLimit = RateLimit(Total(5), Remaining(5))) //discovery
-        rateLimiter.sendRequest(clock, 2, 1, rateLimit = RateLimit(Total(5), Remaining(5)))
+        rateLimiter.sendRequest(clock, 1, 1, rateLimit = RateLimit(Total(5), Remaining(5))) //discovery
+        rateLimiter.sendRequest(clock, 1, 1, rateLimit = RateLimit(Total(5), Remaining(5)))
 
         assertEquals(timeout.inWholeMilliseconds, currentTime)
     }


### PR DESCRIPTION
The tests were updated because the tests themselves were borked: Now that the guild ID is used as a major parameter, the tests fail because the requests won't get rate limited.

* Fixes the same thing that was fixed in #699, so if this is merged, that PR can be closed.
* Use different buckets for different request identifiers. Before it was using a shared bucket, even if it was for different request identifiers, which caused all requests with the same bucket ID to halt until the rate limit was lifted, which sucked.
* I decreased the `autoBanRateLimiter` max requests from 25_000 to 10_000, because that's what's in the Discord's docs.
* Now Kord calculates the rate limit reset timer correctly. Before it was using the current time + `x-ratelimit-reset-after`, which is incorrect because it would mean that the reset timer is always in the future. Now the timer is calculated using `x-ratelimit-reset` + `x-ratelimit-reset-after`
* Now Kord correctly respects rate limits: If a resource is exausted (`x-ratelimit-remaining` == 0), Kord will wait for the rate limit timer before proceeding. If the `rateLimit` information is null, it will await every time, since we don't know the resource limit.

___

It all started with this [Kord's Guild](https://canary.discord.com/channels/556525343595298817/587324906702766226/1030111757689159790):

the bucket logs seem to be fine, but there is still a suspiciously high amount of suspended coroutines waiting for messages to be sent
```
14:15:09.196 [eventLoopGroupProxy-7-3] TRACE d.k.r.r.ParallelRequestRateLimiter - [BUCKET]:Bucket a06de0de4a08126315431cc0c55ee3dc waiting until Reset(value=2022-10-13T14:15:08.580456038Z)
14:15:09.457 [eventLoopGroupProxy-7-3] TRACE d.k.r.r.ParallelRequestRateLimiter - [RATE LIMIT]:[BUCKET]:Bucket a06de0de4a08126315431cc0c55ee3dc was exhausted until 2022-10-13T14:15:13.705031783Z
```

MY THEORY: It is ratelimiting requests incorrectly: It is basing on the bucket ID, but different routes have different ratelimit values, example:

```
curl https://discord.com/api/v10/channels/547119872568459284/messages
< x-ratelimit-bucket: a06de0de4a08126315431cc0c55ee3dc
< x-ratelimit-limit: 5
< x-ratelimit-remaining: 4
curl https://discord.com/api/v10/channels/739823666891849729/messages
< x-ratelimit-bucket: a06de0de4a08126315431cc0c55ee3dc
< x-ratelimit-limit: 5
< x-ratelimit-remaining: 4
curl https://discord.com/api/v10/channels/547119872568459284/messages
< x-ratelimit-bucket: a06de0de4a08126315431cc0c55ee3dc
< x-ratelimit-limit: 5
< x-ratelimit-remaining: 3
curl https://discord.com/api/v10/channels/739823666891849729/messages
< x-ratelimit-bucket: a06de0de4a08126315431cc0c55ee3dc
< x-ratelimit-limit: 5
< x-ratelimit-remaining: 3
```
Posting messages to different channels have different ratelimit values

But Kord is basing on the bucket ID, when in reality it should base on the "keys" (in this case, the channel ID) of the route

However, looking at the code... it seems that Kord already does this?

I think I found the issue...? :dogeweird:

when a bucket gets rate limited, every request suspends, even if it has a major ID in the route

I changed `AbstractRateLimiter` to
```kotlin
        fun updateReset(newValue: Reset) {
            reset.update { Reset(newValue.value + 1.minutes) }
        }
```

and did this

![https://cdn.discordapp.com/attachments/587324906702766226/1030129007062159460/unknown.png](https://cdn.discordapp.com/attachments/587324906702766226/1030129007062159460/unknown.png)

I found the issue (fr this time) :Alert:
```
Request Identifier: MajorParamIdentifier(route=Route(method:POST,path:/channels/{channel.id}/messages,mapper:ValueJsonMapper(strategy=dev.kord.common.entity.DiscordMessage$$serializer@b676ebf)), param=739823666891849729)
1671961687
Buckets: [dev.kord.rest.ratelimit.AbstractRateLimiter$Bucket@be27323]

Request Identifier: MajorParamIdentifier(route=Route(method:POST,path:/channels/{channel.id}/messages,mapper:ValueJsonMapper(strategy=dev.kord.common.entity.DiscordMessage$$serializer@b676ebf)), param=790676480640155700)
-895711629
Buckets: [dev.kord.rest.ratelimit.AbstractRateLimiter$Bucket@be27323]
```
They are using the same bucket instance :sad_cat3: