### PR TITLE
Add a getGuildOrNull function to the Kord class

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -51,6 +51,8 @@ public final class dev/kord/core/Kord : kotlinx/coroutines/CoroutineScope {
 	public final fun getGuildApplicationCommandOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getGuildApplicationCommands (Ldev/kord/common/entity/Snowflake;Ljava/lang/Boolean;)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun getGuildApplicationCommands$default (Ldev/kord/core/Kord;Ldev/kord/common/entity/Snowflake;Ljava/lang/Boolean;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public final fun getGuildOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getGuildOrNull$default (Ldev/kord/core/Kord;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun getGuildPreview (Ldev/kord/common/entity/Snowflake;Ldev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getGuildPreview$default (Ldev/kord/core/Kord;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun getGuildPreviewOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -53,6 +53,8 @@ public final class dev/kord/core/Kord : kotlinx/coroutines/CoroutineScope {
 	public static synthetic fun getGuildApplicationCommands$default (Ldev/kord/core/Kord;Ldev/kord/common/entity/Snowflake;Ljava/lang/Boolean;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 	public final fun getGuildOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getGuildOrNull$default (Ldev/kord/core/Kord;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getGuildOrThrow (Ldev/kord/common/entity/Snowflake;Ldev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getGuildOrThrow$default (Ldev/kord/core/Kord;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun getGuildPreview (Ldev/kord/common/entity/Snowflake;Ldev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getGuildPreview$default (Ldev/kord/core/Kord;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun getGuildPreviewOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/core/src/main/kotlin/Kord.kt
+++ b/core/src/main/kotlin/Kord.kt
@@ -64,11 +64,7 @@ public class Kord(
      *
      * @suppress
      */
-    @Deprecated(
-        "Replace with function call for localizations",
-        ReplaceWith("getGlobalApplicationCommands()"),
-        level = HIDDEN
-    )
+    @Deprecated("Replace with function call for localizations", ReplaceWith("getGlobalApplicationCommands()"), level = HIDDEN)
     public val globalCommands: Flow<GlobalApplicationCommand>
         get() = defaultSupplier.getGlobalApplicationCommands(resources.applicationId)
 
@@ -252,7 +248,7 @@ public class Kord(
      */
     public suspend fun getGuildOrNull(
         id: Snowflake,
-        strategy: EntitySupplyStrategy<*> = resources.defaultStrategy
+        strategy: EntitySupplyStrategy<*> = resources.defaultStrategy,
     ): Guild? = strategy.supply(this).getGuildOrNull(id)
 
     /**
@@ -261,9 +257,10 @@ public class Kord(
      * @throws RequestException if something went wrong while retrieving the guild.
      */
     @Deprecated(
-        "This function incorrectly returns a nullable and has been deprecated in favour of [getGuildOrNull]",
-        ReplaceWith("kord.getGuildOrNull()"),
-        WARNING
+        "This function has an inconsistent name for its nullable return type and has been deprecated in favour of " +
+                "'getGuildOrNull()'.",
+        ReplaceWith("this.getGuildOrNull(id, strategy)"),
+        level = WARNING,
     )
     public suspend fun getGuild(
         id: Snowflake,
@@ -273,14 +270,14 @@ public class Kord(
     /**
      * Requests the [Guild] with the given [id].
      *
-     * This will be renamed to `getGuild` once the deprecated function is removed
+     * This will be renamed to `getGuild` once the [deprecated function][getGuild] is removed.
      *
      * @throws RequestException if something went wrong while retrieving the guild.
      * @throws EntityNotFoundException if the guild is null.
      */
     public suspend fun getGuildOrThrow(
         id: Snowflake,
-        strategy: EntitySupplyStrategy<*> = resources.defaultStrategy
+        strategy: EntitySupplyStrategy<*> = resources.defaultStrategy,
     ): Guild = strategy.supply(this).getGuild(id)
 
     /**
@@ -463,7 +460,7 @@ public class Kord(
 
     public fun getGuildApplicationCommands(
         guildId: Snowflake,
-        withLocalizations: Boolean? = null
+        withLocalizations: Boolean? = null,
     ): Flow<GuildApplicationCommand> {
         return defaultSupplier.getGuildApplicationCommands(resources.applicationId, guildId, withLocalizations)
     }

--- a/core/src/main/kotlin/Kord.kt
+++ b/core/src/main/kotlin/Kord.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.flow.*
 import mu.KLogger
 import mu.KotlinLogging
 import kotlin.DeprecationLevel.HIDDEN
+import kotlin.DeprecationLevel.WARNING
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 import kotlin.coroutines.CoroutineContext
@@ -63,7 +64,11 @@ public class Kord(
      *
      * @suppress
      */
-    @Deprecated("Replace with function call for localizations", ReplaceWith("getGlobalApplicationCommands()"), level = HIDDEN)
+    @Deprecated(
+        "Replace with function call for localizations",
+        ReplaceWith("getGlobalApplicationCommands()"),
+        level = HIDDEN
+    )
     public val globalCommands: Flow<GlobalApplicationCommand>
         get() = defaultSupplier.getGlobalApplicationCommands(resources.applicationId)
 
@@ -247,16 +252,33 @@ public class Kord(
      */
     public suspend fun getGuildOrNull(
         id: Snowflake,
+        strategy: EntitySupplyStrategy<*> = resources.defaultStrategy
+    ): Guild? = strategy.supply(this).getGuildOrNull(id)
+
+    /**
+     * Requests the [Guild] with the given [id], returns `null` when the guild isn't present.
+     *
+     * @throws RequestException if something went wrong while retrieving the guild.
+     */
+    @Deprecated(
+        "This function incorrectly returns a nullable and has been deprecated in favour of [getGuildOrNull]",
+        ReplaceWith("getGuildOrNull"),
+        WARNING
+    )
+    public suspend fun getGuild(
+        id: Snowflake,
         strategy: EntitySupplyStrategy<*> = resources.defaultStrategy,
     ): Guild? = strategy.supply(this).getGuildOrNull(id)
 
     /**
      * Requests the [Guild] with the given [id].
      *
+     * This will be renamed to `getGuild` once the deprecated function is removed
+     *
      * @throws RequestException if something went wrong while retrieving the guild.
      * @throws EntityNotFoundException if the guild is null.
      */
-    public suspend fun getGuild(
+    public suspend fun getGuildOrThrow(
         id: Snowflake,
         strategy: EntitySupplyStrategy<*> = resources.defaultStrategy
     ): Guild = strategy.supply(this).getGuild(id)
@@ -372,7 +394,6 @@ public class Kord(
     public suspend fun getSticker(id: Snowflake): Sticker = defaultSupplier.getSticker(id)
 
 
-
     /**
      * Requests to edit the presence of the bot user configured by the [builder].
      * The new presence will be shown on all shards. Use [MasterGateway.gateways] or [Event.gateway] to
@@ -439,7 +460,11 @@ public class Kord(
     public fun getGlobalApplicationCommands(withLocalizations: Boolean? = null): Flow<GlobalApplicationCommand> {
         return defaultSupplier.getGlobalApplicationCommands(resources.applicationId, withLocalizations)
     }
-    public fun getGuildApplicationCommands(guildId: Snowflake, withLocalizations: Boolean? = null): Flow<GuildApplicationCommand> {
+
+    public fun getGuildApplicationCommands(
+        guildId: Snowflake,
+        withLocalizations: Boolean? = null
+    ): Flow<GuildApplicationCommand> {
         return defaultSupplier.getGuildApplicationCommands(resources.applicationId, guildId, withLocalizations)
     }
 

--- a/core/src/main/kotlin/Kord.kt
+++ b/core/src/main/kotlin/Kord.kt
@@ -226,8 +226,7 @@ public class Kord(
      */
     public suspend fun getChannel(
         id: Snowflake,
-        strategy: EntitySupplyStrategy<*> =
-            resources.defaultStrategy,
+        strategy: EntitySupplyStrategy<*> = resources.defaultStrategy,
     ): Channel? = strategy.supply(this).getChannelOrNull(id)
 
     /**
@@ -241,11 +240,26 @@ public class Kord(
         strategy: EntitySupplyStrategy<*> = resources.defaultStrategy,
     ): T? = strategy.supply(this).getChannelOfOrNull(id)
 
+    /**
+     * Requests the [Guild] with the given [id], returns `null` when the guild isn't present.
+     *
+     * @throws RequestException if something went wrong while retrieving the guild.
+     */
+    public suspend fun getGuildOrNull(
+        id: Snowflake,
+        strategy: EntitySupplyStrategy<*> = resources.defaultStrategy,
+    ): Guild? = strategy.supply(this).getGuildOrNull(id)
+
+    /**
+     * Requests the [Guild] with the given [id].
+     *
+     * @throws RequestException if something went wrong while retrieving the guild.
+     * @throws EntityNotFoundException if the guild is null.
+     */
     public suspend fun getGuild(
         id: Snowflake,
-        strategy: EntitySupplyStrategy<*> =
-            resources.defaultStrategy,
-    ): Guild? = strategy.supply(this).getGuildOrNull(id)
+        strategy: EntitySupplyStrategy<*> = resources.defaultStrategy
+    ): Guild = strategy.supply(this).getGuild(id)
 
     /**
      * Requests to get the [Webhook] in this guild.

--- a/core/src/main/kotlin/Kord.kt
+++ b/core/src/main/kotlin/Kord.kt
@@ -262,7 +262,7 @@ public class Kord(
      */
     @Deprecated(
         "This function incorrectly returns a nullable and has been deprecated in favour of [getGuildOrNull]",
-        ReplaceWith("getGuildOrNull"),
+        ReplaceWith("kord.getGuildOrNull()"),
         WARNING
     )
     public suspend fun getGuild(

--- a/core/src/test/kotlin/rest/RestTest.kt
+++ b/core/src/test/kotlin/rest/RestTest.kt
@@ -86,7 +86,7 @@ class RestServiceTest {
 
         guildId = guild.id
 
-        this@RestServiceTest.guild = kord.getGuild(guildId)!!
+        this@RestServiceTest.guild = kord.getGuildOrNull(guildId)!!
 
         guild.edit {
             name = "Edited Guild Test"
@@ -555,7 +555,7 @@ class RestServiceTest {
     fun `create role with image icon`(): Unit = runBlocking {
         if (!boostEnabled)
             return@runBlocking
-        val guild = kord.getGuild(publicGuildId)!!
+        val guild = kord.getGuildOrNull(publicGuildId)!!
         guild.createRole {
             name = "Test Image Icon"
             hoist = true
@@ -567,7 +567,7 @@ class RestServiceTest {
     fun `create role with unicode icon`(): Unit = runBlocking {
         if (!boostEnabled)
             return@runBlocking
-        val guild = kord.getGuild(publicGuildId)!!
+        val guild = kord.getGuildOrNull(publicGuildId)!!
         guild.createRole {
             name = "Test Unicode Icon"
             hoist = true

--- a/core/src/test/kotlin/rest/RestTest.kt
+++ b/core/src/test/kotlin/rest/RestTest.kt
@@ -86,7 +86,7 @@ class RestServiceTest {
 
         guildId = guild.id
 
-        this@RestServiceTest.guild = kord.getGuildOrNull(guildId)!!
+        this@RestServiceTest.guild = kord.getGuildOrThrow(guildId)
 
         guild.edit {
             name = "Edited Guild Test"
@@ -555,7 +555,7 @@ class RestServiceTest {
     fun `create role with image icon`(): Unit = runBlocking {
         if (!boostEnabled)
             return@runBlocking
-        val guild = kord.getGuildOrNull(publicGuildId)!!
+        val guild = kord.getGuildOrThrow(publicGuildId)
         guild.createRole {
             name = "Test Image Icon"
             hoist = true
@@ -567,7 +567,7 @@ class RestServiceTest {
     fun `create role with unicode icon`(): Unit = runBlocking {
         if (!boostEnabled)
             return@runBlocking
-        val guild = kord.getGuildOrNull(publicGuildId)!!
+        val guild = kord.getGuildOrThrow(publicGuildId)
         guild.createRole {
             name = "Test Unicode Icon"
             hoist = true


### PR DESCRIPTION
Previously there was just a `getGuild` function that called the nullable variant below the hood, but the non-nullable variant also exists.
 I've created the `getGuildOrNull` function to clearly show it function returns a null, and the `getGuild` function now calls the non-nullable function, and as such will throw `EntityNotFoundException` when called and the guild is null.

This  could be quite a breaking change for bots, as the `getGuild` function no longer returns null, it throws. This should be announced somewhere, or a release created to document.

I also KDoc'd these functions :)