### PR TITLE
fix: make LinearRetry behave linearly for all inputs

### DIFF
--- a/gateway/src/main/kotlin/retry/LinearRetry.kt
+++ b/gateway/src/main/kotlin/retry/LinearRetry.kt
@@ -28,7 +28,7 @@ public class LinearRetry(
         require(
             maxBackoff.minus(firstBackoff).isPositive()
         ) { "maxBackoff ${maxBackoff.inWholeMilliseconds} ms needs to be bigger than firstBackoff ${firstBackoff.inWholeMilliseconds} ms" }
-        require(maxTries > 1) { "maxTries needs to be positive but was $maxTries" }
+        require(maxTries > 1) { "maxTries needs to be greater than 1 but was $maxTries" }
     }
 
     private val tries = atomic(0)

--- a/gateway/src/main/kotlin/retry/LinearRetry.kt
+++ b/gateway/src/main/kotlin/retry/LinearRetry.kt
@@ -5,7 +5,7 @@ import kotlinx.atomicfu.update
 import kotlinx.coroutines.delay
 import mu.KotlinLogging
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.times
 
 private val linearRetryLogger = KotlinLogging.logger { }
 
@@ -45,8 +45,7 @@ public class LinearRetry(
 
         // tries/maxTries ratio * (backOffDiff) = retryProgress
         val ratio = tries.getAndIncrement() / (maxTries - 1).toDouble()
-        val retryProgress =
-            (ratio * (maxBackoff - firstBackoff).inWholeMilliseconds).toLong().milliseconds
+        val retryProgress = ratio * (maxBackoff - firstBackoff)
         val diff = firstBackoff + retryProgress
 
         linearRetryLogger.trace { "retry attempt ${tries.value}, delaying for $diff" }

--- a/gateway/src/main/kotlin/retry/LinearRetry.kt
+++ b/gateway/src/main/kotlin/retry/LinearRetry.kt
@@ -49,7 +49,7 @@ public class LinearRetry(
             (ratio * (maxBackoff - firstBackoff).inWholeMilliseconds).toLong().milliseconds
         val diff = firstBackoff + retryProgress
 
-        linearRetryLogger.trace { "retry attempt ${tries.value}, delaying for $diff ms" }
+        linearRetryLogger.trace { "retry attempt ${tries.value}, delaying for $diff" }
         delay(diff)
     }
 

--- a/gateway/src/test/kotlin/helper/LinearRetryTest.kt
+++ b/gateway/src/test/kotlin/helper/LinearRetryTest.kt
@@ -1,13 +1,11 @@
 package helper
 
 import dev.kord.gateway.retry.LinearRetry
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.currentTime
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
-import kotlin.time.TimeSource
-import kotlin.time.measureTime
 
 class LinearRetryTest {
 
@@ -15,15 +13,32 @@ class LinearRetryTest {
     fun testLinearity() = runTest {
         val linearRetry = LinearRetry(1.seconds, 10.seconds, 10)
         var i = 0
-        val elapsed = TimeSource.Monotonic.measureTime {
-            while (linearRetry.hasNext) {
-                linearRetry.retry()
-                i++
-            }
+        val start = currentTime
+
+        while (linearRetry.hasNext) {
+            linearRetry.retry()
+            i++
         }
 
-        println(elapsed)
+        val end = currentTime
+        val elapsed = (end-start).milliseconds
         assert(elapsed >= 55.seconds)
         assert(i == 10)
+    }
+
+    @Test
+    fun testExtreme() = runTest {
+        val linearRetry = LinearRetry(1.seconds, 60.seconds, Integer.MAX_VALUE)
+        var i = 0
+        val start = currentTime
+
+        while (linearRetry.hasNext && i < 1000) {
+            linearRetry.retry()
+            i++
+        }
+
+        val end = currentTime
+        val elapsed = (end-start).milliseconds
+        assert(elapsed <= 1100.seconds)
     }
 }

--- a/gateway/src/test/kotlin/helper/LinearRetryTest.kt
+++ b/gateway/src/test/kotlin/helper/LinearRetryTest.kt
@@ -2,23 +2,28 @@ package helper
 
 import dev.kord.gateway.retry.LinearRetry
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
+import kotlin.time.measureTime
 
 class LinearRetryTest {
 
     @Test
-    fun testLinearity() {
-        val linearRetry = LinearRetry(1.milliseconds, 10.milliseconds, 10)
-        val startTime = System.currentTimeMillis()
+    fun testLinearity() = runTest {
+        val linearRetry = LinearRetry(1.seconds, 10.seconds, 10)
         var i = 0
-        runBlocking {
+        val elapsed = TimeSource.Monotonic.measureTime {
             while (linearRetry.hasNext) {
                 linearRetry.retry()
                 i++
             }
         }
-        assert(System.currentTimeMillis() > (startTime + 55))
+
+        println(elapsed)
+        assert(elapsed >= 55.seconds)
         assert(i == 10)
     }
 }

--- a/gateway/src/test/kotlin/helper/LinearRetryTest.kt
+++ b/gateway/src/test/kotlin/helper/LinearRetryTest.kt
@@ -21,7 +21,7 @@ class LinearRetryTest {
         }
 
         val end = currentTime
-        val elapsed = (end-start).milliseconds
+        val elapsed = (end - start).milliseconds
 
         assert(elapsed == 55.seconds)
         assert(i == 10)
@@ -29,7 +29,7 @@ class LinearRetryTest {
 
     @Test
     fun testExtreme() = runTest {
-        val linearRetry = LinearRetry(1.seconds, 60.seconds, Integer.MAX_VALUE)
+        val linearRetry = LinearRetry(1.seconds, 60.seconds, Int.MAX_VALUE)
         var i = 0
         val start = currentTime
 
@@ -39,7 +39,7 @@ class LinearRetryTest {
         }
 
         val end = currentTime
-        val elapsed = (end-start).milliseconds
+        val elapsed = (end - start).milliseconds
 
         assert(elapsed == 1000.seconds)
     }

--- a/gateway/src/test/kotlin/helper/LinearRetryTest.kt
+++ b/gateway/src/test/kotlin/helper/LinearRetryTest.kt
@@ -1,0 +1,24 @@
+package helper
+
+import dev.kord.gateway.retry.LinearRetry
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.time.Duration.Companion.milliseconds
+
+class LinearRetryTest {
+
+    @Test
+    fun testLinearity() {
+        val linearRetry = LinearRetry(1.milliseconds, 10.milliseconds, 10)
+        val startTime = System.currentTimeMillis()
+        var i = 0
+        runBlocking {
+            while (linearRetry.hasNext) {
+                linearRetry.retry()
+                i++
+            }
+        }
+        assert(System.currentTimeMillis() > (startTime + 55))
+        assert(i == 10)
+    }
+}

--- a/gateway/src/test/kotlin/helper/LinearRetryTest.kt
+++ b/gateway/src/test/kotlin/helper/LinearRetryTest.kt
@@ -22,7 +22,8 @@ class LinearRetryTest {
 
         val end = currentTime
         val elapsed = (end-start).milliseconds
-        assert(elapsed >= 55.seconds)
+
+        assert(elapsed == 55.seconds)
         assert(i == 10)
     }
 
@@ -39,6 +40,7 @@ class LinearRetryTest {
 
         val end = currentTime
         val elapsed = (end-start).milliseconds
-        assert(elapsed <= 1100.seconds)
+
+        assert(elapsed == 1000.seconds)
     }
 }


### PR DESCRIPTION
fixes #596 