### PR TITLE
Add regex support for Auto Moderation

### DIFF
--- a/common/api/common.api
+++ b/common/api/common.api
@@ -2639,20 +2639,22 @@ public final class dev/kord/common/entity/DiscordAutoModerationRule$Companion {
 public final class dev/kord/common/entity/DiscordAutoModerationRuleTriggerMetadata {
 	public static final field Companion Ldev/kord/common/entity/DiscordAutoModerationRuleTriggerMetadata$Companion;
 	public fun <init> ()V
-	public synthetic fun <init> (ILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (ILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;)V
+	public synthetic fun <init> (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component2 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component3 ()Ldev/kord/common/entity/optional/Optional;
-	public final fun component4 ()Ldev/kord/common/entity/optional/OptionalInt;
-	public final fun copy (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;)Ldev/kord/common/entity/DiscordAutoModerationRuleTriggerMetadata;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordAutoModerationRuleTriggerMetadata;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordAutoModerationRuleTriggerMetadata;
+	public final fun component4 ()Ldev/kord/common/entity/optional/Optional;
+	public final fun component5 ()Ldev/kord/common/entity/optional/OptionalInt;
+	public final fun copy (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;)Ldev/kord/common/entity/DiscordAutoModerationRuleTriggerMetadata;
+	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordAutoModerationRuleTriggerMetadata;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordAutoModerationRuleTriggerMetadata;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAllowList ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getKeywordFilter ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getMentionTotalLimit ()Ldev/kord/common/entity/optional/OptionalInt;
 	public final fun getPresets ()Ldev/kord/common/entity/optional/Optional;
+	public final fun getRegexPatterns ()Ldev/kord/common/entity/optional/Optional;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public static final fun write$Self (Ldev/kord/common/entity/DiscordAutoModerationRuleTriggerMetadata;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
@@ -8163,6 +8165,7 @@ public final class dev/kord/common/entity/optional/OptionalKt {
 	public static final fun firstOrNull (Ldev/kord/common/entity/optional/Optional;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun flatMap (Ldev/kord/common/entity/optional/Optional;Lkotlin/jvm/functions/Function1;)Ldev/kord/common/entity/optional/Optional;
 	public static final fun map (Ldev/kord/common/entity/optional/Optional;Lkotlin/jvm/functions/Function1;)Ldev/kord/common/entity/optional/Optional;
+	public static final fun mapCopy (Ldev/kord/common/entity/optional/Optional;)Ldev/kord/common/entity/optional/Optional;
 	public static final fun mapList (Ldev/kord/common/entity/optional/Optional;Lkotlin/jvm/functions/Function1;)Ldev/kord/common/entity/optional/Optional;
 	public static final fun mapNotNull (Ldev/kord/common/entity/optional/Optional;Lkotlin/jvm/functions/Function1;)Ldev/kord/common/entity/optional/Optional;
 	public static final fun mapNullable (Ldev/kord/common/entity/optional/Optional;Lkotlin/jvm/functions/Function1;)Ldev/kord/common/entity/optional/Optional;

--- a/common/src/main/kotlin/entity/AutoModeration.kt
+++ b/common/src/main/kotlin/entity/AutoModeration.kt
@@ -89,6 +89,8 @@ public data class DiscordAutoModerationRule(
 public data class DiscordAutoModerationRuleTriggerMetadata(
     @SerialName("keyword_filter")
     val keywordFilter: Optional<List<String>> = Optional.Missing(),
+    @SerialName("regex_patterns")
+    val regexPatterns: Optional<List<String>> = Optional.Missing(),
     val presets: Optional<List<AutoModerationRuleKeywordPresetType>> = Optional.Missing(),
     @SerialName("allow_list")
     val allowList: Optional<List<String>> = Optional.Missing(),

--- a/common/src/main/kotlin/entity/optional/Optional.kt
+++ b/common/src/main/kotlin/entity/optional/Optional.kt
@@ -213,6 +213,8 @@ public inline fun <E, T> Optional<List<E>>.mapList(mapper: (E) -> T): Optional<L
     is Value -> Value(value.map(mapper))
 }
 
+public fun <T> Optional<MutableList<T>>.mapCopy(): Optional<List<T>> = map { mutable -> mutable.toList() }
+
 
 @Suppress("UNCHECKED_CAST")
 public inline fun <K, V, R> Optional<Map<K, V>>.mapValues(mapper: (Map.Entry<K, V>) -> R): Optional<Map<K, R>> = when (this) {
@@ -221,7 +223,6 @@ public inline fun <K, V, R> Optional<Map<K, V>>.mapValues(mapper: (Map.Entry<K, 
 }
 
 
-@Suppress("UNCHECKED_CAST")
 public inline fun <E> Optional<List<E>>.filterList(mapper: (E) -> Boolean): Optional<List<E>> = when (this) {
     is Missing, is Null<*> -> this
     is Value -> Value(value.filter(mapper))

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -2839,20 +2839,22 @@ public final class dev/kord/core/cache/data/AutoModerationRuleData$Companion {
 public final class dev/kord/core/cache/data/AutoModerationRuleTriggerMetadataData {
 	public static final field Companion Ldev/kord/core/cache/data/AutoModerationRuleTriggerMetadataData$Companion;
 	public fun <init> ()V
-	public synthetic fun <init> (ILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (ILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;)V
+	public synthetic fun <init> (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component2 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component3 ()Ldev/kord/common/entity/optional/Optional;
-	public final fun component4 ()Ldev/kord/common/entity/optional/OptionalInt;
-	public final fun copy (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;)Ldev/kord/core/cache/data/AutoModerationRuleTriggerMetadataData;
-	public static synthetic fun copy$default (Ldev/kord/core/cache/data/AutoModerationRuleTriggerMetadataData;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;ILjava/lang/Object;)Ldev/kord/core/cache/data/AutoModerationRuleTriggerMetadataData;
+	public final fun component4 ()Ldev/kord/common/entity/optional/Optional;
+	public final fun component5 ()Ldev/kord/common/entity/optional/OptionalInt;
+	public final fun copy (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;)Ldev/kord/core/cache/data/AutoModerationRuleTriggerMetadataData;
+	public static synthetic fun copy$default (Ldev/kord/core/cache/data/AutoModerationRuleTriggerMetadataData;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;ILjava/lang/Object;)Ldev/kord/core/cache/data/AutoModerationRuleTriggerMetadataData;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAllowList ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getKeywordFilter ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getMentionTotalLimit ()Ldev/kord/common/entity/optional/OptionalInt;
 	public final fun getPresets ()Ldev/kord/common/entity/optional/Optional;
+	public final fun getRegexPatterns ()Ldev/kord/common/entity/optional/Optional;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public static final fun write$Self (Ldev/kord/core/cache/data/AutoModerationRuleTriggerMetadataData;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
@@ -7589,6 +7591,7 @@ public final class dev/kord/core/entity/automoderation/KeywordAutoModerationRule
 	public fun asAutoModerationRule (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun asAutoModerationRuleOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getKeywords ()Ljava/util/List;
+	public final fun getRegexPatterns ()Ljava/util/List;
 	public fun getTriggerType ()Ldev/kord/common/entity/AutoModerationRuleTriggerType$Keyword;
 	public synthetic fun getTriggerType ()Ldev/kord/common/entity/AutoModerationRuleTriggerType;
 	public fun toString ()Ljava/lang/String;

--- a/core/src/main/kotlin/cache/data/AutoModeration.kt
+++ b/core/src/main/kotlin/cache/data/AutoModeration.kt
@@ -49,6 +49,7 @@ public data class AutoModerationRuleData(
 @Serializable
 public data class AutoModerationRuleTriggerMetadataData(
     val keywordFilter: Optional<List<String>> = Optional.Missing(),
+    val regexPatterns: Optional<List<String>> = Optional.Missing(),
     val presets: Optional<List<AutoModerationRuleKeywordPresetType>> = Optional.Missing(),
     val allowList: Optional<List<String>> = Optional.Missing(),
     val mentionTotalLimit: OptionalInt = OptionalInt.Missing,
@@ -58,6 +59,7 @@ public data class AutoModerationRuleTriggerMetadataData(
             with(metadata) {
                 AutoModerationRuleTriggerMetadataData(
                     keywordFilter = keywordFilter,
+                    regexPatterns = regexPatterns,
                     presets = presets,
                     allowList = allowList,
                     mentionTotalLimit = mentionTotalLimit,

--- a/core/src/main/kotlin/entity/automoderation/AutoModerationRule.kt
+++ b/core/src/main/kotlin/entity/automoderation/AutoModerationRule.kt
@@ -127,6 +127,13 @@ public class KeywordAutoModerationRule(data: AutoModerationRuleData, kord: Kord,
      */
     public val keywords: List<String> get() = data.triggerMetadata.keywordFilter.orEmpty()
 
+    /**
+     * Regular expression patterns which will be matched against content.
+     *
+     * Only Rust flavored regex is currently supported.
+     */
+    public val regexPatterns: List<String> get() = data.triggerMetadata.regexPatterns.orEmpty()
+
     override suspend fun asAutoModerationRuleOrNull(): KeywordAutoModerationRule = this
     override suspend fun asAutoModerationRule(): KeywordAutoModerationRule = this
 

--- a/rest/api/rest.api
+++ b/rest/api/rest.api
@@ -128,6 +128,7 @@ public final class dev/kord/rest/builder/automoderation/AutoModerationRuleBuilde
 	public static final fun keyword (Ldev/kord/rest/builder/automoderation/KeywordAutoModerationRuleBuilder;Ljava/lang/String;)V
 	public static final fun prefixKeyword (Ldev/kord/rest/builder/automoderation/KeywordAutoModerationRuleBuilder;Ljava/lang/String;)V
 	public static final fun preset (Ldev/kord/rest/builder/automoderation/KeywordPresetAutoModerationRuleBuilder;Ldev/kord/common/entity/AutoModerationRuleKeywordPresetType;)V
+	public static final fun regexPattern (Ldev/kord/rest/builder/automoderation/KeywordAutoModerationRuleBuilder;Ljava/lang/String;)V
 	public static final fun sendAlertMessage (Ldev/kord/rest/builder/automoderation/AutoModerationRuleBuilder;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;)V
 	public static synthetic fun sendAlertMessage$default (Ldev/kord/rest/builder/automoderation/AutoModerationRuleBuilder;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public static final fun suffixKeyword (Ldev/kord/rest/builder/automoderation/KeywordAutoModerationRuleBuilder;Ljava/lang/String;)V
@@ -189,32 +190,40 @@ public final class dev/kord/rest/builder/automoderation/BlockMessageAutoModerati
 }
 
 public abstract interface class dev/kord/rest/builder/automoderation/KeywordAutoModerationRuleBuilder : dev/kord/rest/builder/automoderation/TimeoutAutoModerationRuleBuilder {
-	public abstract fun assignKeywords (Ljava/util/List;)V
+	public abstract synthetic fun assignKeywords (Ljava/util/List;)V
 	public abstract fun getKeywords ()Ljava/util/List;
+	public abstract fun getRegexPatterns ()Ljava/util/List;
 	public abstract fun getTriggerType ()Ldev/kord/common/entity/AutoModerationRuleTriggerType$Keyword;
+	public abstract fun setKeywords (Ljava/util/List;)V
+	public abstract fun setRegexPatterns (Ljava/util/List;)V
 }
 
 public final class dev/kord/rest/builder/automoderation/KeywordAutoModerationRuleBuilder$DefaultImpls {
+	public static synthetic fun assignKeywords (Ldev/kord/rest/builder/automoderation/KeywordAutoModerationRuleBuilder;Ljava/util/List;)V
 	public static fun getTriggerType (Ldev/kord/rest/builder/automoderation/KeywordAutoModerationRuleBuilder;)Ldev/kord/common/entity/AutoModerationRuleTriggerType$Keyword;
 }
 
 public final class dev/kord/rest/builder/automoderation/KeywordAutoModerationRuleCreateBuilder : dev/kord/rest/builder/automoderation/AutoModerationRuleCreateBuilder, dev/kord/rest/builder/automoderation/KeywordAutoModerationRuleBuilder {
 	public fun <init> (Ljava/lang/String;Ldev/kord/common/entity/AutoModerationRuleEventType;)V
-	public fun assignKeywords (Ljava/util/List;)V
+	public synthetic fun assignKeywords (Ljava/util/List;)V
 	public synthetic fun buildTriggerMetadata ()Ldev/kord/common/entity/optional/Optional;
 	public fun getKeywords ()Ljava/util/List;
+	public fun getRegexPatterns ()Ljava/util/List;
 	public fun getTriggerType ()Ldev/kord/common/entity/AutoModerationRuleTriggerType$Keyword;
 	public synthetic fun getTriggerType ()Ldev/kord/common/entity/AutoModerationRuleTriggerType;
 	public fun setKeywords (Ljava/util/List;)V
+	public fun setRegexPatterns (Ljava/util/List;)V
 }
 
 public final class dev/kord/rest/builder/automoderation/KeywordAutoModerationRuleModifyBuilder : dev/kord/rest/builder/automoderation/AutoModerationRuleModifyBuilder, dev/kord/rest/builder/automoderation/KeywordAutoModerationRuleBuilder {
 	public fun <init> ()V
-	public fun assignKeywords (Ljava/util/List;)V
+	public synthetic fun assignKeywords (Ljava/util/List;)V
 	public fun getKeywords ()Ljava/util/List;
+	public fun getRegexPatterns ()Ljava/util/List;
 	public fun getTriggerType ()Ldev/kord/common/entity/AutoModerationRuleTriggerType$Keyword;
 	public synthetic fun getTriggerType ()Ldev/kord/common/entity/AutoModerationRuleTriggerType;
 	public fun setKeywords (Ljava/util/List;)V
+	public fun setRegexPatterns (Ljava/util/List;)V
 }
 
 public abstract interface class dev/kord/rest/builder/automoderation/KeywordPresetAutoModerationRuleBuilder : dev/kord/rest/builder/automoderation/TypedAutoModerationRuleBuilder {

--- a/rest/src/main/kotlin/builder/automoderation/AutoModerationRuleBuilder.kt
+++ b/rest/src/main/kotlin/builder/automoderation/AutoModerationRuleBuilder.kt
@@ -9,6 +9,7 @@ import dev.kord.common.entity.AutoModerationRuleTriggerType.*
 import dev.kord.common.entity.Permission.ModerateMembers
 import dev.kord.common.entity.Snowflake
 import dev.kord.rest.builder.AuditBuilder
+import kotlin.DeprecationLevel.HIDDEN
 import kotlin.contracts.InvocationKind.EXACTLY_ONCE
 import kotlin.contracts.contract
 import kotlin.time.Duration
@@ -137,35 +138,46 @@ public sealed interface KeywordAutoModerationRuleBuilder : TimeoutAutoModeration
     override val triggerType: Keyword get() = Keyword
 
     /**
-     * Substrings which will be searched for in content.
+     * Substrings which will be searched for in content (maximum of 1000).
      *
      * A keyword can be a phrase which contains multiple words. Wildcard symbols can be used to customize how each
      * keyword will be matched. See
      * [keyword matching strategies](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-keyword-matching-strategies).
+     * Each keyword must be 30 characters or less.
      */
-    public val keywords: MutableList<String>?
+    public var keywords: MutableList<String>?
 
-    /** Use this to set [keywords][KeywordAutoModerationRuleBuilder.keywords] for [KeywordAutoModerationRuleBuilder]. */
-    public fun assignKeywords(keywords: MutableList<String>)
+    @Deprecated("Binary compatibility", level = HIDDEN)
+    public fun assignKeywords(keywords: MutableList<String>) {
+        this.keywords = keywords
+    }
+
+    /**
+     * Regular expression patterns which will be matched against content (maximum of 10).
+     *
+     * Only Rust flavored regex is currently supported. Each regex pattern must be 75 characters or less.
+     */
+    public var regexPatterns: MutableList<String>?
 }
 
 /**
- * Add a [keyword] to [keywords][KeywordAutoModerationRuleBuilder.keywords].
+ * Add a [keyword] to [keywords][KeywordAutoModerationRuleBuilder.keywords] (maximum of 1000).
  *
  * A keyword can be a phrase which contains multiple words. Wildcard symbols can be used to customize how each
  * keyword will be matched. See
  * [keyword matching strategies](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-keyword-matching-strategies).
+ * Each keyword must be 30 characters or less.
  */
 public fun KeywordAutoModerationRuleBuilder.keyword(keyword: String) {
-    keywords?.add(keyword) ?: assignKeywords(mutableListOf(keyword))
+    keywords?.add(keyword) ?: run { keywords = mutableListOf(keyword) }
 }
 
 /**
  * Add a [keyword] with keyword matching strategy
  * [Prefix](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-keyword-matching-strategies)
- * to [keywords][KeywordAutoModerationRuleBuilder.keywords].
+ * to [keywords][KeywordAutoModerationRuleBuilder.keywords] (maximum of 1000).
  *
- * A keyword can be a phrase which contains multiple words.
+ * A keyword can be a phrase which contains multiple words. Each keyword must be 30 characters or less.
  */
 public fun KeywordAutoModerationRuleBuilder.prefixKeyword(keyword: String) {
     keyword("$keyword*")
@@ -174,9 +186,9 @@ public fun KeywordAutoModerationRuleBuilder.prefixKeyword(keyword: String) {
 /**
  * Add a [keyword] with keyword matching strategy
  * [Suffix](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-keyword-matching-strategies)
- * to [keywords][KeywordAutoModerationRuleBuilder.keywords].
+ * to [keywords][KeywordAutoModerationRuleBuilder.keywords] (maximum of 1000).
  *
- * A keyword can be a phrase which contains multiple words.
+ * A keyword can be a phrase which contains multiple words. Each keyword must be 30 characters or less.
  */
 public fun KeywordAutoModerationRuleBuilder.suffixKeyword(keyword: String) {
     keyword("*$keyword")
@@ -185,12 +197,21 @@ public fun KeywordAutoModerationRuleBuilder.suffixKeyword(keyword: String) {
 /**
  * Add a [keyword] with keyword matching strategy
  * [Anywhere](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-keyword-matching-strategies)
- * to [keywords][KeywordAutoModerationRuleBuilder.keywords].
+ * to [keywords][KeywordAutoModerationRuleBuilder.keywords] (maximum of 1000).
  *
- * A keyword can be a phrase which contains multiple words.
+ * A keyword can be a phrase which contains multiple words. Each keyword must be 30 characters or less.
  */
 public fun KeywordAutoModerationRuleBuilder.anywhereKeyword(keyword: String) {
     keyword("*$keyword*")
+}
+
+/**
+ * Add a [pattern] to [regexPatterns][KeywordAutoModerationRuleBuilder.regexPatterns] (maximum of 10).
+ *
+ * Only Rust flavored regex is currently supported. Each regex pattern must be 75 characters or less.
+ */
+public fun KeywordAutoModerationRuleBuilder.regexPattern(pattern: String) {
+    regexPatterns?.add(pattern) ?: run { regexPatterns = mutableListOf(pattern) }
 }
 
 
@@ -217,9 +238,9 @@ public sealed interface KeywordPresetAutoModerationRuleBuilder : TypedAutoModera
     public fun assignPresets(presets: MutableList<AutoModerationRuleKeywordPresetType>)
 
     /**
-     * Substrings which will be exempt from triggering the [presets].
+     * Substrings which will be exempt from triggering the [presets] (maximum of 1000).
      *
-     * A keyword can be a phrase which contains multiple words.
+     * A keyword can be a phrase which contains multiple words. Each keyword must be 30 characters or less.
      */
     public var allowedKeywords: MutableList<String>?
 }
@@ -230,9 +251,9 @@ public fun KeywordPresetAutoModerationRuleBuilder.preset(preset: AutoModerationR
 }
 
 /**
- * Add a [keyword] to [allowedKeywords][KeywordPresetAutoModerationRuleBuilder.allowedKeywords].
+ * Add a [keyword] to [allowedKeywords][KeywordPresetAutoModerationRuleBuilder.allowedKeywords] (maximum of 1000).
  *
- * A keyword can be a phrase which contains multiple words.
+ * A keyword can be a phrase which contains multiple words. Each keyword must be 30 characters or less.
  */
 public fun KeywordPresetAutoModerationRuleBuilder.allowKeyword(keyword: String) {
     allowedKeywords?.add(keyword) ?: run { allowedKeywords = mutableListOf(keyword) }

--- a/rest/src/main/kotlin/builder/automoderation/AutoModerationRuleCreateBuilder.kt
+++ b/rest/src/main/kotlin/builder/automoderation/AutoModerationRuleCreateBuilder.kt
@@ -53,8 +53,8 @@ public sealed class AutoModerationRuleCreateBuilder(
         triggerMetadata = buildTriggerMetadata(),
         actions = actions.map { it.toRequest() },
         enabled = _enabled,
-        exemptRoles = _exemptRoles.map { it.toList() },
-        exemptChannels = _exemptChannels.map { it.toList() },
+        exemptRoles = _exemptRoles.mapCopy(),
+        exemptChannels = _exemptChannels.mapCopy(),
     )
 }
 
@@ -65,15 +65,18 @@ public class KeywordAutoModerationRuleCreateBuilder(
     eventType: AutoModerationRuleEventType,
 ) : AutoModerationRuleCreateBuilder(name, eventType), KeywordAutoModerationRuleBuilder {
 
-    override var keywords: MutableList<String> = mutableListOf()
+    private var _keywords: Optional<MutableList<String>> = Optional.Missing()
+    override var keywords: MutableList<String>? by ::_keywords.delegate()
 
-    /** @suppress Use `this.keywords = keywords` instead. */
-    override fun assignKeywords(keywords: MutableList<String>) {
-        this.keywords = keywords
-    }
+    private var _regexPatterns: Optional<MutableList<String>> = Optional.Missing()
+    override var regexPatterns: MutableList<String>? by ::_regexPatterns.delegate()
 
+    // one of keywords or regexPatterns is required, don't bother to send missing trigger metadata if both are missing
     override fun buildTriggerMetadata(): Optional.Value<DiscordAutoModerationRuleTriggerMetadata> =
-        DiscordAutoModerationRuleTriggerMetadata(keywordFilter = keywords.toList().optional()).optional()
+        DiscordAutoModerationRuleTriggerMetadata(
+            keywordFilter = _keywords.mapCopy(),
+            regexPatterns = _regexPatterns.mapCopy(),
+        ).optional()
 }
 
 /** A [SpamAutoModerationRuleBuilder] for building [AutoModerationRuleCreateRequest]s. */
@@ -103,7 +106,7 @@ public class KeywordPresetAutoModerationRuleCreateBuilder(
     override fun buildTriggerMetadata(): Optional.Value<DiscordAutoModerationRuleTriggerMetadata> =
         DiscordAutoModerationRuleTriggerMetadata(
             presets = presets.toList().optional(),
-            allowList = _allowedKeywords.map { it.toList() },
+            allowList = _allowedKeywords.mapCopy(),
         ).optional()
 }
 


### PR DESCRIPTION
The DSL looks like this:
```kotlin
val rule = guild.createKeywordAutoModerationRule("name") {
    regexPattern("^b(a|@)d\$w(o|0)rd(s|$)")
    blockMessage()
    enabled = true
}
println(rule.regexPatterns)
```

`KeywordAutoModerationRuleBuilder.assignKeywords()` was dropped and `KeywordAutoModerationRuleBuilder.keywords` was changed to `var` instead because it is no longer strictly required for creating rules. At least one of `keywords` or `regexPatterns` is required instead.

The builder documentation was also updated to include the limits documented in #5504.

see https://github.com/discord/discord-api-docs/pull/5504