### PR TITLE
Lightweight Snowflakes

### DIFF
--- a/common/api/common.api
+++ b/common/api/common.api
@@ -268,18 +268,18 @@ public final class dev/kord/common/entity/ActivityType$Watching : dev/kord/commo
 
 public final class dev/kord/common/entity/AllRemovedMessageReactions {
 	public static final field Companion Ldev/kord/common/entity/AllRemovedMessageReactions$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLdev/kord/common/entity/optional/OptionalSnowflake;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLdev/kord/common/entity/optional/OptionalSnowflake;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
+	public final fun component2-4_xYDEk ()J
 	public final fun component3 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;)Ldev/kord/common/entity/AllRemovedMessageReactions;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/AllRemovedMessageReactions;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;ILjava/lang/Object;)Ldev/kord/common/entity/AllRemovedMessageReactions;
+	public final fun copy-U2evHYk (JJLdev/kord/common/entity/optional/OptionalSnowflake;)Ldev/kord/common/entity/AllRemovedMessageReactions;
+	public static synthetic fun copy-U2evHYk$default (Ldev/kord/common/entity/AllRemovedMessageReactions;JJLdev/kord/common/entity/optional/OptionalSnowflake;ILjava/lang/Object;)Ldev/kord/common/entity/AllRemovedMessageReactions;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-4_xYDEk ()J
 	public final fun getGuildId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
-	public final fun getMessageId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getMessageId-4_xYDEk ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public static final fun write$Self (Ldev/kord/common/entity/AllRemovedMessageReactions;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
@@ -1325,7 +1325,7 @@ public abstract interface class dev/kord/common/entity/BaseDiscordApplication {
 	public abstract fun getFlags ()Ldev/kord/common/entity/optional/Optional;
 	public abstract fun getGuildId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public abstract fun getIcon ()Ljava/lang/String;
-	public abstract fun getId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getId-4_xYDEk ()J
 	public abstract fun getInstallParams ()Ldev/kord/common/entity/optional/Optional;
 	public abstract fun getName ()Ljava/lang/String;
 	public abstract fun getOwner ()Ldev/kord/common/entity/optional/Optional;
@@ -1354,16 +1354,16 @@ public abstract interface class dev/kord/common/entity/BaseDiscordInvite {
 
 public final class dev/kord/common/entity/BulkDeleteData {
 	public static final field Companion Ldev/kord/common/entity/BulkDeleteData$Companion;
-	public synthetic fun <init> (ILjava/util/List;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ljava/util/List;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;)V
-	public synthetic fun <init> (Ljava/util/List;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (ILjava/util/List;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/util/List;JLdev/kord/common/entity/optional/OptionalSnowflake;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/util/List;JLdev/kord/common/entity/optional/OptionalSnowflake;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/util/List;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component2-4_xYDEk ()J
 	public final fun component3 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
-	public final fun copy (Ljava/util/List;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;)Ldev/kord/common/entity/BulkDeleteData;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/BulkDeleteData;Ljava/util/List;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;ILjava/lang/Object;)Ldev/kord/common/entity/BulkDeleteData;
+	public final fun copy-o5qqygM (Ljava/util/List;JLdev/kord/common/entity/optional/OptionalSnowflake;)Ldev/kord/common/entity/BulkDeleteData;
+	public static synthetic fun copy-o5qqygM$default (Ldev/kord/common/entity/BulkDeleteData;Ljava/util/List;JLdev/kord/common/entity/optional/OptionalSnowflake;ILjava/lang/Object;)Ldev/kord/common/entity/BulkDeleteData;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-4_xYDEk ()J
 	public final fun getGuildId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun getIds ()Ljava/util/List;
 	public fun hashCode ()I
@@ -1568,19 +1568,19 @@ public abstract class dev/kord/common/entity/CommandArgument : dev/kord/common/e
 }
 
 public final class dev/kord/common/entity/CommandArgument$AttachmentArgument : dev/kord/common/entity/CommandArgument {
-	public fun <init> (Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;)V
-	public synthetic fun <init> (Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;JLdev/kord/common/entity/optional/OptionalBoolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;JLdev/kord/common/entity/optional/OptionalBoolean;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component2-4_xYDEk ()J
 	public final fun component3 ()Ldev/kord/common/entity/optional/OptionalBoolean;
-	public final fun copy (Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;)Ldev/kord/common/entity/CommandArgument$AttachmentArgument;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/CommandArgument$AttachmentArgument;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;ILjava/lang/Object;)Ldev/kord/common/entity/CommandArgument$AttachmentArgument;
+	public final fun copy-o5qqygM (Ljava/lang/String;JLdev/kord/common/entity/optional/OptionalBoolean;)Ldev/kord/common/entity/CommandArgument$AttachmentArgument;
+	public static synthetic fun copy-o5qqygM$default (Ldev/kord/common/entity/CommandArgument$AttachmentArgument;Ljava/lang/String;JLdev/kord/common/entity/optional/OptionalBoolean;ILjava/lang/Object;)Ldev/kord/common/entity/CommandArgument$AttachmentArgument;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getFocused ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public fun getName ()Ljava/lang/String;
 	public fun getType ()Ldev/kord/common/entity/ApplicationCommandOptionType;
-	public fun getValue ()Ldev/kord/common/entity/Snowflake;
 	public synthetic fun getValue ()Ljava/lang/Object;
+	public fun getValue-4_xYDEk ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -1622,19 +1622,19 @@ public final class dev/kord/common/entity/CommandArgument$BooleanArgument : dev/
 }
 
 public final class dev/kord/common/entity/CommandArgument$ChannelArgument : dev/kord/common/entity/CommandArgument {
-	public fun <init> (Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;)V
-	public synthetic fun <init> (Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;JLdev/kord/common/entity/optional/OptionalBoolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;JLdev/kord/common/entity/optional/OptionalBoolean;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component2-4_xYDEk ()J
 	public final fun component3 ()Ldev/kord/common/entity/optional/OptionalBoolean;
-	public final fun copy (Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;)Ldev/kord/common/entity/CommandArgument$ChannelArgument;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/CommandArgument$ChannelArgument;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;ILjava/lang/Object;)Ldev/kord/common/entity/CommandArgument$ChannelArgument;
+	public final fun copy-o5qqygM (Ljava/lang/String;JLdev/kord/common/entity/optional/OptionalBoolean;)Ldev/kord/common/entity/CommandArgument$ChannelArgument;
+	public static synthetic fun copy-o5qqygM$default (Ldev/kord/common/entity/CommandArgument$ChannelArgument;Ljava/lang/String;JLdev/kord/common/entity/optional/OptionalBoolean;ILjava/lang/Object;)Ldev/kord/common/entity/CommandArgument$ChannelArgument;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getFocused ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public fun getName ()Ljava/lang/String;
 	public fun getType ()Ldev/kord/common/entity/ApplicationCommandOptionType;
-	public fun getValue ()Ldev/kord/common/entity/Snowflake;
 	public synthetic fun getValue ()Ljava/lang/Object;
+	public fun getValue-4_xYDEk ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -1662,19 +1662,19 @@ public final class dev/kord/common/entity/CommandArgument$IntegerArgument : dev/
 }
 
 public final class dev/kord/common/entity/CommandArgument$MentionableArgument : dev/kord/common/entity/CommandArgument {
-	public fun <init> (Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;)V
-	public synthetic fun <init> (Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;JLdev/kord/common/entity/optional/OptionalBoolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;JLdev/kord/common/entity/optional/OptionalBoolean;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component2-4_xYDEk ()J
 	public final fun component3 ()Ldev/kord/common/entity/optional/OptionalBoolean;
-	public final fun copy (Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;)Ldev/kord/common/entity/CommandArgument$MentionableArgument;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/CommandArgument$MentionableArgument;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;ILjava/lang/Object;)Ldev/kord/common/entity/CommandArgument$MentionableArgument;
+	public final fun copy-o5qqygM (Ljava/lang/String;JLdev/kord/common/entity/optional/OptionalBoolean;)Ldev/kord/common/entity/CommandArgument$MentionableArgument;
+	public static synthetic fun copy-o5qqygM$default (Ldev/kord/common/entity/CommandArgument$MentionableArgument;Ljava/lang/String;JLdev/kord/common/entity/optional/OptionalBoolean;ILjava/lang/Object;)Ldev/kord/common/entity/CommandArgument$MentionableArgument;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getFocused ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public fun getName ()Ljava/lang/String;
 	public fun getType ()Ldev/kord/common/entity/ApplicationCommandOptionType;
-	public fun getValue ()Ldev/kord/common/entity/Snowflake;
 	public synthetic fun getValue ()Ljava/lang/Object;
+	public fun getValue-4_xYDEk ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -1698,19 +1698,19 @@ public final class dev/kord/common/entity/CommandArgument$NumberArgument : dev/k
 }
 
 public final class dev/kord/common/entity/CommandArgument$RoleArgument : dev/kord/common/entity/CommandArgument {
-	public fun <init> (Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;)V
-	public synthetic fun <init> (Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;JLdev/kord/common/entity/optional/OptionalBoolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;JLdev/kord/common/entity/optional/OptionalBoolean;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component2-4_xYDEk ()J
 	public final fun component3 ()Ldev/kord/common/entity/optional/OptionalBoolean;
-	public final fun copy (Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;)Ldev/kord/common/entity/CommandArgument$RoleArgument;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/CommandArgument$RoleArgument;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;ILjava/lang/Object;)Ldev/kord/common/entity/CommandArgument$RoleArgument;
+	public final fun copy-o5qqygM (Ljava/lang/String;JLdev/kord/common/entity/optional/OptionalBoolean;)Ldev/kord/common/entity/CommandArgument$RoleArgument;
+	public static synthetic fun copy-o5qqygM$default (Ldev/kord/common/entity/CommandArgument$RoleArgument;Ljava/lang/String;JLdev/kord/common/entity/optional/OptionalBoolean;ILjava/lang/Object;)Ldev/kord/common/entity/CommandArgument$RoleArgument;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getFocused ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public fun getName ()Ljava/lang/String;
 	public fun getType ()Ldev/kord/common/entity/ApplicationCommandOptionType;
-	public fun getValue ()Ldev/kord/common/entity/Snowflake;
 	public synthetic fun getValue ()Ljava/lang/Object;
+	public fun getValue-4_xYDEk ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -1734,19 +1734,19 @@ public final class dev/kord/common/entity/CommandArgument$StringArgument : dev/k
 }
 
 public final class dev/kord/common/entity/CommandArgument$UserArgument : dev/kord/common/entity/CommandArgument {
-	public fun <init> (Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;)V
-	public synthetic fun <init> (Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;JLdev/kord/common/entity/optional/OptionalBoolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;JLdev/kord/common/entity/optional/OptionalBoolean;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component2-4_xYDEk ()J
 	public final fun component3 ()Ldev/kord/common/entity/optional/OptionalBoolean;
-	public final fun copy (Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;)Ldev/kord/common/entity/CommandArgument$UserArgument;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/CommandArgument$UserArgument;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;ILjava/lang/Object;)Ldev/kord/common/entity/CommandArgument$UserArgument;
+	public final fun copy-o5qqygM (Ljava/lang/String;JLdev/kord/common/entity/optional/OptionalBoolean;)Ldev/kord/common/entity/CommandArgument$UserArgument;
+	public static synthetic fun copy-o5qqygM$default (Ldev/kord/common/entity/CommandArgument$UserArgument;Ljava/lang/String;JLdev/kord/common/entity/optional/OptionalBoolean;ILjava/lang/Object;)Ldev/kord/common/entity/CommandArgument$UserArgument;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getFocused ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public fun getName ()Ljava/lang/String;
 	public fun getType ()Ldev/kord/common/entity/ApplicationCommandOptionType;
-	public fun getValue ()Ldev/kord/common/entity/Snowflake;
 	public synthetic fun getValue ()Ljava/lang/Object;
+	public fun getValue-4_xYDEk ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -1839,18 +1839,18 @@ public final class dev/kord/common/entity/DefaultMessageNotificationLevel$Unknow
 
 public final class dev/kord/common/entity/DeletedMessage {
 	public static final field Companion Ldev/kord/common/entity/DeletedMessage$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLdev/kord/common/entity/optional/OptionalSnowflake;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLdev/kord/common/entity/optional/OptionalSnowflake;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
+	public final fun component2-4_xYDEk ()J
 	public final fun component3 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;)Ldev/kord/common/entity/DeletedMessage;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DeletedMessage;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;ILjava/lang/Object;)Ldev/kord/common/entity/DeletedMessage;
+	public final fun copy-U2evHYk (JJLdev/kord/common/entity/optional/OptionalSnowflake;)Ldev/kord/common/entity/DeletedMessage;
+	public static synthetic fun copy-U2evHYk$default (Ldev/kord/common/entity/DeletedMessage;JJLdev/kord/common/entity/optional/OptionalSnowflake;ILjava/lang/Object;)Ldev/kord/common/entity/DeletedMessage;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-4_xYDEk ()J
 	public final fun getGuildId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public static final fun write$Self (Ldev/kord/common/entity/DeletedMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
@@ -2128,9 +2128,9 @@ public final class dev/kord/common/entity/DiscordActivityTimestamps$Companion {
 
 public final class dev/kord/common/entity/DiscordAddedGuildMember {
 	public static final field Companion Ldev/kord/common/entity/DiscordAddedGuildMember$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;ZZLdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;ZZLdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;ZZLdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (ILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;ZZLdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;ZZJLdev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;ZZJLdev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component10 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component11 ()Ldev/kord/common/entity/optional/Optional;
@@ -2140,15 +2140,15 @@ public final class dev/kord/common/entity/DiscordAddedGuildMember {
 	public final fun component5 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component6 ()Z
 	public final fun component7 ()Z
-	public final fun component8 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component8-4_xYDEk ()J
 	public final fun component9 ()Ldev/kord/common/entity/optional/OptionalBoolean;
-	public final fun copy (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;ZZLdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/common/entity/DiscordAddedGuildMember;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordAddedGuildMember;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;ZZLdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordAddedGuildMember;
+	public final fun copy-KKqX4sc (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;ZZJLdev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/common/entity/DiscordAddedGuildMember;
+	public static synthetic fun copy-KKqX4sc$default (Ldev/kord/common/entity/DiscordAddedGuildMember;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;ZZJLdev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordAddedGuildMember;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAvatar ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getCommunicationDisabledUntil ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getDeaf ()Z
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public final fun getJoinedAt ()Lkotlinx/datetime/Instant;
 	public final fun getMute ()Z
 	public final fun getNick ()Ldev/kord/common/entity/optional/Optional;
@@ -2179,10 +2179,10 @@ public final class dev/kord/common/entity/DiscordAddedGuildMember$Companion {
 
 public final class dev/kord/common/entity/DiscordApplication : dev/kord/common/entity/BaseDiscordApplication {
 	public static final field Companion Ldev/kord/common/entity/DiscordApplication$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;ZZLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/DiscordTeam;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;ZZLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/DiscordTeam;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;ZZLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/DiscordTeam;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;ZZLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/DiscordTeam;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;ZZLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/DiscordTeam;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;ZZLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/DiscordTeam;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component10 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component11 ()Ljava/lang/String;
 	public final fun component12 ()Ldev/kord/common/entity/DiscordTeam;
@@ -2202,8 +2202,8 @@ public final class dev/kord/common/entity/DiscordApplication : dev/kord/common/e
 	public final fun component7 ()Z
 	public final fun component8 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component9 ()Ldev/kord/common/entity/optional/Optional;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;ZZLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/DiscordTeam;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/common/entity/DiscordApplication;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordApplication;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;ZZLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/DiscordTeam;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordApplication;
+	public final fun copy-yW0FbQg (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;ZZLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/DiscordTeam;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/common/entity/DiscordApplication;
+	public static synthetic fun copy-yW0FbQg$default (Ldev/kord/common/entity/DiscordApplication;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;ZZLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/DiscordTeam;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordApplication;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBotPublic ()Z
 	public final fun getBotRequireCodeGrant ()Z
@@ -2213,7 +2213,7 @@ public final class dev/kord/common/entity/DiscordApplication : dev/kord/common/e
 	public fun getFlags ()Ldev/kord/common/entity/optional/Optional;
 	public fun getGuildId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public fun getIcon ()Ljava/lang/String;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public fun getInstallParams ()Ldev/kord/common/entity/optional/Optional;
 	public fun getName ()Ljava/lang/String;
 	public fun getOwner ()Ldev/kord/common/entity/optional/Optional;
@@ -2248,38 +2248,38 @@ public final class dev/kord/common/entity/DiscordApplication$Companion {
 
 public final class dev/kord/common/entity/DiscordApplicationCommand {
 	public static final field Companion Ldev/kord/common/entity/DiscordApplicationCommand$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Permissions;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Permissions;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/Snowflake;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Permissions;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/Snowflake;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Permissions;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/optional/Optional;JLjava/lang/String;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Permissions;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/optional/Optional;JLjava/lang/String;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Permissions;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;JLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component10 ()Ldev/kord/common/entity/Permissions;
 	public final fun component11 ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun component12 ()Ldev/kord/common/entity/optional/OptionalBoolean;
-	public final fun component13 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component13-4_xYDEk ()J
 	public final fun component2 ()Ldev/kord/common/entity/optional/Optional;
-	public final fun component3 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component3-4_xYDEk ()J
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component6 ()Ljava/lang/String;
 	public final fun component7 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component8 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun component9 ()Ldev/kord/common/entity/optional/Optional;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Permissions;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/Snowflake;)Ldev/kord/common/entity/DiscordApplicationCommand;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordApplicationCommand;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Permissions;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/Snowflake;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordApplicationCommand;
+	public final fun copy-1Ok5F2I (JLdev/kord/common/entity/optional/Optional;JLjava/lang/String;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Permissions;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;J)Ldev/kord/common/entity/DiscordApplicationCommand;
+	public static synthetic fun copy-1Ok5F2I$default (Ldev/kord/common/entity/DiscordApplicationCommand;JLdev/kord/common/entity/optional/Optional;JLjava/lang/String;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Permissions;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;JILjava/lang/Object;)Ldev/kord/common/entity/DiscordApplicationCommand;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getApplicationId-4_xYDEk ()J
 	public final fun getDefaultMemberPermissions ()Ldev/kord/common/entity/Permissions;
 	public final fun getDefaultPermission ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun getDescription ()Ljava/lang/String;
 	public final fun getDescriptionLocalizations ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getDmPermission ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun getGuildId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getName ()Ljava/lang/String;
 	public final fun getNameLocalizations ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getOptions ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getType ()Ldev/kord/common/entity/optional/Optional;
-	public final fun getVersion ()Ldev/kord/common/entity/Snowflake;
+	public final fun getVersion-4_xYDEk ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public static final fun write$Self (Ldev/kord/common/entity/DiscordApplicationCommand;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
@@ -2311,10 +2311,10 @@ public final class dev/kord/common/entity/DiscordApplicationKt {
 
 public final class dev/kord/common/entity/DiscordAttachment {
 	public static final field Companion Ldev/kord/common/entity/DiscordAttachment$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component10 ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ldev/kord/common/entity/optional/Optional;
@@ -2324,15 +2324,15 @@ public final class dev/kord/common/entity/DiscordAttachment {
 	public final fun component7 ()Ljava/lang/String;
 	public final fun component8 ()Ldev/kord/common/entity/optional/OptionalInt;
 	public final fun component9 ()Ldev/kord/common/entity/optional/OptionalInt;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;)Ldev/kord/common/entity/DiscordAttachment;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordAttachment;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordAttachment;
+	public final fun copy-1Wgd_o8 (JLjava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;)Ldev/kord/common/entity/DiscordAttachment;
+	public static synthetic fun copy-1Wgd_o8$default (Ldev/kord/common/entity/DiscordAttachment;JLjava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordAttachment;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getContentType ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getDescription ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getEphemeral ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun getFilename ()Ljava/lang/String;
 	public final fun getHeight ()Ldev/kord/common/entity/optional/OptionalInt;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getProxyUrl ()Ljava/lang/String;
 	public final fun getSize ()I
 	public final fun getUrl ()Ljava/lang/String;
@@ -2402,27 +2402,27 @@ public final class dev/kord/common/entity/DiscordAuditLog$Companion {
 
 public final class dev/kord/common/entity/DiscordAuditLogEntry {
 	public static final field Companion Ldev/kord/common/entity/DiscordAuditLogEntry$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/AuditLogEvent;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/AuditLogEvent;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/AuditLogEvent;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/AuditLogEvent;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;JJLdev/kord/common/entity/AuditLogEvent;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;JJLdev/kord/common/entity/AuditLogEvent;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun component2 ()Ldev/kord/common/entity/optional/Optional;
-	public final fun component3 ()Ldev/kord/common/entity/Snowflake;
-	public final fun component4 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component3-4_xYDEk ()J
+	public final fun component4-4_xYDEk ()J
 	public final fun component5 ()Ldev/kord/common/entity/AuditLogEvent;
 	public final fun component6 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component7 ()Ldev/kord/common/entity/optional/Optional;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/AuditLogEvent;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/common/entity/DiscordAuditLogEntry;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordAuditLogEntry;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/AuditLogEvent;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordAuditLogEntry;
+	public final fun copy-4bGTf6E (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;JJLdev/kord/common/entity/AuditLogEvent;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/common/entity/DiscordAuditLogEntry;
+	public static synthetic fun copy-4bGTf6E$default (Ldev/kord/common/entity/DiscordAuditLogEntry;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;JJLdev/kord/common/entity/AuditLogEvent;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordAuditLogEntry;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun get (Ldev/kord/common/entity/AuditLogChangeKey;)Ldev/kord/common/entity/AuditLogChange;
 	public final fun getActionType ()Ldev/kord/common/entity/AuditLogEvent;
 	public final fun getChanges ()Ldev/kord/common/entity/optional/Optional;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getOptions ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getReason ()Ldev/kord/common/entity/optional/Optional;
-	public final fun getTargetId ()Ldev/kord/common/entity/Snowflake;
-	public final fun getUserId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getTargetId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
+	public final fun getUserId-4_xYDEk ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public static final fun write$Self (Ldev/kord/common/entity/DiscordAuditLogEntry;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
@@ -2588,30 +2588,30 @@ public final class dev/kord/common/entity/DiscordAutoModerationActionMetadata$Co
 
 public final class dev/kord/common/entity/DiscordAutoModerationRule {
 	public static final field Companion Ldev/kord/common/entity/DiscordAutoModerationRule$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/AutoModerationRuleEventType;Ldev/kord/common/entity/AutoModerationRuleTriggerType;Ldev/kord/common/entity/DiscordAutoModerationRuleTriggerMetadata;Ljava/util/List;ZLjava/util/List;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/AutoModerationRuleEventType;Ldev/kord/common/entity/AutoModerationRuleTriggerType;Ldev/kord/common/entity/DiscordAutoModerationRuleTriggerMetadata;Ljava/util/List;ZLjava/util/List;Ljava/util/List;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/AutoModerationRuleEventType;Ldev/kord/common/entity/AutoModerationRuleTriggerType;Ldev/kord/common/entity/DiscordAutoModerationRuleTriggerMetadata;Ljava/util/List;ZLjava/util/List;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLjava/lang/String;JLdev/kord/common/entity/AutoModerationRuleEventType;Ldev/kord/common/entity/AutoModerationRuleTriggerType;Ldev/kord/common/entity/DiscordAutoModerationRuleTriggerMetadata;Ljava/util/List;ZLjava/util/List;Ljava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component10 ()Ljava/util/List;
 	public final fun component11 ()Ljava/util/List;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component2-4_xYDEk ()J
 	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component4-4_xYDEk ()J
 	public final fun component5 ()Ldev/kord/common/entity/AutoModerationRuleEventType;
 	public final fun component6 ()Ldev/kord/common/entity/AutoModerationRuleTriggerType;
 	public final fun component7 ()Ldev/kord/common/entity/DiscordAutoModerationRuleTriggerMetadata;
 	public final fun component8 ()Ljava/util/List;
 	public final fun component9 ()Z
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/AutoModerationRuleEventType;Ldev/kord/common/entity/AutoModerationRuleTriggerType;Ldev/kord/common/entity/DiscordAutoModerationRuleTriggerMetadata;Ljava/util/List;ZLjava/util/List;Ljava/util/List;)Ldev/kord/common/entity/DiscordAutoModerationRule;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordAutoModerationRule;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/AutoModerationRuleEventType;Ldev/kord/common/entity/AutoModerationRuleTriggerType;Ldev/kord/common/entity/DiscordAutoModerationRuleTriggerMetadata;Ljava/util/List;ZLjava/util/List;Ljava/util/List;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordAutoModerationRule;
+	public final fun copy-gQPKoLI (JJLjava/lang/String;JLdev/kord/common/entity/AutoModerationRuleEventType;Ldev/kord/common/entity/AutoModerationRuleTriggerType;Ldev/kord/common/entity/DiscordAutoModerationRuleTriggerMetadata;Ljava/util/List;ZLjava/util/List;Ljava/util/List;)Ldev/kord/common/entity/DiscordAutoModerationRule;
+	public static synthetic fun copy-gQPKoLI$default (Ldev/kord/common/entity/DiscordAutoModerationRule;JJLjava/lang/String;JLdev/kord/common/entity/AutoModerationRuleEventType;Ldev/kord/common/entity/AutoModerationRuleTriggerType;Ldev/kord/common/entity/DiscordAutoModerationRuleTriggerMetadata;Ljava/util/List;ZLjava/util/List;Ljava/util/List;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordAutoModerationRule;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getActions ()Ljava/util/List;
-	public final fun getCreatorId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getCreatorId-4_xYDEk ()J
 	public final fun getEnabled ()Z
 	public final fun getEventType ()Ldev/kord/common/entity/AutoModerationRuleEventType;
 	public final fun getExemptChannels ()Ljava/util/List;
 	public final fun getExemptRoles ()Ljava/util/List;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
+	public final fun getId-4_xYDEk ()J
 	public final fun getName ()Ljava/lang/String;
 	public final fun getTriggerMetadata ()Ldev/kord/common/entity/DiscordAutoModerationRuleTriggerMetadata;
 	public final fun getTriggerType ()Ldev/kord/common/entity/AutoModerationRuleTriggerType;
@@ -2713,10 +2713,10 @@ public final class dev/kord/common/entity/DiscordBotActivity$Companion {
 
 public final class dev/kord/common/entity/DiscordChannel {
 	public static final field Companion Ldev/kord/common/entity/DiscordChannel$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/ChannelType;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/ChannelType;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/ChannelType;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/ChannelType;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/ChannelType;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/ChannelType;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component10 ()Ldev/kord/common/entity/optional/OptionalInt;
 	public final fun component11 ()Ldev/kord/common/entity/optional/OptionalInt;
 	public final fun component12 ()Ldev/kord/common/entity/optional/Optional;
@@ -2742,15 +2742,15 @@ public final class dev/kord/common/entity/DiscordChannel {
 	public final fun component7 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component8 ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun component9 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/ChannelType;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/common/entity/DiscordChannel;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordChannel;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/ChannelType;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordChannel;
+	public final fun copy-Mi66umk (JLdev/kord/common/entity/ChannelType;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/common/entity/DiscordChannel;
+	public static synthetic fun copy-Mi66umk$default (Ldev/kord/common/entity/DiscordChannel;JLdev/kord/common/entity/ChannelType;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordChannel;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getApplicationId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun getBitrate ()Ldev/kord/common/entity/optional/OptionalInt;
 	public final fun getDefaultAutoArchiveDuration ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getGuildId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun getIcon ()Ldev/kord/common/entity/optional/Optional;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getLastMessageId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun getLastPinTimestamp ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getMember ()Ldev/kord/common/entity/optional/Optional;
@@ -2987,15 +2987,15 @@ public final class dev/kord/common/entity/DiscordConnectionVisibility$Unknown : 
 
 public final class dev/kord/common/entity/DiscordDeletedGuildRole {
 	public static final field Companion Ldev/kord/common/entity/DiscordDeletedGuildRole$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)Ldev/kord/common/entity/DiscordDeletedGuildRole;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordDeletedGuildRole;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordDeletedGuildRole;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
+	public final fun component2-4_xYDEk ()J
+	public final fun copy-Xcgsvs4 (JJ)Ldev/kord/common/entity/DiscordDeletedGuildRole;
+	public static synthetic fun copy-Xcgsvs4$default (Ldev/kord/common/entity/DiscordDeletedGuildRole;JJILjava/lang/Object;)Ldev/kord/common/entity/DiscordDeletedGuildRole;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
+	public final fun getId-4_xYDEk ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public static final fun write$Self (Ldev/kord/common/entity/DiscordDeletedGuildRole;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
@@ -3329,10 +3329,10 @@ public final class dev/kord/common/entity/DiscordEmbed$Video$Companion {
 
 public final class dev/kord/common/entity/DiscordEmoji {
 	public static final field Companion Ldev/kord/common/entity/DiscordEmoji$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;)V
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component4 ()Ldev/kord/common/entity/optional/Optional;
@@ -3340,12 +3340,12 @@ public final class dev/kord/common/entity/DiscordEmoji {
 	public final fun component6 ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun component7 ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun component8 ()Ldev/kord/common/entity/optional/OptionalBoolean;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;)Ldev/kord/common/entity/DiscordEmoji;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordEmoji;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordEmoji;
+	public final fun copy-kxNvhl8 (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;)Ldev/kord/common/entity/DiscordEmoji;
+	public static synthetic fun copy-kxNvhl8$default (Ldev/kord/common/entity/DiscordEmoji;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordEmoji;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAnimated ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun getAvailable ()Ldev/kord/common/entity/optional/OptionalBoolean;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getManaged ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getRequireColons ()Ldev/kord/common/entity/optional/OptionalBoolean;
@@ -3375,11 +3375,11 @@ public final class dev/kord/common/entity/DiscordEmoji$Companion {
 public final class dev/kord/common/entity/DiscordGuild {
 	public static final field Companion Ldev/kord/common/entity/DiscordGuild$Companion;
 	public synthetic fun <init> (IILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlin/time/Duration;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/VerificationLevel;Ldev/kord/common/entity/DefaultMessageNotificationLevel;Ldev/kord/common/entity/ExplicitContentFilter;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ldev/kord/common/entity/MFALevel;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/SystemChannelFlags;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/PremiumTier;Ldev/kord/common/entity/optional/OptionalInt;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/NsfwLevel;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZLkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;JLdev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/VerificationLevel;Ldev/kord/common/entity/DefaultMessageNotificationLevel;Ldev/kord/common/entity/ExplicitContentFilter;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ldev/kord/common/entity/MFALevel;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/SystemChannelFlags;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/PremiumTier;Ldev/kord/common/entity/optional/OptionalInt;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/NsfwLevel;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZIILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;JLdev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/VerificationLevel;Ldev/kord/common/entity/DefaultMessageNotificationLevel;Ldev/kord/common/entity/ExplicitContentFilter;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ldev/kord/common/entity/MFALevel;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/SystemChannelFlags;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/PremiumTier;Ldev/kord/common/entity/optional/OptionalInt;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/NsfwLevel;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;JLdev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;JLdev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/VerificationLevel;Ldev/kord/common/entity/DefaultMessageNotificationLevel;Ldev/kord/common/entity/ExplicitContentFilter;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ldev/kord/common/entity/MFALevel;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/SystemChannelFlags;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/PremiumTier;Ldev/kord/common/entity/optional/OptionalInt;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/NsfwLevel;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;JLdev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;JLdev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/VerificationLevel;Ldev/kord/common/entity/DefaultMessageNotificationLevel;Ldev/kord/common/entity/ExplicitContentFilter;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ldev/kord/common/entity/MFALevel;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/SystemChannelFlags;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/PremiumTier;Ldev/kord/common/entity/optional/OptionalInt;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/NsfwLevel;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component10 ()Ljava/lang/String;
-	public final fun component11 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component11-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun component12-UwyO8pc ()J
 	public final fun component13 ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun component14 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
@@ -3391,10 +3391,10 @@ public final class dev/kord/common/entity/DiscordGuild {
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component20 ()Ljava/util/List;
 	public final fun component21 ()Ldev/kord/common/entity/MFALevel;
-	public final fun component22 ()Ldev/kord/common/entity/Snowflake;
-	public final fun component23 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component22-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
+	public final fun component23-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun component24 ()Ldev/kord/common/entity/SystemChannelFlags;
-	public final fun component25 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component25-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun component26 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component27 ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun component28 ()Ldev/kord/common/entity/optional/OptionalBoolean;
@@ -3414,7 +3414,7 @@ public final class dev/kord/common/entity/DiscordGuild {
 	public final fun component40 ()Ldev/kord/common/entity/PremiumTier;
 	public final fun component41 ()Ldev/kord/common/entity/optional/OptionalInt;
 	public final fun component42 ()Ljava/lang/String;
-	public final fun component43 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component43-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun component44 ()Ldev/kord/common/entity/optional/OptionalInt;
 	public final fun component45 ()Ldev/kord/common/entity/optional/OptionalInt;
 	public final fun component46 ()Ldev/kord/common/entity/optional/OptionalInt;
@@ -3427,14 +3427,14 @@ public final class dev/kord/common/entity/DiscordGuild {
 	public final fun component52 ()Z
 	public final fun component6 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component7 ()Ldev/kord/common/entity/optional/OptionalBoolean;
-	public final fun component8 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component8-4_xYDEk ()J
 	public final fun component9 ()Ldev/kord/common/entity/optional/Optional;
-	public final fun copy-hB4F934 (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;JLdev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/VerificationLevel;Ldev/kord/common/entity/DefaultMessageNotificationLevel;Ldev/kord/common/entity/ExplicitContentFilter;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ldev/kord/common/entity/MFALevel;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/SystemChannelFlags;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/PremiumTier;Ldev/kord/common/entity/optional/OptionalInt;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/NsfwLevel;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Z)Ldev/kord/common/entity/DiscordGuild;
-	public static synthetic fun copy-hB4F934$default (Ldev/kord/common/entity/DiscordGuild;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;JLdev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/VerificationLevel;Ldev/kord/common/entity/DefaultMessageNotificationLevel;Ldev/kord/common/entity/ExplicitContentFilter;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ldev/kord/common/entity/MFALevel;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/SystemChannelFlags;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/PremiumTier;Ldev/kord/common/entity/optional/OptionalInt;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/NsfwLevel;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZIILjava/lang/Object;)Ldev/kord/common/entity/DiscordGuild;
+	public final fun copy-RrYEjxo (JLjava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;JLdev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;JLdev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/VerificationLevel;Ldev/kord/common/entity/DefaultMessageNotificationLevel;Ldev/kord/common/entity/ExplicitContentFilter;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ldev/kord/common/entity/MFALevel;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/SystemChannelFlags;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/PremiumTier;Ldev/kord/common/entity/optional/OptionalInt;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/NsfwLevel;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Z)Ldev/kord/common/entity/DiscordGuild;
+	public static synthetic fun copy-RrYEjxo$default (Ldev/kord/common/entity/DiscordGuild;JLjava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;JLdev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;JLdev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/VerificationLevel;Ldev/kord/common/entity/DefaultMessageNotificationLevel;Ldev/kord/common/entity/ExplicitContentFilter;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ldev/kord/common/entity/MFALevel;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/SystemChannelFlags;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/PremiumTier;Ldev/kord/common/entity/optional/OptionalInt;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/NsfwLevel;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZIILjava/lang/Object;)Ldev/kord/common/entity/DiscordGuild;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getAfkChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getAfkChannelId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getAfkTimeout-UwyO8pc ()J
-	public final fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getApplicationId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getApproximateMemberCount ()Ldev/kord/common/entity/optional/OptionalInt;
 	public final fun getApproximatePresenceCount ()Ldev/kord/common/entity/optional/OptionalInt;
 	public final fun getBanner ()Ljava/lang/String;
@@ -3448,7 +3448,7 @@ public final class dev/kord/common/entity/DiscordGuild {
 	public final fun getGuildScheduledEvents ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getIcon ()Ljava/lang/String;
 	public final fun getIconHash ()Ldev/kord/common/entity/optional/Optional;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getJoinedAt ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getLarge ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun getMaxMembers ()Ldev/kord/common/entity/optional/OptionalInt;
@@ -3460,22 +3460,22 @@ public final class dev/kord/common/entity/DiscordGuild {
 	public final fun getName ()Ljava/lang/String;
 	public final fun getNsfwLevel ()Ldev/kord/common/entity/NsfwLevel;
 	public final fun getOwner ()Ldev/kord/common/entity/optional/OptionalBoolean;
-	public final fun getOwnerId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getOwnerId-4_xYDEk ()J
 	public final fun getPermissions ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getPreferredLocale ()Ljava/lang/String;
 	public final fun getPremiumProgressBarEnabled ()Z
 	public final fun getPremiumSubscriptionCount ()Ldev/kord/common/entity/optional/OptionalInt;
 	public final fun getPremiumTier ()Ldev/kord/common/entity/PremiumTier;
 	public final fun getPresences ()Ldev/kord/common/entity/optional/Optional;
-	public final fun getPublicUpdatesChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getPublicUpdatesChannelId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getRegion ()Ljava/lang/String;
 	public final fun getRoles ()Ljava/util/List;
-	public final fun getRulesChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getRulesChannelId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getSplash ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getStageInstances ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getStickers ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getSystemChannelFlags ()Ldev/kord/common/entity/SystemChannelFlags;
-	public final fun getSystemChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getSystemChannelId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getThreads ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getUnavailable ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun getVanityUrlCode ()Ljava/lang/String;
@@ -3507,19 +3507,19 @@ public final class dev/kord/common/entity/DiscordGuild$Companion {
 
 public final class dev/kord/common/entity/DiscordGuildApplicationCommandPermission {
 	public static final field Companion Ldev/kord/common/entity/DiscordGuildApplicationCommandPermission$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/ApplicationCommandPermissionType;ZLkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/ApplicationCommandPermissionType;Z)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordGuildApplicationCommandPermission$Type;Z)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/ApplicationCommandPermissionType;ZLkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/ApplicationCommandPermissionType;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/DiscordGuildApplicationCommandPermission$Type;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component2 ()Ldev/kord/common/entity/ApplicationCommandPermissionType;
 	public final synthetic fun component2 ()Ldev/kord/common/entity/DiscordGuildApplicationCommandPermission$Type;
 	public final fun component3 ()Z
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/ApplicationCommandPermissionType;Z)Ldev/kord/common/entity/DiscordGuildApplicationCommandPermission;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordGuildApplicationCommandPermission$Type;Z)Ldev/kord/common/entity/DiscordGuildApplicationCommandPermission;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordGuildApplicationCommandPermission;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/ApplicationCommandPermissionType;ZILjava/lang/Object;)Ldev/kord/common/entity/DiscordGuildApplicationCommandPermission;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordGuildApplicationCommandPermission;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordGuildApplicationCommandPermission$Type;ZILjava/lang/Object;)Ldev/kord/common/entity/DiscordGuildApplicationCommandPermission;
+	public final fun copy-9y3P_48 (JLdev/kord/common/entity/ApplicationCommandPermissionType;Z)Ldev/kord/common/entity/DiscordGuildApplicationCommandPermission;
+	public final fun copy-9y3P_48 (JLdev/kord/common/entity/DiscordGuildApplicationCommandPermission$Type;Z)Ldev/kord/common/entity/DiscordGuildApplicationCommandPermission;
+	public static synthetic fun copy-9y3P_48$default (Ldev/kord/common/entity/DiscordGuildApplicationCommandPermission;JLdev/kord/common/entity/ApplicationCommandPermissionType;ZILjava/lang/Object;)Ldev/kord/common/entity/DiscordGuildApplicationCommandPermission;
+	public static synthetic fun copy-9y3P_48$default (Ldev/kord/common/entity/DiscordGuildApplicationCommandPermission;JLdev/kord/common/entity/DiscordGuildApplicationCommandPermission$Type;ZILjava/lang/Object;)Ldev/kord/common/entity/DiscordGuildApplicationCommandPermission;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getPermission ()Z
 	public final fun getType ()Ldev/kord/common/entity/ApplicationCommandPermissionType;
 	public final synthetic fun getType ()Ldev/kord/common/entity/DiscordGuildApplicationCommandPermission$Type;
@@ -3581,18 +3581,18 @@ public final class dev/kord/common/entity/DiscordGuildApplicationCommandPermissi
 
 public final class dev/kord/common/entity/DiscordGuildApplicationCommandPermissions {
 	public static final field Companion Ldev/kord/common/entity/DiscordGuildApplicationCommandPermissions$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/util/List;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
-	public final fun component3 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJJLjava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
+	public final fun component2-4_xYDEk ()J
+	public final fun component3-4_xYDEk ()J
 	public final fun component4 ()Ljava/util/List;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/util/List;)Ldev/kord/common/entity/DiscordGuildApplicationCommandPermissions;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordGuildApplicationCommandPermissions;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/util/List;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordGuildApplicationCommandPermissions;
+	public final fun copy-SmFlTYk (JJJLjava/util/List;)Ldev/kord/common/entity/DiscordGuildApplicationCommandPermissions;
+	public static synthetic fun copy-SmFlTYk$default (Ldev/kord/common/entity/DiscordGuildApplicationCommandPermissions;JJJLjava/util/List;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordGuildApplicationCommandPermissions;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getApplicationId-4_xYDEk ()J
+	public final fun getGuildId-4_xYDEk ()J
+	public final fun getId-4_xYDEk ()J
 	public final fun getPermissions ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -3617,14 +3617,14 @@ public final class dev/kord/common/entity/DiscordGuildApplicationCommandPermissi
 
 public final class dev/kord/common/entity/DiscordGuildBan {
 	public static final field Companion Ldev/kord/common/entity/DiscordGuildBan$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordUser;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordUser;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordUser;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/DiscordUser;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component2 ()Ldev/kord/common/entity/DiscordUser;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordUser;)Ldev/kord/common/entity/DiscordGuildBan;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordGuildBan;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordUser;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordGuildBan;
+	public final fun copy-wYKCHeA (JLdev/kord/common/entity/DiscordUser;)Ldev/kord/common/entity/DiscordGuildBan;
+	public static synthetic fun copy-wYKCHeA$default (Ldev/kord/common/entity/DiscordGuildBan;JLdev/kord/common/entity/DiscordUser;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordGuildBan;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public final fun getUser ()Ldev/kord/common/entity/DiscordUser;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -3649,13 +3649,13 @@ public final class dev/kord/common/entity/DiscordGuildBan$Companion {
 
 public final class dev/kord/common/entity/DiscordGuildIntegrations {
 	public static final field Companion Ldev/kord/common/entity/DiscordGuildIntegrations$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;)Ldev/kord/common/entity/DiscordGuildIntegrations;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordGuildIntegrations;Ldev/kord/common/entity/Snowflake;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordGuildIntegrations;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
+	public final fun copy-IO-hELI (J)Ldev/kord/common/entity/DiscordGuildIntegrations;
+	public static synthetic fun copy-IO-hELI$default (Ldev/kord/common/entity/DiscordGuildIntegrations;JILjava/lang/Object;)Ldev/kord/common/entity/DiscordGuildIntegrations;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public static final fun write$Self (Ldev/kord/common/entity/DiscordGuildIntegrations;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
@@ -3728,9 +3728,9 @@ public final class dev/kord/common/entity/DiscordGuildMember$Companion {
 
 public final class dev/kord/common/entity/DiscordGuildPreview {
 	public static final field Companion Ldev/kord/common/entity/DiscordGuildPreview$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;IILjava/lang/String;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;IILjava/lang/String;Ljava/util/List;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;IILjava/lang/String;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;IILjava/lang/String;Ljava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component10 ()Ljava/lang/String;
 	public final fun component11 ()Ljava/util/List;
 	public final fun component2 ()Ljava/lang/String;
@@ -3741,8 +3741,8 @@ public final class dev/kord/common/entity/DiscordGuildPreview {
 	public final fun component7 ()Ljava/util/List;
 	public final fun component8 ()I
 	public final fun component9 ()I
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;IILjava/lang/String;Ljava/util/List;)Ldev/kord/common/entity/DiscordGuildPreview;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordGuildPreview;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;IILjava/lang/String;Ljava/util/List;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordGuildPreview;
+	public final fun copy-7oSUoPo (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;IILjava/lang/String;Ljava/util/List;)Ldev/kord/common/entity/DiscordGuildPreview;
+	public static synthetic fun copy-7oSUoPo$default (Ldev/kord/common/entity/DiscordGuildPreview;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;IILjava/lang/String;Ljava/util/List;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordGuildPreview;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getApproximateMemberCount ()I
 	public final fun getApproximatePresenceCount ()I
@@ -3751,7 +3751,7 @@ public final class dev/kord/common/entity/DiscordGuildPreview {
 	public final fun getEmojis ()Ljava/util/List;
 	public final fun getFeatures ()Ljava/util/List;
 	public final fun getIcon ()Ljava/lang/String;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getName ()Ljava/lang/String;
 	public final fun getSplash ()Ljava/lang/String;
 	public final fun getStickers ()Ljava/util/List;
@@ -3778,14 +3778,14 @@ public final class dev/kord/common/entity/DiscordGuildPreview$Companion {
 
 public final class dev/kord/common/entity/DiscordGuildRole {
 	public static final field Companion Ldev/kord/common/entity/DiscordGuildRole$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordRole;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordRole;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordRole;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/DiscordRole;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component2 ()Ldev/kord/common/entity/DiscordRole;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordRole;)Ldev/kord/common/entity/DiscordGuildRole;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordGuildRole;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordRole;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordGuildRole;
+	public final fun copy-wYKCHeA (JLdev/kord/common/entity/DiscordRole;)Ldev/kord/common/entity/DiscordGuildRole;
+	public static synthetic fun copy-wYKCHeA$default (Ldev/kord/common/entity/DiscordGuildRole;JLdev/kord/common/entity/DiscordRole;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordGuildRole;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public final fun getRole ()Ldev/kord/common/entity/DiscordRole;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -3810,37 +3810,37 @@ public final class dev/kord/common/entity/DiscordGuildRole$Companion {
 
 public final class dev/kord/common/entity/DiscordGuildScheduledEvent {
 	public static final field Companion Ldev/kord/common/entity/DiscordGuildScheduledEvent$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/GuildScheduledEventPrivacyLevel;Ldev/kord/common/entity/GuildScheduledEventStatus;Ldev/kord/common/entity/ScheduledEntityType;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/GuildScheduledEventEntityMetadata;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/GuildScheduledEventPrivacyLevel;Ldev/kord/common/entity/GuildScheduledEventStatus;Ldev/kord/common/entity/ScheduledEntityType;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/GuildScheduledEventEntityMetadata;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/GuildScheduledEventPrivacyLevel;Ldev/kord/common/entity/GuildScheduledEventStatus;Ldev/kord/common/entity/ScheduledEntityType;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/GuildScheduledEventEntityMetadata;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/GuildScheduledEventPrivacyLevel;Ldev/kord/common/entity/GuildScheduledEventStatus;Ldev/kord/common/entity/ScheduledEntityType;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/GuildScheduledEventEntityMetadata;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/GuildScheduledEventPrivacyLevel;Ldev/kord/common/entity/GuildScheduledEventStatus;Ldev/kord/common/entity/ScheduledEntityType;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/GuildScheduledEventEntityMetadata;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/GuildScheduledEventPrivacyLevel;Ldev/kord/common/entity/GuildScheduledEventStatus;Ldev/kord/common/entity/ScheduledEntityType;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/GuildScheduledEventEntityMetadata;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component10 ()Ldev/kord/common/entity/GuildScheduledEventStatus;
 	public final fun component11 ()Ldev/kord/common/entity/ScheduledEntityType;
-	public final fun component12 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component12-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun component13 ()Ldev/kord/common/entity/GuildScheduledEventEntityMetadata;
 	public final fun component14 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component15 ()Ldev/kord/common/entity/optional/OptionalInt;
 	public final fun component16 ()Ldev/kord/common/entity/optional/Optional;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
-	public final fun component3 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component2-4_xYDEk ()J
+	public final fun component3-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun component4 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun component5 ()Ljava/lang/String;
 	public final fun component6 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component7 ()Lkotlinx/datetime/Instant;
 	public final fun component8 ()Lkotlinx/datetime/Instant;
 	public final fun component9 ()Ldev/kord/common/entity/GuildScheduledEventPrivacyLevel;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/GuildScheduledEventPrivacyLevel;Ldev/kord/common/entity/GuildScheduledEventStatus;Ldev/kord/common/entity/ScheduledEntityType;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/GuildScheduledEventEntityMetadata;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/common/entity/DiscordGuildScheduledEvent;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordGuildScheduledEvent;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/GuildScheduledEventPrivacyLevel;Ldev/kord/common/entity/GuildScheduledEventStatus;Ldev/kord/common/entity/ScheduledEntityType;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/GuildScheduledEventEntityMetadata;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordGuildScheduledEvent;
+	public final fun copy-5NAF68E (JJLdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/GuildScheduledEventPrivacyLevel;Ldev/kord/common/entity/GuildScheduledEventStatus;Ldev/kord/common/entity/ScheduledEntityType;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/GuildScheduledEventEntityMetadata;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/common/entity/DiscordGuildScheduledEvent;
+	public static synthetic fun copy-5NAF68E$default (Ldev/kord/common/entity/DiscordGuildScheduledEvent;JJLdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/GuildScheduledEventPrivacyLevel;Ldev/kord/common/entity/GuildScheduledEventStatus;Ldev/kord/common/entity/ScheduledEntityType;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/GuildScheduledEventEntityMetadata;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordGuildScheduledEvent;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getCreator ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getCreatorId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun getDescription ()Ldev/kord/common/entity/optional/Optional;
-	public final fun getEntityId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getEntityId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getEntityMetadata ()Ldev/kord/common/entity/GuildScheduledEventEntityMetadata;
 	public final fun getEntityType ()Ldev/kord/common/entity/ScheduledEntityType;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
+	public final fun getId-4_xYDEk ()J
 	public final fun getImage ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getPrivacyLevel ()Ldev/kord/common/entity/GuildScheduledEventPrivacyLevel;
@@ -3871,14 +3871,14 @@ public final class dev/kord/common/entity/DiscordGuildScheduledEvent$Companion {
 
 public final class dev/kord/common/entity/DiscordGuildWidget {
 	public static final field Companion Ldev/kord/common/entity/DiscordGuildWidget$Companion;
-	public synthetic fun <init> (IZLdev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (ZLdev/kord/common/entity/Snowflake;)V
+	public synthetic fun <init> (IZLdev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (ZLdev/kord/common/entity/Snowflake;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Z
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
-	public final fun copy (ZLdev/kord/common/entity/Snowflake;)Ldev/kord/common/entity/DiscordGuildWidget;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordGuildWidget;ZLdev/kord/common/entity/Snowflake;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordGuildWidget;
+	public final fun component2-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
+	public final fun copy-NsqkgP0 (ZLdev/kord/common/entity/Snowflake;)Ldev/kord/common/entity/DiscordGuildWidget;
+	public static synthetic fun copy-NsqkgP0$default (Ldev/kord/common/entity/DiscordGuildWidget;ZLdev/kord/common/entity/Snowflake;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordGuildWidget;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getEnabled ()Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -3904,9 +3904,9 @@ public final class dev/kord/common/entity/DiscordGuildWidget$Companion {
 public final class dev/kord/common/entity/DiscordIntegration {
 	public static final field Companion Ldev/kord/common/entity/DiscordIntegration$Companion;
 	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;ZZLdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/IntegrationExpireBehavior;Lkotlin/time/Duration;Ldev/kord/common/entity/DiscordUser;Ldev/kord/common/entity/DiscordIntegrationsAccount;Lkotlinx/datetime/Instant;IZLdev/kord/common/entity/IntegrationApplication;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;ZZLdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/IntegrationExpireBehavior;JLdev/kord/common/entity/DiscordUser;Ldev/kord/common/entity/DiscordIntegrationsAccount;Lkotlinx/datetime/Instant;IZLdev/kord/common/entity/IntegrationApplication;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;ZZLdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/IntegrationExpireBehavior;JLdev/kord/common/entity/DiscordUser;Ldev/kord/common/entity/DiscordIntegrationsAccount;Lkotlinx/datetime/Instant;IZLdev/kord/common/entity/IntegrationApplication;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/String;ZZJLdev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/IntegrationExpireBehavior;JLdev/kord/common/entity/DiscordUser;Ldev/kord/common/entity/DiscordIntegrationsAccount;Lkotlinx/datetime/Instant;IZLdev/kord/common/entity/IntegrationApplication;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/String;ZZJLdev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/IntegrationExpireBehavior;JLdev/kord/common/entity/DiscordUser;Ldev/kord/common/entity/DiscordIntegrationsAccount;Lkotlinx/datetime/Instant;IZLdev/kord/common/entity/IntegrationApplication;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component10 ()Ldev/kord/common/entity/DiscordUser;
 	public final fun component11 ()Ldev/kord/common/entity/DiscordIntegrationsAccount;
 	public final fun component12 ()Lkotlinx/datetime/Instant;
@@ -3917,12 +3917,12 @@ public final class dev/kord/common/entity/DiscordIntegration {
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Z
 	public final fun component5 ()Z
-	public final fun component6 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component6-4_xYDEk ()J
 	public final fun component7 ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun component8 ()Ldev/kord/common/entity/IntegrationExpireBehavior;
 	public final fun component9-UwyO8pc ()J
-	public final fun copy-EbcOf54 (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;ZZLdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/IntegrationExpireBehavior;JLdev/kord/common/entity/DiscordUser;Ldev/kord/common/entity/DiscordIntegrationsAccount;Lkotlinx/datetime/Instant;IZLdev/kord/common/entity/IntegrationApplication;)Ldev/kord/common/entity/DiscordIntegration;
-	public static synthetic fun copy-EbcOf54$default (Ldev/kord/common/entity/DiscordIntegration;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;ZZLdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/IntegrationExpireBehavior;JLdev/kord/common/entity/DiscordUser;Ldev/kord/common/entity/DiscordIntegrationsAccount;Lkotlinx/datetime/Instant;IZLdev/kord/common/entity/IntegrationApplication;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordIntegration;
+	public final fun copy-e6G5jtM (JLjava/lang/String;Ljava/lang/String;ZZJLdev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/IntegrationExpireBehavior;JLdev/kord/common/entity/DiscordUser;Ldev/kord/common/entity/DiscordIntegrationsAccount;Lkotlinx/datetime/Instant;IZLdev/kord/common/entity/IntegrationApplication;)Ldev/kord/common/entity/DiscordIntegration;
+	public static synthetic fun copy-e6G5jtM$default (Ldev/kord/common/entity/DiscordIntegration;JLjava/lang/String;Ljava/lang/String;ZZJLdev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/IntegrationExpireBehavior;JLdev/kord/common/entity/DiscordUser;Ldev/kord/common/entity/DiscordIntegrationsAccount;Lkotlinx/datetime/Instant;IZLdev/kord/common/entity/IntegrationApplication;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordIntegration;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAccount ()Ldev/kord/common/entity/DiscordIntegrationsAccount;
 	public final fun getApplication ()Ldev/kord/common/entity/IntegrationApplication;
@@ -3930,10 +3930,10 @@ public final class dev/kord/common/entity/DiscordIntegration {
 	public final fun getEnabled ()Z
 	public final fun getExpireBehavior ()Ldev/kord/common/entity/IntegrationExpireBehavior;
 	public final fun getExpireGracePeriod-UwyO8pc ()J
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getName ()Ljava/lang/String;
 	public final fun getRevoked ()Z
-	public final fun getRoleId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getRoleId-4_xYDEk ()J
 	public final fun getSubscriberCount ()I
 	public final fun getSyncedAt ()Lkotlinx/datetime/Instant;
 	public final fun getSyncing ()Z
@@ -4026,33 +4026,33 @@ public final class dev/kord/common/entity/DiscordIntegrationsAccount$Companion {
 
 public final class dev/kord/common/entity/DiscordInteraction {
 	public static final field Companion Ldev/kord/common/entity/DiscordInteraction$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/InteractionType;Ldev/kord/common/entity/InteractionCallbackData;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;ILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/InteractionType;Ldev/kord/common/entity/InteractionCallbackData;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;ILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/InteractionType;Ldev/kord/common/entity/InteractionCallbackData;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;ILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/InteractionType;Ldev/kord/common/entity/InteractionCallbackData;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;ILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLdev/kord/common/entity/InteractionType;Ldev/kord/common/entity/InteractionCallbackData;Ldev/kord/common/entity/optional/OptionalSnowflake;JLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;ILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLdev/kord/common/entity/InteractionType;Ldev/kord/common/entity/InteractionCallbackData;Ldev/kord/common/entity/optional/OptionalSnowflake;JLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;ILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component10 ()I
 	public final fun component11 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component12 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component13 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component14 ()Ldev/kord/common/entity/optional/Optional;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component2-4_xYDEk ()J
 	public final fun component3 ()Ldev/kord/common/entity/InteractionType;
 	public final fun component4 ()Ldev/kord/common/entity/InteractionCallbackData;
 	public final fun component5 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
-	public final fun component6 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component6-4_xYDEk ()J
 	public final fun component7 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component8 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component9 ()Ljava/lang/String;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/InteractionType;Ldev/kord/common/entity/InteractionCallbackData;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;ILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/common/entity/DiscordInteraction;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordInteraction;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/InteractionType;Ldev/kord/common/entity/InteractionCallbackData;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;ILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordInteraction;
+	public final fun copy-hZik4Ts (JJLdev/kord/common/entity/InteractionType;Ldev/kord/common/entity/InteractionCallbackData;Ldev/kord/common/entity/optional/OptionalSnowflake;JLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;ILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/common/entity/DiscordInteraction;
+	public static synthetic fun copy-hZik4Ts$default (Ldev/kord/common/entity/DiscordInteraction;JJLdev/kord/common/entity/InteractionType;Ldev/kord/common/entity/InteractionCallbackData;Ldev/kord/common/entity/optional/OptionalSnowflake;JLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;ILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordInteraction;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAppPermissions ()Ldev/kord/common/entity/optional/Optional;
-	public final fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getApplicationId-4_xYDEk ()J
+	public final fun getChannelId-4_xYDEk ()J
 	public final fun getData ()Ldev/kord/common/entity/InteractionCallbackData;
 	public final fun getGuildId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun getGuildLocale ()Ldev/kord/common/entity/optional/Optional;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getLocale ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getMember ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getMessage ()Ldev/kord/common/entity/optional/Optional;
@@ -4246,17 +4246,17 @@ public final class dev/kord/common/entity/DiscordInviteWithMetadata$Companion {
 
 public final class dev/kord/common/entity/DiscordMentionedChannel {
 	public static final field Companion Ldev/kord/common/entity/DiscordMentionedChannel$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/ChannelType;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/ChannelType;Ljava/lang/String;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/ChannelType;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLdev/kord/common/entity/ChannelType;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
+	public final fun component2-4_xYDEk ()J
 	public final fun component3 ()Ldev/kord/common/entity/ChannelType;
 	public final fun component4 ()Ljava/lang/String;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/ChannelType;Ljava/lang/String;)Ldev/kord/common/entity/DiscordMentionedChannel;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordMentionedChannel;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/ChannelType;Ljava/lang/String;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordMentionedChannel;
+	public final fun copy-Lfpyfds (JJLdev/kord/common/entity/ChannelType;Ljava/lang/String;)Ldev/kord/common/entity/DiscordMentionedChannel;
+	public static synthetic fun copy-Lfpyfds$default (Ldev/kord/common/entity/DiscordMentionedChannel;JJLdev/kord/common/entity/ChannelType;Ljava/lang/String;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordMentionedChannel;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
+	public final fun getId-4_xYDEk ()J
 	public final fun getName ()Ljava/lang/String;
 	public final fun getType ()Ldev/kord/common/entity/ChannelType;
 	public fun hashCode ()I
@@ -4282,10 +4282,10 @@ public final class dev/kord/common/entity/DiscordMentionedChannel$Companion {
 
 public final class dev/kord/common/entity/DiscordMessage {
 	public static final field Companion Ldev/kord/common/entity/DiscordMessage$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/DiscordUser;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;ZZLjava/util/List;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/MessageType;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/DiscordUser;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;ZZLjava/util/List;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/MessageType;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/DiscordUser;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;ZZLjava/util/List;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/MessageType;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/DiscordUser;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;ZZLjava/util/List;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/MessageType;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/DiscordUser;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;ZZLjava/util/List;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/MessageType;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/DiscordUser;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;ZZLjava/util/List;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/MessageType;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component10 ()Z
 	public final fun component11 ()Ljava/util/List;
 	public final fun component12 ()Ljava/util/List;
@@ -4296,7 +4296,7 @@ public final class dev/kord/common/entity/DiscordMessage {
 	public final fun component17 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component18 ()Z
 	public final fun component19 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component2-4_xYDEk ()J
 	public final fun component20 ()Ldev/kord/common/entity/MessageType;
 	public final fun component21 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component22 ()Ldev/kord/common/entity/optional/Optional;
@@ -4315,22 +4315,22 @@ public final class dev/kord/common/entity/DiscordMessage {
 	public final fun component7 ()Lkotlinx/datetime/Instant;
 	public final fun component8 ()Lkotlinx/datetime/Instant;
 	public final fun component9 ()Z
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/DiscordUser;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;ZZLjava/util/List;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/MessageType;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/common/entity/DiscordMessage;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordMessage;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/DiscordUser;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;ZZLjava/util/List;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/MessageType;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordMessage;
+	public final fun copy-FRW_wEY (JJLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/DiscordUser;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;ZZLjava/util/List;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/MessageType;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/common/entity/DiscordMessage;
+	public static synthetic fun copy-FRW_wEY$default (Ldev/kord/common/entity/DiscordMessage;JJLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/DiscordUser;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;ZZLjava/util/List;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/MessageType;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordMessage;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getActivity ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getApplication ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getApplicationId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun getAttachments ()Ljava/util/List;
 	public final fun getAuthor ()Ldev/kord/common/entity/DiscordUser;
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-4_xYDEk ()J
 	public final fun getComponents ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getContent ()Ljava/lang/String;
 	public final fun getEditedTimestamp ()Lkotlinx/datetime/Instant;
 	public final fun getEmbeds ()Ljava/util/List;
 	public final fun getFlags ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getGuildId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getInteraction ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getMember ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getMentionEveryone ()Z
@@ -4371,16 +4371,16 @@ public final class dev/kord/common/entity/DiscordMessage$Companion {
 
 public final class dev/kord/common/entity/DiscordMessageInteraction {
 	public static final field Companion Ldev/kord/common/entity/DiscordMessageInteraction$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/InteractionType;Ljava/lang/String;Ldev/kord/common/entity/DiscordUser;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/InteractionType;Ljava/lang/String;Ldev/kord/common/entity/DiscordUser;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/InteractionType;Ljava/lang/String;Ldev/kord/common/entity/DiscordUser;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/InteractionType;Ljava/lang/String;Ldev/kord/common/entity/DiscordUser;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component2 ()Ldev/kord/common/entity/InteractionType;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ldev/kord/common/entity/DiscordUser;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/InteractionType;Ljava/lang/String;Ldev/kord/common/entity/DiscordUser;)Ldev/kord/common/entity/DiscordMessageInteraction;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordMessageInteraction;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/InteractionType;Ljava/lang/String;Ldev/kord/common/entity/DiscordUser;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordMessageInteraction;
+	public final fun copy-9VmEaQQ (JLdev/kord/common/entity/InteractionType;Ljava/lang/String;Ldev/kord/common/entity/DiscordUser;)Ldev/kord/common/entity/DiscordMessageInteraction;
+	public static synthetic fun copy-9VmEaQQ$default (Ldev/kord/common/entity/DiscordMessageInteraction;JLdev/kord/common/entity/InteractionType;Ljava/lang/String;Ldev/kord/common/entity/DiscordUser;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordMessageInteraction;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getName ()Ljava/lang/String;
 	public final fun getType ()Ldev/kord/common/entity/InteractionType;
 	public final fun getUser ()Ldev/kord/common/entity/DiscordUser;
@@ -4453,10 +4453,10 @@ public final class dev/kord/common/entity/DiscordMessageReference$Companion {
 
 public final class dev/kord/common/entity/DiscordMessageSticker {
 	public static final field Companion Ldev/kord/common/entity/DiscordMessageSticker$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/MessageStickerType;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/MessageStickerType;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/MessageStickerType;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/MessageStickerType;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/MessageStickerType;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/MessageStickerType;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component10 ()Ldev/kord/common/entity/optional/OptionalInt;
 	public final fun component2 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun component3 ()Ljava/lang/String;
@@ -4466,14 +4466,14 @@ public final class dev/kord/common/entity/DiscordMessageSticker {
 	public final fun component7 ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun component8 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun component9 ()Ldev/kord/common/entity/optional/Optional;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/MessageStickerType;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;)Ldev/kord/common/entity/DiscordMessageSticker;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordMessageSticker;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/MessageStickerType;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordMessageSticker;
+	public final fun copy-1Wgd_o8 (JLdev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/MessageStickerType;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;)Ldev/kord/common/entity/DiscordMessageSticker;
+	public static synthetic fun copy-1Wgd_o8$default (Ldev/kord/common/entity/DiscordMessageSticker;JLdev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/MessageStickerType;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordMessageSticker;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAvailable ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun getDescription ()Ljava/lang/String;
 	public final fun getFormatType ()Ldev/kord/common/entity/MessageStickerType;
 	public final fun getGuildId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getName ()Ljava/lang/String;
 	public final fun getPackId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun getSortValue ()Ldev/kord/common/entity/optional/OptionalInt;
@@ -4544,10 +4544,10 @@ public final class dev/kord/common/entity/DiscordNull$Companion {
 
 public final class dev/kord/common/entity/DiscordOptionallyMemberUser {
 	public static final field Companion Ldev/kord/common/entity/DiscordOptionallyMemberUser$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component10 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component11 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component12 ()Ldev/kord/common/entity/optional/Optional;
@@ -4561,15 +4561,15 @@ public final class dev/kord/common/entity/DiscordOptionallyMemberUser {
 	public final fun component7 ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun component8 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component9 ()Ldev/kord/common/entity/optional/OptionalBoolean;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/common/entity/DiscordOptionallyMemberUser;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordOptionallyMemberUser;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordOptionallyMemberUser;
+	public final fun copy-oZ2XyO4 (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/common/entity/DiscordOptionallyMemberUser;
+	public static synthetic fun copy-oZ2XyO4$default (Ldev/kord/common/entity/DiscordOptionallyMemberUser;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordOptionallyMemberUser;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAvatar ()Ljava/lang/String;
 	public final fun getBot ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun getDiscriminator ()Ljava/lang/String;
 	public final fun getEmail ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getFlags ()Ldev/kord/common/entity/optional/Optional;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getLocale ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getMember ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getMfaEnabled ()Ldev/kord/common/entity/optional/OptionalBoolean;
@@ -4601,10 +4601,10 @@ public final class dev/kord/common/entity/DiscordOptionallyMemberUser$Companion 
 
 public final class dev/kord/common/entity/DiscordPartialApplication : dev/kord/common/entity/BaseDiscordApplication {
 	public static final field Companion Ldev/kord/common/entity/DiscordPartialApplication$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component10 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun component11 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun component12 ()Ldev/kord/common/entity/optional/Optional;
@@ -4621,8 +4621,8 @@ public final class dev/kord/common/entity/DiscordPartialApplication : dev/kord/c
 	public final fun component7 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component8 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component9 ()Ljava/lang/String;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/common/entity/DiscordPartialApplication;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordPartialApplication;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordPartialApplication;
+	public final fun copy-X_dMieU (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/common/entity/DiscordPartialApplication;
+	public static synthetic fun copy-X_dMieU$default (Ldev/kord/common/entity/DiscordPartialApplication;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordPartialApplication;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getCoverImage ()Ldev/kord/common/entity/optional/Optional;
 	public fun getCustomInstallUrl ()Ldev/kord/common/entity/optional/Optional;
@@ -4630,7 +4630,7 @@ public final class dev/kord/common/entity/DiscordPartialApplication : dev/kord/c
 	public fun getFlags ()Ldev/kord/common/entity/optional/Optional;
 	public fun getGuildId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public fun getIcon ()Ljava/lang/String;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public fun getInstallParams ()Ldev/kord/common/entity/optional/Optional;
 	public fun getName ()Ljava/lang/String;
 	public fun getOwner ()Ldev/kord/common/entity/optional/Optional;
@@ -4664,18 +4664,17 @@ public final class dev/kord/common/entity/DiscordPartialApplication$Companion {
 
 public final class dev/kord/common/entity/DiscordPartialEmoji {
 	public static final field Companion Ldev/kord/common/entity/DiscordPartialEmoji$Companion;
-	public fun <init> ()V
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;)V
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ldev/kord/common/entity/optional/OptionalBoolean;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;)Ldev/kord/common/entity/DiscordPartialEmoji;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordPartialEmoji;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordPartialEmoji;
+	public final fun copy-Pal3Q04 (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;)Ldev/kord/common/entity/DiscordPartialEmoji;
+	public static synthetic fun copy-Pal3Q04$default (Ldev/kord/common/entity/DiscordPartialEmoji;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordPartialEmoji;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAnimated ()Ldev/kord/common/entity/optional/OptionalBoolean;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -4700,10 +4699,10 @@ public final class dev/kord/common/entity/DiscordPartialEmoji$Companion {
 
 public final class dev/kord/common/entity/DiscordPartialGuild {
 	public static final field Companion Ldev/kord/common/entity/DiscordPartialGuild$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component10 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component11 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component12 ()Ldev/kord/common/entity/optional/Optional;
@@ -4720,15 +4719,15 @@ public final class dev/kord/common/entity/DiscordPartialGuild {
 	public final fun component7 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component8 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component9 ()Ldev/kord/common/entity/optional/Optional;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;)Ldev/kord/common/entity/DiscordPartialGuild;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordPartialGuild;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordPartialGuild;
+	public final fun copy-X_dMieU (JLjava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;)Ldev/kord/common/entity/DiscordPartialGuild;
+	public static synthetic fun copy-X_dMieU$default (Ldev/kord/common/entity/DiscordPartialGuild;JLjava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordPartialGuild;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBanner ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getDescription ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getFeatures ()Ljava/util/List;
 	public final fun getGuildScheduledEvents ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getIcon ()Ljava/lang/String;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getName ()Ljava/lang/String;
 	public final fun getNsfwLevel ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getOwner ()Ldev/kord/common/entity/optional/OptionalBoolean;
@@ -4763,17 +4762,17 @@ public final class dev/kord/common/entity/DiscordPartialGuild$Companion {
 
 public final class dev/kord/common/entity/DiscordPartialIntegration {
 	public static final field Companion Ldev/kord/common/entity/DiscordPartialIntegration$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/DiscordIntegrationsAccount;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/DiscordIntegrationsAccount;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/DiscordIntegrationsAccount;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/DiscordIntegrationsAccount;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ldev/kord/common/entity/DiscordIntegrationsAccount;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/DiscordIntegrationsAccount;)Ldev/kord/common/entity/DiscordPartialIntegration;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordPartialIntegration;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/DiscordIntegrationsAccount;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordPartialIntegration;
+	public final fun copy-9VmEaQQ (JLjava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/DiscordIntegrationsAccount;)Ldev/kord/common/entity/DiscordPartialIntegration;
+	public static synthetic fun copy-9VmEaQQ$default (Ldev/kord/common/entity/DiscordPartialIntegration;JLjava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/DiscordIntegrationsAccount;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordPartialIntegration;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAccount ()Ldev/kord/common/entity/DiscordIntegrationsAccount;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getName ()Ljava/lang/String;
 	public final fun getType ()Ljava/lang/String;
 	public fun hashCode ()I
@@ -4831,10 +4830,10 @@ public final class dev/kord/common/entity/DiscordPartialInvite$Companion {
 
 public final class dev/kord/common/entity/DiscordPartialMessage {
 	public static final field Companion Ldev/kord/common/entity/DiscordPartialMessage$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component10 ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun component11 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component12 ()Ldev/kord/common/entity/optional/Optional;
@@ -4845,7 +4844,7 @@ public final class dev/kord/common/entity/DiscordPartialMessage {
 	public final fun component17 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component18 ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun component19 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component2-4_xYDEk ()J
 	public final fun component20 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component21 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component22 ()Ldev/kord/common/entity/optional/Optional;
@@ -4861,20 +4860,20 @@ public final class dev/kord/common/entity/DiscordPartialMessage {
 	public final fun component7 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component8 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component9 ()Ldev/kord/common/entity/optional/OptionalBoolean;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/common/entity/DiscordPartialMessage;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordPartialMessage;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordPartialMessage;
+	public final fun copy-M-2DjAM (JJLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/common/entity/DiscordPartialMessage;
+	public static synthetic fun copy-M-2DjAM$default (Ldev/kord/common/entity/DiscordPartialMessage;JJLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordPartialMessage;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getActivity ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getApplication ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getAttachments ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getAuthor ()Ldev/kord/common/entity/optional/Optional;
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-4_xYDEk ()J
 	public final fun getContent ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getEditedTimestamp ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getEmbeds ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getFlags ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getGuildId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getInteraction ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getMember ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getMentionEveryone ()Ldev/kord/common/entity/optional/OptionalBoolean;
@@ -4914,10 +4913,10 @@ public final class dev/kord/common/entity/DiscordPartialMessage$Companion {
 
 public final class dev/kord/common/entity/DiscordPartialRole {
 	public static final field Companion Ldev/kord/common/entity/DiscordPartialRole$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component10 ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun component11 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component2 ()Ldev/kord/common/entity/optional/Optional;
@@ -4928,13 +4927,13 @@ public final class dev/kord/common/entity/DiscordPartialRole {
 	public final fun component7 ()Ldev/kord/common/entity/optional/OptionalInt;
 	public final fun component8 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component9 ()Ldev/kord/common/entity/optional/OptionalBoolean;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/common/entity/DiscordPartialRole;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordPartialRole;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordPartialRole;
+	public final fun copy-7oSUoPo (JLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/common/entity/DiscordPartialRole;
+	public static synthetic fun copy-7oSUoPo$default (Ldev/kord/common/entity/DiscordPartialRole;JLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordPartialRole;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getColor ()Ldev/kord/common/entity/optional/OptionalInt;
 	public final fun getHoist ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun getIcon ()Ldev/kord/common/entity/optional/Optional;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getManaged ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun getMentionable ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun getName ()Ldev/kord/common/entity/optional/Optional;
@@ -4965,16 +4964,16 @@ public final class dev/kord/common/entity/DiscordPartialRole$Companion {
 
 public final class dev/kord/common/entity/DiscordPinsUpdateData {
 	public static final field Companion Ldev/kord/common/entity/DiscordPinsUpdateData$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (ILdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ldev/kord/common/entity/optional/OptionalSnowflake;JLdev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ldev/kord/common/entity/optional/OptionalSnowflake;JLdev/kord/common/entity/optional/Optional;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component2-4_xYDEk ()J
 	public final fun component3 ()Ldev/kord/common/entity/optional/Optional;
-	public final fun copy (Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/common/entity/DiscordPinsUpdateData;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordPinsUpdateData;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordPinsUpdateData;
+	public final fun copy-o5qqygM (Ldev/kord/common/entity/optional/OptionalSnowflake;JLdev/kord/common/entity/optional/Optional;)Ldev/kord/common/entity/DiscordPinsUpdateData;
+	public static synthetic fun copy-o5qqygM$default (Ldev/kord/common/entity/DiscordPinsUpdateData;Ldev/kord/common/entity/optional/OptionalSnowflake;JLdev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordPinsUpdateData;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-4_xYDEk ()J
 	public final fun getGuildId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun getLastPinTimestamp ()Ldev/kord/common/entity/optional/Optional;
 	public fun hashCode ()I
@@ -5039,14 +5038,14 @@ public final class dev/kord/common/entity/DiscordPresenceUpdate$Companion {
 
 public final class dev/kord/common/entity/DiscordPresenceUser {
 	public static final field Companion Ldev/kord/common/entity/DiscordPresenceUser$Companion;
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Lkotlinx/serialization/json/JsonObject;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (JLkotlinx/serialization/json/JsonObject;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Lkotlinx/serialization/json/JsonObject;)Ldev/kord/common/entity/DiscordPresenceUser;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordPresenceUser;Ldev/kord/common/entity/Snowflake;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordPresenceUser;
+	public final fun copy-wYKCHeA (JLkotlinx/serialization/json/JsonObject;)Ldev/kord/common/entity/DiscordPresenceUser;
+	public static synthetic fun copy-wYKCHeA$default (Ldev/kord/common/entity/DiscordPresenceUser;JLkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordPresenceUser;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDetails ()Lkotlinx/serialization/json/JsonObject;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -5057,14 +5056,14 @@ public final class dev/kord/common/entity/DiscordPresenceUser$Companion {
 
 public final class dev/kord/common/entity/DiscordRemovedGuildMember {
 	public static final field Companion Ldev/kord/common/entity/DiscordRemovedGuildMember$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordUser;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordUser;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordUser;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/DiscordUser;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component2 ()Ldev/kord/common/entity/DiscordUser;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordUser;)Ldev/kord/common/entity/DiscordRemovedGuildMember;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordRemovedGuildMember;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordUser;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordRemovedGuildMember;
+	public final fun copy-wYKCHeA (JLdev/kord/common/entity/DiscordUser;)Ldev/kord/common/entity/DiscordRemovedGuildMember;
+	public static synthetic fun copy-wYKCHeA$default (Ldev/kord/common/entity/DiscordRemovedGuildMember;JLdev/kord/common/entity/DiscordUser;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordRemovedGuildMember;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public final fun getUser ()Ldev/kord/common/entity/DiscordUser;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -5089,10 +5088,10 @@ public final class dev/kord/common/entity/DiscordRemovedGuildMember$Companion {
 
 public final class dev/kord/common/entity/DiscordRole {
 	public static final field Companion Ldev/kord/common/entity/DiscordRole$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;IZLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILdev/kord/common/entity/Permissions;ZZLdev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;IZLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILdev/kord/common/entity/Permissions;ZZLdev/kord/common/entity/optional/Optional;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;IZLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILdev/kord/common/entity/Permissions;ZZLdev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;IZLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILdev/kord/common/entity/Permissions;ZZLdev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;IZLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILdev/kord/common/entity/Permissions;ZZLdev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;IZLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILdev/kord/common/entity/Permissions;ZZLdev/kord/common/entity/optional/Optional;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component10 ()Z
 	public final fun component11 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component2 ()Ljava/lang/String;
@@ -5103,13 +5102,13 @@ public final class dev/kord/common/entity/DiscordRole {
 	public final fun component7 ()I
 	public final fun component8 ()Ldev/kord/common/entity/Permissions;
 	public final fun component9 ()Z
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;IZLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILdev/kord/common/entity/Permissions;ZZLdev/kord/common/entity/optional/Optional;)Ldev/kord/common/entity/DiscordRole;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordRole;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;IZLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILdev/kord/common/entity/Permissions;ZZLdev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordRole;
+	public final fun copy-7oSUoPo (JLjava/lang/String;IZLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILdev/kord/common/entity/Permissions;ZZLdev/kord/common/entity/optional/Optional;)Ldev/kord/common/entity/DiscordRole;
+	public static synthetic fun copy-7oSUoPo$default (Ldev/kord/common/entity/DiscordRole;JLjava/lang/String;IZLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILdev/kord/common/entity/Permissions;ZZLdev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordRole;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getColor ()I
 	public final fun getHoist ()Z
 	public final fun getIcon ()Ldev/kord/common/entity/optional/Optional;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getManaged ()Z
 	public final fun getMentionable ()Z
 	public final fun getName ()Ljava/lang/String;
@@ -5238,23 +5237,23 @@ public final class dev/kord/common/entity/DiscordShard$Companion : kotlinx/seria
 
 public final class dev/kord/common/entity/DiscordStageInstance {
 	public static final field Companion Ldev/kord/common/entity/DiscordStageInstance$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/StageInstancePrivacyLevel;ZLdev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/StageInstancePrivacyLevel;ZLdev/kord/common/entity/Snowflake;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
-	public final fun component3 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/StageInstancePrivacyLevel;ZLdev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJJLjava/lang/String;Ldev/kord/common/entity/StageInstancePrivacyLevel;ZLdev/kord/common/entity/Snowflake;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
+	public final fun component2-4_xYDEk ()J
+	public final fun component3-4_xYDEk ()J
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Ldev/kord/common/entity/StageInstancePrivacyLevel;
 	public final fun component6 ()Z
-	public final fun component7 ()Ldev/kord/common/entity/Snowflake;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/StageInstancePrivacyLevel;ZLdev/kord/common/entity/Snowflake;)Ldev/kord/common/entity/DiscordStageInstance;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordStageInstance;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/StageInstancePrivacyLevel;ZLdev/kord/common/entity/Snowflake;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordStageInstance;
+	public final fun component7-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
+	public final fun copy-4_U1LYE (JJJLjava/lang/String;Ldev/kord/common/entity/StageInstancePrivacyLevel;ZLdev/kord/common/entity/Snowflake;)Ldev/kord/common/entity/DiscordStageInstance;
+	public static synthetic fun copy-4_U1LYE$default (Ldev/kord/common/entity/DiscordStageInstance;JJJLjava/lang/String;Ldev/kord/common/entity/StageInstancePrivacyLevel;ZLdev/kord/common/entity/Snowflake;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordStageInstance;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-4_xYDEk ()J
 	public final fun getDiscoverableDisabled ()Z
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
-	public final fun getGuildScheduledEventId ()Ldev/kord/common/entity/Snowflake;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
+	public final fun getGuildScheduledEventId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getPrivacyLevel ()Ldev/kord/common/entity/StageInstancePrivacyLevel;
 	public final fun getTopic ()Ljava/lang/String;
 	public fun hashCode ()I
@@ -5280,16 +5279,16 @@ public final class dev/kord/common/entity/DiscordStageInstance$Companion {
 
 public final class dev/kord/common/entity/DiscordStickerItem {
 	public static final field Companion Ldev/kord/common/entity/DiscordStickerItem$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/MessageStickerType;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/MessageStickerType;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/MessageStickerType;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Ldev/kord/common/entity/MessageStickerType;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ldev/kord/common/entity/MessageStickerType;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/MessageStickerType;)Ldev/kord/common/entity/DiscordStickerItem;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordStickerItem;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/MessageStickerType;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordStickerItem;
+	public final fun copy-9y3P_48 (JLjava/lang/String;Ldev/kord/common/entity/MessageStickerType;)Ldev/kord/common/entity/DiscordStickerItem;
+	public static synthetic fun copy-9y3P_48$default (Ldev/kord/common/entity/DiscordStickerItem;JLjava/lang/String;Ldev/kord/common/entity/MessageStickerType;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordStickerItem;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFormatType ()Ldev/kord/common/entity/MessageStickerType;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -5314,25 +5313,25 @@ public final class dev/kord/common/entity/DiscordStickerItem$Companion {
 
 public final class dev/kord/common/entity/DiscordStickerPack {
 	public static final field Companion Ldev/kord/common/entity/DiscordStickerPack$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/util/List;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/util/List;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/util/List;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/util/List;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/util/List;Ljava/lang/String;JLdev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/util/List;Ljava/lang/String;JLdev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;JLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component2 ()Ljava/util/List;
 	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component4-4_xYDEk ()J
 	public final fun component5 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun component6 ()Ljava/lang/String;
-	public final fun component7 ()Ldev/kord/common/entity/Snowflake;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ljava/util/List;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;)Ldev/kord/common/entity/DiscordStickerPack;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordStickerPack;Ldev/kord/common/entity/Snowflake;Ljava/util/List;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordStickerPack;
+	public final fun component7-4_xYDEk ()J
+	public final fun copy-wz6eW_A (JLjava/util/List;Ljava/lang/String;JLdev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;J)Ldev/kord/common/entity/DiscordStickerPack;
+	public static synthetic fun copy-wz6eW_A$default (Ldev/kord/common/entity/DiscordStickerPack;JLjava/util/List;Ljava/lang/String;JLdev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;JILjava/lang/Object;)Ldev/kord/common/entity/DiscordStickerPack;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getBannerAssetId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getBannerAssetId-4_xYDEk ()J
 	public final fun getCoverStickerId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun getDescription ()Ljava/lang/String;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getName ()Ljava/lang/String;
-	public final fun getSkuId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getSkuId-4_xYDEk ()J
 	public final fun getStickers ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -5357,19 +5356,19 @@ public final class dev/kord/common/entity/DiscordStickerPack$Companion {
 
 public final class dev/kord/common/entity/DiscordTeam {
 	public static final field Companion Ldev/kord/common/entity/DiscordTeam$Companion;
-	public synthetic fun <init> (ILjava/lang/String;Ldev/kord/common/entity/Snowflake;Ljava/util/List;Ldev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ljava/util/List;Ldev/kord/common/entity/Snowflake;)V
+	public synthetic fun <init> (ILjava/lang/String;Ldev/kord/common/entity/Snowflake;Ljava/util/List;Ldev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;JLjava/util/List;JLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component2-4_xYDEk ()J
 	public final fun component3 ()Ljava/util/List;
-	public final fun component4 ()Ldev/kord/common/entity/Snowflake;
-	public final fun copy (Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ljava/util/List;Ldev/kord/common/entity/Snowflake;)Ldev/kord/common/entity/DiscordTeam;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordTeam;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ljava/util/List;Ldev/kord/common/entity/Snowflake;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordTeam;
+	public final fun component4-4_xYDEk ()J
+	public final fun copy-dg-lN7g (Ljava/lang/String;JLjava/util/List;J)Ldev/kord/common/entity/DiscordTeam;
+	public static synthetic fun copy-dg-lN7g$default (Ldev/kord/common/entity/DiscordTeam;Ljava/lang/String;JLjava/util/List;JILjava/lang/Object;)Ldev/kord/common/entity/DiscordTeam;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getIcon ()Ljava/lang/String;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getMembers ()Ljava/util/List;
-	public final fun getOwnerUserId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getOwnerUserId-4_xYDEk ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public static final fun write$Self (Ldev/kord/common/entity/DiscordTeam;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
@@ -5393,18 +5392,18 @@ public final class dev/kord/common/entity/DiscordTeam$Companion {
 
 public final class dev/kord/common/entity/DiscordTeamMember {
 	public static final field Companion Ldev/kord/common/entity/DiscordTeamMember$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/TeamMembershipState;Ljava/util/List;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordUser;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/TeamMembershipState;Ljava/util/List;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordUser;)V
+	public synthetic fun <init> (ILdev/kord/common/entity/TeamMembershipState;Ljava/util/List;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordUser;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ldev/kord/common/entity/TeamMembershipState;Ljava/util/List;JLdev/kord/common/entity/DiscordUser;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ldev/kord/common/entity/TeamMembershipState;
 	public final fun component2 ()Ljava/util/List;
-	public final fun component3 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component3-4_xYDEk ()J
 	public final fun component4 ()Ldev/kord/common/entity/DiscordUser;
-	public final fun copy (Ldev/kord/common/entity/TeamMembershipState;Ljava/util/List;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordUser;)Ldev/kord/common/entity/DiscordTeamMember;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordTeamMember;Ldev/kord/common/entity/TeamMembershipState;Ljava/util/List;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordUser;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordTeamMember;
+	public final fun copy-cxNCR2U (Ldev/kord/common/entity/TeamMembershipState;Ljava/util/List;JLdev/kord/common/entity/DiscordUser;)Ldev/kord/common/entity/DiscordTeamMember;
+	public static synthetic fun copy-cxNCR2U$default (Ldev/kord/common/entity/DiscordTeamMember;Ldev/kord/common/entity/TeamMembershipState;Ljava/util/List;JLdev/kord/common/entity/DiscordUser;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordTeamMember;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getMembershipState ()Ldev/kord/common/entity/TeamMembershipState;
 	public final fun getPermissions ()Ljava/util/List;
-	public final fun getTeamId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getTeamId-4_xYDEk ()J
 	public final fun getUser ()Ldev/kord/common/entity/DiscordUser;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -5429,30 +5428,30 @@ public final class dev/kord/common/entity/DiscordTeamMember$Companion {
 
 public final class dev/kord/common/entity/DiscordTemplate {
 	public static final field Companion Ldev/kord/common/entity/DiscordTemplate$Companion;
-	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordUser;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordPartialGuild;Ljava/lang/Boolean;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordUser;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordPartialGuild;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordUser;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordPartialGuild;Ljava/lang/Boolean;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IJLdev/kord/common/entity/DiscordUser;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;JLdev/kord/common/entity/DiscordPartialGuild;Ljava/lang/Boolean;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component10 ()Ldev/kord/common/entity/DiscordPartialGuild;
 	public final fun component11 ()Ljava/lang/Boolean;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()I
-	public final fun component5 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component5-4_xYDEk ()J
 	public final fun component6 ()Ldev/kord/common/entity/DiscordUser;
 	public final fun component7 ()Lkotlinx/datetime/Instant;
 	public final fun component8 ()Lkotlinx/datetime/Instant;
-	public final fun component9 ()Ldev/kord/common/entity/Snowflake;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordUser;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordPartialGuild;Ljava/lang/Boolean;)Ldev/kord/common/entity/DiscordTemplate;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordTemplate;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordUser;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordPartialGuild;Ljava/lang/Boolean;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordTemplate;
+	public final fun component9-4_xYDEk ()J
+	public final fun copy-c3Iea6o (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IJLdev/kord/common/entity/DiscordUser;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;JLdev/kord/common/entity/DiscordPartialGuild;Ljava/lang/Boolean;)Ldev/kord/common/entity/DiscordTemplate;
+	public static synthetic fun copy-c3Iea6o$default (Ldev/kord/common/entity/DiscordTemplate;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IJLdev/kord/common/entity/DiscordUser;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;JLdev/kord/common/entity/DiscordPartialGuild;Ljava/lang/Boolean;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordTemplate;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCode ()Ljava/lang/String;
 	public final fun getCreatedAt ()Lkotlinx/datetime/Instant;
 	public final fun getCreator ()Ldev/kord/common/entity/DiscordUser;
-	public final fun getCreatorId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getCreatorId-4_xYDEk ()J
 	public final fun getDescription ()Ljava/lang/String;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getSerializedSourceGuild ()Ldev/kord/common/entity/DiscordPartialGuild;
-	public final fun getSourceGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getSourceGuildId-4_xYDEk ()J
 	public final fun getUpdatedAt ()Lkotlinx/datetime/Instant;
 	public final fun getUsageCount ()I
 	public fun hashCode ()I
@@ -5618,22 +5617,22 @@ public final class dev/kord/common/entity/DiscordThreadMetadata$Companion {
 
 public final class dev/kord/common/entity/DiscordTyping {
 	public static final field Companion Ldev/kord/common/entity/DiscordTyping$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/optional/OptionalSnowflake;JLkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/optional/OptionalSnowflake;JLkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component2 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
-	public final fun component3 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component3-4_xYDEk ()J
 	public final fun component4 ()Lkotlinx/datetime/Instant;
 	public final fun component5 ()Ldev/kord/common/entity/optional/Optional;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/common/entity/DiscordTyping;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordTyping;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordTyping;
+	public final fun copy-AvpewP4 (JLdev/kord/common/entity/optional/OptionalSnowflake;JLkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/common/entity/DiscordTyping;
+	public static synthetic fun copy-AvpewP4$default (Ldev/kord/common/entity/DiscordTyping;JLdev/kord/common/entity/optional/OptionalSnowflake;JLkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordTyping;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-4_xYDEk ()J
 	public final fun getGuildId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun getMember ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getTimestamp ()Lkotlinx/datetime/Instant;
-	public final fun getUserId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getUserId-4_xYDEk ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public static final fun write$Self (Ldev/kord/common/entity/DiscordTyping;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
@@ -5657,15 +5656,15 @@ public final class dev/kord/common/entity/DiscordTyping$Companion {
 
 public final class dev/kord/common/entity/DiscordUnavailableGuild {
 	public static final field Companion Ldev/kord/common/entity/DiscordUnavailableGuild$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/optional/OptionalBoolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/optional/OptionalBoolean;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component2 ()Ldev/kord/common/entity/optional/OptionalBoolean;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;)Ldev/kord/common/entity/DiscordUnavailableGuild;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordUnavailableGuild;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordUnavailableGuild;
+	public final fun copy-wYKCHeA (JLdev/kord/common/entity/optional/OptionalBoolean;)Ldev/kord/common/entity/DiscordUnavailableGuild;
+	public static synthetic fun copy-wYKCHeA$default (Ldev/kord/common/entity/DiscordUnavailableGuild;JLdev/kord/common/entity/optional/OptionalBoolean;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordUnavailableGuild;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getUnavailable ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -5690,15 +5689,15 @@ public final class dev/kord/common/entity/DiscordUnavailableGuild$Companion {
 
 public final class dev/kord/common/entity/DiscordUpdatedEmojis {
 	public static final field Companion Ldev/kord/common/entity/DiscordUpdatedEmojis$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/util/List;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component2 ()Ljava/util/List;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ljava/util/List;)Ldev/kord/common/entity/DiscordUpdatedEmojis;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordUpdatedEmojis;Ldev/kord/common/entity/Snowflake;Ljava/util/List;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordUpdatedEmojis;
+	public final fun copy-wYKCHeA (JLjava/util/List;)Ldev/kord/common/entity/DiscordUpdatedEmojis;
+	public static synthetic fun copy-wYKCHeA$default (Ldev/kord/common/entity/DiscordUpdatedEmojis;JLjava/util/List;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordUpdatedEmojis;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getEmojis ()Ljava/util/List;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public static final fun write$Self (Ldev/kord/common/entity/DiscordUpdatedEmojis;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
@@ -5722,10 +5721,10 @@ public final class dev/kord/common/entity/DiscordUpdatedEmojis$Companion {
 
 public final class dev/kord/common/entity/DiscordUpdatedGuildMember {
 	public static final field Companion Ldev/kord/common/entity/DiscordUpdatedGuildMember$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/util/List;Ldev/kord/common/entity/DiscordUser;Ldev/kord/common/entity/optional/Optional;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/util/List;Ldev/kord/common/entity/DiscordUser;Ldev/kord/common/entity/optional/Optional;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/util/List;Ldev/kord/common/entity/DiscordUser;Ldev/kord/common/entity/optional/Optional;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/util/List;Ldev/kord/common/entity/DiscordUser;Ldev/kord/common/entity/optional/Optional;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/util/List;Ldev/kord/common/entity/DiscordUser;Ldev/kord/common/entity/optional/Optional;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/util/List;Ldev/kord/common/entity/DiscordUser;Ldev/kord/common/entity/optional/Optional;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component2 ()Ljava/util/List;
 	public final fun component3 ()Ldev/kord/common/entity/DiscordUser;
 	public final fun component4 ()Ldev/kord/common/entity/optional/Optional;
@@ -5734,12 +5733,12 @@ public final class dev/kord/common/entity/DiscordUpdatedGuildMember {
 	public final fun component7 ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun component8 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component9 ()Ldev/kord/common/entity/optional/Optional;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ljava/util/List;Ldev/kord/common/entity/DiscordUser;Ldev/kord/common/entity/optional/Optional;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/common/entity/DiscordUpdatedGuildMember;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordUpdatedGuildMember;Ldev/kord/common/entity/Snowflake;Ljava/util/List;Ldev/kord/common/entity/DiscordUser;Ldev/kord/common/entity/optional/Optional;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordUpdatedGuildMember;
+	public final fun copy-n9CV66Y (JLjava/util/List;Ldev/kord/common/entity/DiscordUser;Ldev/kord/common/entity/optional/Optional;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/common/entity/DiscordUpdatedGuildMember;
+	public static synthetic fun copy-n9CV66Y$default (Ldev/kord/common/entity/DiscordUpdatedGuildMember;JLjava/util/List;Ldev/kord/common/entity/DiscordUser;Ldev/kord/common/entity/optional/Optional;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordUpdatedGuildMember;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAvatar ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getCommunicationDisabledUntil ()Ldev/kord/common/entity/optional/Optional;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public final fun getJoinedAt ()Lkotlinx/datetime/Instant;
 	public final fun getNick ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getPending ()Ldev/kord/common/entity/optional/OptionalBoolean;
@@ -5769,10 +5768,10 @@ public final class dev/kord/common/entity/DiscordUpdatedGuildMember$Companion {
 
 public final class dev/kord/common/entity/DiscordUser {
 	public static final field Companion Ldev/kord/common/entity/DiscordUser$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ljava/lang/Integer;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ljava/lang/Integer;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ljava/lang/Integer;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component10 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component11 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component12 ()Ldev/kord/common/entity/optional/Optional;
@@ -5787,8 +5786,8 @@ public final class dev/kord/common/entity/DiscordUser {
 	public final fun component7 ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun component8 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component9 ()Ldev/kord/common/entity/optional/OptionalBoolean;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ljava/lang/Integer;)Ldev/kord/common/entity/DiscordUser;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordUser;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ljava/lang/Integer;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordUser;
+	public final fun copy-IMrpcrA (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ljava/lang/Integer;)Ldev/kord/common/entity/DiscordUser;
+	public static synthetic fun copy-IMrpcrA$default (Ldev/kord/common/entity/DiscordUser;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ljava/lang/Integer;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordUser;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAccentColor ()Ljava/lang/Integer;
 	public final fun getAvatar ()Ljava/lang/String;
@@ -5797,7 +5796,7 @@ public final class dev/kord/common/entity/DiscordUser {
 	public final fun getDiscriminator ()Ljava/lang/String;
 	public final fun getEmail ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getFlags ()Ldev/kord/common/entity/optional/Optional;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getLocale ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getMfaEnabled ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun getPremiumType ()Ldev/kord/common/entity/optional/Optional;
@@ -5870,16 +5869,16 @@ public final class dev/kord/common/entity/DiscordVoiceRegion$Companion {
 
 public final class dev/kord/common/entity/DiscordVoiceServerUpdateData {
 	public static final field Companion Ldev/kord/common/entity/DiscordVoiceServerUpdateData$Companion;
-	public synthetic fun <init> (ILjava/lang/String;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;)V
+	public synthetic fun <init> (ILjava/lang/String;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;JLjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component2-4_xYDEk ()J
 	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;)Ldev/kord/common/entity/DiscordVoiceServerUpdateData;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordVoiceServerUpdateData;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordVoiceServerUpdateData;
+	public final fun copy-o5qqygM (Ljava/lang/String;JLjava/lang/String;)Ldev/kord/common/entity/DiscordVoiceServerUpdateData;
+	public static synthetic fun copy-o5qqygM$default (Ldev/kord/common/entity/DiscordVoiceServerUpdateData;Ljava/lang/String;JLjava/lang/String;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordVoiceServerUpdateData;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getEndpoint ()Ljava/lang/String;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public final fun getToken ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -5904,26 +5903,26 @@ public final class dev/kord/common/entity/DiscordVoiceServerUpdateData$Companion
 
 public final class dev/kord/common/entity/DiscordVoiceState {
 	public static final field Companion Ldev/kord/common/entity/DiscordVoiceState$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;ZZZZZLdev/kord/common/entity/optional/OptionalBoolean;ZLkotlinx/datetime/Instant;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;ZZZZZLdev/kord/common/entity/optional/OptionalBoolean;ZLkotlinx/datetime/Instant;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;ZZZZZLdev/kord/common/entity/optional/OptionalBoolean;ZLkotlinx/datetime/Instant;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (ILdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;ZZZZZLdev/kord/common/entity/optional/OptionalBoolean;ZLkotlinx/datetime/Instant;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;JLdev/kord/common/entity/optional/Optional;Ljava/lang/String;ZZZZZLdev/kord/common/entity/optional/OptionalBoolean;ZLkotlinx/datetime/Instant;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;JLdev/kord/common/entity/optional/Optional;Ljava/lang/String;ZZZZZLdev/kord/common/entity/optional/OptionalBoolean;ZLkotlinx/datetime/Instant;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun component10 ()Z
 	public final fun component11 ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun component12 ()Z
 	public final fun component13 ()Lkotlinx/datetime/Instant;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
-	public final fun component3 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component2-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
+	public final fun component3-4_xYDEk ()J
 	public final fun component4 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component5 ()Ljava/lang/String;
 	public final fun component6 ()Z
 	public final fun component7 ()Z
 	public final fun component8 ()Z
 	public final fun component9 ()Z
-	public final fun copy (Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;ZZZZZLdev/kord/common/entity/optional/OptionalBoolean;ZLkotlinx/datetime/Instant;)Ldev/kord/common/entity/DiscordVoiceState;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordVoiceState;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;ZZZZZLdev/kord/common/entity/optional/OptionalBoolean;ZLkotlinx/datetime/Instant;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordVoiceState;
+	public final fun copy-Cu75SyE (Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;JLdev/kord/common/entity/optional/Optional;Ljava/lang/String;ZZZZZLdev/kord/common/entity/optional/OptionalBoolean;ZLkotlinx/datetime/Instant;)Ldev/kord/common/entity/DiscordVoiceState;
+	public static synthetic fun copy-Cu75SyE$default (Ldev/kord/common/entity/DiscordVoiceState;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;JLdev/kord/common/entity/optional/Optional;Ljava/lang/String;ZZZZZLdev/kord/common/entity/optional/OptionalBoolean;ZLkotlinx/datetime/Instant;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordVoiceState;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getDeaf ()Z
 	public final fun getGuildId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun getMember ()Ldev/kord/common/entity/optional/Optional;
@@ -5935,7 +5934,7 @@ public final class dev/kord/common/entity/DiscordVoiceState {
 	public final fun getSelfVideo ()Z
 	public final fun getSessionId ()Ljava/lang/String;
 	public final fun getSuppress ()Z
-	public final fun getUserId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getUserId-4_xYDEk ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public static final fun write$Self (Ldev/kord/common/entity/DiscordVoiceState;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
@@ -5959,26 +5958,26 @@ public final class dev/kord/common/entity/DiscordVoiceState$Companion {
 
 public final class dev/kord/common/entity/DiscordWebhook {
 	public static final field Companion Ldev/kord/common/entity/DiscordWebhook$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/WebhookType;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/WebhookType;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/WebhookType;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/WebhookType;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/WebhookType;Ldev/kord/common/entity/optional/OptionalSnowflake;JLdev/kord/common/entity/optional/Optional;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/WebhookType;Ldev/kord/common/entity/optional/OptionalSnowflake;JLdev/kord/common/entity/optional/Optional;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component2 ()Ldev/kord/common/entity/WebhookType;
 	public final fun component3 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
-	public final fun component4 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component4-4_xYDEk ()J
 	public final fun component5 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component6 ()Ljava/lang/String;
 	public final fun component7 ()Ljava/lang/String;
 	public final fun component8 ()Ldev/kord/common/entity/optional/Optional;
-	public final fun component9 ()Ldev/kord/common/entity/Snowflake;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/WebhookType;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;)Ldev/kord/common/entity/DiscordWebhook;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordWebhook;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/WebhookType;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordWebhook;
+	public final fun component9-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
+	public final fun copy-phscL-E (JLdev/kord/common/entity/WebhookType;Ldev/kord/common/entity/optional/OptionalSnowflake;JLdev/kord/common/entity/optional/Optional;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;)Ldev/kord/common/entity/DiscordWebhook;
+	public static synthetic fun copy-phscL-E$default (Ldev/kord/common/entity/DiscordWebhook;JLdev/kord/common/entity/WebhookType;Ldev/kord/common/entity/optional/OptionalSnowflake;JLdev/kord/common/entity/optional/Optional;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordWebhook;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getApplicationId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getAvatar ()Ljava/lang/String;
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-4_xYDEk ()J
 	public final fun getGuildId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getName ()Ljava/lang/String;
 	public final fun getToken ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getType ()Ldev/kord/common/entity/WebhookType;
@@ -6006,15 +6005,15 @@ public final class dev/kord/common/entity/DiscordWebhook$Companion {
 
 public final class dev/kord/common/entity/DiscordWebhooksUpdateData {
 	public static final field Companion Ldev/kord/common/entity/DiscordWebhooksUpdateData$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)Ldev/kord/common/entity/DiscordWebhooksUpdateData;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordWebhooksUpdateData;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordWebhooksUpdateData;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
+	public final fun component2-4_xYDEk ()J
+	public final fun copy-Xcgsvs4 (JJ)Ldev/kord/common/entity/DiscordWebhooksUpdateData;
+	public static synthetic fun copy-Xcgsvs4$default (Ldev/kord/common/entity/DiscordWebhooksUpdateData;JJILjava/lang/Object;)Ldev/kord/common/entity/DiscordWebhooksUpdateData;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-4_xYDEk ()J
+	public final fun getGuildId-4_xYDEk ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public static final fun write$Self (Ldev/kord/common/entity/DiscordWebhooksUpdateData;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
@@ -6070,18 +6069,18 @@ public final class dev/kord/common/entity/DiscordWelcomeScreen$Companion {
 
 public final class dev/kord/common/entity/DiscordWelcomeScreenChannel {
 	public static final field Companion Ldev/kord/common/entity/DiscordWelcomeScreenChannel$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component3-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun component4 ()Ljava/lang/String;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;)Ldev/kord/common/entity/DiscordWelcomeScreenChannel;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordWelcomeScreenChannel;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordWelcomeScreenChannel;
+	public final fun copy-nKCQcT8 (JLjava/lang/String;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;)Ldev/kord/common/entity/DiscordWelcomeScreenChannel;
+	public static synthetic fun copy-nKCQcT8$default (Ldev/kord/common/entity/DiscordWelcomeScreenChannel;JLjava/lang/String;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordWelcomeScreenChannel;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-4_xYDEk ()J
 	public final fun getDescription ()Ljava/lang/String;
-	public final fun getEmojiId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getEmojiId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getEmojiName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -6423,22 +6422,22 @@ public final class dev/kord/common/entity/InstallParams$Companion {
 
 public final class dev/kord/common/entity/IntegrationApplication {
 	public static final field Companion Ldev/kord/common/entity/IntegrationApplication$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Ljava/lang/String;
 	public final fun component6 ()Ldev/kord/common/entity/optional/Optional;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/common/entity/IntegrationApplication;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/IntegrationApplication;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/common/entity/IntegrationApplication;
+	public final fun copy-vwSIg4A (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/common/entity/IntegrationApplication;
+	public static synthetic fun copy-vwSIg4A$default (Ldev/kord/common/entity/IntegrationApplication;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/common/entity/IntegrationApplication;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBot ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getDescription ()Ljava/lang/String;
 	public final fun getIcon ()Ljava/lang/String;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getName ()Ljava/lang/String;
 	public final synthetic fun getSummary ()Ljava/lang/String;
 	public fun hashCode ()I
@@ -6638,7 +6637,7 @@ public final class dev/kord/common/entity/InteractionType$Unknown : dev/kord/com
 public final class dev/kord/common/entity/InteractionsKt {
 	public static final fun boolean (Ldev/kord/common/entity/CommandArgument;)Z
 	public static final fun int (Ldev/kord/common/entity/CommandArgument;)J
-	public static final fun snowflake (Ldev/kord/common/entity/CommandArgument;)Ldev/kord/common/entity/Snowflake;
+	public static final fun snowflake (Ldev/kord/common/entity/CommandArgument;)J
 	public static final fun string (Ldev/kord/common/entity/CommandArgument;)Ljava/lang/String;
 }
 
@@ -6763,21 +6762,21 @@ public final class dev/kord/common/entity/MessageActivityType$Unknown : dev/kord
 
 public final class dev/kord/common/entity/MessageApplication {
 	public static final field Companion Ldev/kord/common/entity/MessageApplication$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/optional/Optional;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/optional/Optional;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component2 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Ljava/lang/String;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ldev/kord/common/entity/MessageApplication;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/MessageApplication;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ldev/kord/common/entity/MessageApplication;
+	public final fun copy-PHjaIKs (JLdev/kord/common/entity/optional/Optional;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ldev/kord/common/entity/MessageApplication;
+	public static synthetic fun copy-PHjaIKs$default (Ldev/kord/common/entity/MessageApplication;JLdev/kord/common/entity/optional/Optional;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ldev/kord/common/entity/MessageApplication;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCoverImage ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getDescription ()Ljava/lang/String;
 	public final fun getIcon ()Ljava/lang/String;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -6851,24 +6850,24 @@ public final class dev/kord/common/entity/MessageFlags$Companion {
 
 public final class dev/kord/common/entity/MessageReactionAddData {
 	public static final field Companion Ldev/kord/common/entity/MessageReactionAddData$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/DiscordPartialEmoji;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/DiscordPartialEmoji;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/DiscordPartialEmoji;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
-	public final fun component3 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/DiscordPartialEmoji;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJJLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/DiscordPartialEmoji;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJJLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/DiscordPartialEmoji;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
+	public final fun component2-4_xYDEk ()J
+	public final fun component3-4_xYDEk ()J
 	public final fun component4 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun component5 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component6 ()Ldev/kord/common/entity/DiscordPartialEmoji;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/DiscordPartialEmoji;)Ldev/kord/common/entity/MessageReactionAddData;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/MessageReactionAddData;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/DiscordPartialEmoji;ILjava/lang/Object;)Ldev/kord/common/entity/MessageReactionAddData;
+	public final fun copy-1Uz_rds (JJJLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/DiscordPartialEmoji;)Ldev/kord/common/entity/MessageReactionAddData;
+	public static synthetic fun copy-1Uz_rds$default (Ldev/kord/common/entity/MessageReactionAddData;JJJLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/DiscordPartialEmoji;ILjava/lang/Object;)Ldev/kord/common/entity/MessageReactionAddData;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-4_xYDEk ()J
 	public final fun getEmoji ()Ldev/kord/common/entity/DiscordPartialEmoji;
 	public final fun getGuildId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun getMember ()Ldev/kord/common/entity/optional/Optional;
-	public final fun getMessageId ()Ldev/kord/common/entity/Snowflake;
-	public final fun getUserId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getMessageId-4_xYDEk ()J
+	public final fun getUserId-4_xYDEk ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public static final fun write$Self (Ldev/kord/common/entity/MessageReactionAddData;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
@@ -6892,22 +6891,22 @@ public final class dev/kord/common/entity/MessageReactionAddData$Companion {
 
 public final class dev/kord/common/entity/MessageReactionRemoveData {
 	public static final field Companion Ldev/kord/common/entity/MessageReactionRemoveData$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/DiscordPartialEmoji;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/DiscordPartialEmoji;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/DiscordPartialEmoji;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
-	public final fun component3 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/DiscordPartialEmoji;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJJLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/DiscordPartialEmoji;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJJLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/DiscordPartialEmoji;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
+	public final fun component2-4_xYDEk ()J
+	public final fun component3-4_xYDEk ()J
 	public final fun component4 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun component5 ()Ldev/kord/common/entity/DiscordPartialEmoji;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/DiscordPartialEmoji;)Ldev/kord/common/entity/MessageReactionRemoveData;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/MessageReactionRemoveData;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/DiscordPartialEmoji;ILjava/lang/Object;)Ldev/kord/common/entity/MessageReactionRemoveData;
+	public final fun copy-duETn5c (JJJLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/DiscordPartialEmoji;)Ldev/kord/common/entity/MessageReactionRemoveData;
+	public static synthetic fun copy-duETn5c$default (Ldev/kord/common/entity/MessageReactionRemoveData;JJJLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/DiscordPartialEmoji;ILjava/lang/Object;)Ldev/kord/common/entity/MessageReactionRemoveData;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-4_xYDEk ()J
 	public final fun getEmoji ()Ldev/kord/common/entity/DiscordPartialEmoji;
 	public final fun getGuildId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
-	public final fun getMessageId ()Ldev/kord/common/entity/Snowflake;
-	public final fun getUserId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getMessageId-4_xYDEk ()J
+	public final fun getUserId-4_xYDEk ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public static final fun write$Self (Ldev/kord/common/entity/MessageReactionRemoveData;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
@@ -7150,18 +7149,18 @@ public final class dev/kord/common/entity/Option$Companion {
 
 public final class dev/kord/common/entity/Overwrite {
 	public static final field Companion Ldev/kord/common/entity/Overwrite$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/OverwriteType;Ldev/kord/common/entity/Permissions;Ldev/kord/common/entity/Permissions;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/OverwriteType;Ldev/kord/common/entity/Permissions;Ldev/kord/common/entity/Permissions;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/OverwriteType;Ldev/kord/common/entity/Permissions;Ldev/kord/common/entity/Permissions;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/OverwriteType;Ldev/kord/common/entity/Permissions;Ldev/kord/common/entity/Permissions;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component2 ()Ldev/kord/common/entity/OverwriteType;
 	public final fun component3 ()Ldev/kord/common/entity/Permissions;
 	public final fun component4 ()Ldev/kord/common/entity/Permissions;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/OverwriteType;Ldev/kord/common/entity/Permissions;Ldev/kord/common/entity/Permissions;)Ldev/kord/common/entity/Overwrite;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/Overwrite;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/OverwriteType;Ldev/kord/common/entity/Permissions;Ldev/kord/common/entity/Permissions;ILjava/lang/Object;)Ldev/kord/common/entity/Overwrite;
+	public final fun copy-9VmEaQQ (JLdev/kord/common/entity/OverwriteType;Ldev/kord/common/entity/Permissions;Ldev/kord/common/entity/Permissions;)Ldev/kord/common/entity/Overwrite;
+	public static synthetic fun copy-9VmEaQQ$default (Ldev/kord/common/entity/Overwrite;JLdev/kord/common/entity/OverwriteType;Ldev/kord/common/entity/Permissions;Ldev/kord/common/entity/Permissions;ILjava/lang/Object;)Ldev/kord/common/entity/Overwrite;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAllow ()Ldev/kord/common/entity/Permissions;
 	public final fun getDeny ()Ldev/kord/common/entity/Permissions;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getType ()Ldev/kord/common/entity/OverwriteType;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -7644,38 +7643,45 @@ public final class dev/kord/common/entity/ScheduledEntityType$Voice : dev/kord/c
 
 public final class dev/kord/common/entity/Snowflake : java/lang/Comparable {
 	public static final field Companion Ldev/kord/common/entity/Snowflake$Companion;
-	public synthetic fun <init> (JLkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun <init> (Ljava/lang/String;)V
-	public fun <init> (Lkotlinx/datetime/Instant;)V
-	public fun compareTo (Ldev/kord/common/entity/Snowflake;)I
+	public static final synthetic fun box-impl (J)Ldev/kord/common/entity/Snowflake;
 	public synthetic fun compareTo (Ljava/lang/Object;)I
-	public final fun component1 ()Lkotlinx/datetime/Instant;
-	public final fun component2-w2LRezQ ()B
-	public final fun component3-w2LRezQ ()B
-	public final fun component4-Mh2AYeg ()S
+	public fun compareTo-IO-hELI (J)I
+	public static fun compareTo-IO-hELI (JJ)I
+	public static final fun component1-impl (J)Lkotlinx/datetime/Instant;
+	public static final fun component2-w2LRezQ (J)B
+	public static final fun component3-w2LRezQ (J)B
+	public static final fun component4-Mh2AYeg (J)S
+	public static fun constructor-impl (J)J
+	public static fun constructor-impl (Ljava/lang/String;)J
+	public static fun constructor-impl (Lkotlinx/datetime/Instant;)J
 	public fun equals (Ljava/lang/Object;)Z
-	public final synthetic fun getAsString ()Ljava/lang/String;
-	public final fun getIncrement-Mh2AYeg ()S
-	public final fun getProcessId-w2LRezQ ()B
-	public final fun getTimeMark ()Lkotlin/time/TimeMark;
-	public final fun getTimestamp ()Lkotlinx/datetime/Instant;
+	public static fun equals-impl (JLjava/lang/Object;)Z
+	public static final fun equals-impl0 (JJ)Z
+	public static final synthetic fun getAsString-impl (J)Ljava/lang/String;
+	public static final fun getIncrement-Mh2AYeg (J)S
+	public static final fun getProcessId-w2LRezQ (J)B
+	public static final fun getTimeMark-impl (J)Lkotlin/time/TimeMark;
+	public static final fun getTimestamp-impl (J)Lkotlinx/datetime/Instant;
 	public final fun getValue-s-VKNKU ()J
-	public final fun getWorkerId-w2LRezQ ()B
+	public static final fun getWorkerId-w2LRezQ (J)B
 	public fun hashCode ()I
+	public static fun hashCode-impl (J)I
 	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (J)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()J
 }
 
 public final class dev/kord/common/entity/Snowflake$Companion {
 	public final fun getDiscordEpoch ()Lkotlinx/datetime/Instant;
 	public final fun getEndOfTime ()Lkotlinx/datetime/Instant;
-	public final fun getMax ()Ldev/kord/common/entity/Snowflake;
-	public final fun getMin ()Ldev/kord/common/entity/Snowflake;
+	public final fun getMax-4_xYDEk ()J
+	public final fun getMin-4_xYDEk ()J
 	public final fun getValidValues ()Lkotlin/ranges/ULongRange;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class dev/kord/common/entity/SnowflakeKt {
-	public static final fun Snowflake (J)Ldev/kord/common/entity/Snowflake;
+	public static final fun Snowflake (J)J
 }
 
 public abstract class dev/kord/common/entity/StageInstancePrivacyLevel {
@@ -8218,8 +8224,8 @@ public final class dev/kord/common/entity/optional/OptionalLongKt {
 public abstract class dev/kord/common/entity/optional/OptionalSnowflake {
 	public static final field Companion Ldev/kord/common/entity/optional/OptionalSnowflake$Companion;
 	public final fun getAsOptional ()Ldev/kord/common/entity/optional/Optional;
-	public fun getValue ()Ldev/kord/common/entity/Snowflake;
-	public final fun orElse (Ldev/kord/common/entity/Snowflake;)Ldev/kord/common/entity/Snowflake;
+	public fun getValue-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
+	public final fun orElse-Prm2rnc (J)J
 }
 
 public final class dev/kord/common/entity/optional/OptionalSnowflake$Companion {
@@ -8233,10 +8239,10 @@ public final class dev/kord/common/entity/optional/OptionalSnowflake$Missing : d
 
 public final class dev/kord/common/entity/optional/OptionalSnowflake$Value : dev/kord/common/entity/optional/OptionalSnowflake {
 	public synthetic fun <init> (JLkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component1-4_xYDEk ()J
 	public fun equals (Ljava/lang/Object;)Z
-	public fun getValue ()Ldev/kord/common/entity/Snowflake;
+	public fun getValue-4_xYDEk ()J
+	public synthetic fun getValue-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -8245,7 +8251,7 @@ public final class dev/kord/common/entity/optional/OptionalSnowflakeKt {
 	public static final fun getValue (Ldev/kord/common/entity/optional/OptionalSnowflake;)Ldev/kord/common/entity/Snowflake;
 	public static final fun map (Ldev/kord/common/entity/optional/OptionalSnowflake;Lkotlin/jvm/functions/Function1;)Ldev/kord/common/entity/optional/Optional;
 	public static final fun optionalNullable (Ldev/kord/common/entity/Snowflake;)Ldev/kord/common/entity/optional/OptionalSnowflake$Value;
-	public static final fun optionalSnowflake (Ldev/kord/common/entity/Snowflake;)Ldev/kord/common/entity/optional/OptionalSnowflake$Value;
+	public static final fun optionalSnowflake-IO-hELI (J)Ldev/kord/common/entity/optional/OptionalSnowflake$Value;
 }
 
 public final class dev/kord/common/entity/optional/delegate/OptionalBooleanDelegateKt {

--- a/common/src/main/kotlin/entity/Snowflake.kt
+++ b/common/src/main/kotlin/entity/Snowflake.kt
@@ -24,23 +24,20 @@ import kotlin.time.TimeMark
  * but [equals] only returns `true` if [compareTo] returns `0`.
  */
 @Serializable(with = Snowflake.Serializer::class)
-public class Snowflake : Comparable<Snowflake> {
-
+@JvmInline
+public value class Snowflake
+/**
+ * Creates a Snowflake from a given ULong [value].
+ *
+ * Values are [coerced in][coerceIn] [validValues].
+ */
+constructor(
     /**
      * The raw value of this Snowflake as specified
      * [here](https://discord.com/developers/docs/reference#snowflakes).
      */
     public val value: ULong
-
-    /**
-     * Creates a Snowflake from a given ULong [value].
-     *
-     * Values are [coerced in][coerceIn] [validValues].
-     */
-    public constructor(value: ULong) {
-        this.value = value.coerceIn(validValues)
-    }
-
+) : Comparable<Snowflake> {
     /**
      * Creates a Snowflake from a given String [value], parsing it as a [ULong] value.
      *
@@ -155,11 +152,6 @@ public class Snowflake : Comparable<Snowflake> {
      * A [String] representation of this Snowflake's [value].
      */
     override fun toString(): String = value.toString()
-
-    override fun hashCode(): Int = value.hashCode()
-
-    override fun equals(other: Any?): Boolean = other is Snowflake && this.value == other.value
-
 
     public companion object {
         // see https://discord.com/developers/docs/reference#snowflakes-snowflake-id-format-structure-left-to-right

--- a/common/src/main/kotlin/entity/optional/OptionalSnowflake.kt
+++ b/common/src/main/kotlin/entity/optional/OptionalSnowflake.kt
@@ -70,12 +70,7 @@ public sealed class OptionalSnowflake {
      * @param uLongValue the raw value this optional wraps.
      * See [Snowflake.value] and [Snowflake.validValues] for more details.
      */
-    public class Value(private val uLongValue: ULong) : OptionalSnowflake() {
-
-        public constructor(value: Snowflake) : this(value.value)
-
-        override val value: Snowflake get() = Snowflake(uLongValue)
-
+    public class Value(override val value: Snowflake) : OptionalSnowflake() {
         /**
          * Destructures this optional to its [value].
          */
@@ -95,7 +90,7 @@ public sealed class OptionalSnowflake {
         override val descriptor: SerialDescriptor = ULong.serializer().descriptor
 
         override fun deserialize(decoder: Decoder): OptionalSnowflake =
-            Value(decoder.decodeInline(descriptor).decodeLong().toULong())
+            Value(Snowflake(decoder.decodeInline(descriptor).decodeLong().toULong()))
 
         override fun serialize(encoder: Encoder, value: OptionalSnowflake) = when (value) {
             Missing -> Unit // ignore value
@@ -113,7 +108,7 @@ public val OptionalSnowflake?.value: Snowflake?
         OptionalSnowflake.Missing, null -> null
     }
 
-public fun Snowflake.optionalSnowflake(): OptionalSnowflake.Value = OptionalSnowflake.Value(this.value)
+public fun Snowflake.optionalSnowflake(): OptionalSnowflake.Value = OptionalSnowflake.Value(Snowflake(this.value))
 
 @JvmName("optionalNullable")
 public fun Snowflake?.optionalSnowflake(): OptionalSnowflake.Value? = this?.optionalSnowflake()

--- a/common/src/main/kotlin/entity/optional/delegate/OptionalSnowflakeDelegate.kt
+++ b/common/src/main/kotlin/entity/optional/delegate/OptionalSnowflakeDelegate.kt
@@ -18,7 +18,7 @@ public fun KMutableProperty0<OptionalSnowflake>.delegate(): ReadWriteProperty<An
 
         override fun setValue(thisRef: Any?, property: KProperty<*>, value: Snowflake?) {
             val optional = if (value == null) OptionalSnowflake.Missing
-            else OptionalSnowflake.Value(value.value)
+            else OptionalSnowflake.Value(Snowflake(value.value))
             this@delegate.set(optional)
         }
     }

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -1,7 +1,7 @@
 public final class dev/kord/core/ClientResources {
-	public fun <init> (Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/gateway/builder/Shards;ILio/ktor/client/HttpClient;Ldev/kord/core/supplier/EntitySupplyStrategy;)V
-	public fun <init> (Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/gateway/builder/Shards;Lio/ktor/client/HttpClient;Ldev/kord/core/supplier/EntitySupplyStrategy;)V
-	public final fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (Ljava/lang/String;JLdev/kord/gateway/builder/Shards;ILio/ktor/client/HttpClient;Ldev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;JLdev/kord/gateway/builder/Shards;Lio/ktor/client/HttpClient;Ldev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getApplicationId-4_xYDEk ()J
 	public final fun getDefaultStrategy ()Ldev/kord/core/supplier/EntitySupplyStrategy;
 	public final fun getHttpClient ()Lio/ktor/client/HttpClient;
 	public final fun getMaxConcurrency ()I
@@ -12,7 +12,7 @@ public final class dev/kord/core/ClientResources {
 
 public final class dev/kord/core/Kord : kotlinx/coroutines/CoroutineScope {
 	public static final field Companion Ldev/kord/core/Kord$Companion;
-	public fun <init> (Ldev/kord/core/ClientResources;Ldev/kord/cache/api/DataCache;Ldev/kord/core/gateway/MasterGateway;Ldev/kord/rest/service/RestClient;Ldev/kord/common/entity/Snowflake;Lkotlinx/coroutines/flow/MutableSharedFlow;Lkotlinx/coroutines/CoroutineDispatcher;Ldev/kord/core/gateway/handler/GatewayEventInterceptor;)V
+	public synthetic fun <init> (Ldev/kord/core/ClientResources;Ldev/kord/cache/api/DataCache;Ldev/kord/core/gateway/MasterGateway;Ldev/kord/rest/service/RestClient;JLkotlinx/coroutines/flow/MutableSharedFlow;Lkotlinx/coroutines/CoroutineDispatcher;Ldev/kord/core/gateway/handler/GatewayEventInterceptor;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun createGlobalApplicationCommands (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun createGlobalChatInputCommand (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun createGlobalChatInputCommand$default (Ldev/kord/core/Kord;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
@@ -22,69 +22,69 @@ public final class dev/kord/core/Kord : kotlinx/coroutines/CoroutineScope {
 	public static synthetic fun createGlobalUserCommand$default (Ldev/kord/core/Kord;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun createGuild (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final synthetic fun createGuild (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun createGuildApplicationCommands (Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun createGuildChatInputCommand (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun createGuildChatInputCommand$default (Ldev/kord/core/Kord;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun createGuildMessageCommand (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun createGuildMessageCommand$default (Ldev/kord/core/Kord;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun createGuildUserCommand (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun createGuildUserCommand$default (Ldev/kord/core/Kord;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun createGuildApplicationCommands-9y3P_48 (JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun createGuildChatInputCommand-PHjaIKs (JLjava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun createGuildChatInputCommand-PHjaIKs$default (Ldev/kord/core/Kord;JLjava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun createGuildMessageCommand-9VmEaQQ (JLjava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun createGuildMessageCommand-9VmEaQQ$default (Ldev/kord/core/Kord;JLjava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun createGuildUserCommand-9VmEaQQ (JLjava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun createGuildUserCommand-9VmEaQQ$default (Ldev/kord/core/Kord;JLjava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun editPresence (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun editSelf (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getApplicationInfo (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getCache ()Ldev/kord/cache/api/DataCache;
-	public final fun getChannel (Ldev/kord/common/entity/Snowflake;Ldev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getChannel$default (Ldev/kord/core/Kord;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getChannel-9y3P_48 (JLdev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getChannel-9y3P_48$default (Ldev/kord/core/Kord;JLdev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
 	public final fun getDefaultSupplier ()Ldev/kord/core/supplier/EntitySupplier;
 	public final fun getEvents ()Lkotlinx/coroutines/flow/SharedFlow;
 	public final fun getGateway ()Ldev/kord/core/gateway/MasterGateway;
-	public final fun getGlobalApplicationCommand (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGlobalApplicationCommandOf (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGlobalApplicationCommandOfOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGlobalApplicationCommandOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getGlobalApplicationCommand-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getGlobalApplicationCommandOf-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getGlobalApplicationCommandOfOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getGlobalApplicationCommandOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getGlobalApplicationCommands (Ljava/lang/Boolean;)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun getGlobalApplicationCommands$default (Ldev/kord/core/Kord;Ljava/lang/Boolean;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 	public final synthetic fun getGlobalCommands ()Lkotlinx/coroutines/flow/Flow;
-	public final fun getGuild (Ldev/kord/common/entity/Snowflake;Ldev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getGuild$default (Ldev/kord/core/Kord;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun getGuildApplicationCommand (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildApplicationCommandOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildApplicationCommands (Ldev/kord/common/entity/Snowflake;Ljava/lang/Boolean;)Lkotlinx/coroutines/flow/Flow;
-	public static synthetic fun getGuildApplicationCommands$default (Ldev/kord/core/Kord;Ldev/kord/common/entity/Snowflake;Ljava/lang/Boolean;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
-	public final fun getGuildOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getGuildOrNull$default (Ldev/kord/core/Kord;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun getGuildOrThrow (Ldev/kord/common/entity/Snowflake;Ldev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getGuildOrThrow$default (Ldev/kord/core/Kord;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun getGuildPreview (Ldev/kord/common/entity/Snowflake;Ldev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getGuildPreview$default (Ldev/kord/core/Kord;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun getGuildPreviewOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getGuildPreviewOrNull$default (Ldev/kord/core/Kord;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getGuild-9y3P_48 (JLdev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getGuild-9y3P_48$default (Ldev/kord/core/Kord;JLdev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getGuildApplicationCommand-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getGuildApplicationCommandOrNull-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getGuildApplicationCommands-wYKCHeA (JLjava/lang/Boolean;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun getGuildApplicationCommands-wYKCHeA$default (Ldev/kord/core/Kord;JLjava/lang/Boolean;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public final fun getGuildOrNull-9y3P_48 (JLdev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getGuildOrNull-9y3P_48$default (Ldev/kord/core/Kord;JLdev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getGuildOrThrow-9y3P_48 (JLdev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getGuildOrThrow-9y3P_48$default (Ldev/kord/core/Kord;JLdev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getGuildPreview-9y3P_48 (JLdev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getGuildPreview-9y3P_48$default (Ldev/kord/core/Kord;JLdev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getGuildPreviewOrNull-9y3P_48 (JLdev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getGuildPreviewOrNull-9y3P_48$default (Ldev/kord/core/Kord;JLdev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun getGuilds ()Lkotlinx/coroutines/flow/Flow;
-	public final fun getInvite (Ljava/lang/String;ZZLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getInvite$default (Ldev/kord/core/Kord;Ljava/lang/String;ZZLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun getInviteOrNull (Ljava/lang/String;ZZLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getInviteOrNull$default (Ldev/kord/core/Kord;Ljava/lang/String;ZZLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getInvite-ReOCJwE (Ljava/lang/String;ZZLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getInvite-ReOCJwE$default (Ldev/kord/core/Kord;Ljava/lang/String;ZZLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getInviteOrNull-ReOCJwE (Ljava/lang/String;ZZLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getInviteOrNull-ReOCJwE$default (Ldev/kord/core/Kord;Ljava/lang/String;ZZLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun getNitroStickerPacks ()Lkotlinx/coroutines/flow/Flow;
 	public final fun getRegions ()Lkotlinx/coroutines/flow/Flow;
 	public final fun getResources ()Ldev/kord/core/ClientResources;
 	public final fun getRest ()Ldev/kord/rest/service/RestClient;
 	public final fun getSelf (Ldev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getSelf$default (Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun getSelfId ()Ldev/kord/common/entity/Snowflake;
-	public final fun getSticker (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getSelfId-4_xYDEk ()J
+	public final fun getSticker-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getUnsafe ()Ldev/kord/core/Unsafe;
-	public final fun getUser (Ldev/kord/common/entity/Snowflake;Ldev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getUser$default (Ldev/kord/core/Kord;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun getWebhook (Ldev/kord/common/entity/Snowflake;Ldev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getWebhook$default (Ldev/kord/core/Kord;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun getWebhookOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getWebhookOrNull$default (Ldev/kord/core/Kord;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun getWebhookWithToken (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getWebhookWithToken$default (Ldev/kord/core/Kord;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun getWebhookWithTokenOrNull (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getWebhookWithTokenOrNull$default (Ldev/kord/core/Kord;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getUser-9y3P_48 (JLdev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getUser-9y3P_48$default (Ldev/kord/core/Kord;JLdev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getWebhook-9y3P_48 (JLdev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getWebhook-9y3P_48$default (Ldev/kord/core/Kord;JLdev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getWebhookOrNull-9y3P_48 (JLdev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getWebhookOrNull-9y3P_48$default (Ldev/kord/core/Kord;JLdev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getWebhookWithToken-9VmEaQQ (JLjava/lang/String;Ldev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getWebhookWithToken-9VmEaQQ$default (Ldev/kord/core/Kord;JLjava/lang/String;Ldev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getWebhookWithTokenOrNull-9VmEaQQ (JLjava/lang/String;Ldev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getWebhookWithTokenOrNull-9VmEaQQ$default (Ldev/kord/core/Kord;JLjava/lang/String;Ldev/kord/core/supplier/EntitySupplyStrategy;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun login (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun login$default (Ldev/kord/core/Kord;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun logout (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -94,8 +94,8 @@ public final class dev/kord/core/Kord : kotlinx/coroutines/CoroutineScope {
 }
 
 public final class dev/kord/core/Kord$Companion {
-	public final fun proxy (Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;)Ldev/kord/core/Kord;
-	public static synthetic fun proxy$default (Ldev/kord/core/Kord$Companion;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/kord/core/Kord;
+	public final fun proxy-wYKCHeA (JLkotlin/jvm/functions/Function1;)Ldev/kord/core/Kord;
+	public static synthetic fun proxy-wYKCHeA$default (Ldev/kord/core/Kord$Companion;JLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/kord/core/Kord;
 	public final fun restOnly (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ldev/kord/core/Kord;
 	public static synthetic fun restOnly$default (Ldev/kord/core/Kord$Companion;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/kord/core/Kord;
 }
@@ -112,45 +112,45 @@ public abstract interface class dev/kord/core/KordObject {
 
 public final class dev/kord/core/Unsafe {
 	public fun <init> (Ldev/kord/core/Kord;)V
-	public final fun applicationCommandInteraction (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/behavior/interaction/ApplicationCommandInteractionBehavior;
-	public final fun autoModerationRule (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/behavior/automoderation/AutoModerationRuleBehavior;
-	public final fun categorizableChannel (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/behavior/channel/CategorizableChannelBehavior;
-	public final fun channel (Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/behavior/channel/ChannelBehavior;
-	public final fun componentInteraction (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/behavior/interaction/ComponentInteractionBehavior;
-	public static synthetic fun componentInteraction$default (Ldev/kord/core/Unsafe;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;ILjava/lang/Object;)Ldev/kord/core/behavior/interaction/ComponentInteractionBehavior;
-	public final fun globalApplicationCommand (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/behavior/GlobalApplicationCommandBehavior;
-	public final fun globalApplicationCommand (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/behavior/GuildApplicationCommandBehavior;
-	public final fun globalApplicationCommand (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/service/InteractionService;)Ldev/kord/core/behavior/GlobalApplicationCommandBehavior;
-	public static synthetic fun globalApplicationCommand$default (Ldev/kord/core/Unsafe;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/service/InteractionService;ILjava/lang/Object;)Ldev/kord/core/behavior/GlobalApplicationCommandBehavior;
-	public final fun guild (Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/behavior/GuildBehavior;
-	public final fun guildApplicationCommand (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/service/InteractionService;)Ldev/kord/core/behavior/GuildApplicationCommandBehavior;
-	public static synthetic fun guildApplicationCommand$default (Ldev/kord/core/Unsafe;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/service/InteractionService;ILjava/lang/Object;)Ldev/kord/core/behavior/GuildApplicationCommandBehavior;
-	public final fun guildChannel (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/behavior/channel/GuildChannelBehavior;
-	public final fun guildEmoji (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;)Ldev/kord/core/behavior/GuildEmojiBehavior;
-	public final fun guildMessageChannel (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/behavior/channel/GuildMessageChannelBehavior;
-	public final fun guildScheduledEvent (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/behavior/GuildScheduledEventBehavior;
-	public final fun keywordAutoModerationRule (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/behavior/automoderation/KeywordAutoModerationRuleBehavior;
-	public final fun keywordPresetAutoModerationRule (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/behavior/automoderation/KeywordPresetAutoModerationRuleBehavior;
-	public final fun member (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/behavior/MemberBehavior;
-	public final fun mentionSpamAutoModerationRule (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/behavior/automoderation/MentionSpamAutoModerationRuleBehavior;
-	public final fun message (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/behavior/MessageBehavior;
-	public final fun messageChannel (Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/behavior/channel/MessageChannelBehavior;
-	public final fun newsChannel (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/behavior/channel/NewsChannelBehavior;
-	public final fun privateThreadParent (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/behavior/channel/threads/PrivateThreadParentChannelBehavior;
-	public final fun publicThreadParent (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/behavior/channel/threads/ThreadParentChannelBehavior;
-	public final fun role (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/behavior/RoleBehavior;
-	public final fun spamAutoModerationRule (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/behavior/automoderation/SpamAutoModerationRuleBehavior;
-	public final fun stageInstance (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/behavior/StageInstanceBehavior;
-	public final synthetic fun storeChannel (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/behavior/channel/StoreChannelBehavior;
-	public final fun textChannel (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/behavior/channel/TextChannelBehavior;
-	public final fun thread (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/behavior/channel/threads/ThreadChannelBehavior;
-	public final fun threadMember (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/behavior/ThreadMemberBehavior;
+	public final fun applicationCommandInteraction-y0HsnCc (JJLjava/lang/String;J)Ldev/kord/core/behavior/interaction/ApplicationCommandInteractionBehavior;
+	public final fun autoModerationRule-Xcgsvs4 (JJ)Ldev/kord/core/behavior/automoderation/AutoModerationRuleBehavior;
+	public final fun categorizableChannel-Xcgsvs4 (JJ)Ldev/kord/core/behavior/channel/CategorizableChannelBehavior;
+	public final fun channel-IO-hELI (J)Ldev/kord/core/behavior/channel/ChannelBehavior;
+	public final fun componentInteraction-y0HsnCc (JJLjava/lang/String;J)Ldev/kord/core/behavior/interaction/ComponentInteractionBehavior;
+	public static synthetic fun componentInteraction-y0HsnCc$default (Ldev/kord/core/Unsafe;JJLjava/lang/String;JILjava/lang/Object;)Ldev/kord/core/behavior/interaction/ComponentInteractionBehavior;
+	public final fun globalApplicationCommand-9IY7LyE (JJJ)Ldev/kord/core/behavior/GuildApplicationCommandBehavior;
+	public final fun globalApplicationCommand-U2evHYk (JJLdev/kord/rest/service/InteractionService;)Ldev/kord/core/behavior/GlobalApplicationCommandBehavior;
+	public static synthetic fun globalApplicationCommand-U2evHYk$default (Ldev/kord/core/Unsafe;JJLdev/kord/rest/service/InteractionService;ILjava/lang/Object;)Ldev/kord/core/behavior/GlobalApplicationCommandBehavior;
+	public final fun globalApplicationCommand-Xcgsvs4 (JJ)Ldev/kord/core/behavior/GlobalApplicationCommandBehavior;
+	public final fun guild-IO-hELI (J)Ldev/kord/core/behavior/GuildBehavior;
+	public final fun guildApplicationCommand-SmFlTYk (JJJLdev/kord/rest/service/InteractionService;)Ldev/kord/core/behavior/GuildApplicationCommandBehavior;
+	public static synthetic fun guildApplicationCommand-SmFlTYk$default (Ldev/kord/core/Unsafe;JJJLdev/kord/rest/service/InteractionService;ILjava/lang/Object;)Ldev/kord/core/behavior/GuildApplicationCommandBehavior;
+	public final fun guildChannel-Xcgsvs4 (JJ)Ldev/kord/core/behavior/channel/GuildChannelBehavior;
+	public final fun guildEmoji-U2evHYk (JJLdev/kord/core/Kord;)Ldev/kord/core/behavior/GuildEmojiBehavior;
+	public final fun guildMessageChannel-Xcgsvs4 (JJ)Ldev/kord/core/behavior/channel/GuildMessageChannelBehavior;
+	public final fun guildScheduledEvent-Xcgsvs4 (JJ)Ldev/kord/core/behavior/GuildScheduledEventBehavior;
+	public final fun keywordAutoModerationRule-Xcgsvs4 (JJ)Ldev/kord/core/behavior/automoderation/KeywordAutoModerationRuleBehavior;
+	public final fun keywordPresetAutoModerationRule-Xcgsvs4 (JJ)Ldev/kord/core/behavior/automoderation/KeywordPresetAutoModerationRuleBehavior;
+	public final fun member-Xcgsvs4 (JJ)Ldev/kord/core/behavior/MemberBehavior;
+	public final fun mentionSpamAutoModerationRule-Xcgsvs4 (JJ)Ldev/kord/core/behavior/automoderation/MentionSpamAutoModerationRuleBehavior;
+	public final fun message-Xcgsvs4 (JJ)Ldev/kord/core/behavior/MessageBehavior;
+	public final fun messageChannel-IO-hELI (J)Ldev/kord/core/behavior/channel/MessageChannelBehavior;
+	public final fun newsChannel-Xcgsvs4 (JJ)Ldev/kord/core/behavior/channel/NewsChannelBehavior;
+	public final fun privateThreadParent-Xcgsvs4 (JJ)Ldev/kord/core/behavior/channel/threads/PrivateThreadParentChannelBehavior;
+	public final fun publicThreadParent-Xcgsvs4 (JJ)Ldev/kord/core/behavior/channel/threads/ThreadParentChannelBehavior;
+	public final fun role-Xcgsvs4 (JJ)Ldev/kord/core/behavior/RoleBehavior;
+	public final fun spamAutoModerationRule-Xcgsvs4 (JJ)Ldev/kord/core/behavior/automoderation/SpamAutoModerationRuleBehavior;
+	public final fun stageInstance-Xcgsvs4 (JJ)Ldev/kord/core/behavior/StageInstanceBehavior;
+	public final synthetic fun storeChannel-Xcgsvs4 (JJ)Ldev/kord/core/behavior/channel/StoreChannelBehavior;
+	public final fun textChannel-Xcgsvs4 (JJ)Ldev/kord/core/behavior/channel/TextChannelBehavior;
+	public final fun thread-9IY7LyE (JJJ)Ldev/kord/core/behavior/channel/threads/ThreadChannelBehavior;
+	public final fun threadMember-Xcgsvs4 (JJ)Ldev/kord/core/behavior/ThreadMemberBehavior;
 	public fun toString ()Ljava/lang/String;
-	public final fun topGuildChannel (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/behavior/channel/TopGuildChannelBehavior;
-	public final fun topGuildMessageChannel (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/behavior/channel/TopGuildMessageChannelBehavior;
-	public final fun user (Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/behavior/UserBehavior;
-	public final fun voiceChannel (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/behavior/channel/VoiceChannelBehavior;
-	public final fun webhook (Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/behavior/WebhookBehavior;
+	public final fun topGuildChannel-Xcgsvs4 (JJ)Ldev/kord/core/behavior/channel/TopGuildChannelBehavior;
+	public final fun topGuildMessageChannel-Xcgsvs4 (JJ)Ldev/kord/core/behavior/channel/TopGuildMessageChannelBehavior;
+	public final fun user-IO-hELI (J)Ldev/kord/core/behavior/UserBehavior;
+	public final fun voiceChannel-Xcgsvs4 (JJ)Ldev/kord/core/behavior/channel/VoiceChannelBehavior;
+	public final fun webhook-IO-hELI (J)Ldev/kord/core/behavior/WebhookBehavior;
 }
 
 public final class dev/kord/core/UtilKt {
@@ -164,7 +164,7 @@ public final class dev/kord/core/UtilKt {
 
 public abstract interface class dev/kord/core/behavior/ApplicationCommandBehavior : dev/kord/core/entity/Entity {
 	public abstract fun delete (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getApplicationId-4_xYDEk ()J
 	public abstract fun getService ()Ldev/kord/rest/service/InteractionService;
 }
 
@@ -190,8 +190,8 @@ public final class dev/kord/core/behavior/GlobalApplicationCommandBehavior$Defau
 }
 
 public final class dev/kord/core/behavior/GlobalApplicationCommandBehaviorKt {
-	public static final fun GlobalApplicationCommandBehavior (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/service/InteractionService;)Ldev/kord/core/behavior/GlobalApplicationCommandBehavior;
-	public static final fun GuildApplicationCommandBehavior (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/service/InteractionService;)Ldev/kord/core/behavior/GuildApplicationCommandBehavior;
+	public static final fun GlobalApplicationCommandBehavior-U2evHYk (JJLdev/kord/rest/service/InteractionService;)Ldev/kord/core/behavior/GlobalApplicationCommandBehavior;
+	public static final fun GuildApplicationCommandBehavior-SmFlTYk (JJJLdev/kord/rest/service/InteractionService;)Ldev/kord/core/behavior/GuildApplicationCommandBehavior;
 }
 
 public abstract interface class dev/kord/core/behavior/GlobalChatInputCommandBehavior : dev/kord/core/behavior/ChatInputCommandBehavior, dev/kord/core/behavior/GlobalApplicationCommandBehavior {
@@ -226,7 +226,7 @@ public final class dev/kord/core/behavior/GlobalUserCommandBehavior$DefaultImpls
 
 public abstract interface class dev/kord/core/behavior/GuildApplicationCommandBehavior : dev/kord/core/behavior/ApplicationCommandBehavior {
 	public abstract fun delete (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getGuildId-4_xYDEk ()J
 }
 
 public final class dev/kord/core/behavior/GuildApplicationCommandBehavior$DefaultImpls {
@@ -246,30 +246,30 @@ public abstract interface class dev/kord/core/behavior/GuildBehavior : dev/kord/
 	public abstract fun fetchGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun fetchGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getActiveThreads ()Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getApplicationCommand (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getApplicationCommandOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getApplicationCommand-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getApplicationCommandOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getApplicationCommands (Ljava/lang/Boolean;)Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getAutoModerationRule (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getAutoModerationRuleOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getAutoModerationRule-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getAutoModerationRuleOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getAutoModerationRules ()Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getBan (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getBanOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getBan-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getBanOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getBans ()Lkotlinx/coroutines/flow/Flow;
 	public abstract fun getCachedThreads ()Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getChannel (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getChannelOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getChannel-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getChannelOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getChannels ()Lkotlinx/coroutines/flow/Flow;
 	public abstract synthetic fun getCommands ()Lkotlinx/coroutines/flow/Flow;
 	public abstract fun getEmojis ()Lkotlinx/coroutines/flow/Flow;
 	public abstract fun getGateway ()Ldev/kord/gateway/Gateway;
-	public abstract fun getGuildScheduledEvent (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getGuildScheduledEventOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getGuildScheduledEvent-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getGuildScheduledEventOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getIntegrations ()Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getInvite (Ljava/lang/String;ZZLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getInviteOrNull (Ljava/lang/String;ZZLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getInvite-ReOCJwE (Ljava/lang/String;ZZLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getInviteOrNull-ReOCJwE (Ljava/lang/String;ZZLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getInvites ()Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getMember (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getMemberOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getMember-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getMemberOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getMembers ()Lkotlinx/coroutines/flow/Flow;
 	public abstract fun getMembers (Ljava/lang/String;I)Lkotlinx/coroutines/flow/Flow;
 	public abstract fun getPresences ()Lkotlinx/coroutines/flow/Flow;
@@ -277,12 +277,12 @@ public abstract interface class dev/kord/core/behavior/GuildBehavior : dev/kord/
 	public abstract fun getPreviewOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getPruneCount (ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getRegions ()Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getRole (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getRoleOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getRole-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getRoleOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getRoles ()Lkotlinx/coroutines/flow/Flow;
 	public abstract fun getScheduledEvents ()Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getSticker (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getStickerOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getSticker-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getStickerOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getStickers ()Lkotlinx/coroutines/flow/Flow;
 	public abstract fun getTemplate (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getTemplateOrNull (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -294,11 +294,11 @@ public abstract interface class dev/kord/core/behavior/GuildBehavior : dev/kord/
 	public abstract fun getWelcomeScreenOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getWidget (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getWidgetOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun kick (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun kick-9y3P_48 (JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun leave (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun prune (ILjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun requestMembers (Ldev/kord/gateway/RequestGuildMembers;)Lkotlinx/coroutines/flow/Flow;
-	public abstract fun unban (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun unban-9y3P_48 (JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/GuildBehavior;
 }
 
@@ -317,33 +317,33 @@ public final class dev/kord/core/behavior/GuildBehavior$DefaultImpls {
 	public static fun fetchGuild (Ldev/kord/core/behavior/GuildBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun fetchGuildOrNull (Ldev/kord/core/behavior/GuildBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getActiveThreads (Ldev/kord/core/behavior/GuildBehavior;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getApplicationCommand (Ldev/kord/core/behavior/GuildBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getApplicationCommandOrNull (Ldev/kord/core/behavior/GuildBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getApplicationCommand-wYKCHeA (Ldev/kord/core/behavior/GuildBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getApplicationCommandOrNull-wYKCHeA (Ldev/kord/core/behavior/GuildBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getApplicationCommands (Ldev/kord/core/behavior/GuildBehavior;Ljava/lang/Boolean;)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun getApplicationCommands$default (Ldev/kord/core/behavior/GuildBehavior;Ljava/lang/Boolean;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getAutoModerationRule (Ldev/kord/core/behavior/GuildBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getAutoModerationRuleOrNull (Ldev/kord/core/behavior/GuildBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getAutoModerationRule-wYKCHeA (Ldev/kord/core/behavior/GuildBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getAutoModerationRuleOrNull-wYKCHeA (Ldev/kord/core/behavior/GuildBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getAutoModerationRules (Ldev/kord/core/behavior/GuildBehavior;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getBan (Ldev/kord/core/behavior/GuildBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getBanOrNull (Ldev/kord/core/behavior/GuildBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getBan-wYKCHeA (Ldev/kord/core/behavior/GuildBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getBanOrNull-wYKCHeA (Ldev/kord/core/behavior/GuildBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getBans (Ldev/kord/core/behavior/GuildBehavior;)Lkotlinx/coroutines/flow/Flow;
 	public static fun getCachedThreads (Ldev/kord/core/behavior/GuildBehavior;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getChannel (Ldev/kord/core/behavior/GuildBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getChannelOrNull (Ldev/kord/core/behavior/GuildBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getChannel-wYKCHeA (Ldev/kord/core/behavior/GuildBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getChannelOrNull-wYKCHeA (Ldev/kord/core/behavior/GuildBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getChannels (Ldev/kord/core/behavior/GuildBehavior;)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun getCommands (Ldev/kord/core/behavior/GuildBehavior;)Lkotlinx/coroutines/flow/Flow;
 	public static fun getEmojis (Ldev/kord/core/behavior/GuildBehavior;)Lkotlinx/coroutines/flow/Flow;
 	public static fun getGateway (Ldev/kord/core/behavior/GuildBehavior;)Ldev/kord/gateway/Gateway;
-	public static fun getGuildScheduledEvent (Ldev/kord/core/behavior/GuildBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getGuildScheduledEventOrNull (Ldev/kord/core/behavior/GuildBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getGuildScheduledEvent-wYKCHeA (Ldev/kord/core/behavior/GuildBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getGuildScheduledEventOrNull-wYKCHeA (Ldev/kord/core/behavior/GuildBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getIntegrations (Ldev/kord/core/behavior/GuildBehavior;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getInvite (Ldev/kord/core/behavior/GuildBehavior;Ljava/lang/String;ZZLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getInvite$default (Ldev/kord/core/behavior/GuildBehavior;Ljava/lang/String;ZZLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static fun getInviteOrNull (Ldev/kord/core/behavior/GuildBehavior;Ljava/lang/String;ZZLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getInviteOrNull$default (Ldev/kord/core/behavior/GuildBehavior;Ljava/lang/String;ZZLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static fun getInvite-ReOCJwE (Ldev/kord/core/behavior/GuildBehavior;Ljava/lang/String;ZZLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getInvite-ReOCJwE$default (Ldev/kord/core/behavior/GuildBehavior;Ljava/lang/String;ZZLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static fun getInviteOrNull-ReOCJwE (Ldev/kord/core/behavior/GuildBehavior;Ljava/lang/String;ZZLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getInviteOrNull-ReOCJwE$default (Ldev/kord/core/behavior/GuildBehavior;Ljava/lang/String;ZZLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static fun getInvites (Ldev/kord/core/behavior/GuildBehavior;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getMember (Ldev/kord/core/behavior/GuildBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getMemberOrNull (Ldev/kord/core/behavior/GuildBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getMember-wYKCHeA (Ldev/kord/core/behavior/GuildBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getMemberOrNull-wYKCHeA (Ldev/kord/core/behavior/GuildBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getMembers (Ldev/kord/core/behavior/GuildBehavior;)Lkotlinx/coroutines/flow/Flow;
 	public static fun getMembers (Ldev/kord/core/behavior/GuildBehavior;Ljava/lang/String;I)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun getMembers$default (Ldev/kord/core/behavior/GuildBehavior;Ljava/lang/String;IILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
@@ -353,12 +353,12 @@ public final class dev/kord/core/behavior/GuildBehavior$DefaultImpls {
 	public static fun getPruneCount (Ldev/kord/core/behavior/GuildBehavior;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getPruneCount$default (Ldev/kord/core/behavior/GuildBehavior;ILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static fun getRegions (Ldev/kord/core/behavior/GuildBehavior;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getRole (Ldev/kord/core/behavior/GuildBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getRoleOrNull (Ldev/kord/core/behavior/GuildBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getRole-wYKCHeA (Ldev/kord/core/behavior/GuildBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getRoleOrNull-wYKCHeA (Ldev/kord/core/behavior/GuildBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getRoles (Ldev/kord/core/behavior/GuildBehavior;)Lkotlinx/coroutines/flow/Flow;
 	public static fun getScheduledEvents (Ldev/kord/core/behavior/GuildBehavior;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getSticker (Ldev/kord/core/behavior/GuildBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getStickerOrNull (Ldev/kord/core/behavior/GuildBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getSticker-wYKCHeA (Ldev/kord/core/behavior/GuildBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getStickerOrNull-wYKCHeA (Ldev/kord/core/behavior/GuildBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getStickers (Ldev/kord/core/behavior/GuildBehavior;)Lkotlinx/coroutines/flow/Flow;
 	public static fun getTemplate (Ldev/kord/core/behavior/GuildBehavior;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getTemplateOrNull (Ldev/kord/core/behavior/GuildBehavior;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -370,21 +370,21 @@ public final class dev/kord/core/behavior/GuildBehavior$DefaultImpls {
 	public static fun getWelcomeScreenOrNull (Ldev/kord/core/behavior/GuildBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getWidget (Ldev/kord/core/behavior/GuildBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getWidgetOrNull (Ldev/kord/core/behavior/GuildBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun kick (Ldev/kord/core/behavior/GuildBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun kick$default (Ldev/kord/core/behavior/GuildBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static fun kick-9y3P_48 (Ldev/kord/core/behavior/GuildBehavior;JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun kick-9y3P_48$default (Ldev/kord/core/behavior/GuildBehavior;JLjava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static fun leave (Ldev/kord/core/behavior/GuildBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun prune (Ldev/kord/core/behavior/GuildBehavior;ILjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun prune$default (Ldev/kord/core/behavior/GuildBehavior;ILjava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static fun requestMembers (Ldev/kord/core/behavior/GuildBehavior;Ldev/kord/gateway/RequestGuildMembers;)Lkotlinx/coroutines/flow/Flow;
-	public static fun unban (Ldev/kord/core/behavior/GuildBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun unban$default (Ldev/kord/core/behavior/GuildBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static fun unban-9y3P_48 (Ldev/kord/core/behavior/GuildBehavior;JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun unban-9y3P_48$default (Ldev/kord/core/behavior/GuildBehavior;JLjava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static fun withStrategy (Ldev/kord/core/behavior/GuildBehavior;Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/GuildBehavior;
 }
 
 public final class dev/kord/core/behavior/GuildBehaviorKt {
-	public static final fun GuildBehavior (Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/GuildBehavior;
-	public static synthetic fun GuildBehavior$default (Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;ILjava/lang/Object;)Ldev/kord/core/behavior/GuildBehavior;
-	public static final fun ban (Ldev/kord/core/behavior/GuildBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun GuildBehavior-9y3P_48 (JLdev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/GuildBehavior;
+	public static synthetic fun GuildBehavior-9y3P_48$default (JLdev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;ILjava/lang/Object;)Ldev/kord/core/behavior/GuildBehavior;
+	public static final fun ban-nMAJGj4 (Ldev/kord/core/behavior/GuildBehavior;JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun createApplicationCommands (Ldev/kord/core/behavior/GuildBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun createCategory (Ldev/kord/core/behavior/GuildBehavior;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final synthetic fun createCategory (Ldev/kord/core/behavior/GuildBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -441,7 +441,7 @@ public final class dev/kord/core/behavior/GuildChatInputCommandBehavior$DefaultI
 public abstract interface class dev/kord/core/behavior/GuildEmojiBehavior : dev/kord/core/entity/KordEntity, dev/kord/core/entity/Strategizable {
 	public abstract fun delete (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
-	public abstract fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getGuildId-4_xYDEk ()J
 	public abstract fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/GuildEmojiBehavior;
 }
 
@@ -473,13 +473,13 @@ public abstract interface class dev/kord/core/behavior/GuildScheduledEventBehavi
 	public abstract fun delete (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun fetchGuildScheduledEvent (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun fetchGuildScheduledEventOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getGuildId-4_xYDEk ()J
 	public abstract fun getMembers ()Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getMembersAfter (Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getMembersBefore (Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getMembersAfter-wYKCHeA (JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getMembersBefore-wYKCHeA (JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
 	public abstract fun getUsers ()Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getUsersAfter (Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getUsersBefore (Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getUsersAfter-wYKCHeA (JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getUsersBefore-wYKCHeA (JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
 }
 
 public final class dev/kord/core/behavior/GuildScheduledEventBehavior$DefaultImpls {
@@ -490,15 +490,15 @@ public final class dev/kord/core/behavior/GuildScheduledEventBehavior$DefaultImp
 	public static fun fetchGuildScheduledEvent (Ldev/kord/core/behavior/GuildScheduledEventBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun fetchGuildScheduledEventOrNull (Ldev/kord/core/behavior/GuildScheduledEventBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getMembers (Ldev/kord/core/behavior/GuildScheduledEventBehavior;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getMembersAfter (Ldev/kord/core/behavior/GuildScheduledEventBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public static synthetic fun getMembersAfter$default (Ldev/kord/core/behavior/GuildScheduledEventBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getMembersBefore (Ldev/kord/core/behavior/GuildScheduledEventBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public static synthetic fun getMembersBefore$default (Ldev/kord/core/behavior/GuildScheduledEventBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getMembersAfter-wYKCHeA (Ldev/kord/core/behavior/GuildScheduledEventBehavior;JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun getMembersAfter-wYKCHeA$default (Ldev/kord/core/behavior/GuildScheduledEventBehavior;JLjava/lang/Integer;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getMembersBefore-wYKCHeA (Ldev/kord/core/behavior/GuildScheduledEventBehavior;JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun getMembersBefore-wYKCHeA$default (Ldev/kord/core/behavior/GuildScheduledEventBehavior;JLjava/lang/Integer;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 	public static fun getUsers (Ldev/kord/core/behavior/GuildScheduledEventBehavior;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getUsersAfter (Ldev/kord/core/behavior/GuildScheduledEventBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public static synthetic fun getUsersAfter$default (Ldev/kord/core/behavior/GuildScheduledEventBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getUsersBefore (Ldev/kord/core/behavior/GuildScheduledEventBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public static synthetic fun getUsersBefore$default (Ldev/kord/core/behavior/GuildScheduledEventBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getUsersAfter-wYKCHeA (Ldev/kord/core/behavior/GuildScheduledEventBehavior;JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun getUsersAfter-wYKCHeA$default (Ldev/kord/core/behavior/GuildScheduledEventBehavior;JLjava/lang/Integer;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getUsersBefore-wYKCHeA (Ldev/kord/core/behavior/GuildScheduledEventBehavior;JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun getUsersBefore-wYKCHeA$default (Ldev/kord/core/behavior/GuildScheduledEventBehavior;JLjava/lang/Integer;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 }
 
 public final class dev/kord/core/behavior/GuildScheduledEventBehaviorKt {
@@ -516,14 +516,14 @@ public final class dev/kord/core/behavior/GuildUserCommandBehavior$DefaultImpls 
 }
 
 public abstract interface class dev/kord/core/behavior/MemberBehavior : dev/kord/core/behavior/UserBehavior, dev/kord/core/entity/KordEntity {
-	public abstract fun addRole (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun addRole-9y3P_48 (JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun asMember (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun asMemberOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun fetchMember (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun fetchMemberOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public abstract fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getGuildId-4_xYDEk ()J
 	public abstract fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract synthetic fun getNicknameMention ()Ljava/lang/String;
 	public abstract fun getPresence (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -531,24 +531,24 @@ public abstract interface class dev/kord/core/behavior/MemberBehavior : dev/kord
 	public abstract fun getVoiceState (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getVoiceStateOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun kick (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun removeRole (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun removeRole-9y3P_48 (JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/MemberBehavior;
 }
 
 public final class dev/kord/core/behavior/MemberBehavior$DefaultImpls {
-	public static fun addRole (Ldev/kord/core/behavior/MemberBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun addRole$default (Ldev/kord/core/behavior/MemberBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static fun asMember (Ldev/kord/core/behavior/MemberBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun addRole-9y3P_48 (Ldev/kord/core/behavior/MemberBehavior;JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun addRole-9y3P_48$default (Ldev/kord/core/behavior/MemberBehavior;JLjava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static fun asMember (Ldev/kord/core/behavior/MemberBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun asMemberOrNull (Ldev/kord/core/behavior/MemberBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun asMember-wYKCHeA (Ldev/kord/core/behavior/MemberBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun asMemberOrNull (Ldev/kord/core/behavior/MemberBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun asMemberOrNull-wYKCHeA (Ldev/kord/core/behavior/MemberBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun asUser (Ldev/kord/core/behavior/MemberBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun asUserOrNull (Ldev/kord/core/behavior/MemberBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun compareTo (Ldev/kord/core/behavior/MemberBehavior;Ldev/kord/core/entity/Entity;)I
-	public static fun fetchMember (Ldev/kord/core/behavior/MemberBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun fetchMember (Ldev/kord/core/behavior/MemberBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun fetchMemberOrNull (Ldev/kord/core/behavior/MemberBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun fetchMember-wYKCHeA (Ldev/kord/core/behavior/MemberBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun fetchMemberOrNull (Ldev/kord/core/behavior/MemberBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun fetchMemberOrNull-wYKCHeA (Ldev/kord/core/behavior/MemberBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun fetchUser (Ldev/kord/core/behavior/MemberBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun fetchUserOrNull (Ldev/kord/core/behavior/MemberBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getDmChannel (Ldev/kord/core/behavior/MemberBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -564,14 +564,14 @@ public final class dev/kord/core/behavior/MemberBehavior$DefaultImpls {
 	public static fun getVoiceStateOrNull (Ldev/kord/core/behavior/MemberBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun kick (Ldev/kord/core/behavior/MemberBehavior;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun kick$default (Ldev/kord/core/behavior/MemberBehavior;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static fun removeRole (Ldev/kord/core/behavior/MemberBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun removeRole$default (Ldev/kord/core/behavior/MemberBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static fun removeRole-9y3P_48 (Ldev/kord/core/behavior/MemberBehavior;JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun removeRole-9y3P_48$default (Ldev/kord/core/behavior/MemberBehavior;JLjava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static fun withStrategy (Ldev/kord/core/behavior/MemberBehavior;Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/MemberBehavior;
 }
 
 public final class dev/kord/core/behavior/MemberBehaviorKt {
-	public static final fun MemberBehavior (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/MemberBehavior;
-	public static synthetic fun MemberBehavior$default (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;ILjava/lang/Object;)Ldev/kord/core/behavior/MemberBehavior;
+	public static final fun MemberBehavior-Lfpyfds (JJLdev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/MemberBehavior;
+	public static synthetic fun MemberBehavior-Lfpyfds$default (JJLdev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;ILjava/lang/Object;)Ldev/kord/core/behavior/MemberBehavior;
 	public static final fun ban (Ldev/kord/core/behavior/MemberBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun ban$default (Ldev/kord/core/behavior/MemberBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun edit (Ldev/kord/core/behavior/MemberBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -582,17 +582,17 @@ public abstract interface class dev/kord/core/behavior/MessageBehavior : dev/kor
 	public abstract fun addReaction (Ldev/kord/core/entity/ReactionEmoji;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun asMessage (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun asMessageOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun delete (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun delete (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun delete-nKCQcT8 (JLjava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun deleteAllReactions (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun deleteOwnReaction (Ldev/kord/core/entity/ReactionEmoji;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun deleteReaction (Ldev/kord/common/entity/Snowflake;Ldev/kord/core/entity/ReactionEmoji;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun deleteReaction (Ldev/kord/core/entity/ReactionEmoji;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun deleteReaction-9y3P_48 (JLdev/kord/core/entity/ReactionEmoji;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun fetchMessage (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun fetchMessageOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getChannel ()Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public abstract fun getChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getChannelId-4_xYDEk ()J
 	public abstract fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getReactors (Ldev/kord/core/entity/ReactionEmoji;)Lkotlinx/coroutines/flow/Flow;
 	public abstract fun pin (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -607,14 +607,14 @@ public final class dev/kord/core/behavior/MessageBehavior$DefaultImpls {
 	public static fun asMessage (Ldev/kord/core/behavior/MessageBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun asMessageOrNull (Ldev/kord/core/behavior/MessageBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun compareTo (Ldev/kord/core/behavior/MessageBehavior;Ldev/kord/core/entity/Entity;)I
-	public static fun delete (Ldev/kord/core/behavior/MessageBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun delete (Ldev/kord/core/behavior/MessageBehavior;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun delete$default (Ldev/kord/core/behavior/MessageBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun delete$default (Ldev/kord/core/behavior/MessageBehavior;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static fun delete-nKCQcT8 (Ldev/kord/core/behavior/MessageBehavior;JLjava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun delete-nKCQcT8$default (Ldev/kord/core/behavior/MessageBehavior;JLjava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static fun deleteAllReactions (Ldev/kord/core/behavior/MessageBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun deleteOwnReaction (Ldev/kord/core/behavior/MessageBehavior;Ldev/kord/core/entity/ReactionEmoji;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun deleteReaction (Ldev/kord/core/behavior/MessageBehavior;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/entity/ReactionEmoji;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun deleteReaction (Ldev/kord/core/behavior/MessageBehavior;Ldev/kord/core/entity/ReactionEmoji;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun deleteReaction-9y3P_48 (Ldev/kord/core/behavior/MessageBehavior;JLdev/kord/core/entity/ReactionEmoji;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun fetchMessage (Ldev/kord/core/behavior/MessageBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun fetchMessageOrNull (Ldev/kord/core/behavior/MessageBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getChannel (Ldev/kord/core/behavior/MessageBehavior;)Ldev/kord/core/behavior/channel/MessageChannelBehavior;
@@ -630,11 +630,11 @@ public final class dev/kord/core/behavior/MessageBehavior$DefaultImpls {
 }
 
 public final class dev/kord/core/behavior/MessageBehaviorKt {
-	public static final fun MessageBehavior (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/MessageBehavior;
-	public static synthetic fun MessageBehavior$default (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;ILjava/lang/Object;)Ldev/kord/core/behavior/MessageBehavior;
-	public static final fun edit (Ldev/kord/core/behavior/MessageBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun MessageBehavior-Lfpyfds (JJLdev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/MessageBehavior;
+	public static synthetic fun MessageBehavior-Lfpyfds$default (JJLdev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;ILjava/lang/Object;)Ldev/kord/core/behavior/MessageBehavior;
 	public static final fun edit (Ldev/kord/core/behavior/MessageBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun edit$default (Ldev/kord/core/behavior/MessageBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun edit-8nRM30U (Ldev/kord/core/behavior/MessageBehavior;JLjava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun edit-8nRM30U$default (Ldev/kord/core/behavior/MessageBehavior;JLjava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun reply (Ldev/kord/core/behavior/MessageBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -654,7 +654,7 @@ public abstract interface class dev/kord/core/behavior/RoleBehavior : dev/kord/c
 	public abstract fun fetchRole (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun fetchRoleOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
-	public abstract fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getGuildId-4_xYDEk ()J
 	public abstract fun getMention ()Ljava/lang/String;
 	public abstract fun getPosition (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/RoleBehavior;
@@ -676,8 +676,8 @@ public final class dev/kord/core/behavior/RoleBehavior$DefaultImpls {
 }
 
 public final class dev/kord/core/behavior/RoleBehaviorKt {
-	public static final fun RoleBehavior (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/RoleBehavior;
-	public static synthetic fun RoleBehavior$default (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;ILjava/lang/Object;)Ldev/kord/core/behavior/RoleBehavior;
+	public static final fun RoleBehavior-Lfpyfds (JJLdev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/RoleBehavior;
+	public static synthetic fun RoleBehavior-Lfpyfds$default (JJLdev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;ILjava/lang/Object;)Ldev/kord/core/behavior/RoleBehavior;
 	public static final fun edit (Ldev/kord/core/behavior/RoleBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -687,7 +687,7 @@ public abstract interface class dev/kord/core/behavior/StageInstanceBehavior : d
 	public abstract fun delete (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun fetchStageInstance (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun fetchStageInstanceOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getChannelId-4_xYDEk ()J
 	public abstract synthetic fun update (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/StageInstanceBehavior;
 }
@@ -714,7 +714,7 @@ public abstract interface class dev/kord/core/behavior/StickerBehavior : dev/kor
 	public abstract fun delete (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun fetchSticker (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun fetchStickerOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getGuildId-4_xYDEk ()J
 }
 
 public final class dev/kord/core/behavior/StickerBehavior$DefaultImpls {
@@ -727,14 +727,14 @@ public final class dev/kord/core/behavior/StickerBehavior$DefaultImpls {
 }
 
 public final class dev/kord/core/behavior/StickerBehaviorKt {
-	public static final fun StickerBehavior (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)Ldev/kord/core/behavior/StickerBehavior;
+	public static final fun StickerBehavior-Lfpyfds (JJLdev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)Ldev/kord/core/behavior/StickerBehavior;
 	public static final fun edit (Ldev/kord/core/behavior/StickerBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class dev/kord/core/behavior/TemplateBehavior : dev/kord/core/KordObject {
 	public abstract fun delete (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getCode ()Ljava/lang/String;
-	public abstract fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getGuildId-4_xYDEk ()J
 	public abstract fun sync (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -744,26 +744,26 @@ public final class dev/kord/core/behavior/TemplateBehavior$DefaultImpls {
 }
 
 public final class dev/kord/core/behavior/TemplateBehaviorKt {
-	public static final fun TemplateBehavior (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/core/Kord;)Ldev/kord/core/behavior/TemplateBehavior;
+	public static final fun TemplateBehavior-9y3P_48 (JLjava/lang/String;Ldev/kord/core/Kord;)Ldev/kord/core/behavior/TemplateBehavior;
 	public static final fun createGuild (Ldev/kord/core/behavior/TemplateBehavior;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun edit (Ldev/kord/core/behavior/TemplateBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class dev/kord/core/behavior/ThreadMemberBehavior : dev/kord/core/behavior/UserBehavior {
 	public abstract fun getThread (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getThreadId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getThreadId-4_xYDEk ()J
 	public abstract fun getThreadOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/UserBehavior;
 }
 
 public final class dev/kord/core/behavior/ThreadMemberBehavior$DefaultImpls {
-	public static fun asMember (Ldev/kord/core/behavior/ThreadMemberBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun asMemberOrNull (Ldev/kord/core/behavior/ThreadMemberBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun asMember-wYKCHeA (Ldev/kord/core/behavior/ThreadMemberBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun asMemberOrNull-wYKCHeA (Ldev/kord/core/behavior/ThreadMemberBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun asUser (Ldev/kord/core/behavior/ThreadMemberBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun asUserOrNull (Ldev/kord/core/behavior/ThreadMemberBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun compareTo (Ldev/kord/core/behavior/ThreadMemberBehavior;Ldev/kord/core/entity/Entity;)I
-	public static fun fetchMember (Ldev/kord/core/behavior/ThreadMemberBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun fetchMemberOrNull (Ldev/kord/core/behavior/ThreadMemberBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun fetchMember-wYKCHeA (Ldev/kord/core/behavior/ThreadMemberBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun fetchMemberOrNull-wYKCHeA (Ldev/kord/core/behavior/ThreadMemberBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun fetchUser (Ldev/kord/core/behavior/ThreadMemberBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun fetchUserOrNull (Ldev/kord/core/behavior/ThreadMemberBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getDmChannel (Ldev/kord/core/behavior/ThreadMemberBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -775,17 +775,17 @@ public final class dev/kord/core/behavior/ThreadMemberBehavior$DefaultImpls {
 }
 
 public final class dev/kord/core/behavior/ThreadMemberBehaviorKt {
-	public static final fun ThreadMemberBehavior (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)Ldev/kord/core/behavior/ThreadMemberBehavior;
-	public static synthetic fun ThreadMemberBehavior$default (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;ILjava/lang/Object;)Ldev/kord/core/behavior/ThreadMemberBehavior;
+	public static final fun ThreadMemberBehavior-Lfpyfds (JJLdev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)Ldev/kord/core/behavior/ThreadMemberBehavior;
+	public static synthetic fun ThreadMemberBehavior-Lfpyfds$default (JJLdev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;ILjava/lang/Object;)Ldev/kord/core/behavior/ThreadMemberBehavior;
 }
 
 public abstract interface class dev/kord/core/behavior/UserBehavior : dev/kord/core/entity/KordEntity, dev/kord/core/entity/Strategizable {
-	public abstract fun asMember (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun asMemberOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun asMember-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun asMemberOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun asUser (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun asUserOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun fetchMember (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun fetchMemberOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun fetchMember-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun fetchMemberOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun fetchUser (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun fetchUserOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getDmChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -795,13 +795,13 @@ public abstract interface class dev/kord/core/behavior/UserBehavior : dev/kord/c
 }
 
 public final class dev/kord/core/behavior/UserBehavior$DefaultImpls {
-	public static fun asMember (Ldev/kord/core/behavior/UserBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun asMemberOrNull (Ldev/kord/core/behavior/UserBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun asMember-wYKCHeA (Ldev/kord/core/behavior/UserBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun asMemberOrNull-wYKCHeA (Ldev/kord/core/behavior/UserBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun asUser (Ldev/kord/core/behavior/UserBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun asUserOrNull (Ldev/kord/core/behavior/UserBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun compareTo (Ldev/kord/core/behavior/UserBehavior;Ldev/kord/core/entity/Entity;)I
-	public static fun fetchMember (Ldev/kord/core/behavior/UserBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun fetchMemberOrNull (Ldev/kord/core/behavior/UserBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun fetchMember-wYKCHeA (Ldev/kord/core/behavior/UserBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun fetchMemberOrNull-wYKCHeA (Ldev/kord/core/behavior/UserBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun fetchUser (Ldev/kord/core/behavior/UserBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun fetchUserOrNull (Ldev/kord/core/behavior/UserBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getDmChannel (Ldev/kord/core/behavior/UserBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -811,8 +811,8 @@ public final class dev/kord/core/behavior/UserBehavior$DefaultImpls {
 }
 
 public final class dev/kord/core/behavior/UserBehaviorKt {
-	public static final fun UserBehavior (Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/UserBehavior;
-	public static synthetic fun UserBehavior$default (Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;ILjava/lang/Object;)Ldev/kord/core/behavior/UserBehavior;
+	public static final fun UserBehavior-9y3P_48 (JLdev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/UserBehavior;
+	public static synthetic fun UserBehavior-9y3P_48$default (JLdev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;ILjava/lang/Object;)Ldev/kord/core/behavior/UserBehavior;
 }
 
 public abstract interface class dev/kord/core/behavior/UserCommandBehavior : dev/kord/core/behavior/ApplicationCommandBehavior {
@@ -826,9 +826,9 @@ public final class dev/kord/core/behavior/UserCommandBehavior$DefaultImpls {
 public abstract interface class dev/kord/core/behavior/WebhookBehavior : dev/kord/core/entity/KordEntity, dev/kord/core/entity/Strategizable {
 	public abstract fun delete (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun delete (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun deleteMessage (Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getMessage (Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getMessageOrNull (Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun deleteMessage-x6thYdA (Ljava/lang/String;JLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getMessage-x6thYdA (Ljava/lang/String;JLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getMessageOrNull-x6thYdA (Ljava/lang/String;JLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/WebhookBehavior;
 }
 
@@ -838,22 +838,22 @@ public final class dev/kord/core/behavior/WebhookBehavior$DefaultImpls {
 	public static fun delete (Ldev/kord/core/behavior/WebhookBehavior;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun delete$default (Ldev/kord/core/behavior/WebhookBehavior;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun delete$default (Ldev/kord/core/behavior/WebhookBehavior;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static fun deleteMessage (Ldev/kord/core/behavior/WebhookBehavior;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun deleteMessage$default (Ldev/kord/core/behavior/WebhookBehavior;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static fun getMessage (Ldev/kord/core/behavior/WebhookBehavior;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getMessage$default (Ldev/kord/core/behavior/WebhookBehavior;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static fun getMessageOrNull (Ldev/kord/core/behavior/WebhookBehavior;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getMessageOrNull$default (Ldev/kord/core/behavior/WebhookBehavior;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static fun deleteMessage-x6thYdA (Ldev/kord/core/behavior/WebhookBehavior;Ljava/lang/String;JLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteMessage-x6thYdA$default (Ldev/kord/core/behavior/WebhookBehavior;Ljava/lang/String;JLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static fun getMessage-x6thYdA (Ldev/kord/core/behavior/WebhookBehavior;Ljava/lang/String;JLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getMessage-x6thYdA$default (Ldev/kord/core/behavior/WebhookBehavior;Ljava/lang/String;JLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static fun getMessageOrNull-x6thYdA (Ldev/kord/core/behavior/WebhookBehavior;Ljava/lang/String;JLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getMessageOrNull-x6thYdA$default (Ldev/kord/core/behavior/WebhookBehavior;Ljava/lang/String;JLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static fun withStrategy (Ldev/kord/core/behavior/WebhookBehavior;Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/WebhookBehavior;
 }
 
 public final class dev/kord/core/behavior/WebhookBehaviorKt {
 	public static final fun edit (Ldev/kord/core/behavior/WebhookBehavior;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun edit (Ldev/kord/core/behavior/WebhookBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun execute (Ldev/kord/core/behavior/WebhookBehavior;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun execute$default (Ldev/kord/core/behavior/WebhookBehavior;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static final fun executeIgnored (Ldev/kord/core/behavior/WebhookBehavior;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun executeIgnored$default (Ldev/kord/core/behavior/WebhookBehavior;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun execute-eO23frA (Ldev/kord/core/behavior/WebhookBehavior;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun execute-eO23frA$default (Ldev/kord/core/behavior/WebhookBehavior;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun executeIgnored-eO23frA (Ldev/kord/core/behavior/WebhookBehavior;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun executeIgnored-eO23frA$default (Ldev/kord/core/behavior/WebhookBehavior;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public abstract interface class dev/kord/core/behavior/automoderation/AutoModerationRuleBehavior : dev/kord/core/entity/KordEntity, dev/kord/core/entity/Strategizable {
@@ -863,7 +863,7 @@ public abstract interface class dev/kord/core/behavior/automoderation/AutoModera
 	public abstract fun equals (Ljava/lang/Object;)Z
 	public abstract fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public abstract fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getGuildId-4_xYDEk ()J
 	public abstract fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getTriggerType ()Ldev/kord/common/entity/AutoModerationRuleTriggerType;
 	public abstract fun hashCode ()I
@@ -1057,8 +1057,8 @@ public final class dev/kord/core/behavior/channel/CategoryBehavior$DefaultImpls 
 }
 
 public final class dev/kord/core/behavior/channel/CategoryBehaviorKt {
-	public static final fun CategoryBehavior (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/channel/CategoryBehavior;
-	public static synthetic fun CategoryBehavior$default (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;ILjava/lang/Object;)Ldev/kord/core/behavior/channel/CategoryBehavior;
+	public static final fun CategoryBehavior-Lfpyfds (JJLdev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/channel/CategoryBehavior;
+	public static synthetic fun CategoryBehavior-Lfpyfds$default (JJLdev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;ILjava/lang/Object;)Ldev/kord/core/behavior/channel/CategoryBehavior;
 	public static final fun createNewsChannel (Ldev/kord/core/behavior/channel/CategoryBehavior;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun createNewsChannel$default (Ldev/kord/core/behavior/channel/CategoryBehavior;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun createTextChannel (Ldev/kord/core/behavior/channel/CategoryBehavior;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -1091,8 +1091,8 @@ public final class dev/kord/core/behavior/channel/ChannelBehavior$DefaultImpls {
 }
 
 public final class dev/kord/core/behavior/channel/ChannelBehaviorKt {
-	public static final fun ChannelBehavior (Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/channel/ChannelBehavior;
-	public static synthetic fun ChannelBehavior$default (Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;ILjava/lang/Object;)Ldev/kord/core/behavior/channel/ChannelBehavior;
+	public static final fun ChannelBehavior-9y3P_48 (JLdev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/channel/ChannelBehavior;
+	public static synthetic fun ChannelBehavior-9y3P_48$default (JLdev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;ILjava/lang/Object;)Ldev/kord/core/behavior/channel/ChannelBehavior;
 }
 
 public abstract interface class dev/kord/core/behavior/channel/GuildChannelBehavior : dev/kord/core/behavior/channel/ChannelBehavior, dev/kord/core/entity/Strategizable {
@@ -1103,7 +1103,7 @@ public abstract interface class dev/kord/core/behavior/channel/GuildChannelBehav
 	public abstract fun fetchChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public abstract fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getGuildId-4_xYDEk ()J
 	public abstract fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/channel/GuildChannelBehavior;
 }
@@ -1123,8 +1123,8 @@ public final class dev/kord/core/behavior/channel/GuildChannelBehavior$DefaultIm
 }
 
 public final class dev/kord/core/behavior/channel/GuildChannelBehaviorKt {
-	public static final fun GuildChannelBehavior (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/channel/GuildChannelBehavior;
-	public static synthetic fun GuildChannelBehavior$default (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;ILjava/lang/Object;)Ldev/kord/core/behavior/channel/GuildChannelBehavior;
+	public static final fun GuildChannelBehavior-Lfpyfds (JJLdev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/channel/GuildChannelBehavior;
+	public static synthetic fun GuildChannelBehavior-Lfpyfds$default (JJLdev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;ILjava/lang/Object;)Ldev/kord/core/behavior/channel/GuildChannelBehavior;
 }
 
 public abstract interface class dev/kord/core/behavior/channel/GuildMessageChannelBehavior : dev/kord/core/behavior/channel/GuildChannelBehavior, dev/kord/core/behavior/channel/MessageChannelBehavior {
@@ -1147,19 +1147,19 @@ public final class dev/kord/core/behavior/channel/GuildMessageChannelBehavior$De
 	public static fun compareTo (Ldev/kord/core/behavior/channel/GuildMessageChannelBehavior;Ldev/kord/core/entity/Entity;)I
 	public static fun createMessage (Ldev/kord/core/behavior/channel/GuildMessageChannelBehavior;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun delete (Ldev/kord/core/behavior/channel/GuildMessageChannelBehavior;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun deleteMessage (Ldev/kord/core/behavior/channel/GuildMessageChannelBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun deleteMessage-9y3P_48 (Ldev/kord/core/behavior/channel/GuildMessageChannelBehavior;JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun fetchChannel (Ldev/kord/core/behavior/channel/GuildMessageChannelBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun fetchChannelOrNull (Ldev/kord/core/behavior/channel/GuildMessageChannelBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getGuild (Ldev/kord/core/behavior/channel/GuildMessageChannelBehavior;)Ldev/kord/core/behavior/GuildBehavior;
 	public static fun getGuild (Ldev/kord/core/behavior/channel/GuildMessageChannelBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getGuildOrNull (Ldev/kord/core/behavior/channel/GuildMessageChannelBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getMention (Ldev/kord/core/behavior/channel/GuildMessageChannelBehavior;)Ljava/lang/String;
-	public static fun getMessage (Ldev/kord/core/behavior/channel/GuildMessageChannelBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getMessageOrNull (Ldev/kord/core/behavior/channel/GuildMessageChannelBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getMessage-wYKCHeA (Ldev/kord/core/behavior/channel/GuildMessageChannelBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getMessageOrNull-wYKCHeA (Ldev/kord/core/behavior/channel/GuildMessageChannelBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getMessages (Ldev/kord/core/behavior/channel/GuildMessageChannelBehavior;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getMessagesAfter (Ldev/kord/core/behavior/channel/GuildMessageChannelBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getMessagesAround (Ldev/kord/core/behavior/channel/GuildMessageChannelBehavior;Ldev/kord/common/entity/Snowflake;I)Lkotlinx/coroutines/flow/Flow;
-	public static fun getMessagesBefore (Ldev/kord/core/behavior/channel/GuildMessageChannelBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getMessagesAfter-wYKCHeA (Ldev/kord/core/behavior/channel/GuildMessageChannelBehavior;JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getMessagesAround-wYKCHeA (Ldev/kord/core/behavior/channel/GuildMessageChannelBehavior;JI)Lkotlinx/coroutines/flow/Flow;
+	public static fun getMessagesBefore-wYKCHeA (Ldev/kord/core/behavior/channel/GuildMessageChannelBehavior;JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
 	public static fun getPinnedMessages (Ldev/kord/core/behavior/channel/GuildMessageChannelBehavior;)Lkotlinx/coroutines/flow/Flow;
 	public static fun type (Ldev/kord/core/behavior/channel/GuildMessageChannelBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun typeUntil (Ldev/kord/core/behavior/channel/GuildMessageChannelBehavior;Lkotlin/time/TimeMark;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -1171,15 +1171,15 @@ public abstract interface class dev/kord/core/behavior/channel/MessageChannelBeh
 	public abstract fun asChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun asChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun createMessage (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun deleteMessage (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun deleteMessage-9y3P_48 (JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun fetchChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun fetchChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getMessage (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getMessageOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getMessage-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getMessageOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getMessages ()Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getMessagesAfter (Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getMessagesAround (Ldev/kord/common/entity/Snowflake;I)Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getMessagesBefore (Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getMessagesAfter-wYKCHeA (JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getMessagesAround-wYKCHeA (JI)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getMessagesBefore-wYKCHeA (JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
 	public abstract fun getPinnedMessages ()Lkotlinx/coroutines/flow/Flow;
 	public abstract fun type (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun typeUntil (Lkotlin/time/TimeMark;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -1193,20 +1193,20 @@ public final class dev/kord/core/behavior/channel/MessageChannelBehavior$Default
 	public static fun compareTo (Ldev/kord/core/behavior/channel/MessageChannelBehavior;Ldev/kord/core/entity/Entity;)I
 	public static fun createMessage (Ldev/kord/core/behavior/channel/MessageChannelBehavior;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun delete (Ldev/kord/core/behavior/channel/MessageChannelBehavior;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun deleteMessage (Ldev/kord/core/behavior/channel/MessageChannelBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun deleteMessage$default (Ldev/kord/core/behavior/channel/MessageChannelBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static fun deleteMessage-9y3P_48 (Ldev/kord/core/behavior/channel/MessageChannelBehavior;JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteMessage-9y3P_48$default (Ldev/kord/core/behavior/channel/MessageChannelBehavior;JLjava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static fun fetchChannel (Ldev/kord/core/behavior/channel/MessageChannelBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun fetchChannelOrNull (Ldev/kord/core/behavior/channel/MessageChannelBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getMention (Ldev/kord/core/behavior/channel/MessageChannelBehavior;)Ljava/lang/String;
-	public static fun getMessage (Ldev/kord/core/behavior/channel/MessageChannelBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getMessageOrNull (Ldev/kord/core/behavior/channel/MessageChannelBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getMessage-wYKCHeA (Ldev/kord/core/behavior/channel/MessageChannelBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getMessageOrNull-wYKCHeA (Ldev/kord/core/behavior/channel/MessageChannelBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getMessages (Ldev/kord/core/behavior/channel/MessageChannelBehavior;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getMessagesAfter (Ldev/kord/core/behavior/channel/MessageChannelBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public static synthetic fun getMessagesAfter$default (Ldev/kord/core/behavior/channel/MessageChannelBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getMessagesAround (Ldev/kord/core/behavior/channel/MessageChannelBehavior;Ldev/kord/common/entity/Snowflake;I)Lkotlinx/coroutines/flow/Flow;
-	public static synthetic fun getMessagesAround$default (Ldev/kord/core/behavior/channel/MessageChannelBehavior;Ldev/kord/common/entity/Snowflake;IILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getMessagesBefore (Ldev/kord/core/behavior/channel/MessageChannelBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public static synthetic fun getMessagesBefore$default (Ldev/kord/core/behavior/channel/MessageChannelBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getMessagesAfter-wYKCHeA (Ldev/kord/core/behavior/channel/MessageChannelBehavior;JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun getMessagesAfter-wYKCHeA$default (Ldev/kord/core/behavior/channel/MessageChannelBehavior;JLjava/lang/Integer;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getMessagesAround-wYKCHeA (Ldev/kord/core/behavior/channel/MessageChannelBehavior;JI)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun getMessagesAround-wYKCHeA$default (Ldev/kord/core/behavior/channel/MessageChannelBehavior;JIILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getMessagesBefore-wYKCHeA (Ldev/kord/core/behavior/channel/MessageChannelBehavior;JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun getMessagesBefore-wYKCHeA$default (Ldev/kord/core/behavior/channel/MessageChannelBehavior;JLjava/lang/Integer;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 	public static fun getPinnedMessages (Ldev/kord/core/behavior/channel/MessageChannelBehavior;)Lkotlinx/coroutines/flow/Flow;
 	public static fun type (Ldev/kord/core/behavior/channel/MessageChannelBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun typeUntil (Ldev/kord/core/behavior/channel/MessageChannelBehavior;Lkotlin/time/TimeMark;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -1215,8 +1215,8 @@ public final class dev/kord/core/behavior/channel/MessageChannelBehavior$Default
 }
 
 public final class dev/kord/core/behavior/channel/MessageChannelBehaviorKt {
-	public static final fun MessageChannelBehavior (Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/channel/MessageChannelBehavior;
-	public static synthetic fun MessageChannelBehavior$default (Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;ILjava/lang/Object;)Ldev/kord/core/behavior/channel/MessageChannelBehavior;
+	public static final fun MessageChannelBehavior-9y3P_48 (JLdev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/channel/MessageChannelBehavior;
+	public static synthetic fun MessageChannelBehavior-9y3P_48$default (JLdev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;ILjava/lang/Object;)Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public static final fun createEmbed (Ldev/kord/core/behavior/channel/MessageChannelBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun createMessage (Ldev/kord/core/behavior/channel/MessageChannelBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final synthetic fun withTyping (Ldev/kord/core/behavior/channel/MessageChannelBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -1228,11 +1228,11 @@ public abstract interface class dev/kord/core/behavior/channel/NewsChannelBehavi
 	public abstract fun asChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun fetchChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun fetchChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun follow (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun follow-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getActiveThreads ()Lkotlinx/coroutines/flow/Flow;
 	public abstract fun getPublicArchivedThreads (Lkotlinx/datetime/Instant;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
 	public abstract fun startPublicThread (Ljava/lang/String;Ldev/kord/common/entity/ArchiveDuration;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun startPublicThreadWithMessage (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/ArchiveDuration;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun startPublicThreadWithMessage-PHjaIKs (JLjava/lang/String;Ldev/kord/common/entity/ArchiveDuration;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/channel/NewsChannelBehavior;
 }
 
@@ -1245,30 +1245,30 @@ public final class dev/kord/core/behavior/channel/NewsChannelBehavior$DefaultImp
 	public static fun compareTo (Ldev/kord/core/behavior/channel/NewsChannelBehavior;Ldev/kord/core/entity/Entity;)I
 	public static fun createMessage (Ldev/kord/core/behavior/channel/NewsChannelBehavior;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun delete (Ldev/kord/core/behavior/channel/NewsChannelBehavior;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun deleteMessage (Ldev/kord/core/behavior/channel/NewsChannelBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun deleteMessage-9y3P_48 (Ldev/kord/core/behavior/channel/NewsChannelBehavior;JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun fetchChannel (Ldev/kord/core/behavior/channel/NewsChannelBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun fetchChannelOrNull (Ldev/kord/core/behavior/channel/NewsChannelBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun follow (Ldev/kord/core/behavior/channel/NewsChannelBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun follow-wYKCHeA (Ldev/kord/core/behavior/channel/NewsChannelBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getActiveThreads (Ldev/kord/core/behavior/channel/NewsChannelBehavior;)Lkotlinx/coroutines/flow/Flow;
 	public static fun getGuild (Ldev/kord/core/behavior/channel/NewsChannelBehavior;)Ldev/kord/core/behavior/GuildBehavior;
 	public static fun getGuild (Ldev/kord/core/behavior/channel/NewsChannelBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getGuildOrNull (Ldev/kord/core/behavior/channel/NewsChannelBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getInvites (Ldev/kord/core/behavior/channel/NewsChannelBehavior;)Lkotlinx/coroutines/flow/Flow;
 	public static fun getMention (Ldev/kord/core/behavior/channel/NewsChannelBehavior;)Ljava/lang/String;
-	public static fun getMessage (Ldev/kord/core/behavior/channel/NewsChannelBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getMessageOrNull (Ldev/kord/core/behavior/channel/NewsChannelBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getMessage-wYKCHeA (Ldev/kord/core/behavior/channel/NewsChannelBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getMessageOrNull-wYKCHeA (Ldev/kord/core/behavior/channel/NewsChannelBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getMessages (Ldev/kord/core/behavior/channel/NewsChannelBehavior;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getMessagesAfter (Ldev/kord/core/behavior/channel/NewsChannelBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getMessagesAround (Ldev/kord/core/behavior/channel/NewsChannelBehavior;Ldev/kord/common/entity/Snowflake;I)Lkotlinx/coroutines/flow/Flow;
-	public static fun getMessagesBefore (Ldev/kord/core/behavior/channel/NewsChannelBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getMessagesAfter-wYKCHeA (Ldev/kord/core/behavior/channel/NewsChannelBehavior;JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getMessagesAround-wYKCHeA (Ldev/kord/core/behavior/channel/NewsChannelBehavior;JI)Lkotlinx/coroutines/flow/Flow;
+	public static fun getMessagesBefore-wYKCHeA (Ldev/kord/core/behavior/channel/NewsChannelBehavior;JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
 	public static fun getPinnedMessages (Ldev/kord/core/behavior/channel/NewsChannelBehavior;)Lkotlinx/coroutines/flow/Flow;
 	public static fun getPosition (Ldev/kord/core/behavior/channel/NewsChannelBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getPublicArchivedThreads (Ldev/kord/core/behavior/channel/NewsChannelBehavior;Lkotlinx/datetime/Instant;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
 	public static fun getWebhooks (Ldev/kord/core/behavior/channel/NewsChannelBehavior;)Lkotlinx/coroutines/flow/Flow;
 	public static fun startPublicThread (Ldev/kord/core/behavior/channel/NewsChannelBehavior;Ljava/lang/String;Ldev/kord/common/entity/ArchiveDuration;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun startPublicThread$default (Ldev/kord/core/behavior/channel/NewsChannelBehavior;Ljava/lang/String;Ldev/kord/common/entity/ArchiveDuration;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static fun startPublicThreadWithMessage (Ldev/kord/core/behavior/channel/NewsChannelBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/ArchiveDuration;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun startPublicThreadWithMessage$default (Ldev/kord/core/behavior/channel/NewsChannelBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/ArchiveDuration;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static fun startPublicThreadWithMessage-PHjaIKs (Ldev/kord/core/behavior/channel/NewsChannelBehavior;JLjava/lang/String;Ldev/kord/common/entity/ArchiveDuration;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun startPublicThreadWithMessage-PHjaIKs$default (Ldev/kord/core/behavior/channel/NewsChannelBehavior;JLjava/lang/String;Ldev/kord/common/entity/ArchiveDuration;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static fun type (Ldev/kord/core/behavior/channel/NewsChannelBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun typeUntil (Ldev/kord/core/behavior/channel/NewsChannelBehavior;Lkotlin/time/TimeMark;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun typeUntil (Ldev/kord/core/behavior/channel/NewsChannelBehavior;Lkotlinx/datetime/Instant;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -1276,8 +1276,8 @@ public final class dev/kord/core/behavior/channel/NewsChannelBehavior$DefaultImp
 }
 
 public final class dev/kord/core/behavior/channel/NewsChannelBehaviorKt {
-	public static final fun NewsChannelBehavior (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/channel/NewsChannelBehavior;
-	public static synthetic fun NewsChannelBehavior$default (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;ILjava/lang/Object;)Ldev/kord/core/behavior/channel/NewsChannelBehavior;
+	public static final fun NewsChannelBehavior-Lfpyfds (JJLdev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/channel/NewsChannelBehavior;
+	public static synthetic fun NewsChannelBehavior-Lfpyfds$default (JJLdev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;ILjava/lang/Object;)Ldev/kord/core/behavior/channel/NewsChannelBehavior;
 	public static final fun edit (Ldev/kord/core/behavior/channel/NewsChannelBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -1308,13 +1308,13 @@ public final class dev/kord/core/behavior/channel/StageChannelBehavior$DefaultIm
 }
 
 public final class dev/kord/core/behavior/channel/StageChannelBehaviorKt {
-	public static final fun StageChannelBehavior (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)Ldev/kord/core/behavior/channel/StageChannelBehavior;
-	public static synthetic fun StageChannelBehavior$default (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;ILjava/lang/Object;)Ldev/kord/core/behavior/channel/StageChannelBehavior;
+	public static final fun StageChannelBehavior-Lfpyfds (JJLdev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)Ldev/kord/core/behavior/channel/StageChannelBehavior;
+	public static synthetic fun StageChannelBehavior-Lfpyfds$default (JJLdev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;ILjava/lang/Object;)Ldev/kord/core/behavior/channel/StageChannelBehavior;
 	public static final fun createStageInstance (Ldev/kord/core/behavior/channel/StageChannelBehavior;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun createStageInstance$default (Ldev/kord/core/behavior/channel/StageChannelBehavior;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun edit (Ldev/kord/core/behavior/channel/StageChannelBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun editCurrentVoiceState (Ldev/kord/core/behavior/channel/StageChannelBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun editVoiceState (Ldev/kord/core/behavior/channel/StageChannelBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun editVoiceState-nMAJGj4 (Ldev/kord/core/behavior/channel/StageChannelBehavior;JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class dev/kord/core/behavior/channel/StoreChannelBehavior : dev/kord/core/behavior/channel/CategorizableChannelBehavior {
@@ -1343,8 +1343,8 @@ public final class dev/kord/core/behavior/channel/StoreChannelBehavior$DefaultIm
 }
 
 public final class dev/kord/core/behavior/channel/StoreChannelBehaviorKt {
-	public static final synthetic fun StoreChannelBehavior (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/channel/StoreChannelBehavior;
-	public static synthetic fun StoreChannelBehavior$default (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;ILjava/lang/Object;)Ldev/kord/core/behavior/channel/StoreChannelBehavior;
+	public static final synthetic fun StoreChannelBehavior-Lfpyfds (JJLdev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/channel/StoreChannelBehavior;
+	public static synthetic fun StoreChannelBehavior-Lfpyfds$default (JJLdev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;ILjava/lang/Object;)Ldev/kord/core/behavior/channel/StoreChannelBehavior;
 	public static final synthetic fun edit (Ldev/kord/core/behavior/channel/StoreChannelBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -1354,12 +1354,12 @@ public abstract interface class dev/kord/core/behavior/channel/TextChannelBehavi
 	public abstract fun fetchChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun fetchChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getActiveThreads ()Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getJoinedPrivateArchivedThreads (Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getJoinedPrivateArchivedThreads-O4FuXRM (Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
 	public abstract fun getPrivateArchivedThreads (Lkotlinx/datetime/Instant;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
 	public abstract fun getPublicArchivedThreads (Lkotlinx/datetime/Instant;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
 	public abstract fun startPrivateThread (Ljava/lang/String;Ldev/kord/common/entity/ArchiveDuration;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun startPublicThread (Ljava/lang/String;Ldev/kord/common/entity/ArchiveDuration;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun startPublicThreadWithMessage (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/ArchiveDuration;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun startPublicThreadWithMessage-PHjaIKs (JLjava/lang/String;Ldev/kord/common/entity/ArchiveDuration;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/channel/TextChannelBehavior;
 }
 
@@ -1372,7 +1372,7 @@ public final class dev/kord/core/behavior/channel/TextChannelBehavior$DefaultImp
 	public static fun compareTo (Ldev/kord/core/behavior/channel/TextChannelBehavior;Ldev/kord/core/entity/Entity;)I
 	public static fun createMessage (Ldev/kord/core/behavior/channel/TextChannelBehavior;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun delete (Ldev/kord/core/behavior/channel/TextChannelBehavior;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun deleteMessage (Ldev/kord/core/behavior/channel/TextChannelBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun deleteMessage-9y3P_48 (Ldev/kord/core/behavior/channel/TextChannelBehavior;JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun fetchChannel (Ldev/kord/core/behavior/channel/TextChannelBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun fetchChannelOrNull (Ldev/kord/core/behavior/channel/TextChannelBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getActiveThreads (Ldev/kord/core/behavior/channel/TextChannelBehavior;)Lkotlinx/coroutines/flow/Flow;
@@ -1380,14 +1380,14 @@ public final class dev/kord/core/behavior/channel/TextChannelBehavior$DefaultImp
 	public static fun getGuild (Ldev/kord/core/behavior/channel/TextChannelBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getGuildOrNull (Ldev/kord/core/behavior/channel/TextChannelBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getInvites (Ldev/kord/core/behavior/channel/TextChannelBehavior;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getJoinedPrivateArchivedThreads (Ldev/kord/core/behavior/channel/TextChannelBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getJoinedPrivateArchivedThreads-O4FuXRM (Ldev/kord/core/behavior/channel/TextChannelBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
 	public static fun getMention (Ldev/kord/core/behavior/channel/TextChannelBehavior;)Ljava/lang/String;
-	public static fun getMessage (Ldev/kord/core/behavior/channel/TextChannelBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getMessageOrNull (Ldev/kord/core/behavior/channel/TextChannelBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getMessage-wYKCHeA (Ldev/kord/core/behavior/channel/TextChannelBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getMessageOrNull-wYKCHeA (Ldev/kord/core/behavior/channel/TextChannelBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getMessages (Ldev/kord/core/behavior/channel/TextChannelBehavior;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getMessagesAfter (Ldev/kord/core/behavior/channel/TextChannelBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getMessagesAround (Ldev/kord/core/behavior/channel/TextChannelBehavior;Ldev/kord/common/entity/Snowflake;I)Lkotlinx/coroutines/flow/Flow;
-	public static fun getMessagesBefore (Ldev/kord/core/behavior/channel/TextChannelBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getMessagesAfter-wYKCHeA (Ldev/kord/core/behavior/channel/TextChannelBehavior;JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getMessagesAround-wYKCHeA (Ldev/kord/core/behavior/channel/TextChannelBehavior;JI)Lkotlinx/coroutines/flow/Flow;
+	public static fun getMessagesBefore-wYKCHeA (Ldev/kord/core/behavior/channel/TextChannelBehavior;JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
 	public static fun getPinnedMessages (Ldev/kord/core/behavior/channel/TextChannelBehavior;)Lkotlinx/coroutines/flow/Flow;
 	public static fun getPosition (Ldev/kord/core/behavior/channel/TextChannelBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getPrivateArchivedThreads (Ldev/kord/core/behavior/channel/TextChannelBehavior;Lkotlinx/datetime/Instant;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
@@ -1397,8 +1397,8 @@ public final class dev/kord/core/behavior/channel/TextChannelBehavior$DefaultImp
 	public static synthetic fun startPrivateThread$default (Ldev/kord/core/behavior/channel/TextChannelBehavior;Ljava/lang/String;Ldev/kord/common/entity/ArchiveDuration;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static fun startPublicThread (Ldev/kord/core/behavior/channel/TextChannelBehavior;Ljava/lang/String;Ldev/kord/common/entity/ArchiveDuration;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun startPublicThread$default (Ldev/kord/core/behavior/channel/TextChannelBehavior;Ljava/lang/String;Ldev/kord/common/entity/ArchiveDuration;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static fun startPublicThreadWithMessage (Ldev/kord/core/behavior/channel/TextChannelBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/ArchiveDuration;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun startPublicThreadWithMessage$default (Ldev/kord/core/behavior/channel/TextChannelBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/ArchiveDuration;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static fun startPublicThreadWithMessage-PHjaIKs (Ldev/kord/core/behavior/channel/TextChannelBehavior;JLjava/lang/String;Ldev/kord/common/entity/ArchiveDuration;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun startPublicThreadWithMessage-PHjaIKs$default (Ldev/kord/core/behavior/channel/TextChannelBehavior;JLjava/lang/String;Ldev/kord/common/entity/ArchiveDuration;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static fun type (Ldev/kord/core/behavior/channel/TextChannelBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun typeUntil (Ldev/kord/core/behavior/channel/TextChannelBehavior;Lkotlin/time/TimeMark;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun typeUntil (Ldev/kord/core/behavior/channel/TextChannelBehavior;Lkotlinx/datetime/Instant;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -1406,8 +1406,8 @@ public final class dev/kord/core/behavior/channel/TextChannelBehavior$DefaultImp
 }
 
 public final class dev/kord/core/behavior/channel/TextChannelBehaviorKt {
-	public static final fun TextChannelBehavior (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/channel/TextChannelBehavior;
-	public static synthetic fun TextChannelBehavior$default (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;ILjava/lang/Object;)Ldev/kord/core/behavior/channel/TextChannelBehavior;
+	public static final fun TextChannelBehavior-Lfpyfds (JJLdev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/channel/TextChannelBehavior;
+	public static synthetic fun TextChannelBehavior-Lfpyfds$default (JJLdev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;ILjava/lang/Object;)Ldev/kord/core/behavior/channel/TextChannelBehavior;
 	public static final fun edit (Ldev/kord/core/behavior/channel/TextChannelBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -1439,8 +1439,8 @@ public final class dev/kord/core/behavior/channel/TopGuildChannelBehavior$Defaul
 }
 
 public final class dev/kord/core/behavior/channel/TopGuildChannelBehaviorKt {
-	public static final fun editMemberPermission (Ldev/kord/core/behavior/channel/TopGuildChannelBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun editRolePermission (Ldev/kord/core/behavior/channel/TopGuildChannelBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun editMemberPermission-nMAJGj4 (Ldev/kord/core/behavior/channel/TopGuildChannelBehavior;JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun editRolePermission-nMAJGj4 (Ldev/kord/core/behavior/channel/TopGuildChannelBehavior;JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class dev/kord/core/behavior/channel/TopGuildMessageChannelBehavior : dev/kord/core/behavior/channel/CategorizableChannelBehavior, dev/kord/core/behavior/channel/GuildMessageChannelBehavior {
@@ -1461,7 +1461,7 @@ public final class dev/kord/core/behavior/channel/TopGuildMessageChannelBehavior
 	public static fun compareTo (Ldev/kord/core/behavior/channel/TopGuildMessageChannelBehavior;Ldev/kord/core/entity/Entity;)I
 	public static fun createMessage (Ldev/kord/core/behavior/channel/TopGuildMessageChannelBehavior;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun delete (Ldev/kord/core/behavior/channel/TopGuildMessageChannelBehavior;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun deleteMessage (Ldev/kord/core/behavior/channel/TopGuildMessageChannelBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun deleteMessage-9y3P_48 (Ldev/kord/core/behavior/channel/TopGuildMessageChannelBehavior;JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun fetchChannel (Ldev/kord/core/behavior/channel/TopGuildMessageChannelBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun fetchChannelOrNull (Ldev/kord/core/behavior/channel/TopGuildMessageChannelBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getGuild (Ldev/kord/core/behavior/channel/TopGuildMessageChannelBehavior;)Ldev/kord/core/behavior/GuildBehavior;
@@ -1469,12 +1469,12 @@ public final class dev/kord/core/behavior/channel/TopGuildMessageChannelBehavior
 	public static fun getGuildOrNull (Ldev/kord/core/behavior/channel/TopGuildMessageChannelBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getInvites (Ldev/kord/core/behavior/channel/TopGuildMessageChannelBehavior;)Lkotlinx/coroutines/flow/Flow;
 	public static fun getMention (Ldev/kord/core/behavior/channel/TopGuildMessageChannelBehavior;)Ljava/lang/String;
-	public static fun getMessage (Ldev/kord/core/behavior/channel/TopGuildMessageChannelBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getMessageOrNull (Ldev/kord/core/behavior/channel/TopGuildMessageChannelBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getMessage-wYKCHeA (Ldev/kord/core/behavior/channel/TopGuildMessageChannelBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getMessageOrNull-wYKCHeA (Ldev/kord/core/behavior/channel/TopGuildMessageChannelBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getMessages (Ldev/kord/core/behavior/channel/TopGuildMessageChannelBehavior;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getMessagesAfter (Ldev/kord/core/behavior/channel/TopGuildMessageChannelBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getMessagesAround (Ldev/kord/core/behavior/channel/TopGuildMessageChannelBehavior;Ldev/kord/common/entity/Snowflake;I)Lkotlinx/coroutines/flow/Flow;
-	public static fun getMessagesBefore (Ldev/kord/core/behavior/channel/TopGuildMessageChannelBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getMessagesAfter-wYKCHeA (Ldev/kord/core/behavior/channel/TopGuildMessageChannelBehavior;JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getMessagesAround-wYKCHeA (Ldev/kord/core/behavior/channel/TopGuildMessageChannelBehavior;JI)Lkotlinx/coroutines/flow/Flow;
+	public static fun getMessagesBefore-wYKCHeA (Ldev/kord/core/behavior/channel/TopGuildMessageChannelBehavior;JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
 	public static fun getPinnedMessages (Ldev/kord/core/behavior/channel/TopGuildMessageChannelBehavior;)Lkotlinx/coroutines/flow/Flow;
 	public static fun getPosition (Ldev/kord/core/behavior/channel/TopGuildMessageChannelBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getWebhooks (Ldev/kord/core/behavior/channel/TopGuildMessageChannelBehavior;)Lkotlinx/coroutines/flow/Flow;
@@ -1506,7 +1506,7 @@ public final class dev/kord/core/behavior/channel/VoiceChannelBehavior$DefaultIm
 	public static fun compareTo (Ldev/kord/core/behavior/channel/VoiceChannelBehavior;Ldev/kord/core/entity/Entity;)I
 	public static fun createMessage (Ldev/kord/core/behavior/channel/VoiceChannelBehavior;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun delete (Ldev/kord/core/behavior/channel/VoiceChannelBehavior;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun deleteMessage (Ldev/kord/core/behavior/channel/VoiceChannelBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun deleteMessage-9y3P_48 (Ldev/kord/core/behavior/channel/VoiceChannelBehavior;JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun fetchChannel (Ldev/kord/core/behavior/channel/VoiceChannelBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun fetchChannelOrNull (Ldev/kord/core/behavior/channel/VoiceChannelBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getGuild (Ldev/kord/core/behavior/channel/VoiceChannelBehavior;)Ldev/kord/core/behavior/GuildBehavior;
@@ -1514,12 +1514,12 @@ public final class dev/kord/core/behavior/channel/VoiceChannelBehavior$DefaultIm
 	public static fun getGuildOrNull (Ldev/kord/core/behavior/channel/VoiceChannelBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getInvites (Ldev/kord/core/behavior/channel/VoiceChannelBehavior;)Lkotlinx/coroutines/flow/Flow;
 	public static fun getMention (Ldev/kord/core/behavior/channel/VoiceChannelBehavior;)Ljava/lang/String;
-	public static fun getMessage (Ldev/kord/core/behavior/channel/VoiceChannelBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getMessageOrNull (Ldev/kord/core/behavior/channel/VoiceChannelBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getMessage-wYKCHeA (Ldev/kord/core/behavior/channel/VoiceChannelBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getMessageOrNull-wYKCHeA (Ldev/kord/core/behavior/channel/VoiceChannelBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getMessages (Ldev/kord/core/behavior/channel/VoiceChannelBehavior;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getMessagesAfter (Ldev/kord/core/behavior/channel/VoiceChannelBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getMessagesAround (Ldev/kord/core/behavior/channel/VoiceChannelBehavior;Ldev/kord/common/entity/Snowflake;I)Lkotlinx/coroutines/flow/Flow;
-	public static fun getMessagesBefore (Ldev/kord/core/behavior/channel/VoiceChannelBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getMessagesAfter-wYKCHeA (Ldev/kord/core/behavior/channel/VoiceChannelBehavior;JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getMessagesAround-wYKCHeA (Ldev/kord/core/behavior/channel/VoiceChannelBehavior;JI)Lkotlinx/coroutines/flow/Flow;
+	public static fun getMessagesBefore-wYKCHeA (Ldev/kord/core/behavior/channel/VoiceChannelBehavior;JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
 	public static fun getPinnedMessages (Ldev/kord/core/behavior/channel/VoiceChannelBehavior;)Lkotlinx/coroutines/flow/Flow;
 	public static fun getPosition (Ldev/kord/core/behavior/channel/VoiceChannelBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getVoiceStates (Ldev/kord/core/behavior/channel/VoiceChannelBehavior;)Lkotlinx/coroutines/flow/Flow;
@@ -1531,13 +1531,13 @@ public final class dev/kord/core/behavior/channel/VoiceChannelBehavior$DefaultIm
 }
 
 public final class dev/kord/core/behavior/channel/VoiceChannelBehaviorKt {
-	public static final fun VoiceChannelBehavior (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/channel/VoiceChannelBehavior;
-	public static synthetic fun VoiceChannelBehavior$default (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;ILjava/lang/Object;)Ldev/kord/core/behavior/channel/VoiceChannelBehavior;
+	public static final fun VoiceChannelBehavior-Lfpyfds (JJLdev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/channel/VoiceChannelBehavior;
+	public static synthetic fun VoiceChannelBehavior-Lfpyfds$default (JJLdev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;ILjava/lang/Object;)Ldev/kord/core/behavior/channel/VoiceChannelBehavior;
 	public static final fun edit (Ldev/kord/core/behavior/channel/VoiceChannelBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class dev/kord/core/behavior/channel/threads/PrivateThreadParentChannelBehavior : dev/kord/core/behavior/channel/threads/ThreadParentChannelBehavior {
-	public abstract fun getJoinedPrivateArchivedThreads (Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getJoinedPrivateArchivedThreads-O4FuXRM (Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
 	public abstract fun getPrivateArchivedThreads (Lkotlinx/datetime/Instant;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
 }
 
@@ -1550,7 +1550,7 @@ public final class dev/kord/core/behavior/channel/threads/PrivateThreadParentCha
 	public static fun compareTo (Ldev/kord/core/behavior/channel/threads/PrivateThreadParentChannelBehavior;Ldev/kord/core/entity/Entity;)I
 	public static fun createMessage (Ldev/kord/core/behavior/channel/threads/PrivateThreadParentChannelBehavior;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun delete (Ldev/kord/core/behavior/channel/threads/PrivateThreadParentChannelBehavior;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun deleteMessage (Ldev/kord/core/behavior/channel/threads/PrivateThreadParentChannelBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun deleteMessage-9y3P_48 (Ldev/kord/core/behavior/channel/threads/PrivateThreadParentChannelBehavior;JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun fetchChannel (Ldev/kord/core/behavior/channel/threads/PrivateThreadParentChannelBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun fetchChannelOrNull (Ldev/kord/core/behavior/channel/threads/PrivateThreadParentChannelBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getActiveThreads (Ldev/kord/core/behavior/channel/threads/PrivateThreadParentChannelBehavior;)Lkotlinx/coroutines/flow/Flow;
@@ -1558,15 +1558,15 @@ public final class dev/kord/core/behavior/channel/threads/PrivateThreadParentCha
 	public static fun getGuild (Ldev/kord/core/behavior/channel/threads/PrivateThreadParentChannelBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getGuildOrNull (Ldev/kord/core/behavior/channel/threads/PrivateThreadParentChannelBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getInvites (Ldev/kord/core/behavior/channel/threads/PrivateThreadParentChannelBehavior;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getJoinedPrivateArchivedThreads (Ldev/kord/core/behavior/channel/threads/PrivateThreadParentChannelBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public static synthetic fun getJoinedPrivateArchivedThreads$default (Ldev/kord/core/behavior/channel/threads/PrivateThreadParentChannelBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getJoinedPrivateArchivedThreads-O4FuXRM (Ldev/kord/core/behavior/channel/threads/PrivateThreadParentChannelBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun getJoinedPrivateArchivedThreads-O4FuXRM$default (Ldev/kord/core/behavior/channel/threads/PrivateThreadParentChannelBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 	public static fun getMention (Ldev/kord/core/behavior/channel/threads/PrivateThreadParentChannelBehavior;)Ljava/lang/String;
-	public static fun getMessage (Ldev/kord/core/behavior/channel/threads/PrivateThreadParentChannelBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getMessageOrNull (Ldev/kord/core/behavior/channel/threads/PrivateThreadParentChannelBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getMessage-wYKCHeA (Ldev/kord/core/behavior/channel/threads/PrivateThreadParentChannelBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getMessageOrNull-wYKCHeA (Ldev/kord/core/behavior/channel/threads/PrivateThreadParentChannelBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getMessages (Ldev/kord/core/behavior/channel/threads/PrivateThreadParentChannelBehavior;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getMessagesAfter (Ldev/kord/core/behavior/channel/threads/PrivateThreadParentChannelBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getMessagesAround (Ldev/kord/core/behavior/channel/threads/PrivateThreadParentChannelBehavior;Ldev/kord/common/entity/Snowflake;I)Lkotlinx/coroutines/flow/Flow;
-	public static fun getMessagesBefore (Ldev/kord/core/behavior/channel/threads/PrivateThreadParentChannelBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getMessagesAfter-wYKCHeA (Ldev/kord/core/behavior/channel/threads/PrivateThreadParentChannelBehavior;JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getMessagesAround-wYKCHeA (Ldev/kord/core/behavior/channel/threads/PrivateThreadParentChannelBehavior;JI)Lkotlinx/coroutines/flow/Flow;
+	public static fun getMessagesBefore-wYKCHeA (Ldev/kord/core/behavior/channel/threads/PrivateThreadParentChannelBehavior;JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
 	public static fun getPinnedMessages (Ldev/kord/core/behavior/channel/threads/PrivateThreadParentChannelBehavior;)Lkotlinx/coroutines/flow/Flow;
 	public static fun getPosition (Ldev/kord/core/behavior/channel/threads/PrivateThreadParentChannelBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getPrivateArchivedThreads (Ldev/kord/core/behavior/channel/threads/PrivateThreadParentChannelBehavior;Lkotlinx/datetime/Instant;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
@@ -1579,23 +1579,23 @@ public final class dev/kord/core/behavior/channel/threads/PrivateThreadParentCha
 }
 
 public abstract interface class dev/kord/core/behavior/channel/threads/ThreadChannelBehavior : dev/kord/core/behavior/channel/GuildMessageChannelBehavior {
-	public abstract fun addUser (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun addUser-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun asChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun asChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun delete (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getMembers ()Lkotlinx/coroutines/flow/Flow;
 	public abstract fun getParent ()Ldev/kord/core/behavior/channel/threads/ThreadParentChannelBehavior;
 	public abstract fun getParent (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getParentId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getParentId-4_xYDEk ()J
 	public abstract fun getParentOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun join (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun leave (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun removeUser (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun removeUser-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/channel/threads/ThreadChannelBehavior;
 }
 
 public final class dev/kord/core/behavior/channel/threads/ThreadChannelBehavior$DefaultImpls {
-	public static fun addUser (Ldev/kord/core/behavior/channel/threads/ThreadChannelBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun addUser-wYKCHeA (Ldev/kord/core/behavior/channel/threads/ThreadChannelBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun asChannel (Ldev/kord/core/behavior/channel/threads/ThreadChannelBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun asChannelOrNull (Ldev/kord/core/behavior/channel/threads/ThreadChannelBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun bulkDelete (Ldev/kord/core/behavior/channel/threads/ThreadChannelBehavior;Ljava/lang/Iterable;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -1603,7 +1603,7 @@ public final class dev/kord/core/behavior/channel/threads/ThreadChannelBehavior$
 	public static fun compareTo (Ldev/kord/core/behavior/channel/threads/ThreadChannelBehavior;Ldev/kord/core/entity/Entity;)I
 	public static fun createMessage (Ldev/kord/core/behavior/channel/threads/ThreadChannelBehavior;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun delete (Ldev/kord/core/behavior/channel/threads/ThreadChannelBehavior;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun deleteMessage (Ldev/kord/core/behavior/channel/threads/ThreadChannelBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun deleteMessage-9y3P_48 (Ldev/kord/core/behavior/channel/threads/ThreadChannelBehavior;JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun fetchChannel (Ldev/kord/core/behavior/channel/threads/ThreadChannelBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun fetchChannelOrNull (Ldev/kord/core/behavior/channel/threads/ThreadChannelBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getGuild (Ldev/kord/core/behavior/channel/threads/ThreadChannelBehavior;)Ldev/kord/core/behavior/GuildBehavior;
@@ -1611,19 +1611,19 @@ public final class dev/kord/core/behavior/channel/threads/ThreadChannelBehavior$
 	public static fun getGuildOrNull (Ldev/kord/core/behavior/channel/threads/ThreadChannelBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getMembers (Ldev/kord/core/behavior/channel/threads/ThreadChannelBehavior;)Lkotlinx/coroutines/flow/Flow;
 	public static fun getMention (Ldev/kord/core/behavior/channel/threads/ThreadChannelBehavior;)Ljava/lang/String;
-	public static fun getMessage (Ldev/kord/core/behavior/channel/threads/ThreadChannelBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getMessageOrNull (Ldev/kord/core/behavior/channel/threads/ThreadChannelBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getMessage-wYKCHeA (Ldev/kord/core/behavior/channel/threads/ThreadChannelBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getMessageOrNull-wYKCHeA (Ldev/kord/core/behavior/channel/threads/ThreadChannelBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getMessages (Ldev/kord/core/behavior/channel/threads/ThreadChannelBehavior;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getMessagesAfter (Ldev/kord/core/behavior/channel/threads/ThreadChannelBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getMessagesAround (Ldev/kord/core/behavior/channel/threads/ThreadChannelBehavior;Ldev/kord/common/entity/Snowflake;I)Lkotlinx/coroutines/flow/Flow;
-	public static fun getMessagesBefore (Ldev/kord/core/behavior/channel/threads/ThreadChannelBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getMessagesAfter-wYKCHeA (Ldev/kord/core/behavior/channel/threads/ThreadChannelBehavior;JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getMessagesAround-wYKCHeA (Ldev/kord/core/behavior/channel/threads/ThreadChannelBehavior;JI)Lkotlinx/coroutines/flow/Flow;
+	public static fun getMessagesBefore-wYKCHeA (Ldev/kord/core/behavior/channel/threads/ThreadChannelBehavior;JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
 	public static fun getParent (Ldev/kord/core/behavior/channel/threads/ThreadChannelBehavior;)Ldev/kord/core/behavior/channel/threads/ThreadParentChannelBehavior;
 	public static fun getParent (Ldev/kord/core/behavior/channel/threads/ThreadChannelBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getParentOrNull (Ldev/kord/core/behavior/channel/threads/ThreadChannelBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getPinnedMessages (Ldev/kord/core/behavior/channel/threads/ThreadChannelBehavior;)Lkotlinx/coroutines/flow/Flow;
 	public static fun join (Ldev/kord/core/behavior/channel/threads/ThreadChannelBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun leave (Ldev/kord/core/behavior/channel/threads/ThreadChannelBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun removeUser (Ldev/kord/core/behavior/channel/threads/ThreadChannelBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun removeUser-wYKCHeA (Ldev/kord/core/behavior/channel/threads/ThreadChannelBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun type (Ldev/kord/core/behavior/channel/threads/ThreadChannelBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun typeUntil (Ldev/kord/core/behavior/channel/threads/ThreadChannelBehavior;Lkotlin/time/TimeMark;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun typeUntil (Ldev/kord/core/behavior/channel/threads/ThreadChannelBehavior;Lkotlinx/datetime/Instant;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -1653,7 +1653,7 @@ public final class dev/kord/core/behavior/channel/threads/ThreadParentChannelBeh
 	public static fun compareTo (Ldev/kord/core/behavior/channel/threads/ThreadParentChannelBehavior;Ldev/kord/core/entity/Entity;)I
 	public static fun createMessage (Ldev/kord/core/behavior/channel/threads/ThreadParentChannelBehavior;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun delete (Ldev/kord/core/behavior/channel/threads/ThreadParentChannelBehavior;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun deleteMessage (Ldev/kord/core/behavior/channel/threads/ThreadParentChannelBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun deleteMessage-9y3P_48 (Ldev/kord/core/behavior/channel/threads/ThreadParentChannelBehavior;JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun fetchChannel (Ldev/kord/core/behavior/channel/threads/ThreadParentChannelBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun fetchChannelOrNull (Ldev/kord/core/behavior/channel/threads/ThreadParentChannelBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getActiveThreads (Ldev/kord/core/behavior/channel/threads/ThreadParentChannelBehavior;)Lkotlinx/coroutines/flow/Flow;
@@ -1662,12 +1662,12 @@ public final class dev/kord/core/behavior/channel/threads/ThreadParentChannelBeh
 	public static fun getGuildOrNull (Ldev/kord/core/behavior/channel/threads/ThreadParentChannelBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getInvites (Ldev/kord/core/behavior/channel/threads/ThreadParentChannelBehavior;)Lkotlinx/coroutines/flow/Flow;
 	public static fun getMention (Ldev/kord/core/behavior/channel/threads/ThreadParentChannelBehavior;)Ljava/lang/String;
-	public static fun getMessage (Ldev/kord/core/behavior/channel/threads/ThreadParentChannelBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getMessageOrNull (Ldev/kord/core/behavior/channel/threads/ThreadParentChannelBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getMessage-wYKCHeA (Ldev/kord/core/behavior/channel/threads/ThreadParentChannelBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getMessageOrNull-wYKCHeA (Ldev/kord/core/behavior/channel/threads/ThreadParentChannelBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getMessages (Ldev/kord/core/behavior/channel/threads/ThreadParentChannelBehavior;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getMessagesAfter (Ldev/kord/core/behavior/channel/threads/ThreadParentChannelBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getMessagesAround (Ldev/kord/core/behavior/channel/threads/ThreadParentChannelBehavior;Ldev/kord/common/entity/Snowflake;I)Lkotlinx/coroutines/flow/Flow;
-	public static fun getMessagesBefore (Ldev/kord/core/behavior/channel/threads/ThreadParentChannelBehavior;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getMessagesAfter-wYKCHeA (Ldev/kord/core/behavior/channel/threads/ThreadParentChannelBehavior;JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getMessagesAround-wYKCHeA (Ldev/kord/core/behavior/channel/threads/ThreadParentChannelBehavior;JI)Lkotlinx/coroutines/flow/Flow;
+	public static fun getMessagesBefore-wYKCHeA (Ldev/kord/core/behavior/channel/threads/ThreadParentChannelBehavior;JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
 	public static fun getPinnedMessages (Ldev/kord/core/behavior/channel/threads/ThreadParentChannelBehavior;)Lkotlinx/coroutines/flow/Flow;
 	public static fun getPosition (Ldev/kord/core/behavior/channel/threads/ThreadParentChannelBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getPublicArchivedThreads (Ldev/kord/core/behavior/channel/threads/ThreadParentChannelBehavior;Lkotlinx/datetime/Instant;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
@@ -1707,8 +1707,8 @@ public final class dev/kord/core/behavior/interaction/ActionInteractionBehavior$
 }
 
 public final class dev/kord/core/behavior/interaction/ActionInteractionBehaviorKt {
-	public static final fun ActionInteractionBehavior (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/interaction/ActionInteractionBehavior;
-	public static synthetic fun ActionInteractionBehavior$default (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;ILjava/lang/Object;)Ldev/kord/core/behavior/interaction/ActionInteractionBehavior;
+	public static final fun ActionInteractionBehavior-2iOXgRs (JJLjava/lang/String;JLdev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/interaction/ActionInteractionBehavior;
+	public static synthetic fun ActionInteractionBehavior-2iOXgRs$default (JJLjava/lang/String;JLdev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;ILjava/lang/Object;)Ldev/kord/core/behavior/interaction/ActionInteractionBehavior;
 	public static final fun respondEphemeral (Ldev/kord/core/behavior/interaction/ActionInteractionBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun respondPublic (Ldev/kord/core/behavior/interaction/ActionInteractionBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
@@ -1779,8 +1779,8 @@ public final class dev/kord/core/behavior/interaction/ComponentInteractionBehavi
 }
 
 public final class dev/kord/core/behavior/interaction/ComponentInteractionBehaviorKt {
-	public static final fun ComponentInteractionBehavior (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/interaction/ComponentInteractionBehavior;
-	public static synthetic fun ComponentInteractionBehavior$default (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;ILjava/lang/Object;)Ldev/kord/core/behavior/interaction/ComponentInteractionBehavior;
+	public static final fun ComponentInteractionBehavior-2iOXgRs (JJLjava/lang/String;JLdev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/interaction/ComponentInteractionBehavior;
+	public static synthetic fun ComponentInteractionBehavior-2iOXgRs$default (JJLjava/lang/String;JLdev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplyStrategy;ILjava/lang/Object;)Ldev/kord/core/behavior/interaction/ComponentInteractionBehavior;
 	public static final synthetic fun acknowledgeEphemeralUpdateMessage (Ldev/kord/core/behavior/interaction/ComponentInteractionBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final synthetic fun acknowledgePublicUpdateMessage (Ldev/kord/core/behavior/interaction/ComponentInteractionBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun updateEphemeralMessage (Ldev/kord/core/behavior/interaction/ComponentInteractionBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -1815,7 +1815,7 @@ public abstract interface class dev/kord/core/behavior/interaction/GuildInteract
 	public abstract fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public abstract fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getGuildId-4_xYDEk ()J
 	public abstract fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/interaction/GuildInteractionBehavior;
 }
@@ -1832,15 +1832,15 @@ public final class dev/kord/core/behavior/interaction/GuildInteractionBehavior$D
 }
 
 public final class dev/kord/core/behavior/interaction/GuildInteractionBehaviorKt {
-	public static final fun GuildInteractionBehavior (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)Ldev/kord/core/behavior/interaction/GuildInteractionBehavior;
-	public static synthetic fun GuildInteractionBehavior$default (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;ILjava/lang/Object;)Ldev/kord/core/behavior/interaction/GuildInteractionBehavior;
+	public static final fun GuildInteractionBehavior-FF-nD8A (JJJJLjava/lang/String;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)Ldev/kord/core/behavior/interaction/GuildInteractionBehavior;
+	public static synthetic fun GuildInteractionBehavior-FF-nD8A$default (JJJJLjava/lang/String;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;ILjava/lang/Object;)Ldev/kord/core/behavior/interaction/GuildInteractionBehavior;
 }
 
 public abstract interface class dev/kord/core/behavior/interaction/InteractionBehavior : dev/kord/core/entity/KordEntity, dev/kord/core/entity/Strategizable {
-	public abstract fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getApplicationId-4_xYDEk ()J
 	public abstract fun getChannel ()Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public abstract fun getChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getChannelId-4_xYDEk ()J
 	public abstract fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getToken ()Ljava/lang/String;
 	public abstract fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/interaction/InteractionBehavior;
@@ -1890,16 +1890,16 @@ public final class dev/kord/core/behavior/interaction/followup/EphemeralFollowup
 }
 
 public final class dev/kord/core/behavior/interaction/followup/EphemeralFollowupMessageBehaviorKt {
-	public static final fun EphemeralFollowupMessageBehavior (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)Ldev/kord/core/behavior/interaction/followup/EphemeralFollowupMessageBehavior;
+	public static final fun EphemeralFollowupMessageBehavior-2iOXgRs (JJLjava/lang/String;JLdev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)Ldev/kord/core/behavior/interaction/followup/EphemeralFollowupMessageBehavior;
 	public static final fun edit (Ldev/kord/core/behavior/interaction/followup/EphemeralFollowupMessageBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class dev/kord/core/behavior/interaction/followup/FollowupMessageBehavior : dev/kord/core/entity/KordEntity, dev/kord/core/entity/Strategizable {
 	public abstract fun delete (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getApplicationId-4_xYDEk ()J
 	public abstract fun getChannel ()Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public abstract fun getChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getChannelId-4_xYDEk ()J
 	public abstract fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getToken ()Ljava/lang/String;
 	public abstract fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/interaction/followup/FollowupMessageBehavior;
@@ -1931,13 +1931,13 @@ public final class dev/kord/core/behavior/interaction/followup/PublicFollowupMes
 }
 
 public final class dev/kord/core/behavior/interaction/followup/PublicFollowupMessageBehaviorKt {
-	public static final fun PublicFollowupMessageBehavior (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)Ldev/kord/core/behavior/interaction/followup/PublicFollowupMessageBehavior;
+	public static final fun PublicFollowupMessageBehavior-2iOXgRs (JJLjava/lang/String;JLdev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)Ldev/kord/core/behavior/interaction/followup/PublicFollowupMessageBehavior;
 	public static final fun edit (Ldev/kord/core/behavior/interaction/followup/PublicFollowupMessageBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class dev/kord/core/behavior/interaction/response/DeferredEphemeralMessageInteractionBehaviorKt {
-	public static final fun DeferredEphemeralMessageInteractionResponseBehavior (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)Ldev/kord/core/behavior/interaction/response/DeferredEphemeralMessageInteractionResponseBehavior;
-	public static synthetic fun DeferredEphemeralMessageInteractionResponseBehavior$default (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;ILjava/lang/Object;)Ldev/kord/core/behavior/interaction/response/DeferredEphemeralMessageInteractionResponseBehavior;
+	public static final fun DeferredEphemeralMessageInteractionResponseBehavior-9VmEaQQ (JLjava/lang/String;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)Ldev/kord/core/behavior/interaction/response/DeferredEphemeralMessageInteractionResponseBehavior;
+	public static synthetic fun DeferredEphemeralMessageInteractionResponseBehavior-9VmEaQQ$default (JLjava/lang/String;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;ILjava/lang/Object;)Ldev/kord/core/behavior/interaction/response/DeferredEphemeralMessageInteractionResponseBehavior;
 	public static final fun respond (Ldev/kord/core/behavior/interaction/response/DeferredEphemeralMessageInteractionResponseBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -1947,8 +1947,8 @@ public abstract interface class dev/kord/core/behavior/interaction/response/Defe
 
 public final class dev/kord/core/behavior/interaction/response/DeferredEphemeralMessageInteractionResponseBehavior$DefaultImpls {
 	public static fun delete (Ldev/kord/core/behavior/interaction/response/DeferredEphemeralMessageInteractionResponseBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getFollowupMessage (Ldev/kord/core/behavior/interaction/response/DeferredEphemeralMessageInteractionResponseBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getFollowupMessageOrNull (Ldev/kord/core/behavior/interaction/response/DeferredEphemeralMessageInteractionResponseBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getFollowupMessage-wYKCHeA (Ldev/kord/core/behavior/interaction/response/DeferredEphemeralMessageInteractionResponseBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getFollowupMessageOrNull-wYKCHeA (Ldev/kord/core/behavior/interaction/response/DeferredEphemeralMessageInteractionResponseBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun withStrategy (Ldev/kord/core/behavior/interaction/response/DeferredEphemeralMessageInteractionResponseBehavior;Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/interaction/response/DeferredEphemeralMessageInteractionResponseBehavior;
 }
 
@@ -1959,8 +1959,8 @@ public abstract interface class dev/kord/core/behavior/interaction/response/Defe
 
 public final class dev/kord/core/behavior/interaction/response/DeferredMessageInteractionResponseBehavior$DefaultImpls {
 	public static fun delete (Ldev/kord/core/behavior/interaction/response/DeferredMessageInteractionResponseBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getFollowupMessage (Ldev/kord/core/behavior/interaction/response/DeferredMessageInteractionResponseBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getFollowupMessageOrNull (Ldev/kord/core/behavior/interaction/response/DeferredMessageInteractionResponseBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getFollowupMessage-wYKCHeA (Ldev/kord/core/behavior/interaction/response/DeferredMessageInteractionResponseBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getFollowupMessageOrNull-wYKCHeA (Ldev/kord/core/behavior/interaction/response/DeferredMessageInteractionResponseBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class dev/kord/core/behavior/interaction/response/DeferredMessageInteractionResponseBehaviorKt {
@@ -1973,14 +1973,14 @@ public abstract interface class dev/kord/core/behavior/interaction/response/Defe
 
 public final class dev/kord/core/behavior/interaction/response/DeferredPublicMessageInteractionResponseBehavior$DefaultImpls {
 	public static fun delete (Ldev/kord/core/behavior/interaction/response/DeferredPublicMessageInteractionResponseBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getFollowupMessage (Ldev/kord/core/behavior/interaction/response/DeferredPublicMessageInteractionResponseBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getFollowupMessageOrNull (Ldev/kord/core/behavior/interaction/response/DeferredPublicMessageInteractionResponseBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getFollowupMessage-wYKCHeA (Ldev/kord/core/behavior/interaction/response/DeferredPublicMessageInteractionResponseBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getFollowupMessageOrNull-wYKCHeA (Ldev/kord/core/behavior/interaction/response/DeferredPublicMessageInteractionResponseBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun withStrategy (Ldev/kord/core/behavior/interaction/response/DeferredPublicMessageInteractionResponseBehavior;Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/interaction/response/DeferredPublicMessageInteractionResponseBehavior;
 }
 
 public final class dev/kord/core/behavior/interaction/response/DeferredPublicMessageInteractionResponseBehaviorKt {
-	public static final fun DeferredPublicMessageInteractionResponseBehavior (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)Ldev/kord/core/behavior/interaction/response/DeferredPublicMessageInteractionResponseBehavior;
-	public static synthetic fun DeferredPublicMessageInteractionResponseBehavior$default (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;ILjava/lang/Object;)Ldev/kord/core/behavior/interaction/response/DeferredPublicMessageInteractionResponseBehavior;
+	public static final fun DeferredPublicMessageInteractionResponseBehavior-9VmEaQQ (JLjava/lang/String;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)Ldev/kord/core/behavior/interaction/response/DeferredPublicMessageInteractionResponseBehavior;
+	public static synthetic fun DeferredPublicMessageInteractionResponseBehavior-9VmEaQQ$default (JLjava/lang/String;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;ILjava/lang/Object;)Ldev/kord/core/behavior/interaction/response/DeferredPublicMessageInteractionResponseBehavior;
 	public static final fun respond (Ldev/kord/core/behavior/interaction/response/DeferredPublicMessageInteractionResponseBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -1996,8 +1996,8 @@ public abstract interface class dev/kord/core/behavior/interaction/response/Ephe
 }
 
 public final class dev/kord/core/behavior/interaction/response/EphemeralInteractionResponseBehavior$DefaultImpls {
-	public static fun getFollowupMessage (Ldev/kord/core/behavior/interaction/response/EphemeralInteractionResponseBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getFollowupMessageOrNull (Ldev/kord/core/behavior/interaction/response/EphemeralInteractionResponseBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getFollowupMessage-wYKCHeA (Ldev/kord/core/behavior/interaction/response/EphemeralInteractionResponseBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getFollowupMessageOrNull-wYKCHeA (Ldev/kord/core/behavior/interaction/response/EphemeralInteractionResponseBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class dev/kord/core/behavior/interaction/response/EphemeralMessageInteractionResponseBehavior : dev/kord/core/behavior/interaction/response/EphemeralInteractionResponseBehavior, dev/kord/core/behavior/interaction/response/MessageInteractionResponseBehavior {
@@ -2006,14 +2006,14 @@ public abstract interface class dev/kord/core/behavior/interaction/response/Ephe
 
 public final class dev/kord/core/behavior/interaction/response/EphemeralMessageInteractionResponseBehavior$DefaultImpls {
 	public static fun delete (Ldev/kord/core/behavior/interaction/response/EphemeralMessageInteractionResponseBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getFollowupMessage (Ldev/kord/core/behavior/interaction/response/EphemeralMessageInteractionResponseBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getFollowupMessageOrNull (Ldev/kord/core/behavior/interaction/response/EphemeralMessageInteractionResponseBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getFollowupMessage-wYKCHeA (Ldev/kord/core/behavior/interaction/response/EphemeralMessageInteractionResponseBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getFollowupMessageOrNull-wYKCHeA (Ldev/kord/core/behavior/interaction/response/EphemeralMessageInteractionResponseBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun withStrategy (Ldev/kord/core/behavior/interaction/response/EphemeralMessageInteractionResponseBehavior;Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/interaction/response/EphemeralMessageInteractionResponseBehavior;
 }
 
 public final class dev/kord/core/behavior/interaction/response/EphemeralMessageInteractionResponseBehaviorKt {
-	public static final fun EphemeralMessageInteractionResponseBehavior (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)Ldev/kord/core/behavior/interaction/response/EphemeralMessageInteractionResponseBehavior;
-	public static synthetic fun EphemeralMessageInteractionResponseBehavior$default (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;ILjava/lang/Object;)Ldev/kord/core/behavior/interaction/response/EphemeralMessageInteractionResponseBehavior;
+	public static final fun EphemeralMessageInteractionResponseBehavior-9VmEaQQ (JLjava/lang/String;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)Ldev/kord/core/behavior/interaction/response/EphemeralMessageInteractionResponseBehavior;
+	public static synthetic fun EphemeralMessageInteractionResponseBehavior-9VmEaQQ$default (JLjava/lang/String;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;ILjava/lang/Object;)Ldev/kord/core/behavior/interaction/response/EphemeralMessageInteractionResponseBehavior;
 	public static final fun edit (Ldev/kord/core/behavior/interaction/response/EphemeralMessageInteractionResponseBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -2022,14 +2022,14 @@ public abstract interface class dev/kord/core/behavior/interaction/response/Foll
 }
 
 public final class dev/kord/core/behavior/interaction/response/FollowupPermittingInteractionResponseBehavior$DefaultImpls {
-	public static fun getFollowupMessage (Ldev/kord/core/behavior/interaction/response/FollowupPermittingInteractionResponseBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getFollowupMessageOrNull (Ldev/kord/core/behavior/interaction/response/FollowupPermittingInteractionResponseBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getFollowupMessage-wYKCHeA (Ldev/kord/core/behavior/interaction/response/FollowupPermittingInteractionResponseBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getFollowupMessageOrNull-wYKCHeA (Ldev/kord/core/behavior/interaction/response/FollowupPermittingInteractionResponseBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun withStrategy (Ldev/kord/core/behavior/interaction/response/FollowupPermittingInteractionResponseBehavior;Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/interaction/response/FollowupPermittingInteractionResponseBehavior;
 }
 
 public final class dev/kord/core/behavior/interaction/response/FollowupPermittingInteractionResponseBehaviorKt {
-	public static final fun FollowupPermittingInteractionResponseBehavior (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)Ldev/kord/core/behavior/interaction/response/FollowupPermittingInteractionResponseBehavior;
-	public static synthetic fun FollowupPermittingInteractionResponseBehavior$default (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;ILjava/lang/Object;)Ldev/kord/core/behavior/interaction/response/FollowupPermittingInteractionResponseBehavior;
+	public static final fun FollowupPermittingInteractionResponseBehavior-9VmEaQQ (JLjava/lang/String;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)Ldev/kord/core/behavior/interaction/response/FollowupPermittingInteractionResponseBehavior;
+	public static synthetic fun FollowupPermittingInteractionResponseBehavior-9VmEaQQ$default (JLjava/lang/String;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;ILjava/lang/Object;)Ldev/kord/core/behavior/interaction/response/FollowupPermittingInteractionResponseBehavior;
 	public static final fun createEphemeralFollowup (Ldev/kord/core/behavior/interaction/response/FollowupPermittingInteractionResponseBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun createPublicFollowup (Ldev/kord/core/behavior/interaction/response/FollowupPermittingInteractionResponseBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final synthetic fun followUp (Ldev/kord/core/behavior/interaction/response/FollowupPermittingInteractionResponseBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -2037,16 +2037,21 @@ public final class dev/kord/core/behavior/interaction/response/FollowupPermittin
 }
 
 public abstract interface class dev/kord/core/behavior/interaction/response/InteractionResponseBehavior : dev/kord/core/KordObject, dev/kord/core/entity/Strategizable {
-	public abstract fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
-	public abstract fun getFollowupMessage (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getFollowupMessageOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getApplicationId-4_xYDEk ()J
+	public abstract fun getFollowupMessage-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getFollowupMessageOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getToken ()Ljava/lang/String;
 	public abstract fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/interaction/response/InteractionResponseBehavior;
 }
 
 public final class dev/kord/core/behavior/interaction/response/InteractionResponseBehavior$DefaultImpls {
-	public static fun getFollowupMessage (Ldev/kord/core/behavior/interaction/response/InteractionResponseBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getFollowupMessageOrNull (Ldev/kord/core/behavior/interaction/response/InteractionResponseBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getFollowupMessage-wYKCHeA (Ldev/kord/core/behavior/interaction/response/InteractionResponseBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getFollowupMessageOrNull-wYKCHeA (Ldev/kord/core/behavior/interaction/response/InteractionResponseBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class dev/kord/core/behavior/interaction/response/InteractionResponseBehaviorKt {
+	public static final synthetic fun followUp (Ldev/kord/core/behavior/interaction/response/InteractionResponseBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final synthetic fun followUpEphemeral (Ldev/kord/core/behavior/interaction/response/InteractionResponseBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class dev/kord/core/behavior/interaction/response/MessageInteractionResponseBehavior : dev/kord/core/behavior/interaction/response/FollowupPermittingInteractionResponseBehavior {
@@ -2056,8 +2061,8 @@ public abstract interface class dev/kord/core/behavior/interaction/response/Mess
 
 public final class dev/kord/core/behavior/interaction/response/MessageInteractionResponseBehavior$DefaultImpls {
 	public static fun delete (Ldev/kord/core/behavior/interaction/response/MessageInteractionResponseBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getFollowupMessage (Ldev/kord/core/behavior/interaction/response/MessageInteractionResponseBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getFollowupMessageOrNull (Ldev/kord/core/behavior/interaction/response/MessageInteractionResponseBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getFollowupMessage-wYKCHeA (Ldev/kord/core/behavior/interaction/response/MessageInteractionResponseBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getFollowupMessageOrNull-wYKCHeA (Ldev/kord/core/behavior/interaction/response/MessageInteractionResponseBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class dev/kord/core/behavior/interaction/response/MessageInteractionResponseBehaviorKt {
@@ -2069,14 +2074,14 @@ public abstract interface class dev/kord/core/behavior/interaction/response/Popu
 }
 
 public final class dev/kord/core/behavior/interaction/response/PopupInteractionResponseBehavior$DefaultImpls {
-	public static fun getFollowupMessage (Ldev/kord/core/behavior/interaction/response/PopupInteractionResponseBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getFollowupMessageOrNull (Ldev/kord/core/behavior/interaction/response/PopupInteractionResponseBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getFollowupMessage-wYKCHeA (Ldev/kord/core/behavior/interaction/response/PopupInteractionResponseBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getFollowupMessageOrNull-wYKCHeA (Ldev/kord/core/behavior/interaction/response/PopupInteractionResponseBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun withStrategy (Ldev/kord/core/behavior/interaction/response/PopupInteractionResponseBehavior;Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/interaction/response/PopupInteractionResponseBehavior;
 }
 
 public final class dev/kord/core/behavior/interaction/response/PopupInteractionResponseBehaviorKt {
-	public static final fun PopupInteractionResponseBehavior (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)Ldev/kord/core/behavior/interaction/response/PopupInteractionResponseBehavior;
-	public static synthetic fun PopupInteractionResponseBehavior$default (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;ILjava/lang/Object;)Ldev/kord/core/behavior/interaction/response/PopupInteractionResponseBehavior;
+	public static final fun PopupInteractionResponseBehavior-9VmEaQQ (JLjava/lang/String;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)Ldev/kord/core/behavior/interaction/response/PopupInteractionResponseBehavior;
+	public static synthetic fun PopupInteractionResponseBehavior-9VmEaQQ$default (JLjava/lang/String;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;ILjava/lang/Object;)Ldev/kord/core/behavior/interaction/response/PopupInteractionResponseBehavior;
 }
 
 public abstract interface class dev/kord/core/behavior/interaction/response/PublicInteractionResponseBehavior : dev/kord/core/behavior/interaction/response/InteractionResponseBehavior {
@@ -2084,13 +2089,13 @@ public abstract interface class dev/kord/core/behavior/interaction/response/Publ
 }
 
 public final class dev/kord/core/behavior/interaction/response/PublicInteractionResponseBehavior$DefaultImpls {
-	public static fun getFollowupMessage (Ldev/kord/core/behavior/interaction/response/PublicInteractionResponseBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getFollowupMessageOrNull (Ldev/kord/core/behavior/interaction/response/PublicInteractionResponseBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getFollowupMessage-wYKCHeA (Ldev/kord/core/behavior/interaction/response/PublicInteractionResponseBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getFollowupMessageOrNull-wYKCHeA (Ldev/kord/core/behavior/interaction/response/PublicInteractionResponseBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class dev/kord/core/behavior/interaction/response/PublicMesageInteractionResponseBehaviorKt {
-	public static final fun PublicMessageInteractionResponseBehavior (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)Ldev/kord/core/behavior/interaction/response/PublicMessageInteractionResponseBehavior;
-	public static synthetic fun PublicMessageInteractionResponseBehavior$default (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;ILjava/lang/Object;)Ldev/kord/core/behavior/interaction/response/PublicMessageInteractionResponseBehavior;
+	public static final fun PublicMessageInteractionResponseBehavior-9VmEaQQ (JLjava/lang/String;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)Ldev/kord/core/behavior/interaction/response/PublicMessageInteractionResponseBehavior;
+	public static synthetic fun PublicMessageInteractionResponseBehavior-9VmEaQQ$default (JLjava/lang/String;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;ILjava/lang/Object;)Ldev/kord/core/behavior/interaction/response/PublicMessageInteractionResponseBehavior;
 	public static final fun edit (Ldev/kord/core/behavior/interaction/response/PublicMessageInteractionResponseBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -2100,8 +2105,8 @@ public abstract interface class dev/kord/core/behavior/interaction/response/Publ
 
 public final class dev/kord/core/behavior/interaction/response/PublicMessageInteractionResponseBehavior$DefaultImpls {
 	public static fun delete (Ldev/kord/core/behavior/interaction/response/PublicMessageInteractionResponseBehavior;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getFollowupMessage (Ldev/kord/core/behavior/interaction/response/PublicMessageInteractionResponseBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getFollowupMessageOrNull (Ldev/kord/core/behavior/interaction/response/PublicMessageInteractionResponseBehavior;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getFollowupMessage-wYKCHeA (Ldev/kord/core/behavior/interaction/response/PublicMessageInteractionResponseBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getFollowupMessageOrNull-wYKCHeA (Ldev/kord/core/behavior/interaction/response/PublicMessageInteractionResponseBehavior;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun withStrategy (Ldev/kord/core/behavior/interaction/response/PublicMessageInteractionResponseBehavior;Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/interaction/response/PublicMessageInteractionResponseBehavior;
 }
 
@@ -2116,7 +2121,7 @@ public final class dev/kord/core/builder/kord/KordBuilder {
 	public final fun build (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun cache (Lkotlin/jvm/functions/Function2;)V
 	public final fun gateways (Lkotlin/jvm/functions/Function2;)V
-	public final fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getApplicationId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getDefaultDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
 	public final fun getDefaultStrategy ()Ldev/kord/core/supplier/EntitySupplyStrategy;
 	public final fun getEnableShutdownHook ()Z
@@ -2126,7 +2131,7 @@ public final class dev/kord/core/builder/kord/KordBuilder {
 	public final fun getStackTraceRecovery ()Z
 	public final fun getToken ()Ljava/lang/String;
 	public final fun requestHandler (Lkotlin/jvm/functions/Function1;)V
-	public final fun setApplicationId (Ldev/kord/common/entity/Snowflake;)V
+	public final fun setApplicationId-JTHp4pg (Ldev/kord/common/entity/Snowflake;)V
 	public final fun setDefaultDispatcher (Lkotlinx/coroutines/CoroutineDispatcher;)V
 	public final fun setDefaultStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)V
 	public final fun setEnableShutdownHook (Z)V
@@ -2143,29 +2148,29 @@ public final class dev/kord/core/builder/kord/KordBuilderKt {
 }
 
 public final class dev/kord/core/builder/kord/KordProxyBuilder : dev/kord/core/builder/kord/RestOnlyBuilder {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;)V
-	public fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
-	public fun setApplicationId (Ldev/kord/common/entity/Snowflake;)V
+	public synthetic fun <init> (JLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getApplicationId-4_xYDEk ()J
+	public fun setApplicationId-IO-hELI (J)V
 }
 
 public final class dev/kord/core/builder/kord/KordRestOnlyBuilder : dev/kord/core/builder/kord/RestOnlyBuilder {
 	public fun <init> (Ljava/lang/String;)V
-	public fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
+	public fun getApplicationId-4_xYDEk ()J
 	public fun getToken ()Ljava/lang/String;
-	public fun setApplicationId (Ldev/kord/common/entity/Snowflake;)V
+	public fun setApplicationId-IO-hELI (J)V
 	public fun setToken (Ljava/lang/String;)V
 }
 
 public abstract class dev/kord/core/builder/kord/RestOnlyBuilder {
 	public fun <init> ()V
 	public final fun build ()Ldev/kord/core/Kord;
-	public abstract fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getApplicationId-4_xYDEk ()J
 	public final fun getDefaultDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
 	protected final fun getHandlerBuilder ()Lkotlin/jvm/functions/Function1;
 	public final fun getHttpClient ()Lio/ktor/client/HttpClient;
 	protected abstract fun getToken ()Ljava/lang/String;
 	public final fun requestHandler (Lkotlin/jvm/functions/Function1;)V
-	public abstract fun setApplicationId (Ldev/kord/common/entity/Snowflake;)V
+	public abstract fun setApplicationId-IO-hELI (J)V
 	public final fun setDefaultDispatcher (Lkotlinx/coroutines/CoroutineDispatcher;)V
 	protected final fun setHandlerBuilder (Lkotlin/jvm/functions/Function1;)V
 	public final fun setHttpClient (Lio/ktor/client/HttpClient;)V
@@ -2227,10 +2232,10 @@ public final class dev/kord/core/cache/KordCacheBuilder {
 
 public final class dev/kord/core/cache/QueryKt {
 	public static final fun booleanEq (Ldev/kord/cache/api/QueryBuilder;Lkotlin/reflect/KProperty1;Ljava/lang/Boolean;)V
-	public static final fun idEq (Ldev/kord/cache/api/QueryBuilder;Lkotlin/reflect/KProperty1;Ldev/kord/common/entity/Snowflake;)V
 	public static final fun idEq (Ldev/kord/cache/api/QueryBuilder;Lkotlin/reflect/KProperty1;Ljava/lang/String;)V
-	public static final fun idGt (Ldev/kord/cache/api/QueryBuilder;Lkotlin/reflect/KProperty1;Ldev/kord/common/entity/Snowflake;)V
-	public static final fun idLt (Ldev/kord/cache/api/QueryBuilder;Lkotlin/reflect/KProperty1;Ldev/kord/common/entity/Snowflake;)V
+	public static final fun idEq-CjZJgt0 (Ldev/kord/cache/api/QueryBuilder;Lkotlin/reflect/KProperty1;Ldev/kord/common/entity/Snowflake;)V
+	public static final fun idGt-DGTxqCw (Ldev/kord/cache/api/QueryBuilder;Lkotlin/reflect/KProperty1;J)V
+	public static final fun idLt-DGTxqCw (Ldev/kord/cache/api/QueryBuilder;Lkotlin/reflect/KProperty1;J)V
 	public static final fun optionalIdEq (Ldev/kord/cache/api/QueryBuilder;Lkotlin/reflect/KProperty1;Ldev/kord/common/entity/Snowflake;)V
 	public static final fun optionalNullableIdEq (Ldev/kord/cache/api/QueryBuilder;Lkotlin/reflect/KProperty1;Ldev/kord/common/entity/Snowflake;)V
 	public static final fun stringEq (Ldev/kord/cache/api/QueryBuilder;Lkotlin/reflect/KProperty1;Ljava/lang/String;)V
@@ -2306,38 +2311,38 @@ public final class dev/kord/core/cache/data/ActivityData$Companion {
 
 public final class dev/kord/core/cache/data/ApplicationCommandData {
 	public static final field Companion Ldev/kord/core/cache/data/ApplicationCommandData$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Permissions;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Permissions;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/Snowflake;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Permissions;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/Snowflake;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Permissions;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/optional/Optional;JLjava/lang/String;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Permissions;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/optional/Optional;JLjava/lang/String;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Permissions;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;JLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component10 ()Ldev/kord/common/entity/Permissions;
 	public final fun component11 ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun component12 ()Ldev/kord/common/entity/optional/OptionalBoolean;
-	public final fun component13 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component13-4_xYDEk ()J
 	public final fun component2 ()Ldev/kord/common/entity/optional/Optional;
-	public final fun component3 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component3-4_xYDEk ()J
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component6 ()Ljava/lang/String;
 	public final fun component7 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component8 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun component9 ()Ldev/kord/common/entity/optional/Optional;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Permissions;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/cache/data/ApplicationCommandData;
-	public static synthetic fun copy$default (Ldev/kord/core/cache/data/ApplicationCommandData;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Permissions;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/Snowflake;ILjava/lang/Object;)Ldev/kord/core/cache/data/ApplicationCommandData;
+	public final fun copy-1Ok5F2I (JLdev/kord/common/entity/optional/Optional;JLjava/lang/String;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Permissions;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;J)Ldev/kord/core/cache/data/ApplicationCommandData;
+	public static synthetic fun copy-1Ok5F2I$default (Ldev/kord/core/cache/data/ApplicationCommandData;JLdev/kord/common/entity/optional/Optional;JLjava/lang/String;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Permissions;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;JILjava/lang/Object;)Ldev/kord/core/cache/data/ApplicationCommandData;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getApplicationId-4_xYDEk ()J
 	public final fun getDefaultMemberPermissions ()Ldev/kord/common/entity/Permissions;
 	public final fun getDefaultPermission ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun getDescription ()Ljava/lang/String;
 	public final fun getDescriptionLocalizations ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getDmPermission ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun getGuildId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getName ()Ljava/lang/String;
 	public final fun getNameLocalizations ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getOptions ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getType ()Ldev/kord/common/entity/optional/Optional;
-	public final fun getVersion ()Ldev/kord/common/entity/Snowflake;
+	public final fun getVersion-4_xYDEk ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public static final fun write$Self (Ldev/kord/core/cache/data/ApplicationCommandData;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
@@ -2556,10 +2561,10 @@ public final class dev/kord/core/cache/data/ApplicationCommandSubcommandData$Com
 
 public final class dev/kord/core/cache/data/ApplicationData : dev/kord/core/cache/data/BaseApplicationData {
 	public static final field Companion Ldev/kord/core/cache/data/ApplicationData$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;ZZLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/core/cache/data/TeamData;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;ZZLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/core/cache/data/TeamData;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;ZZLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/core/cache/data/TeamData;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;ZZLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/core/cache/data/TeamData;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;ZZLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/core/cache/data/TeamData;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;ZZLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/core/cache/data/TeamData;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component10 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun component11 ()Ljava/lang/String;
 	public final fun component12 ()Ldev/kord/core/cache/data/TeamData;
@@ -2579,8 +2584,8 @@ public final class dev/kord/core/cache/data/ApplicationData : dev/kord/core/cach
 	public final fun component7 ()Z
 	public final fun component8 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component9 ()Ldev/kord/common/entity/optional/Optional;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;ZZLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/core/cache/data/TeamData;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/core/cache/data/ApplicationData;
-	public static synthetic fun copy$default (Ldev/kord/core/cache/data/ApplicationData;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;ZZLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/core/cache/data/TeamData;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/core/cache/data/ApplicationData;
+	public final fun copy-yW0FbQg (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;ZZLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/core/cache/data/TeamData;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/core/cache/data/ApplicationData;
+	public static synthetic fun copy-yW0FbQg$default (Ldev/kord/core/cache/data/ApplicationData;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;ZZLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/core/cache/data/TeamData;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/core/cache/data/ApplicationData;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBotPublic ()Z
 	public final fun getBotRequireCodeGrant ()Z
@@ -2590,7 +2595,7 @@ public final class dev/kord/core/cache/data/ApplicationData : dev/kord/core/cach
 	public fun getFlags ()Ldev/kord/common/entity/optional/Optional;
 	public fun getGuildId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public fun getIcon ()Ljava/lang/String;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public fun getInstallParams ()Ldev/kord/common/entity/optional/Optional;
 	public fun getName ()Ljava/lang/String;
 	public fun getOwnerId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
@@ -2673,16 +2678,16 @@ public final class dev/kord/core/cache/data/ApplicationInteractionData$$serializ
 }
 
 public final class dev/kord/core/cache/data/ApplicationInteractionData$Companion {
-	public final fun from (Ldev/kord/common/entity/InteractionCallbackData;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/cache/data/ApplicationInteractionData;
+	public final fun from-NsqkgP0 (Ldev/kord/common/entity/InteractionCallbackData;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/cache/data/ApplicationInteractionData;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class dev/kord/core/cache/data/AttachmentData {
 	public static final field Companion Ldev/kord/core/cache/data/AttachmentData$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component10 ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ldev/kord/common/entity/optional/Optional;
@@ -2692,15 +2697,15 @@ public final class dev/kord/core/cache/data/AttachmentData {
 	public final fun component7 ()Ljava/lang/String;
 	public final fun component8 ()Ldev/kord/common/entity/optional/OptionalInt;
 	public final fun component9 ()Ldev/kord/common/entity/optional/OptionalInt;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;)Ldev/kord/core/cache/data/AttachmentData;
-	public static synthetic fun copy$default (Ldev/kord/core/cache/data/AttachmentData;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;ILjava/lang/Object;)Ldev/kord/core/cache/data/AttachmentData;
+	public final fun copy-1Wgd_o8 (JLjava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;)Ldev/kord/core/cache/data/AttachmentData;
+	public static synthetic fun copy-1Wgd_o8$default (Ldev/kord/core/cache/data/AttachmentData;JLjava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;ILjava/lang/Object;)Ldev/kord/core/cache/data/AttachmentData;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getContentType ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getDescription ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getEphemeral ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun getFilename ()Ljava/lang/String;
 	public final fun getHeight ()Ldev/kord/common/entity/optional/OptionalInt;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getProxyUrl ()Ljava/lang/String;
 	public final fun getSize ()I
 	public final fun getUrl ()Ljava/lang/String;
@@ -2798,30 +2803,30 @@ public final class dev/kord/core/cache/data/AutoModerationActionMetadataData$Com
 
 public final class dev/kord/core/cache/data/AutoModerationRuleData {
 	public static final field Companion Ldev/kord/core/cache/data/AutoModerationRuleData$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/AutoModerationRuleEventType;Ldev/kord/common/entity/AutoModerationRuleTriggerType;Ldev/kord/core/cache/data/AutoModerationRuleTriggerMetadataData;Ljava/util/List;ZLjava/util/List;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/AutoModerationRuleEventType;Ldev/kord/common/entity/AutoModerationRuleTriggerType;Ldev/kord/core/cache/data/AutoModerationRuleTriggerMetadataData;Ljava/util/List;ZLjava/util/List;Ljava/util/List;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/AutoModerationRuleEventType;Ldev/kord/common/entity/AutoModerationRuleTriggerType;Ldev/kord/core/cache/data/AutoModerationRuleTriggerMetadataData;Ljava/util/List;ZLjava/util/List;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLjava/lang/String;JLdev/kord/common/entity/AutoModerationRuleEventType;Ldev/kord/common/entity/AutoModerationRuleTriggerType;Ldev/kord/core/cache/data/AutoModerationRuleTriggerMetadataData;Ljava/util/List;ZLjava/util/List;Ljava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component10 ()Ljava/util/List;
 	public final fun component11 ()Ljava/util/List;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component2-4_xYDEk ()J
 	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component4-4_xYDEk ()J
 	public final fun component5 ()Ldev/kord/common/entity/AutoModerationRuleEventType;
 	public final fun component6 ()Ldev/kord/common/entity/AutoModerationRuleTriggerType;
 	public final fun component7 ()Ldev/kord/core/cache/data/AutoModerationRuleTriggerMetadataData;
 	public final fun component8 ()Ljava/util/List;
 	public final fun component9 ()Z
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/AutoModerationRuleEventType;Ldev/kord/common/entity/AutoModerationRuleTriggerType;Ldev/kord/core/cache/data/AutoModerationRuleTriggerMetadataData;Ljava/util/List;ZLjava/util/List;Ljava/util/List;)Ldev/kord/core/cache/data/AutoModerationRuleData;
-	public static synthetic fun copy$default (Ldev/kord/core/cache/data/AutoModerationRuleData;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/AutoModerationRuleEventType;Ldev/kord/common/entity/AutoModerationRuleTriggerType;Ldev/kord/core/cache/data/AutoModerationRuleTriggerMetadataData;Ljava/util/List;ZLjava/util/List;Ljava/util/List;ILjava/lang/Object;)Ldev/kord/core/cache/data/AutoModerationRuleData;
+	public final fun copy-gQPKoLI (JJLjava/lang/String;JLdev/kord/common/entity/AutoModerationRuleEventType;Ldev/kord/common/entity/AutoModerationRuleTriggerType;Ldev/kord/core/cache/data/AutoModerationRuleTriggerMetadataData;Ljava/util/List;ZLjava/util/List;Ljava/util/List;)Ldev/kord/core/cache/data/AutoModerationRuleData;
+	public static synthetic fun copy-gQPKoLI$default (Ldev/kord/core/cache/data/AutoModerationRuleData;JJLjava/lang/String;JLdev/kord/common/entity/AutoModerationRuleEventType;Ldev/kord/common/entity/AutoModerationRuleTriggerType;Ldev/kord/core/cache/data/AutoModerationRuleTriggerMetadataData;Ljava/util/List;ZLjava/util/List;Ljava/util/List;ILjava/lang/Object;)Ldev/kord/core/cache/data/AutoModerationRuleData;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getActions ()Ljava/util/List;
-	public final fun getCreatorId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getCreatorId-4_xYDEk ()J
 	public final fun getEnabled ()Z
 	public final fun getEventType ()Ldev/kord/common/entity/AutoModerationRuleEventType;
 	public final fun getExemptChannels ()Ljava/util/List;
 	public final fun getExemptRoles ()Ljava/util/List;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
+	public final fun getId-4_xYDEk ()J
 	public final fun getName ()Ljava/lang/String;
 	public final fun getTriggerMetadata ()Ldev/kord/core/cache/data/AutoModerationRuleTriggerMetadataData;
 	public final fun getTriggerType ()Ldev/kord/common/entity/AutoModerationRuleTriggerType;
@@ -2891,18 +2896,18 @@ public final class dev/kord/core/cache/data/AutoModerationRuleTriggerMetadataDat
 
 public final class dev/kord/core/cache/data/BanData {
 	public static final field Companion Ldev/kord/core/cache/data/BanData$Companion;
-	public synthetic fun <init> (ILjava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)V
-	public synthetic fun <init> (Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (ILjava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;JJILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;JJLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
-	public final fun component3 ()Ldev/kord/common/entity/Snowflake;
-	public final fun copy (Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/cache/data/BanData;
-	public static synthetic fun copy$default (Ldev/kord/core/cache/data/BanData;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;ILjava/lang/Object;)Ldev/kord/core/cache/data/BanData;
+	public final fun component2-4_xYDEk ()J
+	public final fun component3-4_xYDEk ()J
+	public final fun copy-NW1KesY (Ljava/lang/String;JJ)Ldev/kord/core/cache/data/BanData;
+	public static synthetic fun copy-NW1KesY$default (Ldev/kord/core/cache/data/BanData;Ljava/lang/String;JJILjava/lang/Object;)Ldev/kord/core/cache/data/BanData;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public final fun getReason ()Ljava/lang/String;
-	public final fun getUserId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getUserId-4_xYDEk ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public static final fun write$Self (Ldev/kord/core/cache/data/BanData;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
@@ -2921,7 +2926,7 @@ public final class dev/kord/core/cache/data/BanData$$serializer : kotlinx/serial
 }
 
 public final class dev/kord/core/cache/data/BanData$Companion {
-	public final fun from (Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/response/BanResponse;)Ldev/kord/core/cache/data/BanData;
+	public final fun from-wYKCHeA (JLdev/kord/rest/json/response/BanResponse;)Ldev/kord/core/cache/data/BanData;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -2932,7 +2937,7 @@ public abstract interface class dev/kord/core/cache/data/BaseApplicationData {
 	public abstract fun getFlags ()Ldev/kord/common/entity/optional/Optional;
 	public abstract fun getGuildId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public abstract fun getIcon ()Ljava/lang/String;
-	public abstract fun getId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getId-4_xYDEk ()J
 	public abstract fun getInstallParams ()Ldev/kord/common/entity/optional/Optional;
 	public abstract fun getName ()Ljava/lang/String;
 	public abstract fun getOwnerId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
@@ -2948,7 +2953,7 @@ public abstract interface class dev/kord/core/cache/data/BaseApplicationData {
 public abstract interface class dev/kord/core/cache/data/BaseInviteData {
 	public abstract fun getApproximateMemberCount ()Ldev/kord/common/entity/optional/OptionalInt;
 	public abstract fun getApproximatePresenceCount ()Ldev/kord/common/entity/optional/OptionalInt;
-	public abstract fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getChannelId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public abstract fun getCode ()Ljava/lang/String;
 	public abstract fun getExpiresAt ()Ldev/kord/common/entity/optional/Optional;
 	public abstract fun getGuild ()Ldev/kord/common/entity/optional/Optional;
@@ -2961,10 +2966,10 @@ public abstract interface class dev/kord/core/cache/data/BaseInviteData {
 
 public final class dev/kord/core/cache/data/ChannelData {
 	public static final field Companion Ldev/kord/core/cache/data/ChannelData$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/ChannelType;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/ChannelType;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/ChannelType;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/ChannelType;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/ChannelType;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/ChannelType;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component10 ()Ldev/kord/common/entity/optional/OptionalInt;
 	public final fun component11 ()Ldev/kord/common/entity/optional/OptionalInt;
 	public final fun component12 ()Ldev/kord/common/entity/optional/Optional;
@@ -2990,15 +2995,15 @@ public final class dev/kord/core/cache/data/ChannelData {
 	public final fun component7 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component8 ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun component9 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/ChannelType;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/core/cache/data/ChannelData;
-	public static synthetic fun copy$default (Ldev/kord/core/cache/data/ChannelData;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/ChannelType;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/core/cache/data/ChannelData;
+	public final fun copy-Mi66umk (JLdev/kord/common/entity/ChannelType;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/core/cache/data/ChannelData;
+	public static synthetic fun copy-Mi66umk$default (Ldev/kord/core/cache/data/ChannelData;JLdev/kord/common/entity/ChannelType;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/core/cache/data/ChannelData;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getApplicationId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun getBitrate ()Ldev/kord/common/entity/optional/OptionalInt;
 	public final fun getDefaultAutoArchiveDuration ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getGuildId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun getIcon ()Ldev/kord/common/entity/optional/Optional;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getLastMessageId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun getLastPinTimestamp ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getMember ()Ldev/kord/common/entity/optional/Optional;
@@ -3490,11 +3495,11 @@ public final class dev/kord/core/cache/data/EmbedVideoData$Companion {
 
 public final class dev/kord/core/cache/data/EmojiData {
 	public static final field Companion Ldev/kord/core/cache/data/EmojiData$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLjava/lang/String;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLjava/lang/String;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
+	public final fun component2-4_xYDEk ()J
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun component5 ()Ldev/kord/common/entity/optional/Optional;
@@ -3502,13 +3507,13 @@ public final class dev/kord/core/cache/data/EmojiData {
 	public final fun component7 ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun component8 ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun component9 ()Ldev/kord/common/entity/optional/OptionalBoolean;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;)Ldev/kord/core/cache/data/EmojiData;
-	public static synthetic fun copy$default (Ldev/kord/core/cache/data/EmojiData;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;ILjava/lang/Object;)Ldev/kord/core/cache/data/EmojiData;
+	public final fun copy-gri41mk (JJLjava/lang/String;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;)Ldev/kord/core/cache/data/EmojiData;
+	public static synthetic fun copy-gri41mk$default (Ldev/kord/core/cache/data/EmojiData;JJLjava/lang/String;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalBoolean;ILjava/lang/Object;)Ldev/kord/core/cache/data/EmojiData;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAnimated ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun getAvailable ()Ldev/kord/common/entity/optional/OptionalBoolean;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
+	public final fun getId-4_xYDEk ()J
 	public final fun getManaged ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getRequireColons ()Ldev/kord/common/entity/optional/OptionalBoolean;
@@ -3532,29 +3537,29 @@ public final class dev/kord/core/cache/data/EmojiData$$serializer : kotlinx/seri
 }
 
 public final class dev/kord/core/cache/data/EmojiData$Companion {
-	public final fun from (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordEmoji;)Ldev/kord/core/cache/data/EmojiData;
+	public final fun from-U2evHYk (JJLdev/kord/common/entity/DiscordEmoji;)Ldev/kord/core/cache/data/EmojiData;
 	public final fun getDescription ()Ldev/kord/cache/api/data/DataDescription;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class dev/kord/core/cache/data/EmojiDataKt {
-	public static final fun toData (Ldev/kord/common/entity/DiscordEmoji;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/cache/data/EmojiData;
+	public static final fun toData-NW1KesY (Ldev/kord/common/entity/DiscordEmoji;JJ)Ldev/kord/core/cache/data/EmojiData;
 }
 
 public final class dev/kord/core/cache/data/GuildApplicationCommandPermissionData {
 	public static final field Companion Ldev/kord/core/cache/data/GuildApplicationCommandPermissionData$Companion;
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/ApplicationCommandPermissionType;Z)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordGuildApplicationCommandPermission$Type;Z)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (JLdev/kord/common/entity/ApplicationCommandPermissionType;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/DiscordGuildApplicationCommandPermission$Type;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component2 ()Ldev/kord/common/entity/ApplicationCommandPermissionType;
 	public final synthetic fun component2 ()Ldev/kord/common/entity/DiscordGuildApplicationCommandPermission$Type;
 	public final fun component3 ()Z
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/ApplicationCommandPermissionType;Z)Ldev/kord/core/cache/data/GuildApplicationCommandPermissionData;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordGuildApplicationCommandPermission$Type;Z)Ldev/kord/core/cache/data/GuildApplicationCommandPermissionData;
-	public static synthetic fun copy$default (Ldev/kord/core/cache/data/GuildApplicationCommandPermissionData;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/ApplicationCommandPermissionType;ZILjava/lang/Object;)Ldev/kord/core/cache/data/GuildApplicationCommandPermissionData;
-	public static synthetic fun copy$default (Ldev/kord/core/cache/data/GuildApplicationCommandPermissionData;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordGuildApplicationCommandPermission$Type;ZILjava/lang/Object;)Ldev/kord/core/cache/data/GuildApplicationCommandPermissionData;
+	public final fun copy-9y3P_48 (JLdev/kord/common/entity/ApplicationCommandPermissionType;Z)Ldev/kord/core/cache/data/GuildApplicationCommandPermissionData;
+	public final fun copy-9y3P_48 (JLdev/kord/common/entity/DiscordGuildApplicationCommandPermission$Type;Z)Ldev/kord/core/cache/data/GuildApplicationCommandPermissionData;
+	public static synthetic fun copy-9y3P_48$default (Ldev/kord/core/cache/data/GuildApplicationCommandPermissionData;JLdev/kord/common/entity/ApplicationCommandPermissionType;ZILjava/lang/Object;)Ldev/kord/core/cache/data/GuildApplicationCommandPermissionData;
+	public static synthetic fun copy-9y3P_48$default (Ldev/kord/core/cache/data/GuildApplicationCommandPermissionData;JLdev/kord/common/entity/DiscordGuildApplicationCommandPermission$Type;ZILjava/lang/Object;)Ldev/kord/core/cache/data/GuildApplicationCommandPermissionData;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getPermission ()Z
 	public final fun getType ()Ldev/kord/common/entity/ApplicationCommandPermissionType;
 	public final synthetic fun getType ()Ldev/kord/common/entity/DiscordGuildApplicationCommandPermission$Type;
@@ -3568,17 +3573,17 @@ public final class dev/kord/core/cache/data/GuildApplicationCommandPermissionDat
 
 public final class dev/kord/core/cache/data/GuildApplicationCommandPermissionsData {
 	public static final field Companion Ldev/kord/core/cache/data/GuildApplicationCommandPermissionsData$Companion;
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/util/List;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
-	public final fun component3 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (JJJLjava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
+	public final fun component2-4_xYDEk ()J
+	public final fun component3-4_xYDEk ()J
 	public final fun component4 ()Ljava/util/List;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/util/List;)Ldev/kord/core/cache/data/GuildApplicationCommandPermissionsData;
-	public static synthetic fun copy$default (Ldev/kord/core/cache/data/GuildApplicationCommandPermissionsData;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/util/List;ILjava/lang/Object;)Ldev/kord/core/cache/data/GuildApplicationCommandPermissionsData;
+	public final fun copy-SmFlTYk (JJJLjava/util/List;)Ldev/kord/core/cache/data/GuildApplicationCommandPermissionsData;
+	public static synthetic fun copy-SmFlTYk$default (Ldev/kord/core/cache/data/GuildApplicationCommandPermissionsData;JJJLjava/util/List;ILjava/lang/Object;)Ldev/kord/core/cache/data/GuildApplicationCommandPermissionsData;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getApplicationId-4_xYDEk ()J
+	public final fun getGuildId-4_xYDEk ()J
+	public final fun getId-4_xYDEk ()J
 	public final fun getPermissions ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -3592,10 +3597,10 @@ public final class dev/kord/core/cache/data/GuildApplicationCommandPermissionsDa
 public final class dev/kord/core/cache/data/GuildData {
 	public static final field Companion Ldev/kord/core/cache/data/GuildData$Companion;
 	public synthetic fun <init> (IILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlin/time/Duration;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/VerificationLevel;Ldev/kord/common/entity/DefaultMessageNotificationLevel;Ldev/kord/common/entity/ExplicitContentFilter;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ldev/kord/common/entity/MFALevel;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/SystemChannelFlags;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/PremiumTier;Ldev/kord/common/entity/optional/OptionalInt;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/NsfwLevel;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZLkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;JLdev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/VerificationLevel;Ldev/kord/common/entity/DefaultMessageNotificationLevel;Ldev/kord/common/entity/ExplicitContentFilter;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ldev/kord/common/entity/MFALevel;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/SystemChannelFlags;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/PremiumTier;Ldev/kord/common/entity/optional/OptionalInt;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/NsfwLevel;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZIILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;JLdev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/VerificationLevel;Ldev/kord/common/entity/DefaultMessageNotificationLevel;Ldev/kord/common/entity/ExplicitContentFilter;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ldev/kord/common/entity/MFALevel;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/SystemChannelFlags;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/PremiumTier;Ldev/kord/common/entity/optional/OptionalInt;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/NsfwLevel;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
-	public final fun component10 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;JLdev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;JLdev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/VerificationLevel;Ldev/kord/common/entity/DefaultMessageNotificationLevel;Ldev/kord/common/entity/ExplicitContentFilter;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ldev/kord/common/entity/MFALevel;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/SystemChannelFlags;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/PremiumTier;Ldev/kord/common/entity/optional/OptionalInt;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/NsfwLevel;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;JLdev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;JLdev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/VerificationLevel;Ldev/kord/common/entity/DefaultMessageNotificationLevel;Ldev/kord/common/entity/ExplicitContentFilter;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ldev/kord/common/entity/MFALevel;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/SystemChannelFlags;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/PremiumTier;Ldev/kord/common/entity/optional/OptionalInt;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/NsfwLevel;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
+	public final fun component10-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun component11-UwyO8pc ()J
 	public final fun component12 ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun component13 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
@@ -3607,10 +3612,10 @@ public final class dev/kord/core/cache/data/GuildData {
 	public final fun component19 ()Ljava/util/List;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component20 ()Ldev/kord/common/entity/MFALevel;
-	public final fun component21 ()Ldev/kord/common/entity/Snowflake;
-	public final fun component22 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component21-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
+	public final fun component22-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun component23 ()Ldev/kord/common/entity/SystemChannelFlags;
-	public final fun component24 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component24-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun component25 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component26 ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun component27 ()Ldev/kord/common/entity/optional/OptionalInt;
@@ -3624,7 +3629,7 @@ public final class dev/kord/core/cache/data/GuildData {
 	public final fun component34 ()Ldev/kord/common/entity/PremiumTier;
 	public final fun component35 ()Ldev/kord/common/entity/optional/OptionalInt;
 	public final fun component36 ()Ljava/lang/String;
-	public final fun component37 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component37-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun component38 ()Ldev/kord/common/entity/optional/OptionalInt;
 	public final fun component39 ()Ldev/kord/common/entity/optional/OptionalInt;
 	public final fun component4 ()Ldev/kord/common/entity/optional/Optional;
@@ -3638,15 +3643,15 @@ public final class dev/kord/core/cache/data/GuildData {
 	public final fun component47 ()Z
 	public final fun component5 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component6 ()Ldev/kord/common/entity/optional/Optional;
-	public final fun component7 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component7-4_xYDEk ()J
 	public final fun component8 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component9 ()Ljava/lang/String;
-	public final fun copy-JhoTrSQ (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;JLdev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/VerificationLevel;Ldev/kord/common/entity/DefaultMessageNotificationLevel;Ldev/kord/common/entity/ExplicitContentFilter;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ldev/kord/common/entity/MFALevel;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/SystemChannelFlags;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/PremiumTier;Ldev/kord/common/entity/optional/OptionalInt;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/NsfwLevel;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Z)Ldev/kord/core/cache/data/GuildData;
-	public static synthetic fun copy-JhoTrSQ$default (Ldev/kord/core/cache/data/GuildData;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;JLdev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/VerificationLevel;Ldev/kord/common/entity/DefaultMessageNotificationLevel;Ldev/kord/common/entity/ExplicitContentFilter;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ldev/kord/common/entity/MFALevel;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/SystemChannelFlags;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/PremiumTier;Ldev/kord/common/entity/optional/OptionalInt;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/NsfwLevel;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZIILjava/lang/Object;)Ldev/kord/core/cache/data/GuildData;
+	public final fun copy-NKKJKa8 (JLjava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;JLdev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;JLdev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/VerificationLevel;Ldev/kord/common/entity/DefaultMessageNotificationLevel;Ldev/kord/common/entity/ExplicitContentFilter;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ldev/kord/common/entity/MFALevel;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/SystemChannelFlags;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/PremiumTier;Ldev/kord/common/entity/optional/OptionalInt;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/NsfwLevel;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Z)Ldev/kord/core/cache/data/GuildData;
+	public static synthetic fun copy-NKKJKa8$default (Ldev/kord/core/cache/data/GuildData;JLjava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;JLdev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;JLdev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/VerificationLevel;Ldev/kord/common/entity/DefaultMessageNotificationLevel;Ldev/kord/common/entity/ExplicitContentFilter;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ldev/kord/common/entity/MFALevel;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/SystemChannelFlags;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/PremiumTier;Ldev/kord/common/entity/optional/OptionalInt;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/NsfwLevel;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZIILjava/lang/Object;)Ldev/kord/core/cache/data/GuildData;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getAfkChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getAfkChannelId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getAfkTimeout-UwyO8pc ()J
-	public final fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getApplicationId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getApproximateMemberCount ()Ldev/kord/common/entity/optional/OptionalInt;
 	public final fun getApproximatePresenceCount ()Ldev/kord/common/entity/optional/OptionalInt;
 	public final fun getBanner ()Ljava/lang/String;
@@ -3660,7 +3665,7 @@ public final class dev/kord/core/cache/data/GuildData {
 	public final fun getGuildScheduledEvents ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getIcon ()Ljava/lang/String;
 	public final fun getIconHash ()Ldev/kord/common/entity/optional/Optional;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getJoinedAt ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getLarge ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun getMaxMembers ()Ldev/kord/common/entity/optional/OptionalInt;
@@ -3670,21 +3675,21 @@ public final class dev/kord/core/cache/data/GuildData {
 	public final fun getMfaLevel ()Ldev/kord/common/entity/MFALevel;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getNsfwLevel ()Ldev/kord/common/entity/NsfwLevel;
-	public final fun getOwnerId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getOwnerId-4_xYDEk ()J
 	public final fun getPermissions ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getPreferredLocale ()Ljava/lang/String;
 	public final fun getPremiumProgressBarEnabled ()Z
 	public final fun getPremiumSubscriptionCount ()Ldev/kord/common/entity/optional/OptionalInt;
 	public final fun getPremiumTier ()Ldev/kord/common/entity/PremiumTier;
-	public final fun getPublicUpdatesChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getPublicUpdatesChannelId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getRegion ()Ljava/lang/String;
 	public final fun getRoles ()Ljava/util/List;
-	public final fun getRulesChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getRulesChannelId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getSplash ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getStageInstances ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getStickers ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getSystemChannelFlags ()Ldev/kord/common/entity/SystemChannelFlags;
-	public final fun getSystemChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getSystemChannelId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getThreads ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getVanityUrlCode ()Ljava/lang/String;
 	public final fun getVerificationLevel ()Ldev/kord/common/entity/VerificationLevel;
@@ -3720,9 +3725,9 @@ public final class dev/kord/core/cache/data/GuildDataKt {
 
 public final class dev/kord/core/cache/data/GuildPreviewData {
 	public static final field Companion Ldev/kord/core/cache/data/GuildPreviewData$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;IILjava/lang/String;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;IILjava/lang/String;Ljava/util/List;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;IILjava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;IILjava/lang/String;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;IILjava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;IILjava/lang/String;Ljava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getApproximateMemberCount ()I
 	public final fun getApproximatePresenceCount ()I
 	public final fun getDescription ()Ljava/lang/String;
@@ -3730,7 +3735,7 @@ public final class dev/kord/core/cache/data/GuildPreviewData {
 	public final fun getEmojis ()Ljava/util/List;
 	public final fun getFeatures ()Ljava/util/List;
 	public final fun getIcon ()Ljava/lang/String;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getName ()Ljava/lang/String;
 	public final fun getSplash ()Ljava/lang/String;
 	public final fun getStickers ()Ljava/util/List;
@@ -3756,37 +3761,37 @@ public final class dev/kord/core/cache/data/GuildPreviewData$Companion {
 
 public final class dev/kord/core/cache/data/GuildScheduledEventData {
 	public static final field Companion Ldev/kord/core/cache/data/GuildScheduledEventData$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/GuildScheduledEventPrivacyLevel;Ldev/kord/common/entity/GuildScheduledEventStatus;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/ScheduledEntityType;Ldev/kord/common/entity/GuildScheduledEventEntityMetadata;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/GuildScheduledEventPrivacyLevel;Ldev/kord/common/entity/GuildScheduledEventStatus;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/ScheduledEntityType;Ldev/kord/common/entity/GuildScheduledEventEntityMetadata;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/GuildScheduledEventPrivacyLevel;Ldev/kord/common/entity/GuildScheduledEventStatus;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/ScheduledEntityType;Ldev/kord/common/entity/GuildScheduledEventEntityMetadata;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/GuildScheduledEventPrivacyLevel;Ldev/kord/common/entity/GuildScheduledEventStatus;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/ScheduledEntityType;Ldev/kord/common/entity/GuildScheduledEventEntityMetadata;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/GuildScheduledEventPrivacyLevel;Ldev/kord/common/entity/GuildScheduledEventStatus;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/ScheduledEntityType;Ldev/kord/common/entity/GuildScheduledEventEntityMetadata;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/GuildScheduledEventPrivacyLevel;Ldev/kord/common/entity/GuildScheduledEventStatus;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/ScheduledEntityType;Ldev/kord/common/entity/GuildScheduledEventEntityMetadata;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component10 ()Ldev/kord/common/entity/GuildScheduledEventStatus;
-	public final fun component11 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component11-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun component12 ()Ldev/kord/common/entity/ScheduledEntityType;
 	public final fun component13 ()Ldev/kord/common/entity/GuildScheduledEventEntityMetadata;
 	public final fun component14 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component15 ()Ldev/kord/common/entity/optional/OptionalInt;
 	public final fun component16 ()Ldev/kord/common/entity/optional/Optional;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
-	public final fun component3 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component2-4_xYDEk ()J
+	public final fun component3-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun component4 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun component5 ()Ljava/lang/String;
 	public final fun component6 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component7 ()Lkotlinx/datetime/Instant;
 	public final fun component8 ()Lkotlinx/datetime/Instant;
 	public final fun component9 ()Ldev/kord/common/entity/GuildScheduledEventPrivacyLevel;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/GuildScheduledEventPrivacyLevel;Ldev/kord/common/entity/GuildScheduledEventStatus;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/ScheduledEntityType;Ldev/kord/common/entity/GuildScheduledEventEntityMetadata;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/core/cache/data/GuildScheduledEventData;
-	public static synthetic fun copy$default (Ldev/kord/core/cache/data/GuildScheduledEventData;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/GuildScheduledEventPrivacyLevel;Ldev/kord/common/entity/GuildScheduledEventStatus;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/ScheduledEntityType;Ldev/kord/common/entity/GuildScheduledEventEntityMetadata;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/core/cache/data/GuildScheduledEventData;
+	public final fun copy-hfPGgOE (JJLdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/GuildScheduledEventPrivacyLevel;Ldev/kord/common/entity/GuildScheduledEventStatus;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/ScheduledEntityType;Ldev/kord/common/entity/GuildScheduledEventEntityMetadata;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/core/cache/data/GuildScheduledEventData;
+	public static synthetic fun copy-hfPGgOE$default (Ldev/kord/core/cache/data/GuildScheduledEventData;JJLdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/GuildScheduledEventPrivacyLevel;Ldev/kord/common/entity/GuildScheduledEventStatus;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/ScheduledEntityType;Ldev/kord/common/entity/GuildScheduledEventEntityMetadata;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/core/cache/data/GuildScheduledEventData;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getCreator ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getCreatorId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun getDescription ()Ldev/kord/common/entity/optional/Optional;
-	public final fun getEntityId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getEntityId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getEntityMetadata ()Ldev/kord/common/entity/GuildScheduledEventEntityMetadata;
 	public final fun getEntityType ()Ldev/kord/common/entity/ScheduledEntityType;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
+	public final fun getId-4_xYDEk ()J
 	public final fun getImage ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getPrivacyLevel ()Ldev/kord/common/entity/GuildScheduledEventPrivacyLevel;
@@ -3818,14 +3823,14 @@ public final class dev/kord/core/cache/data/GuildScheduledEventData$Companion {
 
 public final class dev/kord/core/cache/data/GuildWidgetData {
 	public static final field Companion Ldev/kord/core/cache/data/GuildWidgetData$Companion;
-	public synthetic fun <init> (IZLdev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (ZLdev/kord/common/entity/Snowflake;)V
+	public synthetic fun <init> (IZLdev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (ZLdev/kord/common/entity/Snowflake;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Z
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
-	public final fun copy (ZLdev/kord/common/entity/Snowflake;)Ldev/kord/core/cache/data/GuildWidgetData;
-	public static synthetic fun copy$default (Ldev/kord/core/cache/data/GuildWidgetData;ZLdev/kord/common/entity/Snowflake;ILjava/lang/Object;)Ldev/kord/core/cache/data/GuildWidgetData;
+	public final fun component2-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
+	public final fun copy-NsqkgP0 (ZLdev/kord/common/entity/Snowflake;)Ldev/kord/core/cache/data/GuildWidgetData;
+	public static synthetic fun copy-NsqkgP0$default (Ldev/kord/core/cache/data/GuildWidgetData;ZLdev/kord/common/entity/Snowflake;ILjava/lang/Object;)Ldev/kord/core/cache/data/GuildWidgetData;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getEnabled ()Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -3852,9 +3857,9 @@ public final class dev/kord/core/cache/data/GuildWidgetData$Companion {
 public final class dev/kord/core/cache/data/IntegrationData {
 	public static final field Companion Ldev/kord/core/cache/data/IntegrationData$Companion;
 	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;ZZLdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/IntegrationExpireBehavior;Lkotlin/time/Duration;Ldev/kord/common/entity/DiscordUser;Ldev/kord/core/cache/data/IntegrationsAccountData;Lkotlinx/datetime/Instant;IZLdev/kord/common/entity/IntegrationApplication;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;ZZLdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/IntegrationExpireBehavior;JLdev/kord/common/entity/DiscordUser;Ldev/kord/core/cache/data/IntegrationsAccountData;Lkotlinx/datetime/Instant;IZLdev/kord/common/entity/IntegrationApplication;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;ZZLdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/IntegrationExpireBehavior;JLdev/kord/common/entity/DiscordUser;Ldev/kord/core/cache/data/IntegrationsAccountData;Lkotlinx/datetime/Instant;IZLdev/kord/common/entity/IntegrationApplication;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (JJLjava/lang/String;Ljava/lang/String;ZZJLdev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/IntegrationExpireBehavior;JLdev/kord/common/entity/DiscordUser;Ldev/kord/core/cache/data/IntegrationsAccountData;Lkotlinx/datetime/Instant;IZLdev/kord/common/entity/IntegrationApplication;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLjava/lang/String;Ljava/lang/String;ZZJLdev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/IntegrationExpireBehavior;JLdev/kord/common/entity/DiscordUser;Ldev/kord/core/cache/data/IntegrationsAccountData;Lkotlinx/datetime/Instant;IZLdev/kord/common/entity/IntegrationApplication;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component10-UwyO8pc ()J
 	public final fun component11 ()Ldev/kord/common/entity/DiscordUser;
 	public final fun component12 ()Ldev/kord/core/cache/data/IntegrationsAccountData;
@@ -3862,16 +3867,16 @@ public final class dev/kord/core/cache/data/IntegrationData {
 	public final fun component14 ()I
 	public final fun component15 ()Z
 	public final fun component16 ()Ldev/kord/common/entity/IntegrationApplication;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component2-4_xYDEk ()J
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Z
 	public final fun component6 ()Z
-	public final fun component7 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component7-4_xYDEk ()J
 	public final fun component8 ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun component9 ()Ldev/kord/common/entity/IntegrationExpireBehavior;
-	public final fun copy-fynAM7E (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;ZZLdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/IntegrationExpireBehavior;JLdev/kord/common/entity/DiscordUser;Ldev/kord/core/cache/data/IntegrationsAccountData;Lkotlinx/datetime/Instant;IZLdev/kord/common/entity/IntegrationApplication;)Ldev/kord/core/cache/data/IntegrationData;
-	public static synthetic fun copy-fynAM7E$default (Ldev/kord/core/cache/data/IntegrationData;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;ZZLdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/IntegrationExpireBehavior;JLdev/kord/common/entity/DiscordUser;Ldev/kord/core/cache/data/IntegrationsAccountData;Lkotlinx/datetime/Instant;IZLdev/kord/common/entity/IntegrationApplication;ILjava/lang/Object;)Ldev/kord/core/cache/data/IntegrationData;
+	public final fun copy-5U2g1vI (JJLjava/lang/String;Ljava/lang/String;ZZJLdev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/IntegrationExpireBehavior;JLdev/kord/common/entity/DiscordUser;Ldev/kord/core/cache/data/IntegrationsAccountData;Lkotlinx/datetime/Instant;IZLdev/kord/common/entity/IntegrationApplication;)Ldev/kord/core/cache/data/IntegrationData;
+	public static synthetic fun copy-5U2g1vI$default (Ldev/kord/core/cache/data/IntegrationData;JJLjava/lang/String;Ljava/lang/String;ZZJLdev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/IntegrationExpireBehavior;JLdev/kord/common/entity/DiscordUser;Ldev/kord/core/cache/data/IntegrationsAccountData;Lkotlinx/datetime/Instant;IZLdev/kord/common/entity/IntegrationApplication;ILjava/lang/Object;)Ldev/kord/core/cache/data/IntegrationData;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAccount ()Ldev/kord/core/cache/data/IntegrationsAccountData;
 	public final fun getApplication ()Ldev/kord/common/entity/IntegrationApplication;
@@ -3879,11 +3884,11 @@ public final class dev/kord/core/cache/data/IntegrationData {
 	public final fun getEnabled ()Z
 	public final fun getExpireBehavior ()Ldev/kord/common/entity/IntegrationExpireBehavior;
 	public final fun getExpireGracePeriod-UwyO8pc ()J
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
+	public final fun getId-4_xYDEk ()J
 	public final fun getName ()Ljava/lang/String;
 	public final fun getRevoked ()Z
-	public final fun getRoleId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getRoleId-4_xYDEk ()J
 	public final fun getSubscriberCount ()I
 	public final fun getSyncedAt ()Lkotlinx/datetime/Instant;
 	public final fun getSyncing ()Z
@@ -3907,7 +3912,7 @@ public final class dev/kord/core/cache/data/IntegrationData$$serializer : kotlin
 }
 
 public final class dev/kord/core/cache/data/IntegrationData$Companion {
-	public final fun from (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordIntegration;)Ldev/kord/core/cache/data/IntegrationData;
+	public final fun from-wYKCHeA (JLdev/kord/common/entity/DiscordIntegration;)Ldev/kord/core/cache/data/IntegrationData;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -3946,34 +3951,34 @@ public final class dev/kord/core/cache/data/IntegrationsAccountData$Companion {
 
 public final class dev/kord/core/cache/data/InteractionData {
 	public static final field Companion Ldev/kord/core/cache/data/InteractionData$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/InteractionType;Ldev/kord/core/cache/data/ApplicationInteractionData;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;ILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/InteractionType;Ldev/kord/core/cache/data/ApplicationInteractionData;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;ILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/InteractionType;Ldev/kord/core/cache/data/ApplicationInteractionData;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;ILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/InteractionType;Ldev/kord/core/cache/data/ApplicationInteractionData;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;ILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLdev/kord/common/entity/InteractionType;Ldev/kord/core/cache/data/ApplicationInteractionData;Ldev/kord/common/entity/optional/OptionalSnowflake;JLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;ILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLdev/kord/common/entity/InteractionType;Ldev/kord/core/cache/data/ApplicationInteractionData;Ldev/kord/common/entity/optional/OptionalSnowflake;JLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;ILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component10 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component11 ()I
 	public final fun component12 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component13 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component14 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component15 ()Ldev/kord/common/entity/optional/Optional;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component2-4_xYDEk ()J
 	public final fun component3 ()Ldev/kord/common/entity/InteractionType;
 	public final fun component4 ()Ldev/kord/core/cache/data/ApplicationInteractionData;
 	public final fun component5 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
-	public final fun component6 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component6-4_xYDEk ()J
 	public final fun component7 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component8 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component9 ()Ljava/lang/String;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/InteractionType;Ldev/kord/core/cache/data/ApplicationInteractionData;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;ILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/core/cache/data/InteractionData;
-	public static synthetic fun copy$default (Ldev/kord/core/cache/data/InteractionData;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/InteractionType;Ldev/kord/core/cache/data/ApplicationInteractionData;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;ILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/core/cache/data/InteractionData;
+	public final fun copy-_TPX9kI (JJLdev/kord/common/entity/InteractionType;Ldev/kord/core/cache/data/ApplicationInteractionData;Ldev/kord/common/entity/optional/OptionalSnowflake;JLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;ILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/core/cache/data/InteractionData;
+	public static synthetic fun copy-_TPX9kI$default (Ldev/kord/core/cache/data/InteractionData;JJLdev/kord/common/entity/InteractionType;Ldev/kord/core/cache/data/ApplicationInteractionData;Ldev/kord/common/entity/optional/OptionalSnowflake;JLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;ILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/core/cache/data/InteractionData;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAppPermissions ()Ldev/kord/common/entity/optional/Optional;
-	public final fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getApplicationId-4_xYDEk ()J
+	public final fun getChannelId-4_xYDEk ()J
 	public final fun getData ()Ldev/kord/core/cache/data/ApplicationInteractionData;
 	public final fun getGuildId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun getGuildLocale ()Ldev/kord/common/entity/optional/Optional;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getLocale ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getMember ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getMessage ()Ldev/kord/common/entity/optional/Optional;
@@ -4007,9 +4012,9 @@ public final class dev/kord/core/cache/data/InteractionData$Companion {
 public final class dev/kord/core/cache/data/InviteCreateData {
 	public static final field Companion Ldev/kord/core/cache/data/InviteCreateData$Companion;
 	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Lkotlin/time/Duration;ILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZILkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;JILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZIILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;JILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (JLjava/lang/String;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;JILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;JILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component10 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component11 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component12 ()Z
@@ -4022,10 +4027,10 @@ public final class dev/kord/core/cache/data/InviteCreateData {
 	public final fun component7 ()I
 	public final fun component8 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component9 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
-	public final fun copy-5ndHN30 (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;JILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZI)Ldev/kord/core/cache/data/InviteCreateData;
-	public static synthetic fun copy-5ndHN30$default (Ldev/kord/core/cache/data/InviteCreateData;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;JILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZIILjava/lang/Object;)Ldev/kord/core/cache/data/InviteCreateData;
+	public final fun copy-68rp8C4 (JLjava/lang/String;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;JILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZI)Ldev/kord/core/cache/data/InviteCreateData;
+	public static synthetic fun copy-68rp8C4$default (Ldev/kord/core/cache/data/InviteCreateData;JLjava/lang/String;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;JILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZIILjava/lang/Object;)Ldev/kord/core/cache/data/InviteCreateData;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-4_xYDEk ()J
 	public final fun getCode ()Ljava/lang/String;
 	public final fun getCreatedAt ()Lkotlinx/datetime/Instant;
 	public final fun getGuildId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
@@ -4062,27 +4067,27 @@ public final class dev/kord/core/cache/data/InviteCreateData$Companion {
 
 public final class dev/kord/core/cache/data/InviteData : dev/kord/core/cache/data/BaseInviteData {
 	public static final field Companion Ldev/kord/core/cache/data/InviteData$Companion;
-	public synthetic fun <init> (ILjava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)V
+	public synthetic fun <init> (ILjava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component10 ()Ldev/kord/common/entity/optional/OptionalInt;
 	public final fun component11 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component12 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component2 ()Ldev/kord/common/entity/optional/Optional;
-	public final fun component3 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component3-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun component4 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun component5 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component6 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun component7 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component8 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component9 ()Ldev/kord/common/entity/optional/OptionalInt;
-	public final fun copy (Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/core/cache/data/InviteData;
-	public static synthetic fun copy$default (Ldev/kord/core/cache/data/InviteData;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/core/cache/data/InviteData;
+	public final fun copy-0EAFPkI (Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/core/cache/data/InviteData;
+	public static synthetic fun copy-0EAFPkI$default (Ldev/kord/core/cache/data/InviteData;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/core/cache/data/InviteData;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getApproximateMemberCount ()Ldev/kord/common/entity/optional/OptionalInt;
 	public fun getApproximatePresenceCount ()Ldev/kord/common/entity/optional/OptionalInt;
-	public fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public fun getChannelId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public fun getCode ()Ljava/lang/String;
 	public fun getExpiresAt ()Ldev/kord/common/entity/optional/Optional;
 	public fun getGuild ()Ldev/kord/common/entity/optional/Optional;
@@ -4116,16 +4121,16 @@ public final class dev/kord/core/cache/data/InviteData$Companion {
 
 public final class dev/kord/core/cache/data/InviteDeleteData {
 	public static final field Companion Ldev/kord/core/cache/data/InviteDeleteData$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component2 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;)Ldev/kord/core/cache/data/InviteDeleteData;
-	public static synthetic fun copy$default (Ldev/kord/core/cache/data/InviteDeleteData;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;ILjava/lang/Object;)Ldev/kord/core/cache/data/InviteDeleteData;
+	public final fun copy-9y3P_48 (JLdev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;)Ldev/kord/core/cache/data/InviteDeleteData;
+	public static synthetic fun copy-9y3P_48$default (Ldev/kord/core/cache/data/InviteDeleteData;JLdev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;ILjava/lang/Object;)Ldev/kord/core/cache/data/InviteDeleteData;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-4_xYDEk ()J
 	public final fun getCode ()Ljava/lang/String;
 	public final fun getGuildId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public fun hashCode ()I
@@ -4164,19 +4169,19 @@ public final class dev/kord/core/cache/data/InviteWithMetadataData : dev/kord/co
 	public final fun component15 ()Z
 	public final fun component16 ()Lkotlinx/datetime/Instant;
 	public final fun component2 ()Ldev/kord/common/entity/optional/Optional;
-	public final fun component3 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component3-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun component4 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun component5 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component6 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun component7 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component8 ()Ldev/kord/common/entity/optional/OptionalInt;
 	public final fun component9 ()Ldev/kord/common/entity/optional/OptionalInt;
-	public final fun copy-GiGF46s (Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;IIJZLkotlinx/datetime/Instant;)Ldev/kord/core/cache/data/InviteWithMetadataData;
-	public static synthetic fun copy-GiGF46s$default (Ldev/kord/core/cache/data/InviteWithMetadataData;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;IIJZLkotlinx/datetime/Instant;ILjava/lang/Object;)Ldev/kord/core/cache/data/InviteWithMetadataData;
+	public final fun copy-R4Vqhic (Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;IIJZLkotlinx/datetime/Instant;)Ldev/kord/core/cache/data/InviteWithMetadataData;
+	public static synthetic fun copy-R4Vqhic$default (Ldev/kord/core/cache/data/InviteWithMetadataData;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;IIJZLkotlinx/datetime/Instant;ILjava/lang/Object;)Ldev/kord/core/cache/data/InviteWithMetadataData;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getApproximateMemberCount ()Ldev/kord/common/entity/optional/OptionalInt;
 	public fun getApproximatePresenceCount ()Ldev/kord/common/entity/optional/OptionalInt;
-	public fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public fun getChannelId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public fun getCode ()Ljava/lang/String;
 	public final fun getCreatedAt ()Lkotlinx/datetime/Instant;
 	public fun getExpiresAt ()Ldev/kord/common/entity/optional/Optional;
@@ -4214,11 +4219,11 @@ public final class dev/kord/core/cache/data/InviteWithMetadataData$Companion {
 
 public final class dev/kord/core/cache/data/MemberData {
 	public static final field Companion Ldev/kord/core/cache/data/MemberData$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLdev/kord/common/entity/optional/Optional;Ljava/util/List;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLdev/kord/common/entity/optional/Optional;Ljava/util/List;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
+	public final fun component2-4_xYDEk ()J
 	public final fun component3 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component4 ()Ljava/util/List;
 	public final fun component5 ()Lkotlinx/datetime/Instant;
@@ -4226,18 +4231,18 @@ public final class dev/kord/core/cache/data/MemberData {
 	public final fun component7 ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun component8 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component9 ()Ldev/kord/common/entity/optional/Optional;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/core/cache/data/MemberData;
-	public static synthetic fun copy$default (Ldev/kord/core/cache/data/MemberData;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/core/cache/data/MemberData;
+	public final fun copy-gri41mk (JJLdev/kord/common/entity/optional/Optional;Ljava/util/List;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/core/cache/data/MemberData;
+	public static synthetic fun copy-gri41mk$default (Ldev/kord/core/cache/data/MemberData;JJLdev/kord/common/entity/optional/Optional;Ljava/util/List;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/core/cache/data/MemberData;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAvatar ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getCommunicationDisabledUntil ()Ldev/kord/common/entity/optional/Optional;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public final fun getJoinedAt ()Lkotlinx/datetime/Instant;
 	public final fun getNick ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getPending ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun getPremiumSince ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getRoles ()Ljava/util/List;
-	public final fun getUserId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getUserId-4_xYDEk ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public static final fun write$Self (Ldev/kord/core/cache/data/MemberData;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
@@ -4257,24 +4262,24 @@ public final class dev/kord/core/cache/data/MemberData$$serializer : kotlinx/ser
 
 public final class dev/kord/core/cache/data/MemberData$Companion {
 	public final fun from (Ldev/kord/common/entity/DiscordUpdatedGuildMember;)Ldev/kord/core/cache/data/MemberData;
-	public final fun from (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordAddedGuildMember;)Ldev/kord/core/cache/data/MemberData;
-	public final fun from (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordGuildMember;)Ldev/kord/core/cache/data/MemberData;
-	public final fun from (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordInteractionGuildMember;)Ldev/kord/core/cache/data/MemberData;
+	public final fun from-U2evHYk (JJLdev/kord/common/entity/DiscordGuildMember;)Ldev/kord/core/cache/data/MemberData;
+	public final fun from-U2evHYk (JJLdev/kord/common/entity/DiscordInteractionGuildMember;)Ldev/kord/core/cache/data/MemberData;
+	public final fun from-wYKCHeA (JLdev/kord/common/entity/DiscordAddedGuildMember;)Ldev/kord/core/cache/data/MemberData;
 	public final fun getDescription ()Ldev/kord/cache/api/data/DataDescription;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class dev/kord/core/cache/data/MemberDataKt {
-	public static final fun toData (Ldev/kord/common/entity/DiscordGuildMember;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/cache/data/MemberData;
-	public static final fun toData (Ldev/kord/common/entity/DiscordInteractionGuildMember;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/cache/data/MemberData;
+	public static final fun toData-NW1KesY (Ldev/kord/common/entity/DiscordGuildMember;JJ)Ldev/kord/core/cache/data/MemberData;
+	public static final fun toData-NW1KesY (Ldev/kord/common/entity/DiscordInteractionGuildMember;JJ)Ldev/kord/core/cache/data/MemberData;
 }
 
 public final class dev/kord/core/cache/data/MembersChunkData {
 	public static final field Companion Ldev/kord/core/cache/data/MembersChunkData$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/util/Set;Ljava/util/Set;IILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/util/Set;Ljava/util/Set;IILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/util/Set;Ljava/util/Set;IILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/util/Set;Ljava/util/Set;IILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/util/Set;Ljava/util/Set;IILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/util/Set;Ljava/util/Set;IILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component2 ()Ljava/util/Set;
 	public final fun component3 ()Ljava/util/Set;
 	public final fun component4 ()I
@@ -4282,12 +4287,12 @@ public final class dev/kord/core/cache/data/MembersChunkData {
 	public final fun component6 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component7 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component8 ()Ldev/kord/common/entity/optional/Optional;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ljava/util/Set;Ljava/util/Set;IILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/core/cache/data/MembersChunkData;
-	public static synthetic fun copy$default (Ldev/kord/core/cache/data/MembersChunkData;Ldev/kord/common/entity/Snowflake;Ljava/util/Set;Ljava/util/Set;IILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/core/cache/data/MembersChunkData;
+	public final fun copy-wGWicR4 (JLjava/util/Set;Ljava/util/Set;IILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/core/cache/data/MembersChunkData;
+	public static synthetic fun copy-wGWicR4$default (Ldev/kord/core/cache/data/MembersChunkData;JLjava/util/Set;Ljava/util/Set;IILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/core/cache/data/MembersChunkData;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getChunkCount ()I
 	public final fun getChunkIndex ()I
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public final fun getMembers ()Ljava/util/Set;
 	public final fun getNonce ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getNotFound ()Ldev/kord/common/entity/optional/Optional;
@@ -4317,10 +4322,10 @@ public final class dev/kord/core/cache/data/MembersChunkData$Companion {
 
 public final class dev/kord/core/cache/data/MessageData {
 	public static final field Companion Ldev/kord/core/cache/data/MessageData$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/core/cache/data/UserData;Ljava/lang/String;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;ZZLjava/util/List;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/MessageType;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/core/cache/data/UserData;Ljava/lang/String;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;ZZLjava/util/List;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/MessageType;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/core/cache/data/UserData;Ljava/lang/String;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;ZZLjava/util/List;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/MessageType;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/core/cache/data/UserData;Ljava/lang/String;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;ZZLjava/util/List;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/MessageType;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/core/cache/data/UserData;Ljava/lang/String;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;ZZLjava/util/List;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/MessageType;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/core/cache/data/UserData;Ljava/lang/String;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;ZZLjava/util/List;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/MessageType;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component10 ()Ljava/util/List;
 	public final fun component11 ()Ljava/util/List;
 	public final fun component12 ()Ldev/kord/common/entity/optional/Optional;
@@ -4331,7 +4336,7 @@ public final class dev/kord/core/cache/data/MessageData {
 	public final fun component17 ()Z
 	public final fun component18 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun component19 ()Ldev/kord/common/entity/MessageType;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component2-4_xYDEk ()J
 	public final fun component20 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component21 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component22 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
@@ -4348,22 +4353,22 @@ public final class dev/kord/core/cache/data/MessageData {
 	public final fun component7 ()Lkotlinx/datetime/Instant;
 	public final fun component8 ()Z
 	public final fun component9 ()Z
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/core/cache/data/UserData;Ljava/lang/String;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;ZZLjava/util/List;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/MessageType;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/core/cache/data/MessageData;
-	public static synthetic fun copy$default (Ldev/kord/core/cache/data/MessageData;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/core/cache/data/UserData;Ljava/lang/String;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;ZZLjava/util/List;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/MessageType;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/core/cache/data/MessageData;
+	public final fun copy--1RLglI (JJLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/core/cache/data/UserData;Ljava/lang/String;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;ZZLjava/util/List;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/MessageType;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/core/cache/data/MessageData;
+	public static synthetic fun copy--1RLglI$default (Ldev/kord/core/cache/data/MessageData;JJLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/core/cache/data/UserData;Ljava/lang/String;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;ZZLjava/util/List;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/MessageType;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/core/cache/data/MessageData;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getActivity ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getApplication ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getApplicationId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun getAttachments ()Ljava/util/List;
 	public final fun getAuthor ()Ldev/kord/core/cache/data/UserData;
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-4_xYDEk ()J
 	public final fun getComponents ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getContent ()Ljava/lang/String;
 	public final fun getEditedTimestamp ()Lkotlinx/datetime/Instant;
 	public final fun getEmbeds ()Ljava/util/List;
 	public final fun getFlags ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getGuildId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getInteraction ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getMentionEveryone ()Z
 	public final fun getMentionRoles ()Ljava/util/List;
@@ -4381,7 +4386,7 @@ public final class dev/kord/core/cache/data/MessageData {
 	public final fun getWebhookId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public fun hashCode ()I
 	public final fun plus (Ldev/kord/common/entity/DiscordPartialMessage;)Ldev/kord/core/cache/data/MessageData;
-	public final fun plus (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/MessageReactionAddData;)Ldev/kord/core/cache/data/MessageData;
+	public final fun plus-wYKCHeA (JLdev/kord/common/entity/MessageReactionAddData;)Ldev/kord/core/cache/data/MessageData;
 	public fun toString ()Ljava/lang/String;
 	public static final fun write$Self (Ldev/kord/core/cache/data/MessageData;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
@@ -4410,19 +4415,19 @@ public final class dev/kord/core/cache/data/MessageDataKt {
 
 public final class dev/kord/core/cache/data/MessageInteractionData {
 	public static final field Companion Ldev/kord/core/cache/data/MessageInteractionData$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/InteractionType;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/InteractionType;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/InteractionType;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/InteractionType;Ljava/lang/String;JLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component2 ()Ldev/kord/common/entity/InteractionType;
 	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Ldev/kord/common/entity/Snowflake;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/InteractionType;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/cache/data/MessageInteractionData;
-	public static synthetic fun copy$default (Ldev/kord/core/cache/data/MessageInteractionData;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/InteractionType;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;ILjava/lang/Object;)Ldev/kord/core/cache/data/MessageInteractionData;
+	public final fun component4-4_xYDEk ()J
+	public final fun copy-PwNx6gs (JLdev/kord/common/entity/InteractionType;Ljava/lang/String;J)Ldev/kord/core/cache/data/MessageInteractionData;
+	public static synthetic fun copy-PwNx6gs$default (Ldev/kord/core/cache/data/MessageInteractionData;JLdev/kord/common/entity/InteractionType;Ljava/lang/String;JILjava/lang/Object;)Ldev/kord/core/cache/data/MessageInteractionData;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getName ()Ljava/lang/String;
 	public final fun getType ()Ldev/kord/common/entity/InteractionType;
-	public final fun getUser ()Ldev/kord/common/entity/Snowflake;
+	public final fun getUser-4_xYDEk ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public static final fun write$Self (Ldev/kord/core/cache/data/MessageInteractionData;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
@@ -4533,10 +4538,10 @@ public final class dev/kord/core/cache/data/OptionData$Companion {
 
 public final class dev/kord/core/cache/data/PartialApplicationData : dev/kord/core/cache/data/BaseApplicationData {
 	public static final field Companion Ldev/kord/core/cache/data/PartialApplicationData$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component10 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun component11 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun component12 ()Ldev/kord/common/entity/optional/Optional;
@@ -4553,8 +4558,8 @@ public final class dev/kord/core/cache/data/PartialApplicationData : dev/kord/co
 	public final fun component7 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component8 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun component9 ()Ljava/lang/String;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/core/cache/data/PartialApplicationData;
-	public static synthetic fun copy$default (Ldev/kord/core/cache/data/PartialApplicationData;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/core/cache/data/PartialApplicationData;
+	public final fun copy-X_dMieU (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/core/cache/data/PartialApplicationData;
+	public static synthetic fun copy-X_dMieU$default (Ldev/kord/core/cache/data/PartialApplicationData;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/core/cache/data/PartialApplicationData;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getCoverImage ()Ldev/kord/common/entity/optional/Optional;
 	public fun getCustomInstallUrl ()Ldev/kord/common/entity/optional/Optional;
@@ -4562,7 +4567,7 @@ public final class dev/kord/core/cache/data/PartialApplicationData : dev/kord/co
 	public fun getFlags ()Ldev/kord/common/entity/optional/Optional;
 	public fun getGuildId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public fun getIcon ()Ljava/lang/String;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public fun getInstallParams ()Ldev/kord/common/entity/optional/Optional;
 	public fun getName ()Ljava/lang/String;
 	public fun getOwnerId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
@@ -4597,15 +4602,15 @@ public final class dev/kord/core/cache/data/PartialApplicationData$Companion {
 
 public final class dev/kord/core/cache/data/PartialGuildData {
 	public static final field Companion Ldev/kord/core/cache/data/PartialGuildData$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getBanner ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getDescription ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getFeatures ()Ljava/util/List;
 	public final fun getGuildScheduledEvents ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getIcon ()Ljava/lang/String;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getName ()Ljava/lang/String;
 	public final fun getNsfwLevel ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getOwner ()Ldev/kord/common/entity/optional/OptionalBoolean;
@@ -4639,18 +4644,18 @@ public final class dev/kord/core/cache/data/PartialGuildData$Companion {
 
 public final class dev/kord/core/cache/data/PermissionOverwriteData {
 	public static final field Companion Ldev/kord/core/cache/data/PermissionOverwriteData$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/OverwriteType;Ldev/kord/common/entity/Permissions;Ldev/kord/common/entity/Permissions;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/OverwriteType;Ldev/kord/common/entity/Permissions;Ldev/kord/common/entity/Permissions;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/OverwriteType;Ldev/kord/common/entity/Permissions;Ldev/kord/common/entity/Permissions;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/OverwriteType;Ldev/kord/common/entity/Permissions;Ldev/kord/common/entity/Permissions;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component2 ()Ldev/kord/common/entity/OverwriteType;
 	public final fun component3 ()Ldev/kord/common/entity/Permissions;
 	public final fun component4 ()Ldev/kord/common/entity/Permissions;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/OverwriteType;Ldev/kord/common/entity/Permissions;Ldev/kord/common/entity/Permissions;)Ldev/kord/core/cache/data/PermissionOverwriteData;
-	public static synthetic fun copy$default (Ldev/kord/core/cache/data/PermissionOverwriteData;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/OverwriteType;Ldev/kord/common/entity/Permissions;Ldev/kord/common/entity/Permissions;ILjava/lang/Object;)Ldev/kord/core/cache/data/PermissionOverwriteData;
+	public final fun copy-9VmEaQQ (JLdev/kord/common/entity/OverwriteType;Ldev/kord/common/entity/Permissions;Ldev/kord/common/entity/Permissions;)Ldev/kord/core/cache/data/PermissionOverwriteData;
+	public static synthetic fun copy-9VmEaQQ$default (Ldev/kord/core/cache/data/PermissionOverwriteData;JLdev/kord/common/entity/OverwriteType;Ldev/kord/common/entity/Permissions;Ldev/kord/common/entity/Permissions;ILjava/lang/Object;)Ldev/kord/core/cache/data/PermissionOverwriteData;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAllowed ()Ldev/kord/common/entity/Permissions;
 	public final fun getDenied ()Ldev/kord/common/entity/Permissions;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getType ()Ldev/kord/common/entity/OverwriteType;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -4676,21 +4681,21 @@ public final class dev/kord/core/cache/data/PermissionOverwriteData$Companion {
 
 public final class dev/kord/core/cache/data/PresenceData {
 	public static final field Companion Ldev/kord/core/cache/data/PresenceData$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/PresenceStatus;Ljava/util/List;Ldev/kord/core/cache/data/ClientStatusData;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/PresenceStatus;Ljava/util/List;Ldev/kord/core/cache/data/ClientStatusData;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/PresenceStatus;Ljava/util/List;Ldev/kord/core/cache/data/ClientStatusData;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLdev/kord/common/entity/PresenceStatus;Ljava/util/List;Ldev/kord/core/cache/data/ClientStatusData;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
+	public final fun component2-4_xYDEk ()J
 	public final fun component3 ()Ldev/kord/common/entity/PresenceStatus;
 	public final fun component4 ()Ljava/util/List;
 	public final fun component5 ()Ldev/kord/core/cache/data/ClientStatusData;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/PresenceStatus;Ljava/util/List;Ldev/kord/core/cache/data/ClientStatusData;)Ldev/kord/core/cache/data/PresenceData;
-	public static synthetic fun copy$default (Ldev/kord/core/cache/data/PresenceData;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/PresenceStatus;Ljava/util/List;Ldev/kord/core/cache/data/ClientStatusData;ILjava/lang/Object;)Ldev/kord/core/cache/data/PresenceData;
+	public final fun copy-CJS6HZA (JJLdev/kord/common/entity/PresenceStatus;Ljava/util/List;Ldev/kord/core/cache/data/ClientStatusData;)Ldev/kord/core/cache/data/PresenceData;
+	public static synthetic fun copy-CJS6HZA$default (Ldev/kord/core/cache/data/PresenceData;JJLdev/kord/common/entity/PresenceStatus;Ljava/util/List;Ldev/kord/core/cache/data/ClientStatusData;ILjava/lang/Object;)Ldev/kord/core/cache/data/PresenceData;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getActivities ()Ljava/util/List;
 	public final fun getClientStatus ()Ldev/kord/core/cache/data/ClientStatusData;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public final fun getStatus ()Ldev/kord/common/entity/PresenceStatus;
-	public final fun getUserId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getUserId-4_xYDEk ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public static final fun write$Self (Ldev/kord/core/cache/data/PresenceData;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
@@ -4709,7 +4714,7 @@ public final class dev/kord/core/cache/data/PresenceData$$serializer : kotlinx/s
 }
 
 public final class dev/kord/core/cache/data/PresenceData$Companion {
-	public final fun from (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordPresenceUpdate;)Ldev/kord/core/cache/data/PresenceData;
+	public final fun from-wYKCHeA (JLdev/kord/common/entity/DiscordPresenceUpdate;)Ldev/kord/core/cache/data/PresenceData;
 	public final fun getDescription ()Ldev/kord/cache/api/data/DataDescription;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -4720,20 +4725,20 @@ public final class dev/kord/core/cache/data/PresenceDataKt {
 
 public final class dev/kord/core/cache/data/ReactionData {
 	public static final field Companion Ldev/kord/core/cache/data/ReactionData$Companion;
-	public synthetic fun <init> (IIZLdev/kord/common/entity/Snowflake;Ljava/lang/String;ZLkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (IZLdev/kord/common/entity/Snowflake;Ljava/lang/String;Z)V
+	public synthetic fun <init> (IIZLdev/kord/common/entity/Snowflake;Ljava/lang/String;ZLkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (IZLdev/kord/common/entity/Snowflake;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (IZLdev/kord/common/entity/Snowflake;Ljava/lang/String;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()I
 	public final fun component2 ()Z
-	public final fun component3 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component3-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Z
-	public final fun copy (IZLdev/kord/common/entity/Snowflake;Ljava/lang/String;Z)Ldev/kord/core/cache/data/ReactionData;
-	public static synthetic fun copy$default (Ldev/kord/core/cache/data/ReactionData;IZLdev/kord/common/entity/Snowflake;Ljava/lang/String;ZILjava/lang/Object;)Ldev/kord/core/cache/data/ReactionData;
+	public final fun copy-eO23frA (IZLdev/kord/common/entity/Snowflake;Ljava/lang/String;Z)Ldev/kord/core/cache/data/ReactionData;
+	public static synthetic fun copy-eO23frA$default (Ldev/kord/core/cache/data/ReactionData;IZLdev/kord/common/entity/Snowflake;Ljava/lang/String;ZILjava/lang/Object;)Ldev/kord/core/cache/data/ReactionData;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCount ()I
 	public final fun getEmojiAnimated ()Z
-	public final fun getEmojiId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getEmojiId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getEmojiName ()Ljava/lang/String;
 	public final fun getMe ()Z
 	public fun hashCode ()I
@@ -4761,19 +4766,19 @@ public final class dev/kord/core/cache/data/ReactionData$Companion {
 
 public final class dev/kord/core/cache/data/ReactionRemoveEmojiData {
 	public static final field Companion Ldev/kord/core/cache/data/ReactionRemoveEmojiData$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/cache/data/RemovedReactionData;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/cache/data/RemovedReactionData;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
-	public final fun component3 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/cache/data/RemovedReactionData;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJJLdev/kord/core/cache/data/RemovedReactionData;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
+	public final fun component2-4_xYDEk ()J
+	public final fun component3-4_xYDEk ()J
 	public final fun component4 ()Ldev/kord/core/cache/data/RemovedReactionData;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/cache/data/RemovedReactionData;)Ldev/kord/core/cache/data/ReactionRemoveEmojiData;
-	public static synthetic fun copy$default (Ldev/kord/core/cache/data/ReactionRemoveEmojiData;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/cache/data/RemovedReactionData;ILjava/lang/Object;)Ldev/kord/core/cache/data/ReactionRemoveEmojiData;
+	public final fun copy-SmFlTYk (JJJLdev/kord/core/cache/data/RemovedReactionData;)Ldev/kord/core/cache/data/ReactionRemoveEmojiData;
+	public static synthetic fun copy-SmFlTYk$default (Ldev/kord/core/cache/data/ReactionRemoveEmojiData;JJJLdev/kord/core/cache/data/RemovedReactionData;ILjava/lang/Object;)Ldev/kord/core/cache/data/ReactionRemoveEmojiData;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-4_xYDEk ()J
 	public final fun getEmoji ()Ldev/kord/core/cache/data/RemovedReactionData;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
-	public final fun getMessageId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
+	public final fun getMessageId-4_xYDEk ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public static final fun write$Self (Ldev/kord/core/cache/data/ReactionRemoveEmojiData;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
@@ -4839,15 +4844,15 @@ public final class dev/kord/core/cache/data/RegionData$Companion {
 
 public final class dev/kord/core/cache/data/RemovedReactionData {
 	public static final field Companion Ldev/kord/core/cache/data/RemovedReactionData$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;)V
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun component2 ()Ljava/lang/String;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;)Ldev/kord/core/cache/data/RemovedReactionData;
-	public static synthetic fun copy$default (Ldev/kord/core/cache/data/RemovedReactionData;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;ILjava/lang/Object;)Ldev/kord/core/cache/data/RemovedReactionData;
+	public final fun copy-O4FuXRM (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;)Ldev/kord/core/cache/data/RemovedReactionData;
+	public static synthetic fun copy-O4FuXRM$default (Ldev/kord/core/cache/data/RemovedReactionData;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;ILjava/lang/Object;)Ldev/kord/core/cache/data/RemovedReactionData;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -4910,20 +4915,20 @@ public final class dev/kord/core/cache/data/ResolvedObjectsData$$serializer : ko
 }
 
 public final class dev/kord/core/cache/data/ResolvedObjectsData$Companion {
-	public final fun from (Ldev/kord/common/entity/ResolvedObjects;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/cache/data/ResolvedObjectsData;
+	public final fun from-NsqkgP0 (Ldev/kord/common/entity/ResolvedObjects;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/cache/data/ResolvedObjectsData;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class dev/kord/core/cache/data/RoleData {
 	public static final field Companion Ldev/kord/core/cache/data/RoleData$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;IZLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILdev/kord/common/entity/Permissions;ZZLdev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;IZLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILdev/kord/common/entity/Permissions;ZZLdev/kord/common/entity/optional/Optional;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;IZLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILdev/kord/common/entity/Permissions;ZZLdev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;IZLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILdev/kord/common/entity/Permissions;ZZLdev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLjava/lang/String;IZLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILdev/kord/common/entity/Permissions;ZZLdev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLjava/lang/String;IZLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILdev/kord/common/entity/Permissions;ZZLdev/kord/common/entity/optional/Optional;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component10 ()Z
 	public final fun component11 ()Z
 	public final fun component12 ()Ldev/kord/common/entity/optional/Optional;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component2-4_xYDEk ()J
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()I
 	public final fun component5 ()Z
@@ -4931,14 +4936,14 @@ public final class dev/kord/core/cache/data/RoleData {
 	public final fun component7 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component8 ()I
 	public final fun component9 ()Ldev/kord/common/entity/Permissions;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;IZLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILdev/kord/common/entity/Permissions;ZZLdev/kord/common/entity/optional/Optional;)Ldev/kord/core/cache/data/RoleData;
-	public static synthetic fun copy$default (Ldev/kord/core/cache/data/RoleData;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;IZLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILdev/kord/common/entity/Permissions;ZZLdev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/core/cache/data/RoleData;
+	public final fun copy-TLkr63U (JJLjava/lang/String;IZLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILdev/kord/common/entity/Permissions;ZZLdev/kord/common/entity/optional/Optional;)Ldev/kord/core/cache/data/RoleData;
+	public static synthetic fun copy-TLkr63U$default (Ldev/kord/core/cache/data/RoleData;JJLjava/lang/String;IZLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILdev/kord/common/entity/Permissions;ZZLdev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/core/cache/data/RoleData;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getColor ()I
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public final fun getHoisted ()Z
 	public final fun getIcon ()Ldev/kord/common/entity/optional/Optional;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getManaged ()Z
 	public final fun getMentionable ()Z
 	public final fun getName ()Ljava/lang/String;
@@ -4965,13 +4970,13 @@ public final class dev/kord/core/cache/data/RoleData$$serializer : kotlinx/seria
 
 public final class dev/kord/core/cache/data/RoleData$Companion {
 	public final fun from (Ldev/kord/common/entity/DiscordGuildRole;)Ldev/kord/core/cache/data/RoleData;
-	public final fun from (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordRole;)Ldev/kord/core/cache/data/RoleData;
+	public final fun from-wYKCHeA (JLdev/kord/common/entity/DiscordRole;)Ldev/kord/core/cache/data/RoleData;
 	public final fun getDescription ()Ldev/kord/cache/api/data/DataDescription;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class dev/kord/core/cache/data/RoleDataKt {
-	public static final fun toData (Ldev/kord/common/entity/DiscordRole;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/cache/data/RoleData;
+	public static final fun toData-Vn1WZo8 (Ldev/kord/common/entity/DiscordRole;J)Ldev/kord/core/cache/data/RoleData;
 }
 
 public final class dev/kord/core/cache/data/RoleTagsData {
@@ -5052,21 +5057,21 @@ public final class dev/kord/core/cache/data/SelectOptionData$Companion {
 
 public final class dev/kord/core/cache/data/StageInstanceData {
 	public static final field Companion Ldev/kord/core/cache/data/StageInstanceData$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/StageInstancePrivacyLevel;Ldev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/StageInstancePrivacyLevel;Ldev/kord/common/entity/Snowflake;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
-	public final fun component3 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/StageInstancePrivacyLevel;Ldev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJJLjava/lang/String;Ldev/kord/common/entity/StageInstancePrivacyLevel;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
+	public final fun component2-4_xYDEk ()J
+	public final fun component3-4_xYDEk ()J
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Ldev/kord/common/entity/StageInstancePrivacyLevel;
-	public final fun component6 ()Ldev/kord/common/entity/Snowflake;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/StageInstancePrivacyLevel;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/cache/data/StageInstanceData;
-	public static synthetic fun copy$default (Ldev/kord/core/cache/data/StageInstanceData;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/StageInstancePrivacyLevel;Ldev/kord/common/entity/Snowflake;ILjava/lang/Object;)Ldev/kord/core/cache/data/StageInstanceData;
+	public final fun component6-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
+	public final fun copy-qvEblQo (JJJLjava/lang/String;Ldev/kord/common/entity/StageInstancePrivacyLevel;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/cache/data/StageInstanceData;
+	public static synthetic fun copy-qvEblQo$default (Ldev/kord/core/cache/data/StageInstanceData;JJJLjava/lang/String;Ldev/kord/common/entity/StageInstancePrivacyLevel;Ldev/kord/common/entity/Snowflake;ILjava/lang/Object;)Ldev/kord/core/cache/data/StageInstanceData;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
-	public final fun getGuildScheduledEventId ()Ldev/kord/common/entity/Snowflake;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-4_xYDEk ()J
+	public final fun getGuildId-4_xYDEk ()J
+	public final fun getGuildScheduledEventId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getPrivacyLevel ()Ldev/kord/common/entity/StageInstancePrivacyLevel;
 	public final fun getTopic ()Ljava/lang/String;
 	public fun hashCode ()I
@@ -5097,10 +5102,10 @@ public final class dev/kord/core/cache/data/StageInstanceDataKt {
 
 public final class dev/kord/core/cache/data/StickerData {
 	public static final field Companion Ldev/kord/core/cache/data/StickerData$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/MessageStickerType;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/MessageStickerType;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/MessageStickerType;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/MessageStickerType;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/MessageStickerType;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/MessageStickerType;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component10 ()Ldev/kord/common/entity/optional/OptionalInt;
 	public final fun component2 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun component3 ()Ljava/lang/String;
@@ -5110,14 +5115,14 @@ public final class dev/kord/core/cache/data/StickerData {
 	public final fun component7 ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun component8 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun component9 ()Ldev/kord/common/entity/optional/Optional;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/MessageStickerType;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;)Ldev/kord/core/cache/data/StickerData;
-	public static synthetic fun copy$default (Ldev/kord/core/cache/data/StickerData;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/MessageStickerType;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;ILjava/lang/Object;)Ldev/kord/core/cache/data/StickerData;
+	public final fun copy-1Wgd_o8 (JLdev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/MessageStickerType;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;)Ldev/kord/core/cache/data/StickerData;
+	public static synthetic fun copy-1Wgd_o8$default (Ldev/kord/core/cache/data/StickerData;JLdev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/MessageStickerType;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;ILjava/lang/Object;)Ldev/kord/core/cache/data/StickerData;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAvailable ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun getDescription ()Ljava/lang/String;
 	public final fun getFormatType ()Ldev/kord/common/entity/MessageStickerType;
 	public final fun getGuildId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getName ()Ljava/lang/String;
 	public final fun getPackId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun getSortValue ()Ldev/kord/common/entity/optional/OptionalInt;
@@ -5148,16 +5153,16 @@ public final class dev/kord/core/cache/data/StickerData$Companion {
 
 public final class dev/kord/core/cache/data/StickerItemData {
 	public static final field Companion Ldev/kord/core/cache/data/StickerItemData$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/MessageStickerType;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/MessageStickerType;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/MessageStickerType;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Ldev/kord/common/entity/MessageStickerType;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ldev/kord/common/entity/MessageStickerType;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/MessageStickerType;)Ldev/kord/core/cache/data/StickerItemData;
-	public static synthetic fun copy$default (Ldev/kord/core/cache/data/StickerItemData;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/MessageStickerType;ILjava/lang/Object;)Ldev/kord/core/cache/data/StickerItemData;
+	public final fun copy-9y3P_48 (JLjava/lang/String;Ldev/kord/common/entity/MessageStickerType;)Ldev/kord/core/cache/data/StickerItemData;
+	public static synthetic fun copy-9y3P_48$default (Ldev/kord/core/cache/data/StickerItemData;JLjava/lang/String;Ldev/kord/common/entity/MessageStickerType;ILjava/lang/Object;)Ldev/kord/core/cache/data/StickerItemData;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFormatType ()Ldev/kord/common/entity/MessageStickerType;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -5183,24 +5188,24 @@ public final class dev/kord/core/cache/data/StickerItemData$Companion {
 
 public final class dev/kord/core/cache/data/StickerPackData {
 	public static final field Companion Ldev/kord/core/cache/data/StickerPackData$Companion;
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/util/List;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/util/List;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (JLjava/util/List;Ljava/lang/String;JLdev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/util/List;Ljava/lang/String;JLdev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;JLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component2 ()Ljava/util/List;
 	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component4-4_xYDEk ()J
 	public final fun component5 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun component6 ()Ljava/lang/String;
-	public final fun component7 ()Ldev/kord/common/entity/Snowflake;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ljava/util/List;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/cache/data/StickerPackData;
-	public static synthetic fun copy$default (Ldev/kord/core/cache/data/StickerPackData;Ldev/kord/common/entity/Snowflake;Ljava/util/List;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;ILjava/lang/Object;)Ldev/kord/core/cache/data/StickerPackData;
+	public final fun component7-4_xYDEk ()J
+	public final fun copy-wz6eW_A (JLjava/util/List;Ljava/lang/String;JLdev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;J)Ldev/kord/core/cache/data/StickerPackData;
+	public static synthetic fun copy-wz6eW_A$default (Ldev/kord/core/cache/data/StickerPackData;JLjava/util/List;Ljava/lang/String;JLdev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;JILjava/lang/Object;)Ldev/kord/core/cache/data/StickerPackData;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getBannerAssetId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getBannerAssetId-4_xYDEk ()J
 	public final fun getCoverStickerId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun getDescription ()Ljava/lang/String;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getName ()Ljava/lang/String;
-	public final fun getSkuId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getSkuId-4_xYDEk ()J
 	public final fun getStickers ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -5213,20 +5218,20 @@ public final class dev/kord/core/cache/data/StickerPackData$Companion {
 
 public final class dev/kord/core/cache/data/TeamData {
 	public static final field Companion Ldev/kord/core/cache/data/TeamData$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/util/List;Ldev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/util/List;Ldev/kord/common/entity/Snowflake;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/util/List;Ldev/kord/common/entity/Snowflake;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/util/List;Ldev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Ljava/util/List;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Ljava/util/List;JLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/util/List;
-	public final fun component4 ()Ldev/kord/common/entity/Snowflake;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/util/List;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/cache/data/TeamData;
-	public static synthetic fun copy$default (Ldev/kord/core/cache/data/TeamData;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/util/List;Ldev/kord/common/entity/Snowflake;ILjava/lang/Object;)Ldev/kord/core/cache/data/TeamData;
+	public final fun component4-4_xYDEk ()J
+	public final fun copy-PwNx6gs (JLjava/lang/String;Ljava/util/List;J)Ldev/kord/core/cache/data/TeamData;
+	public static synthetic fun copy-PwNx6gs$default (Ldev/kord/core/cache/data/TeamData;JLjava/lang/String;Ljava/util/List;JILjava/lang/Object;)Ldev/kord/core/cache/data/TeamData;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getIcon ()Ljava/lang/String;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getMembers ()Ljava/util/List;
-	public final fun getOwnerUserId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getOwnerUserId-4_xYDEk ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public static final fun write$Self (Ldev/kord/core/cache/data/TeamData;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
@@ -5251,12 +5256,12 @@ public final class dev/kord/core/cache/data/TeamData$Companion {
 
 public final class dev/kord/core/cache/data/TeamMemberData {
 	public static final field Companion Ldev/kord/core/cache/data/TeamMemberData$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/TeamMembershipState;Ljava/util/List;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/TeamMembershipState;Ljava/util/List;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)V
+	public synthetic fun <init> (ILdev/kord/common/entity/TeamMembershipState;Ljava/util/List;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ldev/kord/common/entity/TeamMembershipState;Ljava/util/List;JJLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getMembershipState ()Ldev/kord/common/entity/TeamMembershipState;
 	public final fun getPermissions ()Ljava/util/List;
-	public final fun getTeamId ()Ldev/kord/common/entity/Snowflake;
-	public final fun getUserId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getTeamId-4_xYDEk ()J
+	public final fun getUserId-4_xYDEk ()J
 	public static final fun write$Self (Ldev/kord/core/cache/data/TeamMemberData;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
@@ -5279,30 +5284,30 @@ public final class dev/kord/core/cache/data/TeamMemberData$Companion {
 
 public final class dev/kord/core/cache/data/TemplateData {
 	public static final field Companion Ldev/kord/core/cache/data/TemplateData$Companion;
-	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;ILdev/kord/common/entity/Snowflake;Ldev/kord/core/cache/data/UserData;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/cache/data/PartialGuildData;Ljava/lang/Boolean;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILdev/kord/common/entity/Snowflake;Ldev/kord/core/cache/data/UserData;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/cache/data/PartialGuildData;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;ILdev/kord/common/entity/Snowflake;Ldev/kord/core/cache/data/UserData;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/cache/data/PartialGuildData;Ljava/lang/Boolean;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IJLdev/kord/core/cache/data/UserData;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;JLdev/kord/core/cache/data/PartialGuildData;Ljava/lang/Boolean;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component10 ()Ldev/kord/core/cache/data/PartialGuildData;
 	public final fun component11 ()Ljava/lang/Boolean;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()I
-	public final fun component5 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component5-4_xYDEk ()J
 	public final fun component6 ()Ldev/kord/core/cache/data/UserData;
 	public final fun component7 ()Lkotlinx/datetime/Instant;
 	public final fun component8 ()Lkotlinx/datetime/Instant;
-	public final fun component9 ()Ldev/kord/common/entity/Snowflake;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILdev/kord/common/entity/Snowflake;Ldev/kord/core/cache/data/UserData;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/cache/data/PartialGuildData;Ljava/lang/Boolean;)Ldev/kord/core/cache/data/TemplateData;
-	public static synthetic fun copy$default (Ldev/kord/core/cache/data/TemplateData;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILdev/kord/common/entity/Snowflake;Ldev/kord/core/cache/data/UserData;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/cache/data/PartialGuildData;Ljava/lang/Boolean;ILjava/lang/Object;)Ldev/kord/core/cache/data/TemplateData;
+	public final fun component9-4_xYDEk ()J
+	public final fun copy-c3Iea6o (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IJLdev/kord/core/cache/data/UserData;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;JLdev/kord/core/cache/data/PartialGuildData;Ljava/lang/Boolean;)Ldev/kord/core/cache/data/TemplateData;
+	public static synthetic fun copy-c3Iea6o$default (Ldev/kord/core/cache/data/TemplateData;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IJLdev/kord/core/cache/data/UserData;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;JLdev/kord/core/cache/data/PartialGuildData;Ljava/lang/Boolean;ILjava/lang/Object;)Ldev/kord/core/cache/data/TemplateData;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCode ()Ljava/lang/String;
 	public final fun getCreatedAt ()Lkotlinx/datetime/Instant;
 	public final fun getCreator ()Ldev/kord/core/cache/data/UserData;
-	public final fun getCreatorId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getCreatorId-4_xYDEk ()J
 	public final fun getDescription ()Ljava/lang/String;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getSerializedSourceGuild ()Ldev/kord/core/cache/data/PartialGuildData;
-	public final fun getSourceGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getSourceGuildId-4_xYDEk ()J
 	public final fun getUpdatedAt ()Lkotlinx/datetime/Instant;
 	public final fun getUsageCount ()I
 	public fun hashCode ()I
@@ -5395,10 +5400,10 @@ public final class dev/kord/core/cache/data/TextInputComponentData$Companion {
 
 public final class dev/kord/core/cache/data/ThreadListSyncData {
 	public static final field Companion Ldev/kord/core/cache/data/ThreadListSyncData$Companion;
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Ljava/util/List;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/optional/Optional;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/optional/Optional;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getChannelIds ()Ldev/kord/common/entity/optional/Optional;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public final fun getMembers ()Ljava/util/List;
 	public final fun getThreads ()Ljava/util/List;
 }
@@ -5409,18 +5414,18 @@ public final class dev/kord/core/cache/data/ThreadListSyncData$Companion {
 
 public final class dev/kord/core/cache/data/ThreadMemberData {
 	public static final field Companion Ldev/kord/core/cache/data/ThreadMemberData$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Lkotlinx/datetime/Instant;ILkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Lkotlinx/datetime/Instant;I)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Lkotlinx/datetime/Instant;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Lkotlinx/datetime/Instant;ILkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/optional/OptionalSnowflake;Lkotlinx/datetime/Instant;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/optional/OptionalSnowflake;Lkotlinx/datetime/Instant;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component2 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun component3 ()Lkotlinx/datetime/Instant;
 	public final fun component4 ()I
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Lkotlinx/datetime/Instant;I)Ldev/kord/core/cache/data/ThreadMemberData;
-	public static synthetic fun copy$default (Ldev/kord/core/cache/data/ThreadMemberData;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Lkotlinx/datetime/Instant;IILjava/lang/Object;)Ldev/kord/core/cache/data/ThreadMemberData;
+	public final fun copy-9VmEaQQ (JLdev/kord/common/entity/optional/OptionalSnowflake;Lkotlinx/datetime/Instant;I)Ldev/kord/core/cache/data/ThreadMemberData;
+	public static synthetic fun copy-9VmEaQQ$default (Ldev/kord/core/cache/data/ThreadMemberData;JLdev/kord/common/entity/optional/OptionalSnowflake;Lkotlinx/datetime/Instant;IILjava/lang/Object;)Ldev/kord/core/cache/data/ThreadMemberData;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFlags ()I
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getJoinTimestamp ()Lkotlinx/datetime/Instant;
 	public final fun getUserId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public fun hashCode ()I
@@ -5441,23 +5446,23 @@ public final class dev/kord/core/cache/data/ThreadMemberData$$serializer : kotli
 }
 
 public final class dev/kord/core/cache/data/ThreadMemberData$Companion {
-	public final fun from (Ldev/kord/common/entity/DiscordThreadMember;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/cache/data/ThreadMemberData;
-	public static synthetic fun from$default (Ldev/kord/core/cache/data/ThreadMemberData$Companion;Ldev/kord/common/entity/DiscordThreadMember;Ldev/kord/common/entity/Snowflake;ILjava/lang/Object;)Ldev/kord/core/cache/data/ThreadMemberData;
+	public final fun from-NsqkgP0 (Ldev/kord/common/entity/DiscordThreadMember;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/cache/data/ThreadMemberData;
+	public static synthetic fun from-NsqkgP0$default (Ldev/kord/core/cache/data/ThreadMemberData$Companion;Ldev/kord/common/entity/DiscordThreadMember;Ldev/kord/common/entity/Snowflake;ILjava/lang/Object;)Ldev/kord/core/cache/data/ThreadMemberData;
 	public final fun getDescription ()Ldev/kord/cache/api/data/DataDescription;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class dev/kord/core/cache/data/ThreadMemberDataKt {
-	public static final fun toData (Ldev/kord/common/entity/DiscordThreadMember;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/cache/data/ThreadMemberData;
+	public static final fun toData-NsqkgP0 (Ldev/kord/common/entity/DiscordThreadMember;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/cache/data/ThreadMemberData;
 }
 
 public final class dev/kord/core/cache/data/ThreadMembersUpdateEventData {
 	public static final field Companion Ldev/kord/core/cache/data/ThreadMembersUpdateEventData$Companion;
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;ILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;ILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAddedMembers ()Ldev/kord/common/entity/optional/Optional;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
+	public final fun getId-4_xYDEk ()J
 	public final fun getMemberCount ()I
 	public final fun getRemovedMemberIds ()Ldev/kord/common/entity/optional/Optional;
 }
@@ -5510,10 +5515,10 @@ public final class dev/kord/core/cache/data/ThreadMetadataData$Companion {
 
 public final class dev/kord/core/cache/data/UserData {
 	public static final field Companion Ldev/kord/core/cache/data/UserData$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ljava/lang/Integer;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ljava/lang/Integer;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ljava/lang/Integer;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
@@ -5521,15 +5526,15 @@ public final class dev/kord/core/cache/data/UserData {
 	public final fun component6 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component7 ()Ljava/lang/String;
 	public final fun component8 ()Ljava/lang/Integer;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ljava/lang/Integer;)Ldev/kord/core/cache/data/UserData;
-	public static synthetic fun copy$default (Ldev/kord/core/cache/data/UserData;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ljava/lang/Integer;ILjava/lang/Object;)Ldev/kord/core/cache/data/UserData;
+	public final fun copy-wGWicR4 (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ljava/lang/Integer;)Ldev/kord/core/cache/data/UserData;
+	public static synthetic fun copy-wGWicR4$default (Ldev/kord/core/cache/data/UserData;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ljava/lang/String;Ljava/lang/Integer;ILjava/lang/Object;)Ldev/kord/core/cache/data/UserData;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAccentColor ()Ljava/lang/Integer;
 	public final fun getAvatar ()Ljava/lang/String;
 	public final fun getBanner ()Ljava/lang/String;
 	public final fun getBot ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun getDiscriminator ()Ljava/lang/String;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getPublicFlags ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getUsername ()Ljava/lang/String;
 	public fun hashCode ()I
@@ -5563,28 +5568,28 @@ public final class dev/kord/core/cache/data/UserDataKt {
 
 public final class dev/kord/core/cache/data/VoiceStateData {
 	public static final field Companion Ldev/kord/core/cache/data/VoiceStateData$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;ZZZZZZLdev/kord/common/entity/optional/OptionalBoolean;Lkotlinx/datetime/Instant;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;ZZZZZZLdev/kord/common/entity/optional/OptionalBoolean;Lkotlinx/datetime/Instant;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;ZZZZZZLdev/kord/common/entity/optional/OptionalBoolean;Lkotlinx/datetime/Instant;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;ZZZZZZLdev/kord/common/entity/optional/OptionalBoolean;Lkotlinx/datetime/Instant;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/Snowflake;JLdev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;ZZZZZZLdev/kord/common/entity/optional/OptionalBoolean;Lkotlinx/datetime/Instant;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/Snowflake;JLdev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;ZZZZZZLdev/kord/common/entity/optional/OptionalBoolean;Lkotlinx/datetime/Instant;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component10 ()Z
 	public final fun component11 ()Z
 	public final fun component12 ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun component13 ()Lkotlinx/datetime/Instant;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
-	public final fun component3 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component2-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
+	public final fun component3-4_xYDEk ()J
 	public final fun component4 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun component5 ()Ljava/lang/String;
 	public final fun component6 ()Z
 	public final fun component7 ()Z
 	public final fun component8 ()Z
 	public final fun component9 ()Z
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;ZZZZZZLdev/kord/common/entity/optional/OptionalBoolean;Lkotlinx/datetime/Instant;)Ldev/kord/core/cache/data/VoiceStateData;
-	public static synthetic fun copy$default (Ldev/kord/core/cache/data/VoiceStateData;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;ZZZZZZLdev/kord/common/entity/optional/OptionalBoolean;Lkotlinx/datetime/Instant;ILjava/lang/Object;)Ldev/kord/core/cache/data/VoiceStateData;
+	public final fun copy-fV9Bq7g (JLdev/kord/common/entity/Snowflake;JLdev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;ZZZZZZLdev/kord/common/entity/optional/OptionalBoolean;Lkotlinx/datetime/Instant;)Ldev/kord/core/cache/data/VoiceStateData;
+	public static synthetic fun copy-fV9Bq7g$default (Ldev/kord/core/cache/data/VoiceStateData;JLdev/kord/common/entity/Snowflake;JLdev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;ZZZZZZLdev/kord/common/entity/optional/OptionalBoolean;Lkotlinx/datetime/Instant;ILjava/lang/Object;)Ldev/kord/core/cache/data/VoiceStateData;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getDeaf ()Z
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public final fun getMemberId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun getMute ()Z
 	public final fun getRequestToSpeakTimestamp ()Lkotlinx/datetime/Instant;
@@ -5594,7 +5599,7 @@ public final class dev/kord/core/cache/data/VoiceStateData {
 	public final fun getSelfVideo ()Z
 	public final fun getSessionId ()Ljava/lang/String;
 	public final fun getSuppress ()Z
-	public final fun getUserId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getUserId-4_xYDEk ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public static final fun write$Self (Ldev/kord/core/cache/data/VoiceStateData;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
@@ -5613,7 +5618,7 @@ public final class dev/kord/core/cache/data/VoiceStateData$$serializer : kotlinx
 }
 
 public final class dev/kord/core/cache/data/VoiceStateData$Companion {
-	public final fun from (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordVoiceState;)Ldev/kord/core/cache/data/VoiceStateData;
+	public final fun from-wYKCHeA (JLdev/kord/common/entity/DiscordVoiceState;)Ldev/kord/core/cache/data/VoiceStateData;
 	public final fun getDescription ()Ldev/kord/cache/api/data/DataDescription;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -5624,26 +5629,26 @@ public final class dev/kord/core/cache/data/VoiceStateDataKt {
 
 public final class dev/kord/core/cache/data/WebhookData {
 	public static final field Companion Ldev/kord/core/cache/data/WebhookData$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/WebhookType;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/WebhookType;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/WebhookType;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/WebhookType;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/WebhookType;Ldev/kord/common/entity/optional/OptionalSnowflake;JLdev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/WebhookType;Ldev/kord/common/entity/optional/OptionalSnowflake;JLdev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component2 ()Ldev/kord/common/entity/WebhookType;
 	public final fun component3 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
-	public final fun component4 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component4-4_xYDEk ()J
 	public final fun component5 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun component6 ()Ljava/lang/String;
 	public final fun component7 ()Ljava/lang/String;
 	public final fun component8 ()Ldev/kord/common/entity/optional/Optional;
-	public final fun component9 ()Ldev/kord/common/entity/Snowflake;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/WebhookType;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/cache/data/WebhookData;
-	public static synthetic fun copy$default (Ldev/kord/core/cache/data/WebhookData;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/WebhookType;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;ILjava/lang/Object;)Ldev/kord/core/cache/data/WebhookData;
+	public final fun component9-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
+	public final fun copy-phscL-E (JLdev/kord/common/entity/WebhookType;Ldev/kord/common/entity/optional/OptionalSnowflake;JLdev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/cache/data/WebhookData;
+	public static synthetic fun copy-phscL-E$default (Ldev/kord/core/cache/data/WebhookData;JLdev/kord/common/entity/WebhookType;Ldev/kord/common/entity/optional/OptionalSnowflake;JLdev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/Snowflake;ILjava/lang/Object;)Ldev/kord/core/cache/data/WebhookData;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getApplicationId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getAvatar ()Ljava/lang/String;
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-4_xYDEk ()J
 	public final fun getGuildId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getName ()Ljava/lang/String;
 	public final fun getToken ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getType ()Ldev/kord/common/entity/WebhookType;
@@ -5673,18 +5678,18 @@ public final class dev/kord/core/cache/data/WebhookData$Companion {
 
 public final class dev/kord/core/cache/data/WelcomeScreenChannelData {
 	public static final field Companion Ldev/kord/core/cache/data/WelcomeScreenChannelData$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component3-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun component4 ()Ljava/lang/String;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;)Ldev/kord/core/cache/data/WelcomeScreenChannelData;
-	public static synthetic fun copy$default (Ldev/kord/core/cache/data/WelcomeScreenChannelData;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;ILjava/lang/Object;)Ldev/kord/core/cache/data/WelcomeScreenChannelData;
+	public final fun copy-nKCQcT8 (JLjava/lang/String;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;)Ldev/kord/core/cache/data/WelcomeScreenChannelData;
+	public static synthetic fun copy-nKCQcT8$default (Ldev/kord/core/cache/data/WelcomeScreenChannelData;JLjava/lang/String;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;ILjava/lang/Object;)Ldev/kord/core/cache/data/WelcomeScreenChannelData;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-4_xYDEk ()J
 	public final fun getDescription ()Ljava/lang/String;
-	public final fun getEmojiId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getEmojiId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getEmojiName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -5743,7 +5748,7 @@ public final class dev/kord/core/cache/data/WelcomeScreenData$Companion {
 
 public final class dev/kord/core/entity/Activity {
 	public fun <init> (Ldev/kord/core/cache/data/ActivityData;)V
-	public final fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getApplicationId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getAssets ()Ldev/kord/core/entity/Activity$Assets;
 	public final fun getButtons ()Ljava/util/List;
 	public final fun getData ()Ldev/kord/core/cache/data/ActivityData;
@@ -5816,7 +5821,7 @@ public final class dev/kord/core/entity/Application : dev/kord/core/entity/BaseA
 	public synthetic fun getData ()Ldev/kord/core/cache/data/BaseApplicationData;
 	public final fun getRequireCodeGrant ()Z
 	public final fun getTeam ()Ldev/kord/core/entity/Team;
-	public final fun getTeamId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getTeamId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun isPublic ()Z
 	public fun toString ()Ljava/lang/String;
 	public fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/entity/Application;
@@ -5838,7 +5843,7 @@ public final class dev/kord/core/entity/Attachment : dev/kord/core/entity/KordEn
 	public final fun getDescription ()Ljava/lang/String;
 	public final fun getFilename ()Ljava/lang/String;
 	public final fun getHeight ()Ljava/lang/Integer;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getProxyUrl ()Ljava/lang/String;
 	public final fun getSize ()I
@@ -5856,12 +5861,12 @@ public final class dev/kord/core/entity/AttachmentKt {
 }
 
 public final class dev/kord/core/entity/AuditLog : dev/kord/core/KordObject {
-	public fun <init> (Ldev/kord/common/entity/DiscordAuditLog;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;)V
+	public synthetic fun <init> (Ldev/kord/common/entity/DiscordAuditLog;JLdev/kord/core/Kord;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getApplicationCommands ()Ljava/util/List;
 	public final fun getAutoModerationRules ()Ljava/util/List;
 	public final fun getData ()Ldev/kord/common/entity/DiscordAuditLog;
 	public final fun getEntries ()Ljava/util/List;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public final fun getIntegrations ()Ljava/util/List;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getThreads ()Ljava/util/List;
@@ -5875,12 +5880,12 @@ public final class dev/kord/core/entity/AuditLogEntry : dev/kord/core/KordObject
 	public final fun getActionType ()Ldev/kord/common/entity/AuditLogEvent;
 	public final fun getChanges ()Ljava/util/List;
 	public final fun getData ()Ldev/kord/common/entity/DiscordAuditLogEntry;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getOptions ()Ldev/kord/common/entity/AuditLogEntryOptionalInfo;
 	public final fun getReason ()Ljava/lang/String;
-	public final fun getTargetId ()Ldev/kord/common/entity/Snowflake;
-	public final fun getUserId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getTargetId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
+	public final fun getUserId-4_xYDEk ()J
 }
 
 public final class dev/kord/core/entity/Ban : dev/kord/core/KordObject, dev/kord/core/entity/Strategizable {
@@ -5892,7 +5897,7 @@ public final class dev/kord/core/entity/Ban : dev/kord/core/KordObject, dev/kord
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
 	public final fun getUser ()Ldev/kord/core/behavior/UserBehavior;
 	public final fun getUser (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getUserId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getUserId-4_xYDEk ()J
 	public final fun getUserOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun toString ()Ljava/lang/String;
 	public fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/entity/Ban;
@@ -5911,17 +5916,17 @@ public abstract class dev/kord/core/entity/BaseApplication : dev/kord/core/entit
 	public final fun getDescription ()Ljava/lang/String;
 	public final fun getFlags ()Ldev/kord/common/entity/ApplicationFlags;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getIconHash ()Ljava/lang/String;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getInstallParams ()Ldev/kord/common/entity/InstallParams;
 	public final fun getKord ()Ldev/kord/core/Kord;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getOwner ()Ldev/kord/core/behavior/UserBehavior;
-	public final fun getOwnerId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getOwnerId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getOwnerOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getPrimarySkuId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getPrimarySkuId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getPrivacyPolicyUrl ()Ljava/lang/String;
 	public final fun getRpcOrigins ()Ljava/util/List;
 	public final fun getSlug ()Ljava/lang/String;
@@ -6103,7 +6108,7 @@ public final class dev/kord/core/entity/Embed$Video : dev/kord/core/KordObject {
 public abstract interface class dev/kord/core/entity/Entity : java/lang/Comparable {
 	public static final field Companion Ldev/kord/core/entity/Entity$Companion;
 	public abstract fun compareTo (Ldev/kord/core/entity/Entity;)I
-	public abstract fun getId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getId-4_xYDEk ()J
 }
 
 public final class dev/kord/core/entity/Entity$Companion {
@@ -6133,28 +6138,28 @@ public final class dev/kord/core/entity/Guild : dev/kord/core/behavior/GuildBeha
 	public fun getActiveThreads ()Lkotlinx/coroutines/flow/Flow;
 	public final fun getAfkChannel ()Ldev/kord/core/behavior/channel/VoiceChannelBehavior;
 	public final fun getAfkChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getAfkChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getAfkChannelId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getAfkTimeout-UwyO8pc ()J
-	public fun getApplicationCommand (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getApplicationCommandOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getApplicationCommand-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getApplicationCommandOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getApplicationCommands (Ljava/lang/Boolean;)Lkotlinx/coroutines/flow/Flow;
-	public final fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getApplicationId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getApproximateMemberCount ()Ljava/lang/Integer;
 	public final fun getApproximatePresenceCount ()Ljava/lang/Integer;
-	public fun getAutoModerationRule (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getAutoModerationRuleOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getAutoModerationRule-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getAutoModerationRuleOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getAutoModerationRules ()Lkotlinx/coroutines/flow/Flow;
-	public fun getBan (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getBanOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getBan-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getBanOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getBanner (Ldev/kord/rest/Image$Format;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getBannerHash ()Ljava/lang/String;
 	public final fun getBannerUrl (Ldev/kord/rest/Image$Format;)Ljava/lang/String;
 	public fun getBans ()Lkotlinx/coroutines/flow/Flow;
 	public fun getCachedThreads ()Lkotlinx/coroutines/flow/Flow;
-	public fun getChannel (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getChannel-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getChannelBehaviors ()Ljava/util/Set;
 	public final fun getChannelIds ()Ljava/util/Set;
-	public fun getChannelOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getChannelOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getChannels ()Lkotlinx/coroutines/flow/Flow;
 	public synthetic fun getCommands ()Lkotlinx/coroutines/flow/Flow;
 	public final fun getContentFilter ()Ldev/kord/common/entity/ExplicitContentFilter;
@@ -6165,33 +6170,33 @@ public final class dev/kord/core/entity/Guild : dev/kord/core/behavior/GuildBeha
 	public final fun getDiscoverySplashHash ()Ljava/lang/String;
 	public final fun getDiscoverySplashUrl (Ldev/kord/rest/Image$Format;)Ljava/lang/String;
 	public final fun getEmbedChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getEmoji (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getEmoji-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getEmojiIds ()Ljava/util/Set;
-	public final fun getEmojiOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getEmojiOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getEmojis ()Lkotlinx/coroutines/flow/Flow;
 	public final fun getEveryoneRole ()Ldev/kord/core/behavior/RoleBehavior;
 	public final fun getEveryoneRole (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getEveryoneRoleOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getFeatures ()Ljava/util/Set;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
-	public fun getGuildScheduledEvent (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildScheduledEventOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGuildScheduledEvent-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGuildScheduledEventOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getIcon (Ldev/kord/rest/Image$Format;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getIconHash ()Ljava/lang/String;
 	public final fun getIconUrl (Ldev/kord/rest/Image$Format;)Ljava/lang/String;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public fun getIntegrations ()Lkotlinx/coroutines/flow/Flow;
-	public fun getInvite (Ljava/lang/String;ZZLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getInviteOrNull (Ljava/lang/String;ZZLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getInvite-ReOCJwE (Ljava/lang/String;ZZLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getInviteOrNull-ReOCJwE (Ljava/lang/String;ZZLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getInvites ()Lkotlinx/coroutines/flow/Flow;
 	public final fun getJoinedTime ()Lkotlinx/datetime/Instant;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getMaxMembers ()Ljava/lang/Integer;
 	public final fun getMaxPresences ()I
 	public final fun getMaxVideoChannelUsers ()Ljava/lang/Integer;
-	public fun getMember (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getMember-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getMemberCount ()Ljava/lang/Integer;
-	public fun getMemberOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getMemberOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getMembers ()Lkotlinx/coroutines/flow/Flow;
 	public fun getMembers (Ljava/lang/String;I)Lkotlinx/coroutines/flow/Flow;
 	public final fun getMfaLevel ()Ldev/kord/common/entity/MFALevel;
@@ -6199,7 +6204,7 @@ public final class dev/kord/core/entity/Guild : dev/kord/core/behavior/GuildBeha
 	public final fun getNsfw ()Ldev/kord/common/entity/NsfwLevel;
 	public final fun getOwner ()Ldev/kord/core/behavior/MemberBehavior;
 	public final fun getOwner (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getOwnerId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getOwnerId-4_xYDEk ()J
 	public final fun getOwnerOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getPermissions ()Ldev/kord/common/entity/Permissions;
 	public final fun getPreferredLocale ()Ljava/util/Locale;
@@ -6212,30 +6217,30 @@ public final class dev/kord/core/entity/Guild : dev/kord/core/behavior/GuildBeha
 	public fun getPruneCount (ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getPublicUpdatesChannel ()Ldev/kord/core/behavior/channel/TopGuildMessageChannelBehavior;
 	public final fun getPublicUpdatesChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getPublicUpdatesChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getPublicUpdatesChannelId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getRegionId ()Ljava/lang/String;
 	public fun getRegions ()Lkotlinx/coroutines/flow/Flow;
-	public fun getRole (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getRole-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getRoleBehaviors ()Ljava/util/Set;
 	public final fun getRoleIds ()Ljava/util/Set;
-	public fun getRoleOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getRoleOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getRoles ()Lkotlinx/coroutines/flow/Flow;
 	public final fun getRulesChannel ()Ldev/kord/core/behavior/channel/TopGuildMessageChannelBehavior;
 	public final fun getRulesChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getRulesChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getRulesChannelId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public fun getScheduledEvents ()Lkotlinx/coroutines/flow/Flow;
 	public final fun getSplash (Ldev/kord/rest/Image$Format;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getSplashHash ()Ljava/lang/String;
 	public final fun getSplashUrl (Ldev/kord/rest/Image$Format;)Ljava/lang/String;
 	public final fun getStageInstances ()Ljava/util/Set;
-	public fun getSticker (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getStickerOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getSticker-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getStickerOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getStickers ()Lkotlinx/coroutines/flow/Flow;
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
 	public final fun getSystemChannel ()Ldev/kord/core/behavior/channel/TextChannelBehavior;
 	public final fun getSystemChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getSystemChannelFlags ()Ldev/kord/common/entity/SystemChannelFlags;
-	public final fun getSystemChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getSystemChannelId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public fun getTemplate (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getTemplateOrNull (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getTemplates ()Lkotlinx/coroutines/flow/Flow;
@@ -6252,18 +6257,18 @@ public final class dev/kord/core/entity/Guild : dev/kord/core/behavior/GuildBeha
 	public fun getWidget (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getWidgetChannel ()Ldev/kord/core/behavior/channel/TopGuildChannelBehavior;
 	public final fun getWidgetChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getWidgetChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getWidgetChannelId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public fun getWidgetOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun hashCode ()I
 	public final fun isLarge ()Ljava/lang/Boolean;
 	public final fun isOwner ()Z
 	public final fun isWidgetEnabled ()Z
-	public fun kick (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun kick-9y3P_48 (JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun leave (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun prune (ILjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun requestMembers (Ldev/kord/gateway/RequestGuildMembers;)Lkotlinx/coroutines/flow/Flow;
 	public fun toString ()Ljava/lang/String;
-	public fun unban (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun unban-9y3P_48 (JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public synthetic fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/GuildBehavior;
 	public fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/entity/Guild;
 	public synthetic fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/entity/Strategizable;
@@ -6279,8 +6284,8 @@ public final class dev/kord/core/entity/GuildEmoji : dev/kord/core/entity/KordEn
 	public final fun edit (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getData ()Ldev/kord/core/cache/data/EmojiData;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
+	public fun getId-4_xYDEk ()J
 	public final fun getImage ()Ldev/kord/core/entity/Icon;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getMember ()Ldev/kord/core/behavior/MemberBehavior;
@@ -6294,7 +6299,7 @@ public final class dev/kord/core/entity/GuildEmoji : dev/kord/core/entity/KordEn
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
 	public final fun getUser ()Ldev/kord/core/behavior/UserBehavior;
 	public final fun getUser (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getUserId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getUserId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public fun hashCode ()I
 	public final fun isAnimated ()Z
 	public final fun isAvailable ()Z
@@ -6316,7 +6321,7 @@ public final class dev/kord/core/entity/GuildPreview : dev/kord/core/entity/Kord
 	public final fun getEmojis ()Ljava/util/Set;
 	public final fun getFeatures ()Ljava/util/Set;
 	public final fun getIcon ()Ljava/lang/String;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getSplash ()Ljava/lang/String;
@@ -6334,24 +6339,24 @@ public final class dev/kord/core/entity/GuildScheduledEvent : dev/kord/core/beha
 	public fun delete (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun fetchGuildScheduledEvent (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun fetchGuildScheduledEventOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getCreator ()Ldev/kord/core/entity/User;
-	public final fun getCreatorId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getCreatorId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getData ()Ldev/kord/core/cache/data/GuildScheduledEventData;
 	public final fun getDescription ()Ljava/lang/String;
-	public final fun getEntityId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getEntityId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getEntityMetadata ()Ldev/kord/common/entity/GuildScheduledEventEntityMetadata;
 	public final fun getEntityType ()Ldev/kord/common/entity/ScheduledEntityType;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public fun getGuildId-4_xYDEk ()J
 	public final fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public final fun getImageHash ()Ljava/lang/String;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getMembers ()Lkotlinx/coroutines/flow/Flow;
-	public fun getMembersAfter (Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public fun getMembersBefore (Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getMembersAfter-wYKCHeA (JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getMembersBefore-wYKCHeA (JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getPrivacyLevel ()Ldev/kord/common/entity/GuildScheduledEventPrivacyLevel;
 	public final fun getScheduledEndTime ()Lkotlinx/datetime/Instant;
@@ -6360,8 +6365,8 @@ public final class dev/kord/core/entity/GuildScheduledEvent : dev/kord/core/beha
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
 	public final fun getUserCount ()Ljava/lang/Integer;
 	public fun getUsers ()Lkotlinx/coroutines/flow/Flow;
-	public fun getUsersAfter (Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public fun getUsersBefore (Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getUsersAfter-wYKCHeA (JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getUsersBefore-wYKCHeA (JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
 	public fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/entity/Strategizable;
 }
 
@@ -6373,22 +6378,22 @@ public final class dev/kord/core/entity/GuildSticker : dev/kord/core/entity/Stic
 	public fun delete (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun fetchSticker (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun fetchStickerOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public fun getGuildId-4_xYDEk ()J
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
 	public fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/entity/Strategizable;
 }
 
 public final class dev/kord/core/entity/GuildWidget : dev/kord/core/KordObject, dev/kord/core/entity/Strategizable {
-	public fun <init> (Ldev/kord/core/cache/data/GuildWidgetData;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)V
-	public synthetic fun <init> (Ldev/kord/core/cache/data/GuildWidgetData;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ldev/kord/core/cache/data/GuildWidgetData;JLdev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ldev/kord/core/cache/data/GuildWidgetData;JLdev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun edit (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getChannel ()Ldev/kord/core/behavior/channel/ChannelBehavior;
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getData ()Ldev/kord/core/cache/data/GuildWidgetData;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public final fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
@@ -6416,19 +6421,19 @@ public final class dev/kord/core/entity/Icon$DefaultUserAvatar : dev/kord/core/e
 }
 
 public final class dev/kord/core/entity/Icon$EmojiIcon : dev/kord/core/entity/Icon {
-	public fun <init> (ZLdev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;)V
+	public synthetic fun <init> (ZJLdev/kord/core/Kord;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class dev/kord/core/entity/Icon$MemberAvatar : dev/kord/core/entity/Icon {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/core/Kord;)V
+	public synthetic fun <init> (JJLjava/lang/String;Ldev/kord/core/Kord;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class dev/kord/core/entity/Icon$RoleIcon : dev/kord/core/entity/Icon {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/core/Kord;)V
+	public synthetic fun <init> (JLjava/lang/String;Ldev/kord/core/Kord;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class dev/kord/core/entity/Icon$UserAvatar : dev/kord/core/entity/Icon {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/core/Kord;)V
+	public synthetic fun <init> (JLjava/lang/String;Ldev/kord/core/Kord;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class dev/kord/core/entity/Integration : dev/kord/core/entity/KordEntity, dev/kord/core/entity/Strategizable {
@@ -6445,20 +6450,20 @@ public final class dev/kord/core/entity/Integration : dev/kord/core/entity/KordE
 	public final fun getExpireGracePeriod-UwyO8pc ()J
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public final fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getRole ()Ldev/kord/core/behavior/RoleBehavior;
 	public final fun getRole (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getRoleId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getRoleId-4_xYDEk ()J
 	public final fun getRoleOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
 	public final fun getSyncedAt ()Lkotlinx/datetime/Instant;
 	public final fun getType ()Ljava/lang/String;
 	public final fun getUser ()Ldev/kord/core/behavior/UserBehavior;
-	public final fun getUserId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getUserId-4_xYDEk ()J
 	public fun hashCode ()I
 	public final fun isEnabled ()Z
 	public final fun isSyncing ()Z
@@ -6480,14 +6485,14 @@ public class dev/kord/core/entity/Invite : dev/kord/core/KordObject, dev/kord/co
 	public final fun getApproximateMemberCount ()Ljava/lang/Integer;
 	public final fun getApproximatePresenceCount ()Ljava/lang/Integer;
 	public final fun getChannel ()Ldev/kord/core/behavior/channel/ChannelBehavior;
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getCode ()Ljava/lang/String;
 	public fun getData ()Ldev/kord/core/cache/data/BaseInviteData;
 	public final fun getExpiresAt ()Lkotlinx/datetime/Instant;
 	public final fun getGuildScheduledEvent ()Ldev/kord/core/entity/GuildScheduledEvent;
 	public final fun getInviter ()Ldev/kord/core/behavior/UserBehavior;
-	public final fun getInviterId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getInviterId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getInviterOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getKord ()Ldev/kord/core/Kord;
 	public final fun getPartialGuild ()Ldev/kord/core/entity/PartialGuild;
@@ -6495,7 +6500,7 @@ public class dev/kord/core/entity/Invite : dev/kord/core/KordObject, dev/kord/co
 	public final fun getTargetApplication ()Ldev/kord/core/entity/PartialApplication;
 	public final fun getTargetType ()Ldev/kord/common/entity/InviteTargetType;
 	public final fun getTargetUser ()Ldev/kord/core/behavior/UserBehavior;
-	public final fun getTargetUserId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getTargetUserId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getTargetUserOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final synthetic fun getTargetUserType ()Ldev/kord/common/entity/TargetUserType;
 	public fun toString ()Ljava/lang/String;
@@ -6529,11 +6534,11 @@ public final class dev/kord/core/entity/KordEntity$DefaultImpls {
 public final class dev/kord/core/entity/Member : dev/kord/core/entity/User, dev/kord/core/behavior/MemberBehavior {
 	public fun <init> (Ldev/kord/core/cache/data/MemberData;Ldev/kord/core/cache/data/UserData;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)V
 	public synthetic fun <init> (Ldev/kord/core/cache/data/MemberData;Ldev/kord/core/cache/data/UserData;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun addRole (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun asMember (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun addRole-9y3P_48 (JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun asMember (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun asMemberOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun asMember-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun asMemberOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun asMemberOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun asUser (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun asUserOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun equals (Ljava/lang/Object;)Z
@@ -6543,7 +6548,7 @@ public final class dev/kord/core/entity/Member : dev/kord/core/entity/User, dev/
 	public final fun getDisplayName ()Ljava/lang/String;
 	public fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public fun getGuildId-4_xYDEk ()J
 	public fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getJoinedAt ()Lkotlinx/datetime/Instant;
 	public final fun getMemberAvatar ()Ldev/kord/core/entity/Icon;
@@ -6563,7 +6568,7 @@ public final class dev/kord/core/entity/Member : dev/kord/core/entity/User, dev/
 	public final fun isOwner (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun isPending ()Z
 	public fun kick (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun removeRole (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun removeRole-9y3P_48 (JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun toString ()Ljava/lang/String;
 	public synthetic fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/MemberBehavior;
 	public synthetic fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/UserBehavior;
@@ -6581,23 +6586,23 @@ public final class dev/kord/core/entity/Message : dev/kord/core/behavior/Message
 	public fun asMessageOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun compareTo (Ldev/kord/core/entity/Entity;)I
 	public synthetic fun compareTo (Ljava/lang/Object;)I
-	public fun delete (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun delete (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun delete-nKCQcT8 (JLjava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun deleteAllReactions (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun deleteOwnReaction (Ldev/kord/core/entity/ReactionEmoji;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun deleteReaction (Ldev/kord/common/entity/Snowflake;Ldev/kord/core/entity/ReactionEmoji;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun deleteReaction (Ldev/kord/core/entity/ReactionEmoji;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun deleteReaction-9y3P_48 (JLdev/kord/core/entity/ReactionEmoji;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun fetchMessage (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun fetchMessageOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getActionRows ()Ljava/util/List;
-	public final fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getApplicationId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getAttachments ()Ljava/util/Set;
 	public final fun getAuthor ()Ldev/kord/core/entity/User;
 	public final fun getAuthorAsMember (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getChannel ()Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public fun getChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public fun getChannelId-4_xYDEk ()J
 	public fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final synthetic fun getComponents ()Ljava/util/List;
 	public final fun getContent ()Ljava/lang/String;
@@ -6607,7 +6612,7 @@ public final class dev/kord/core/entity/Message : dev/kord/core/behavior/Message
 	public final fun getFlags ()Ldev/kord/common/entity/MessageFlags;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public final fun getInteraction ()Ldev/kord/core/entity/Message$Interaction;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getMentionedChannelBehaviors ()Ljava/util/Set;
@@ -6628,7 +6633,7 @@ public final class dev/kord/core/entity/Message : dev/kord/core/behavior/Message
 	public final fun getTimestamp ()Lkotlinx/datetime/Instant;
 	public final fun getTts ()Z
 	public final fun getType ()Ldev/kord/common/entity/MessageType;
-	public final fun getWebhookId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getWebhookId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public fun hashCode ()I
 	public final fun isPinned ()Z
 	public fun pin (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -6646,7 +6651,7 @@ public final class dev/kord/core/entity/Message$Interaction : dev/kord/core/enti
 	public fun compareTo (Ldev/kord/core/entity/Entity;)I
 	public synthetic fun compareTo (Ljava/lang/Object;)I
 	public final fun getData ()Ldev/kord/core/cache/data/MessageInteractionData;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getName ()Ljava/lang/String;
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
@@ -6695,20 +6700,20 @@ public final class dev/kord/core/entity/PartialGuild : dev/kord/core/behavior/Gu
 	public fun fetchGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun fetchGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getActiveThreads ()Lkotlinx/coroutines/flow/Flow;
-	public fun getApplicationCommand (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getApplicationCommandOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getApplicationCommand-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getApplicationCommandOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getApplicationCommands (Ljava/lang/Boolean;)Lkotlinx/coroutines/flow/Flow;
-	public fun getAutoModerationRule (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getAutoModerationRuleOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getAutoModerationRule-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getAutoModerationRuleOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getAutoModerationRules ()Lkotlinx/coroutines/flow/Flow;
-	public fun getBan (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getBanOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getBan-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getBanOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getBanner (Ldev/kord/rest/Image$Format;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getBannerUrl (Ldev/kord/rest/Image$Format;)Ljava/lang/String;
 	public fun getBans ()Lkotlinx/coroutines/flow/Flow;
 	public fun getCachedThreads ()Lkotlinx/coroutines/flow/Flow;
-	public fun getChannel (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getChannelOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getChannel-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getChannelOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getChannels ()Lkotlinx/coroutines/flow/Flow;
 	public synthetic fun getCommands ()Lkotlinx/coroutines/flow/Flow;
 	public final fun getData ()Ldev/kord/core/cache/data/PartialGuildData;
@@ -6719,19 +6724,19 @@ public final class dev/kord/core/entity/PartialGuild : dev/kord/core/behavior/Gu
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildScheduledEvent (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildScheduledEventOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGuildScheduledEvent-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGuildScheduledEventOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getIcon (Ldev/kord/rest/Image$Format;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getIconHash ()Ljava/lang/String;
 	public final fun getIconUrl (Ldev/kord/rest/Image$Format;)Ljava/lang/String;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public fun getIntegrations ()Lkotlinx/coroutines/flow/Flow;
-	public fun getInvite (Ljava/lang/String;ZZLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getInviteOrNull (Ljava/lang/String;ZZLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getInvite-ReOCJwE (Ljava/lang/String;ZZLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getInviteOrNull-ReOCJwE (Ljava/lang/String;ZZLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getInvites ()Lkotlinx/coroutines/flow/Flow;
 	public fun getKord ()Ldev/kord/core/Kord;
-	public fun getMember (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getMemberOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getMember-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getMemberOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getMembers ()Lkotlinx/coroutines/flow/Flow;
 	public fun getMembers (Ljava/lang/String;I)Lkotlinx/coroutines/flow/Flow;
 	public final fun getName ()Ljava/lang/String;
@@ -6743,13 +6748,13 @@ public final class dev/kord/core/entity/PartialGuild : dev/kord/core/behavior/Gu
 	public fun getPreviewOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getPruneCount (ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getRegions ()Lkotlinx/coroutines/flow/Flow;
-	public fun getRole (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getRoleOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getRole-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getRoleOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getRoles ()Lkotlinx/coroutines/flow/Flow;
 	public fun getScheduledEvents ()Lkotlinx/coroutines/flow/Flow;
 	public final fun getSplashHash ()Ljava/lang/String;
-	public fun getSticker (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getStickerOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getSticker-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getStickerOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getStickers ()Lkotlinx/coroutines/flow/Flow;
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
 	public fun getTemplate (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -6767,12 +6772,12 @@ public final class dev/kord/core/entity/PartialGuild : dev/kord/core/behavior/Gu
 	public fun getWidget (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getWidgetOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun hashCode ()I
-	public fun kick (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun kick-9y3P_48 (JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun leave (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun prune (ILjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun requestMembers (Ldev/kord/gateway/RequestGuildMembers;)Lkotlinx/coroutines/flow/Flow;
 	public fun toString ()Ljava/lang/String;
-	public fun unban (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun unban-9y3P_48 (JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public synthetic fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/GuildBehavior;
 	public fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/entity/PartialGuild;
 	public synthetic fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/entity/Strategizable;
@@ -6785,33 +6790,33 @@ public class dev/kord/core/entity/PermissionOverwrite {
 	public final fun getAllowed ()Ldev/kord/common/entity/Permissions;
 	public final fun getData ()Ldev/kord/core/cache/data/PermissionOverwriteData;
 	public final fun getDenied ()Ldev/kord/common/entity/Permissions;
-	public final fun getTarget ()Ldev/kord/common/entity/Snowflake;
+	public final fun getTarget-4_xYDEk ()J
 	public final fun getType ()Ldev/kord/common/entity/OverwriteType;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class dev/kord/core/entity/PermissionOverwrite$Companion {
-	public final fun forEveryone (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Permissions;Ldev/kord/common/entity/Permissions;)Ldev/kord/core/entity/PermissionOverwrite;
-	public static synthetic fun forEveryone$default (Ldev/kord/core/entity/PermissionOverwrite$Companion;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Permissions;Ldev/kord/common/entity/Permissions;ILjava/lang/Object;)Ldev/kord/core/entity/PermissionOverwrite;
-	public final fun forMember (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Permissions;Ldev/kord/common/entity/Permissions;)Ldev/kord/core/entity/PermissionOverwrite;
-	public static synthetic fun forMember$default (Ldev/kord/core/entity/PermissionOverwrite$Companion;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Permissions;Ldev/kord/common/entity/Permissions;ILjava/lang/Object;)Ldev/kord/core/entity/PermissionOverwrite;
-	public final fun forRole (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Permissions;Ldev/kord/common/entity/Permissions;)Ldev/kord/core/entity/PermissionOverwrite;
-	public static synthetic fun forRole$default (Ldev/kord/core/entity/PermissionOverwrite$Companion;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Permissions;Ldev/kord/common/entity/Permissions;ILjava/lang/Object;)Ldev/kord/core/entity/PermissionOverwrite;
+	public final fun forEveryone-9y3P_48 (JLdev/kord/common/entity/Permissions;Ldev/kord/common/entity/Permissions;)Ldev/kord/core/entity/PermissionOverwrite;
+	public static synthetic fun forEveryone-9y3P_48$default (Ldev/kord/core/entity/PermissionOverwrite$Companion;JLdev/kord/common/entity/Permissions;Ldev/kord/common/entity/Permissions;ILjava/lang/Object;)Ldev/kord/core/entity/PermissionOverwrite;
+	public final fun forMember-9y3P_48 (JLdev/kord/common/entity/Permissions;Ldev/kord/common/entity/Permissions;)Ldev/kord/core/entity/PermissionOverwrite;
+	public static synthetic fun forMember-9y3P_48$default (Ldev/kord/core/entity/PermissionOverwrite$Companion;JLdev/kord/common/entity/Permissions;Ldev/kord/common/entity/Permissions;ILjava/lang/Object;)Ldev/kord/core/entity/PermissionOverwrite;
+	public final fun forRole-9y3P_48 (JLdev/kord/common/entity/Permissions;Ldev/kord/common/entity/Permissions;)Ldev/kord/core/entity/PermissionOverwrite;
+	public static synthetic fun forRole-9y3P_48$default (Ldev/kord/core/entity/PermissionOverwrite$Companion;JLdev/kord/common/entity/Permissions;Ldev/kord/common/entity/Permissions;ILjava/lang/Object;)Ldev/kord/core/entity/PermissionOverwrite;
 }
 
 public final class dev/kord/core/entity/PermissionOverwriteEntity : dev/kord/core/entity/PermissionOverwrite, dev/kord/core/KordObject, dev/kord/core/entity/Strategizable {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/cache/data/PermissionOverwriteData;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/cache/data/PermissionOverwriteData;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLdev/kord/core/cache/data/PermissionOverwriteData;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLdev/kord/core/cache/data/PermissionOverwriteData;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun delete (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun delete$default (Ldev/kord/core/entity/PermissionOverwriteEntity;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun getChannel ()Ldev/kord/core/behavior/channel/TopGuildChannelBehavior;
 	public final fun getChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-4_xYDEk ()J
 	public final fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public final fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
@@ -6826,12 +6831,12 @@ public final class dev/kord/core/entity/Presence : dev/kord/core/KordObject, dev
 	public final fun getActivities ()Ljava/util/List;
 	public final fun getClientStatus ()Ldev/kord/core/entity/ClientStatus;
 	public final fun getData ()Ldev/kord/core/cache/data/PresenceData;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getStatus ()Ldev/kord/common/entity/PresenceStatus;
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
 	public final fun getUser (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getUserId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getUserId-4_xYDEk ()J
 	public final fun getUserOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun toString ()Ljava/lang/String;
 	public fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/entity/Presence;
@@ -6843,7 +6848,7 @@ public final class dev/kord/core/entity/Reaction : dev/kord/core/KordObject {
 	public final fun getCount ()I
 	public final fun getData ()Ldev/kord/core/cache/data/ReactionData;
 	public final fun getEmoji ()Ldev/kord/core/entity/ReactionEmoji;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getSelfReacted ()Z
 	public final fun isAnimated ()Z
@@ -6863,14 +6868,14 @@ public final class dev/kord/core/entity/ReactionEmoji$Companion {
 }
 
 public final class dev/kord/core/entity/ReactionEmoji$Custom : dev/kord/core/entity/ReactionEmoji {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Z)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (JLjava/lang/String;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Z
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Z)Ldev/kord/core/entity/ReactionEmoji$Custom;
-	public static synthetic fun copy$default (Ldev/kord/core/entity/ReactionEmoji$Custom;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;ZILjava/lang/Object;)Ldev/kord/core/entity/ReactionEmoji$Custom;
+	public final fun copy-9y3P_48 (JLjava/lang/String;Z)Ldev/kord/core/entity/ReactionEmoji$Custom;
+	public static synthetic fun copy-9y3P_48$default (Ldev/kord/core/entity/ReactionEmoji$Custom;JLjava/lang/String;ZILjava/lang/Object;)Ldev/kord/core/entity/ReactionEmoji$Custom;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public fun getMention ()Ljava/lang/String;
 	public fun getName ()Ljava/lang/String;
 	public fun getUrlFormat ()Ljava/lang/String;
@@ -6926,10 +6931,10 @@ public final class dev/kord/core/entity/Role : dev/kord/core/behavior/RoleBehavi
 	public final fun getColor ()Ldev/kord/common/Color;
 	public final fun getData ()Ldev/kord/core/cache/data/RoleData;
 	public fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
-	public fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public fun getGuildId-4_xYDEk ()J
 	public final fun getHoisted ()Z
 	public final fun getIcon ()Ldev/kord/core/entity/Icon;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getManaged ()Z
 	public fun getMention ()Ljava/lang/String;
@@ -6949,17 +6954,17 @@ public final class dev/kord/core/entity/Role : dev/kord/core/behavior/RoleBehavi
 }
 
 public final class dev/kord/core/entity/RoleTags : dev/kord/core/KordObject, dev/kord/core/entity/Strategizable {
-	public fun <init> (Ldev/kord/core/cache/data/RoleTagsData;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)V
-	public synthetic fun <init> (Ldev/kord/core/cache/data/RoleTagsData;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ldev/kord/core/cache/data/RoleTagsData;JLdev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ldev/kord/core/cache/data/RoleTagsData;JLdev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getBot (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getBotId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getBotId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getData ()Ldev/kord/core/cache/data/RoleTagsData;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public final fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getIntegration (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getIntegrationId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getIntegrationId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
 	public final fun isPremiumRole ()Z
@@ -6976,11 +6981,11 @@ public final class dev/kord/core/entity/StageInstance : dev/kord/core/behavior/S
 	public fun delete (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun fetchStageInstance (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun fetchStageInstanceOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public fun getChannelId-4_xYDEk ()J
 	public final fun getData ()Ldev/kord/core/cache/data/StageInstanceData;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
-	public final fun getGuildScheduledEventId ()Ldev/kord/common/entity/Snowflake;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
+	public final fun getGuildScheduledEventId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getPrivacyLevel ()Ldev/kord/common/entity/StageInstancePrivacyLevel;
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
@@ -6999,10 +7004,10 @@ public class dev/kord/core/entity/Sticker : dev/kord/core/entity/KordEntity {
 	public final fun getData ()Ldev/kord/core/cache/data/StickerData;
 	public final fun getDescription ()Ljava/lang/String;
 	public final fun getFormatType ()Ldev/kord/common/entity/MessageStickerType;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getName ()Ljava/lang/String;
-	public final fun getPackId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getPackId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getSortValue ()Ljava/lang/Integer;
 	public final fun getTags ()Ljava/util/List;
 	public final fun getUser ()Ldev/kord/core/entity/User;
@@ -7015,7 +7020,7 @@ public final class dev/kord/core/entity/StickerItem : dev/kord/core/entity/KordE
 	public synthetic fun compareTo (Ljava/lang/Object;)I
 	public final fun getData ()Ldev/kord/core/cache/data/StickerItemData;
 	public final fun getFormatType ()Ldev/kord/common/entity/MessageStickerType;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getSticker (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -7028,13 +7033,13 @@ public final class dev/kord/core/entity/StickerPack : dev/kord/core/entity/KordE
 	public fun <init> (Ldev/kord/core/cache/data/StickerPackData;Ldev/kord/core/Kord;)V
 	public fun compareTo (Ldev/kord/core/entity/Entity;)I
 	public synthetic fun compareTo (Ljava/lang/Object;)I
-	public final fun getCoverStickerId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getCoverStickerId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getData ()Ldev/kord/core/cache/data/StickerPackData;
 	public final fun getDescription ()Ljava/lang/String;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getName ()Ljava/lang/String;
-	public final fun getSkuId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getSkuId-4_xYDEk ()J
 	public final fun getStickers ()Ljava/util/List;
 }
 
@@ -7050,10 +7055,10 @@ public final class dev/kord/core/entity/Team : dev/kord/core/entity/KordEntity, 
 	public synthetic fun compareTo (Ljava/lang/Object;)I
 	public final fun getData ()Ldev/kord/core/cache/data/TeamData;
 	public final fun getIcon ()Ljava/lang/String;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getMembers ()Ljava/util/List;
-	public final fun getOwnerUserId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getOwnerUserId-4_xYDEk ()J
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
 	public final fun getUser (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getUserOrNUll (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -7068,9 +7073,9 @@ public final class dev/kord/core/entity/TeamMember {
 	public final fun getKord ()Ldev/kord/core/Kord;
 	public final fun getMembershipState ()Ldev/kord/common/entity/TeamMembershipState;
 	public final fun getPermissions ()Ljava/util/List;
-	public final fun getTeamId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getTeamId-4_xYDEk ()J
 	public final fun getUser (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getUserId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getUserId-4_xYDEk ()J
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -7080,11 +7085,11 @@ public final class dev/kord/core/entity/Template : dev/kord/core/KordObject, dev
 	public fun getCode ()Ljava/lang/String;
 	public final fun getCreatedAt ()Lkotlinx/datetime/Instant;
 	public final fun getCreator ()Ldev/kord/core/entity/User;
-	public final fun getCreatorId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getCreatorId-4_xYDEk ()J
 	public final fun getData ()Ldev/kord/core/cache/data/TemplateData;
 	public final fun getDescription ()Ljava/lang/String;
 	public final fun getDirty ()Ljava/lang/Boolean;
-	public fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public fun getGuildId-4_xYDEk ()J
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getPartialGuild ()Ldev/kord/core/entity/PartialGuild;
@@ -7096,15 +7101,15 @@ public final class dev/kord/core/entity/Template : dev/kord/core/KordObject, dev
 public class dev/kord/core/entity/User : dev/kord/core/behavior/UserBehavior {
 	public fun <init> (Ldev/kord/core/cache/data/UserData;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)V
 	public synthetic fun <init> (Ldev/kord/core/cache/data/UserData;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun asMember (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun asMemberOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun asMember-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun asMemberOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun asUser (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun asUserOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun compareTo (Ldev/kord/core/entity/Entity;)I
 	public synthetic fun compareTo (Ljava/lang/Object;)I
 	public fun equals (Ljava/lang/Object;)Z
-	public fun fetchMember (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun fetchMemberOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun fetchMember-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun fetchMemberOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun fetchUser (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun fetchUserOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getAccentColor ()Ldev/kord/common/Color;
@@ -7115,7 +7120,7 @@ public class dev/kord/core/entity/User : dev/kord/core/behavior/UserBehavior {
 	public final fun getDiscriminator ()Ljava/lang/String;
 	public fun getDmChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getDmChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getMention ()Ljava/lang/String;
 	public final fun getPublicFlags ()Ldev/kord/common/entity/UserFlags;
@@ -7159,11 +7164,11 @@ public final class dev/kord/core/entity/User$Avatar : dev/kord/core/KordObject {
 public final class dev/kord/core/entity/VoiceState : dev/kord/core/KordObject, dev/kord/core/entity/Strategizable {
 	public fun <init> (Ldev/kord/core/cache/data/VoiceStateData;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)V
 	public synthetic fun <init> (Ldev/kord/core/cache/data/VoiceStateData;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getData ()Ldev/kord/core/cache/data/VoiceStateData;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public final fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getMember (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -7171,7 +7176,7 @@ public final class dev/kord/core/entity/VoiceState : dev/kord/core/KordObject, d
 	public final fun getRequestToSpeakTimestamp ()Lkotlinx/datetime/Instant;
 	public final fun getSessionId ()Ljava/lang/String;
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
-	public final fun getUserId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getUserId-4_xYDEk ()J
 	public final fun isDeafened ()Z
 	public final fun isMuted ()Z
 	public final fun isSelfDeafened ()Z
@@ -7196,21 +7201,21 @@ public final class dev/kord/core/entity/Webhook : dev/kord/core/behavior/Webhook
 	public static synthetic fun copy$default (Ldev/kord/core/entity/Webhook;Ldev/kord/core/cache/data/WebhookData;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;ILjava/lang/Object;)Ldev/kord/core/entity/Webhook;
 	public fun delete (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun delete (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun deleteMessage (Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun deleteMessage-x6thYdA (Ljava/lang/String;JLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getChannel ()Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public final fun getChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-4_xYDEk ()J
 	public final fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getCreatorId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getCreatorId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getData ()Ldev/kord/core/cache/data/WebhookData;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public fun getKord ()Ldev/kord/core/Kord;
-	public fun getMessage (Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getMessageOrNull (Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getMessage-x6thYdA (Ljava/lang/String;JLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getMessageOrNull-x6thYdA (Ljava/lang/String;JLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getName ()Ljava/lang/String;
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
 	public final fun getToken ()Ljava/lang/String;
@@ -7231,27 +7236,27 @@ public final class dev/kord/core/entity/WelcomeScreen : dev/kord/core/KordObject
 }
 
 public abstract interface class dev/kord/core/entity/application/ApplicationCommand : dev/kord/core/behavior/ApplicationCommandBehavior {
-	public abstract fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getApplicationId-4_xYDEk ()J
 	public abstract fun getData ()Ldev/kord/core/cache/data/ApplicationCommandData;
 	public abstract fun getDefaultMemberPermissions ()Ldev/kord/common/entity/Permissions;
 	public abstract fun getDefaultPermission ()Ljava/lang/Boolean;
-	public abstract fun getId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getId-4_xYDEk ()J
 	public abstract fun getName ()Ljava/lang/String;
 	public abstract fun getNameLocalizations ()Ljava/util/Map;
 	public abstract fun getType ()Ldev/kord/common/entity/ApplicationCommandType;
-	public abstract fun getVersion ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getVersion-4_xYDEk ()J
 }
 
 public final class dev/kord/core/entity/application/ApplicationCommand$DefaultImpls {
 	public static fun compareTo (Ldev/kord/core/entity/application/ApplicationCommand;Ldev/kord/core/entity/Entity;)I
-	public static fun getApplicationId (Ldev/kord/core/entity/application/ApplicationCommand;)Ldev/kord/common/entity/Snowflake;
+	public static fun getApplicationId-4_xYDEk (Ldev/kord/core/entity/application/ApplicationCommand;)J
 	public static fun getDefaultMemberPermissions (Ldev/kord/core/entity/application/ApplicationCommand;)Ldev/kord/common/entity/Permissions;
 	public static fun getDefaultPermission (Ldev/kord/core/entity/application/ApplicationCommand;)Ljava/lang/Boolean;
-	public static fun getId (Ldev/kord/core/entity/application/ApplicationCommand;)Ldev/kord/common/entity/Snowflake;
+	public static fun getId-4_xYDEk (Ldev/kord/core/entity/application/ApplicationCommand;)J
 	public static fun getName (Ldev/kord/core/entity/application/ApplicationCommand;)Ljava/lang/String;
 	public static fun getNameLocalizations (Ldev/kord/core/entity/application/ApplicationCommand;)Ljava/util/Map;
 	public static fun getType (Ldev/kord/core/entity/application/ApplicationCommand;)Ldev/kord/common/entity/ApplicationCommandType;
-	public static fun getVersion (Ldev/kord/core/entity/application/ApplicationCommand;)Ldev/kord/common/entity/Snowflake;
+	public static fun getVersion-4_xYDEk (Ldev/kord/core/entity/application/ApplicationCommand;)J
 }
 
 public final class dev/kord/core/entity/application/ApplicationCommandKt {
@@ -7271,10 +7276,10 @@ public final class dev/kord/core/entity/application/ApplicationCommandParameter 
 
 public final class dev/kord/core/entity/application/ApplicationCommandPermissions {
 	public fun <init> (Ldev/kord/core/cache/data/GuildApplicationCommandPermissionsData;)V
-	public final fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getApplicationId-4_xYDEk ()J
 	public final fun getData ()Ldev/kord/core/cache/data/GuildApplicationCommandPermissionsData;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
+	public final fun getId-4_xYDEk ()J
 	public final fun getPermissions ()Lkotlinx/coroutines/flow/Flow;
 }
 
@@ -7287,18 +7292,18 @@ public abstract interface class dev/kord/core/entity/application/ChatInputComman
 
 public final class dev/kord/core/entity/application/ChatInputCommandCommand$DefaultImpls {
 	public static fun compareTo (Ldev/kord/core/entity/application/ChatInputCommandCommand;Ldev/kord/core/entity/Entity;)I
-	public static fun getApplicationId (Ldev/kord/core/entity/application/ChatInputCommandCommand;)Ldev/kord/common/entity/Snowflake;
+	public static fun getApplicationId-4_xYDEk (Ldev/kord/core/entity/application/ChatInputCommandCommand;)J
 	public static fun getDefaultMemberPermissions (Ldev/kord/core/entity/application/ChatInputCommandCommand;)Ldev/kord/common/entity/Permissions;
 	public static fun getDefaultPermission (Ldev/kord/core/entity/application/ChatInputCommandCommand;)Ljava/lang/Boolean;
 	public static fun getDescription (Ldev/kord/core/entity/application/ChatInputCommandCommand;)Ljava/lang/String;
 	public static fun getDescriptionLocalizations (Ldev/kord/core/entity/application/ChatInputCommandCommand;)Ljava/util/Map;
 	public static fun getGroups (Ldev/kord/core/entity/application/ChatInputCommandCommand;)Ljava/util/Map;
-	public static fun getId (Ldev/kord/core/entity/application/ChatInputCommandCommand;)Ldev/kord/common/entity/Snowflake;
+	public static fun getId-4_xYDEk (Ldev/kord/core/entity/application/ChatInputCommandCommand;)J
 	public static fun getName (Ldev/kord/core/entity/application/ChatInputCommandCommand;)Ljava/lang/String;
 	public static fun getNameLocalizations (Ldev/kord/core/entity/application/ChatInputCommandCommand;)Ljava/util/Map;
 	public static fun getSubCommands (Ldev/kord/core/entity/application/ChatInputCommandCommand;)Ljava/util/Map;
 	public static fun getType (Ldev/kord/core/entity/application/ChatInputCommandCommand;)Ldev/kord/common/entity/ApplicationCommandType;
-	public static fun getVersion (Ldev/kord/core/entity/application/ChatInputCommandCommand;)Ldev/kord/common/entity/Snowflake;
+	public static fun getVersion-4_xYDEk (Ldev/kord/core/entity/application/ChatInputCommandCommand;)J
 }
 
 public final class dev/kord/core/entity/application/ChatInputGroup {
@@ -7324,15 +7329,15 @@ public abstract interface class dev/kord/core/entity/application/GlobalApplicati
 public final class dev/kord/core/entity/application/GlobalApplicationCommand$DefaultImpls {
 	public static fun compareTo (Ldev/kord/core/entity/application/GlobalApplicationCommand;Ldev/kord/core/entity/Entity;)I
 	public static fun delete (Ldev/kord/core/entity/application/GlobalApplicationCommand;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getApplicationId (Ldev/kord/core/entity/application/GlobalApplicationCommand;)Ldev/kord/common/entity/Snowflake;
+	public static fun getApplicationId-4_xYDEk (Ldev/kord/core/entity/application/GlobalApplicationCommand;)J
 	public static fun getDefaultMemberPermissions (Ldev/kord/core/entity/application/GlobalApplicationCommand;)Ldev/kord/common/entity/Permissions;
 	public static fun getDefaultPermission (Ldev/kord/core/entity/application/GlobalApplicationCommand;)Ljava/lang/Boolean;
 	public static fun getDmPermission (Ldev/kord/core/entity/application/GlobalApplicationCommand;)Z
-	public static fun getId (Ldev/kord/core/entity/application/GlobalApplicationCommand;)Ldev/kord/common/entity/Snowflake;
+	public static fun getId-4_xYDEk (Ldev/kord/core/entity/application/GlobalApplicationCommand;)J
 	public static fun getName (Ldev/kord/core/entity/application/GlobalApplicationCommand;)Ljava/lang/String;
 	public static fun getNameLocalizations (Ldev/kord/core/entity/application/GlobalApplicationCommand;)Ljava/util/Map;
 	public static fun getType (Ldev/kord/core/entity/application/GlobalApplicationCommand;)Ldev/kord/common/entity/ApplicationCommandType;
-	public static fun getVersion (Ldev/kord/core/entity/application/GlobalApplicationCommand;)Ldev/kord/common/entity/Snowflake;
+	public static fun getVersion-4_xYDEk (Ldev/kord/core/entity/application/GlobalApplicationCommand;)J
 }
 
 public final class dev/kord/core/entity/application/GlobalChatInputCommand : dev/kord/core/behavior/GlobalChatInputCommandBehavior, dev/kord/core/entity/application/ChatInputCommandCommand, dev/kord/core/entity/application/GlobalApplicationCommand {
@@ -7341,7 +7346,7 @@ public final class dev/kord/core/entity/application/GlobalChatInputCommand : dev
 	public synthetic fun compareTo (Ljava/lang/Object;)I
 	public fun delete (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun edit (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
+	public fun getApplicationId-4_xYDEk ()J
 	public fun getData ()Ldev/kord/core/cache/data/ApplicationCommandData;
 	public fun getDefaultMemberPermissions ()Ldev/kord/common/entity/Permissions;
 	public fun getDefaultPermission ()Ljava/lang/Boolean;
@@ -7349,13 +7354,13 @@ public final class dev/kord/core/entity/application/GlobalChatInputCommand : dev
 	public fun getDescriptionLocalizations ()Ljava/util/Map;
 	public fun getDmPermission ()Z
 	public fun getGroups ()Ljava/util/Map;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public fun getName ()Ljava/lang/String;
 	public fun getNameLocalizations ()Ljava/util/Map;
 	public fun getService ()Ldev/kord/rest/service/InteractionService;
 	public fun getSubCommands ()Ljava/util/Map;
 	public fun getType ()Ldev/kord/common/entity/ApplicationCommandType;
-	public fun getVersion ()Ldev/kord/common/entity/Snowflake;
+	public fun getVersion-4_xYDEk ()J
 }
 
 public final class dev/kord/core/entity/application/GlobalMessageCommand : dev/kord/core/behavior/GlobalMessageCommandBehavior, dev/kord/core/entity/application/GlobalApplicationCommand, dev/kord/core/entity/application/MessageCommand {
@@ -7364,17 +7369,17 @@ public final class dev/kord/core/entity/application/GlobalMessageCommand : dev/k
 	public synthetic fun compareTo (Ljava/lang/Object;)I
 	public fun delete (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun edit (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
+	public fun getApplicationId-4_xYDEk ()J
 	public fun getData ()Ldev/kord/core/cache/data/ApplicationCommandData;
 	public fun getDefaultMemberPermissions ()Ldev/kord/common/entity/Permissions;
 	public fun getDefaultPermission ()Ljava/lang/Boolean;
 	public fun getDmPermission ()Z
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public fun getName ()Ljava/lang/String;
 	public fun getNameLocalizations ()Ljava/util/Map;
 	public fun getService ()Ldev/kord/rest/service/InteractionService;
 	public fun getType ()Ldev/kord/common/entity/ApplicationCommandType;
-	public fun getVersion ()Ldev/kord/common/entity/Snowflake;
+	public fun getVersion-4_xYDEk ()J
 }
 
 public final class dev/kord/core/entity/application/GlobalUserCommand : dev/kord/core/behavior/GlobalUserCommandBehavior, dev/kord/core/entity/application/GlobalApplicationCommand, dev/kord/core/entity/application/UserCommand {
@@ -7383,17 +7388,17 @@ public final class dev/kord/core/entity/application/GlobalUserCommand : dev/kord
 	public synthetic fun compareTo (Ljava/lang/Object;)I
 	public fun delete (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun edit (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
+	public fun getApplicationId-4_xYDEk ()J
 	public fun getData ()Ldev/kord/core/cache/data/ApplicationCommandData;
 	public fun getDefaultMemberPermissions ()Ldev/kord/common/entity/Permissions;
 	public fun getDefaultPermission ()Ljava/lang/Boolean;
 	public fun getDmPermission ()Z
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public fun getName ()Ljava/lang/String;
 	public fun getNameLocalizations ()Ljava/util/Map;
 	public fun getService ()Ldev/kord/rest/service/InteractionService;
 	public fun getType ()Ldev/kord/common/entity/ApplicationCommandType;
-	public fun getVersion ()Ldev/kord/common/entity/Snowflake;
+	public fun getVersion-4_xYDEk ()J
 }
 
 public abstract interface class dev/kord/core/entity/application/GuildApplicationCommand : dev/kord/core/behavior/GuildApplicationCommandBehavior, dev/kord/core/entity/application/ApplicationCommand {
@@ -7402,20 +7407,20 @@ public abstract interface class dev/kord/core/entity/application/GuildApplicatio
 public final class dev/kord/core/entity/application/GuildApplicationCommand$DefaultImpls {
 	public static fun compareTo (Ldev/kord/core/entity/application/GuildApplicationCommand;Ldev/kord/core/entity/Entity;)I
 	public static fun delete (Ldev/kord/core/entity/application/GuildApplicationCommand;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getApplicationId (Ldev/kord/core/entity/application/GuildApplicationCommand;)Ldev/kord/common/entity/Snowflake;
+	public static fun getApplicationId-4_xYDEk (Ldev/kord/core/entity/application/GuildApplicationCommand;)J
 	public static fun getDefaultMemberPermissions (Ldev/kord/core/entity/application/GuildApplicationCommand;)Ldev/kord/common/entity/Permissions;
 	public static fun getDefaultPermission (Ldev/kord/core/entity/application/GuildApplicationCommand;)Ljava/lang/Boolean;
-	public static fun getId (Ldev/kord/core/entity/application/GuildApplicationCommand;)Ldev/kord/common/entity/Snowflake;
+	public static fun getId-4_xYDEk (Ldev/kord/core/entity/application/GuildApplicationCommand;)J
 	public static fun getName (Ldev/kord/core/entity/application/GuildApplicationCommand;)Ljava/lang/String;
 	public static fun getNameLocalizations (Ldev/kord/core/entity/application/GuildApplicationCommand;)Ljava/util/Map;
 	public static fun getType (Ldev/kord/core/entity/application/GuildApplicationCommand;)Ldev/kord/common/entity/ApplicationCommandType;
-	public static fun getVersion (Ldev/kord/core/entity/application/GuildApplicationCommand;)Ldev/kord/common/entity/Snowflake;
+	public static fun getVersion-4_xYDEk (Ldev/kord/core/entity/application/GuildApplicationCommand;)J
 }
 
 public final class dev/kord/core/entity/application/GuildApplicationCommandPermission {
 	public fun <init> (Ldev/kord/core/cache/data/GuildApplicationCommandPermissionData;)V
 	public final fun getData ()Ldev/kord/core/cache/data/GuildApplicationCommandPermissionData;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getPermission ()Z
 	public final fun getType ()Ldev/kord/common/entity/ApplicationCommandPermissionType;
 	public final synthetic fun getType ()Ldev/kord/common/entity/DiscordGuildApplicationCommandPermission$Type;
@@ -7427,21 +7432,21 @@ public final class dev/kord/core/entity/application/GuildChatInputCommand : dev/
 	public synthetic fun compareTo (Ljava/lang/Object;)I
 	public fun delete (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun edit (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
+	public fun getApplicationId-4_xYDEk ()J
 	public fun getData ()Ldev/kord/core/cache/data/ApplicationCommandData;
 	public fun getDefaultMemberPermissions ()Ldev/kord/common/entity/Permissions;
 	public fun getDefaultPermission ()Ljava/lang/Boolean;
 	public fun getDescription ()Ljava/lang/String;
 	public fun getDescriptionLocalizations ()Ljava/util/Map;
 	public fun getGroups ()Ljava/util/Map;
-	public fun getGuildId ()Ldev/kord/common/entity/Snowflake;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getGuildId-4_xYDEk ()J
+	public fun getId-4_xYDEk ()J
 	public fun getName ()Ljava/lang/String;
 	public fun getNameLocalizations ()Ljava/util/Map;
 	public fun getService ()Ldev/kord/rest/service/InteractionService;
 	public fun getSubCommands ()Ljava/util/Map;
 	public fun getType ()Ldev/kord/common/entity/ApplicationCommandType;
-	public fun getVersion ()Ldev/kord/common/entity/Snowflake;
+	public fun getVersion-4_xYDEk ()J
 }
 
 public final class dev/kord/core/entity/application/GuildMessageCommand : dev/kord/core/behavior/GuildMessageCommandBehavior, dev/kord/core/entity/application/GuildApplicationCommand, dev/kord/core/entity/application/MessageCommand {
@@ -7450,17 +7455,17 @@ public final class dev/kord/core/entity/application/GuildMessageCommand : dev/ko
 	public synthetic fun compareTo (Ljava/lang/Object;)I
 	public fun delete (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun edit (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
+	public fun getApplicationId-4_xYDEk ()J
 	public fun getData ()Ldev/kord/core/cache/data/ApplicationCommandData;
 	public fun getDefaultMemberPermissions ()Ldev/kord/common/entity/Permissions;
 	public fun getDefaultPermission ()Ljava/lang/Boolean;
-	public fun getGuildId ()Ldev/kord/common/entity/Snowflake;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getGuildId-4_xYDEk ()J
+	public fun getId-4_xYDEk ()J
 	public fun getName ()Ljava/lang/String;
 	public fun getNameLocalizations ()Ljava/util/Map;
 	public fun getService ()Ldev/kord/rest/service/InteractionService;
 	public fun getType ()Ldev/kord/common/entity/ApplicationCommandType;
-	public fun getVersion ()Ldev/kord/common/entity/Snowflake;
+	public fun getVersion-4_xYDEk ()J
 }
 
 public final class dev/kord/core/entity/application/GuildUserCommand : dev/kord/core/behavior/GuildUserCommandBehavior, dev/kord/core/entity/application/GuildApplicationCommand, dev/kord/core/entity/application/UserCommand {
@@ -7469,17 +7474,17 @@ public final class dev/kord/core/entity/application/GuildUserCommand : dev/kord/
 	public synthetic fun compareTo (Ljava/lang/Object;)I
 	public fun delete (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun edit (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
+	public fun getApplicationId-4_xYDEk ()J
 	public fun getData ()Ldev/kord/core/cache/data/ApplicationCommandData;
 	public fun getDefaultMemberPermissions ()Ldev/kord/common/entity/Permissions;
 	public fun getDefaultPermission ()Ljava/lang/Boolean;
-	public fun getGuildId ()Ldev/kord/common/entity/Snowflake;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getGuildId-4_xYDEk ()J
+	public fun getId-4_xYDEk ()J
 	public fun getName ()Ljava/lang/String;
 	public fun getNameLocalizations ()Ljava/util/Map;
 	public fun getService ()Ldev/kord/rest/service/InteractionService;
 	public fun getType ()Ldev/kord/common/entity/ApplicationCommandType;
-	public fun getVersion ()Ldev/kord/common/entity/Snowflake;
+	public fun getVersion-4_xYDEk ()J
 }
 
 public abstract interface class dev/kord/core/entity/application/MessageCommand : dev/kord/core/behavior/MessageCommandBehavior, dev/kord/core/entity/application/ApplicationCommand {
@@ -7487,14 +7492,14 @@ public abstract interface class dev/kord/core/entity/application/MessageCommand 
 
 public final class dev/kord/core/entity/application/MessageCommand$DefaultImpls {
 	public static fun compareTo (Ldev/kord/core/entity/application/MessageCommand;Ldev/kord/core/entity/Entity;)I
-	public static fun getApplicationId (Ldev/kord/core/entity/application/MessageCommand;)Ldev/kord/common/entity/Snowflake;
+	public static fun getApplicationId-4_xYDEk (Ldev/kord/core/entity/application/MessageCommand;)J
 	public static fun getDefaultMemberPermissions (Ldev/kord/core/entity/application/MessageCommand;)Ldev/kord/common/entity/Permissions;
 	public static fun getDefaultPermission (Ldev/kord/core/entity/application/MessageCommand;)Ljava/lang/Boolean;
-	public static fun getId (Ldev/kord/core/entity/application/MessageCommand;)Ldev/kord/common/entity/Snowflake;
+	public static fun getId-4_xYDEk (Ldev/kord/core/entity/application/MessageCommand;)J
 	public static fun getName (Ldev/kord/core/entity/application/MessageCommand;)Ljava/lang/String;
 	public static fun getNameLocalizations (Ldev/kord/core/entity/application/MessageCommand;)Ljava/util/Map;
 	public static fun getType (Ldev/kord/core/entity/application/MessageCommand;)Ldev/kord/common/entity/ApplicationCommandType;
-	public static fun getVersion (Ldev/kord/core/entity/application/MessageCommand;)Ldev/kord/common/entity/Snowflake;
+	public static fun getVersion-4_xYDEk (Ldev/kord/core/entity/application/MessageCommand;)J
 }
 
 public final class dev/kord/core/entity/application/UnknownGlobalApplicationCommand : dev/kord/core/entity/application/GlobalApplicationCommand {
@@ -7502,17 +7507,17 @@ public final class dev/kord/core/entity/application/UnknownGlobalApplicationComm
 	public fun compareTo (Ldev/kord/core/entity/Entity;)I
 	public synthetic fun compareTo (Ljava/lang/Object;)I
 	public fun delete (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
+	public fun getApplicationId-4_xYDEk ()J
 	public fun getData ()Ldev/kord/core/cache/data/ApplicationCommandData;
 	public fun getDefaultMemberPermissions ()Ldev/kord/common/entity/Permissions;
 	public fun getDefaultPermission ()Ljava/lang/Boolean;
 	public fun getDmPermission ()Z
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public fun getName ()Ljava/lang/String;
 	public fun getNameLocalizations ()Ljava/util/Map;
 	public fun getService ()Ldev/kord/rest/service/InteractionService;
 	public fun getType ()Ldev/kord/common/entity/ApplicationCommandType;
-	public fun getVersion ()Ldev/kord/common/entity/Snowflake;
+	public fun getVersion-4_xYDEk ()J
 }
 
 public final class dev/kord/core/entity/application/UnknownGuildApplicationCommand : dev/kord/core/entity/application/GuildApplicationCommand {
@@ -7520,17 +7525,17 @@ public final class dev/kord/core/entity/application/UnknownGuildApplicationComma
 	public fun compareTo (Ldev/kord/core/entity/Entity;)I
 	public synthetic fun compareTo (Ljava/lang/Object;)I
 	public fun delete (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
+	public fun getApplicationId-4_xYDEk ()J
 	public fun getData ()Ldev/kord/core/cache/data/ApplicationCommandData;
 	public fun getDefaultMemberPermissions ()Ldev/kord/common/entity/Permissions;
 	public fun getDefaultPermission ()Ljava/lang/Boolean;
-	public fun getGuildId ()Ldev/kord/common/entity/Snowflake;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getGuildId-4_xYDEk ()J
+	public fun getId-4_xYDEk ()J
 	public fun getName ()Ljava/lang/String;
 	public fun getNameLocalizations ()Ljava/util/Map;
 	public fun getService ()Ldev/kord/rest/service/InteractionService;
 	public fun getType ()Ldev/kord/common/entity/ApplicationCommandType;
-	public fun getVersion ()Ldev/kord/common/entity/Snowflake;
+	public fun getVersion-4_xYDEk ()J
 }
 
 public abstract interface class dev/kord/core/entity/application/UserCommand : dev/kord/core/behavior/UserCommandBehavior, dev/kord/core/entity/application/ApplicationCommand {
@@ -7538,14 +7543,14 @@ public abstract interface class dev/kord/core/entity/application/UserCommand : d
 
 public final class dev/kord/core/entity/application/UserCommand$DefaultImpls {
 	public static fun compareTo (Ldev/kord/core/entity/application/UserCommand;Ldev/kord/core/entity/Entity;)I
-	public static fun getApplicationId (Ldev/kord/core/entity/application/UserCommand;)Ldev/kord/common/entity/Snowflake;
+	public static fun getApplicationId-4_xYDEk (Ldev/kord/core/entity/application/UserCommand;)J
 	public static fun getDefaultMemberPermissions (Ldev/kord/core/entity/application/UserCommand;)Ldev/kord/common/entity/Permissions;
 	public static fun getDefaultPermission (Ldev/kord/core/entity/application/UserCommand;)Ljava/lang/Boolean;
-	public static fun getId (Ldev/kord/core/entity/application/UserCommand;)Ldev/kord/common/entity/Snowflake;
+	public static fun getId-4_xYDEk (Ldev/kord/core/entity/application/UserCommand;)J
 	public static fun getName (Ldev/kord/core/entity/application/UserCommand;)Ljava/lang/String;
 	public static fun getNameLocalizations (Ldev/kord/core/entity/application/UserCommand;)Ljava/util/Map;
 	public static fun getType (Ldev/kord/core/entity/application/UserCommand;)Ldev/kord/common/entity/ApplicationCommandType;
-	public static fun getVersion (Ldev/kord/core/entity/application/UserCommand;)Ldev/kord/common/entity/Snowflake;
+	public static fun getVersion-4_xYDEk (Ldev/kord/core/entity/application/UserCommand;)J
 }
 
 public abstract class dev/kord/core/entity/automoderation/AutoModerationAction : dev/kord/core/KordObject {
@@ -7566,7 +7571,7 @@ public abstract class dev/kord/core/entity/automoderation/AutoModerationRule : d
 	public final fun equals (Ljava/lang/Object;)Z
 	public final fun getActions ()Ljava/util/List;
 	public final fun getCreator ()Ldev/kord/core/behavior/MemberBehavior;
-	public final fun getCreatorId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getCreatorId-4_xYDEk ()J
 	public final fun getData ()Ldev/kord/core/cache/data/AutoModerationRuleData;
 	public final fun getEventType ()Ldev/kord/common/entity/AutoModerationRuleEventType;
 	public final fun getExemptChannelIds ()Ljava/util/List;
@@ -7575,9 +7580,9 @@ public abstract class dev/kord/core/entity/automoderation/AutoModerationRule : d
 	public final fun getExemptRoles ()Ljava/util/List;
 	public fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getKord ()Ldev/kord/core/Kord;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
@@ -7650,7 +7655,7 @@ public final class dev/kord/core/entity/automoderation/MentionSpamAutoModeration
 
 public final class dev/kord/core/entity/automoderation/SendAlertMessageAutoModerationAction : dev/kord/core/entity/automoderation/AutoModerationAction {
 	public fun <init> (Ldev/kord/core/cache/data/AutoModerationActionData;Ldev/kord/core/Kord;)V
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-4_xYDEk ()J
 	public fun getType ()Ldev/kord/common/entity/AutoModerationActionType$SendAlertMessage;
 	public synthetic fun getType ()Ldev/kord/common/entity/AutoModerationActionType;
 	public fun toString ()Ljava/lang/String;
@@ -7702,7 +7707,7 @@ public final class dev/kord/core/entity/automoderation/UnknownAutoModerationRule
 
 public abstract interface class dev/kord/core/entity/channel/CategorizableChannel : dev/kord/core/behavior/channel/CategorizableChannelBehavior, dev/kord/core/entity/channel/TopGuildChannel {
 	public abstract fun getCategory ()Ldev/kord/core/behavior/channel/CategoryBehavior;
-	public abstract fun getCategoryId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getCategoryId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public abstract fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/entity/channel/CategorizableChannel;
 }
 
@@ -7715,19 +7720,19 @@ public final class dev/kord/core/entity/channel/CategorizableChannel$DefaultImpl
 	public static fun fetchChannel (Ldev/kord/core/entity/channel/CategorizableChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun fetchChannelOrNull (Ldev/kord/core/entity/channel/CategorizableChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getCategory (Ldev/kord/core/entity/channel/CategorizableChannel;)Ldev/kord/core/behavior/channel/CategoryBehavior;
-	public static fun getCategoryId (Ldev/kord/core/entity/channel/CategorizableChannel;)Ldev/kord/common/entity/Snowflake;
-	public static fun getEffectivePermissions (Ldev/kord/core/entity/channel/CategorizableChannel;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getCategoryId-eUG9VGM (Ldev/kord/core/entity/channel/CategorizableChannel;)Ldev/kord/common/entity/Snowflake;
+	public static fun getEffectivePermissions-wYKCHeA (Ldev/kord/core/entity/channel/CategorizableChannel;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getGuild (Ldev/kord/core/entity/channel/CategorizableChannel;)Ldev/kord/core/behavior/GuildBehavior;
 	public static fun getGuild (Ldev/kord/core/entity/channel/CategorizableChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getGuildId (Ldev/kord/core/entity/channel/CategorizableChannel;)Ldev/kord/common/entity/Snowflake;
+	public static fun getGuildId-4_xYDEk (Ldev/kord/core/entity/channel/CategorizableChannel;)J
 	public static fun getGuildOrNull (Ldev/kord/core/entity/channel/CategorizableChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getId (Ldev/kord/core/entity/channel/CategorizableChannel;)Ldev/kord/common/entity/Snowflake;
+	public static fun getId-4_xYDEk (Ldev/kord/core/entity/channel/CategorizableChannel;)J
 	public static fun getInvites (Ldev/kord/core/entity/channel/CategorizableChannel;)Lkotlinx/coroutines/flow/Flow;
 	public static fun getMention (Ldev/kord/core/entity/channel/CategorizableChannel;)Ljava/lang/String;
 	public static fun getName (Ldev/kord/core/entity/channel/CategorizableChannel;)Ljava/lang/String;
 	public static fun getPermissionOverwrites (Ldev/kord/core/entity/channel/CategorizableChannel;)Ljava/util/Set;
-	public static fun getPermissionOverwritesForMember (Ldev/kord/core/entity/channel/CategorizableChannel;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/entity/PermissionOverwriteEntity;
-	public static fun getPermissionOverwritesForRole (Ldev/kord/core/entity/channel/CategorizableChannel;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/entity/PermissionOverwriteEntity;
+	public static fun getPermissionOverwritesForMember-IO-hELI (Ldev/kord/core/entity/channel/CategorizableChannel;J)Ldev/kord/core/entity/PermissionOverwriteEntity;
+	public static fun getPermissionOverwritesForRole-IO-hELI (Ldev/kord/core/entity/channel/CategorizableChannel;J)Ldev/kord/core/entity/PermissionOverwriteEntity;
 	public static fun getPosition (Ldev/kord/core/entity/channel/CategorizableChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getRawPosition (Ldev/kord/core/entity/channel/CategorizableChannel;)I
 	public static fun getType (Ldev/kord/core/entity/channel/CategorizableChannel;)Ldev/kord/common/entity/ChannelType;
@@ -7747,18 +7752,18 @@ public final class dev/kord/core/entity/channel/Category : dev/kord/core/behavio
 	public fun fetchChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getChannels ()Lkotlinx/coroutines/flow/Flow;
 	public fun getData ()Ldev/kord/core/cache/data/ChannelData;
-	public fun getEffectivePermissions (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getEffectivePermissions-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public fun getGuildId-4_xYDEk ()J
 	public fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getMention ()Ljava/lang/String;
 	public fun getName ()Ljava/lang/String;
 	public fun getPermissionOverwrites ()Ljava/util/Set;
-	public fun getPermissionOverwritesForMember (Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/entity/PermissionOverwriteEntity;
-	public fun getPermissionOverwritesForRole (Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/entity/PermissionOverwriteEntity;
+	public fun getPermissionOverwritesForMember-IO-hELI (J)Ldev/kord/core/entity/PermissionOverwriteEntity;
+	public fun getPermissionOverwritesForRole-IO-hELI (J)Ldev/kord/core/entity/PermissionOverwriteEntity;
 	public fun getPosition (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getRawPosition ()I
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
@@ -7779,7 +7784,7 @@ public final class dev/kord/core/entity/channel/Category : dev/kord/core/behavio
 public abstract interface class dev/kord/core/entity/channel/Channel : dev/kord/core/behavior/channel/ChannelBehavior {
 	public static final field Companion Ldev/kord/core/entity/channel/Channel$Companion;
 	public abstract fun getData ()Ldev/kord/core/cache/data/ChannelData;
-	public abstract fun getId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getId-4_xYDEk ()J
 	public abstract fun getType ()Ldev/kord/common/entity/ChannelType;
 	public abstract fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/entity/channel/Channel;
 }
@@ -7796,7 +7801,7 @@ public final class dev/kord/core/entity/channel/Channel$DefaultImpls {
 	public static fun delete (Ldev/kord/core/entity/channel/Channel;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun fetchChannel (Ldev/kord/core/entity/channel/Channel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun fetchChannelOrNull (Ldev/kord/core/entity/channel/Channel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getId (Ldev/kord/core/entity/channel/Channel;)Ldev/kord/common/entity/Snowflake;
+	public static fun getId-4_xYDEk (Ldev/kord/core/entity/channel/Channel;)J
 	public static fun getMention (Ldev/kord/core/entity/channel/Channel;)Ljava/lang/String;
 	public static fun getType (Ldev/kord/core/entity/channel/Channel;)Ldev/kord/common/entity/ChannelType;
 	public static fun withStrategy (Ldev/kord/core/entity/channel/Channel;Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/entity/channel/Channel;
@@ -7816,24 +7821,24 @@ public final class dev/kord/core/entity/channel/DmChannel : dev/kord/core/entity
 	public static synthetic fun copy$default (Ldev/kord/core/entity/channel/DmChannel;Ldev/kord/core/cache/data/ChannelData;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;ILjava/lang/Object;)Ldev/kord/core/entity/channel/DmChannel;
 	public fun createMessage (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun delete (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun deleteMessage (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun deleteMessage-9y3P_48 (JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun fetchChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun fetchChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getData ()Ldev/kord/core/cache/data/ChannelData;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getLastMessage ()Ldev/kord/core/behavior/MessageBehavior;
 	public fun getLastMessage (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getLastMessageId ()Ldev/kord/common/entity/Snowflake;
+	public fun getLastMessageId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public fun getLastPinTimestamp ()Lkotlinx/datetime/Instant;
 	public fun getMention ()Ljava/lang/String;
-	public fun getMessage (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getMessageOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getMessage-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getMessageOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getMessages ()Lkotlinx/coroutines/flow/Flow;
-	public fun getMessagesAfter (Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public fun getMessagesAround (Ldev/kord/common/entity/Snowflake;I)Lkotlinx/coroutines/flow/Flow;
-	public fun getMessagesBefore (Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getMessagesAfter-wYKCHeA (JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getMessagesAround-wYKCHeA (JI)Lkotlinx/coroutines/flow/Flow;
+	public fun getMessagesBefore-wYKCHeA (JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
 	public fun getPinnedMessages ()Lkotlinx/coroutines/flow/Flow;
 	public final fun getRecipientBehaviors ()Ljava/util/Set;
 	public final fun getRecipientIds ()Ljava/util/Set;
@@ -7854,7 +7859,7 @@ public final class dev/kord/core/entity/channel/DmChannel : dev/kord/core/entity
 }
 
 public abstract interface class dev/kord/core/entity/channel/GuildChannel : dev/kord/core/behavior/channel/GuildChannelBehavior, dev/kord/core/entity/channel/Channel {
-	public abstract fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getGuildId-4_xYDEk ()J
 	public abstract fun getName ()Ljava/lang/String;
 	public abstract fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/entity/channel/GuildChannel;
 }
@@ -7868,9 +7873,9 @@ public final class dev/kord/core/entity/channel/GuildChannel$DefaultImpls {
 	public static fun fetchChannelOrNull (Ldev/kord/core/entity/channel/GuildChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getGuild (Ldev/kord/core/entity/channel/GuildChannel;)Ldev/kord/core/behavior/GuildBehavior;
 	public static fun getGuild (Ldev/kord/core/entity/channel/GuildChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getGuildId (Ldev/kord/core/entity/channel/GuildChannel;)Ldev/kord/common/entity/Snowflake;
+	public static fun getGuildId-4_xYDEk (Ldev/kord/core/entity/channel/GuildChannel;)J
 	public static fun getGuildOrNull (Ldev/kord/core/entity/channel/GuildChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getId (Ldev/kord/core/entity/channel/GuildChannel;)Ldev/kord/common/entity/Snowflake;
+	public static fun getId-4_xYDEk (Ldev/kord/core/entity/channel/GuildChannel;)J
 	public static fun getMention (Ldev/kord/core/entity/channel/GuildChannel;)Ljava/lang/String;
 	public static fun getName (Ldev/kord/core/entity/channel/GuildChannel;)Ljava/lang/String;
 	public static fun getType (Ldev/kord/core/entity/channel/GuildChannel;)Ldev/kord/common/entity/ChannelType;
@@ -7888,25 +7893,25 @@ public final class dev/kord/core/entity/channel/GuildMessageChannel$DefaultImpls
 	public static fun compareTo (Ldev/kord/core/entity/channel/GuildMessageChannel;Ldev/kord/core/entity/Entity;)I
 	public static fun createMessage (Ldev/kord/core/entity/channel/GuildMessageChannel;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun delete (Ldev/kord/core/entity/channel/GuildMessageChannel;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun deleteMessage (Ldev/kord/core/entity/channel/GuildMessageChannel;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun deleteMessage-9y3P_48 (Ldev/kord/core/entity/channel/GuildMessageChannel;JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun fetchChannel (Ldev/kord/core/entity/channel/GuildMessageChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun fetchChannelOrNull (Ldev/kord/core/entity/channel/GuildMessageChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getGuild (Ldev/kord/core/entity/channel/GuildMessageChannel;)Ldev/kord/core/behavior/GuildBehavior;
 	public static fun getGuild (Ldev/kord/core/entity/channel/GuildMessageChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getGuildId (Ldev/kord/core/entity/channel/GuildMessageChannel;)Ldev/kord/common/entity/Snowflake;
+	public static fun getGuildId-4_xYDEk (Ldev/kord/core/entity/channel/GuildMessageChannel;)J
 	public static fun getGuildOrNull (Ldev/kord/core/entity/channel/GuildMessageChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getId (Ldev/kord/core/entity/channel/GuildMessageChannel;)Ldev/kord/common/entity/Snowflake;
+	public static fun getId-4_xYDEk (Ldev/kord/core/entity/channel/GuildMessageChannel;)J
 	public static fun getLastMessage (Ldev/kord/core/entity/channel/GuildMessageChannel;)Ldev/kord/core/behavior/MessageBehavior;
 	public static fun getLastMessage (Ldev/kord/core/entity/channel/GuildMessageChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getLastMessageId (Ldev/kord/core/entity/channel/GuildMessageChannel;)Ldev/kord/common/entity/Snowflake;
+	public static fun getLastMessageId-eUG9VGM (Ldev/kord/core/entity/channel/GuildMessageChannel;)Ldev/kord/common/entity/Snowflake;
 	public static fun getLastPinTimestamp (Ldev/kord/core/entity/channel/GuildMessageChannel;)Lkotlinx/datetime/Instant;
 	public static fun getMention (Ldev/kord/core/entity/channel/GuildMessageChannel;)Ljava/lang/String;
-	public static fun getMessage (Ldev/kord/core/entity/channel/GuildMessageChannel;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getMessageOrNull (Ldev/kord/core/entity/channel/GuildMessageChannel;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getMessage-wYKCHeA (Ldev/kord/core/entity/channel/GuildMessageChannel;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getMessageOrNull-wYKCHeA (Ldev/kord/core/entity/channel/GuildMessageChannel;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getMessages (Ldev/kord/core/entity/channel/GuildMessageChannel;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getMessagesAfter (Ldev/kord/core/entity/channel/GuildMessageChannel;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getMessagesAround (Ldev/kord/core/entity/channel/GuildMessageChannel;Ldev/kord/common/entity/Snowflake;I)Lkotlinx/coroutines/flow/Flow;
-	public static fun getMessagesBefore (Ldev/kord/core/entity/channel/GuildMessageChannel;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getMessagesAfter-wYKCHeA (Ldev/kord/core/entity/channel/GuildMessageChannel;JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getMessagesAround-wYKCHeA (Ldev/kord/core/entity/channel/GuildMessageChannel;JI)Lkotlinx/coroutines/flow/Flow;
+	public static fun getMessagesBefore-wYKCHeA (Ldev/kord/core/entity/channel/GuildMessageChannel;JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
 	public static fun getName (Ldev/kord/core/entity/channel/GuildMessageChannel;)Ljava/lang/String;
 	public static fun getPinnedMessages (Ldev/kord/core/entity/channel/GuildMessageChannel;)Lkotlinx/coroutines/flow/Flow;
 	public static fun getType (Ldev/kord/core/entity/channel/GuildMessageChannel;)Ldev/kord/common/entity/ChannelType;
@@ -7918,7 +7923,7 @@ public final class dev/kord/core/entity/channel/GuildMessageChannel$DefaultImpls
 public abstract interface class dev/kord/core/entity/channel/MessageChannel : dev/kord/core/behavior/channel/MessageChannelBehavior, dev/kord/core/entity/channel/Channel {
 	public abstract fun getLastMessage ()Ldev/kord/core/behavior/MessageBehavior;
 	public abstract fun getLastMessage (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getLastMessageId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getLastMessageId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public abstract fun getLastPinTimestamp ()Lkotlinx/datetime/Instant;
 	public abstract fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/entity/channel/MessageChannel;
 }
@@ -7929,21 +7934,21 @@ public final class dev/kord/core/entity/channel/MessageChannel$DefaultImpls {
 	public static fun compareTo (Ldev/kord/core/entity/channel/MessageChannel;Ldev/kord/core/entity/Entity;)I
 	public static fun createMessage (Ldev/kord/core/entity/channel/MessageChannel;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun delete (Ldev/kord/core/entity/channel/MessageChannel;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun deleteMessage (Ldev/kord/core/entity/channel/MessageChannel;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun deleteMessage-9y3P_48 (Ldev/kord/core/entity/channel/MessageChannel;JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun fetchChannel (Ldev/kord/core/entity/channel/MessageChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun fetchChannelOrNull (Ldev/kord/core/entity/channel/MessageChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getId (Ldev/kord/core/entity/channel/MessageChannel;)Ldev/kord/common/entity/Snowflake;
+	public static fun getId-4_xYDEk (Ldev/kord/core/entity/channel/MessageChannel;)J
 	public static fun getLastMessage (Ldev/kord/core/entity/channel/MessageChannel;)Ldev/kord/core/behavior/MessageBehavior;
 	public static fun getLastMessage (Ldev/kord/core/entity/channel/MessageChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getLastMessageId (Ldev/kord/core/entity/channel/MessageChannel;)Ldev/kord/common/entity/Snowflake;
+	public static fun getLastMessageId-eUG9VGM (Ldev/kord/core/entity/channel/MessageChannel;)Ldev/kord/common/entity/Snowflake;
 	public static fun getLastPinTimestamp (Ldev/kord/core/entity/channel/MessageChannel;)Lkotlinx/datetime/Instant;
 	public static fun getMention (Ldev/kord/core/entity/channel/MessageChannel;)Ljava/lang/String;
-	public static fun getMessage (Ldev/kord/core/entity/channel/MessageChannel;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getMessageOrNull (Ldev/kord/core/entity/channel/MessageChannel;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getMessage-wYKCHeA (Ldev/kord/core/entity/channel/MessageChannel;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getMessageOrNull-wYKCHeA (Ldev/kord/core/entity/channel/MessageChannel;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getMessages (Ldev/kord/core/entity/channel/MessageChannel;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getMessagesAfter (Ldev/kord/core/entity/channel/MessageChannel;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getMessagesAround (Ldev/kord/core/entity/channel/MessageChannel;Ldev/kord/common/entity/Snowflake;I)Lkotlinx/coroutines/flow/Flow;
-	public static fun getMessagesBefore (Ldev/kord/core/entity/channel/MessageChannel;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getMessagesAfter-wYKCHeA (Ldev/kord/core/entity/channel/MessageChannel;JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getMessagesAround-wYKCHeA (Ldev/kord/core/entity/channel/MessageChannel;JI)Lkotlinx/coroutines/flow/Flow;
+	public static fun getMessagesBefore-wYKCHeA (Ldev/kord/core/entity/channel/MessageChannel;JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
 	public static fun getPinnedMessages (Ldev/kord/core/entity/channel/MessageChannel;)Lkotlinx/coroutines/flow/Flow;
 	public static fun getType (Ldev/kord/core/entity/channel/MessageChannel;)Ldev/kord/common/entity/ChannelType;
 	public static fun type (Ldev/kord/core/entity/channel/MessageChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -7963,38 +7968,38 @@ public final class dev/kord/core/entity/channel/NewsChannel : dev/kord/core/beha
 	public synthetic fun compareTo (Ljava/lang/Object;)I
 	public fun createMessage (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun delete (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun deleteMessage (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun deleteMessage-9y3P_48 (JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun fetchChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun fetchChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun follow (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun follow-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getActiveThreads ()Lkotlinx/coroutines/flow/Flow;
 	public fun getCategory ()Ldev/kord/core/behavior/channel/CategoryBehavior;
-	public fun getCategoryId ()Ldev/kord/common/entity/Snowflake;
+	public fun getCategoryId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public fun getData ()Ldev/kord/core/cache/data/ChannelData;
-	public fun getEffectivePermissions (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getEffectivePermissions-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public fun getGuildId-4_xYDEk ()J
 	public fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public fun getInvites ()Lkotlinx/coroutines/flow/Flow;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getLastMessage ()Ldev/kord/core/behavior/MessageBehavior;
 	public fun getLastMessage (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getLastMessageId ()Ldev/kord/common/entity/Snowflake;
+	public fun getLastMessageId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public fun getLastPinTimestamp ()Lkotlinx/datetime/Instant;
 	public fun getMention ()Ljava/lang/String;
-	public fun getMessage (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getMessageOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getMessage-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getMessageOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getMessages ()Lkotlinx/coroutines/flow/Flow;
-	public fun getMessagesAfter (Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public fun getMessagesAround (Ldev/kord/common/entity/Snowflake;I)Lkotlinx/coroutines/flow/Flow;
-	public fun getMessagesBefore (Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getMessagesAfter-wYKCHeA (JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getMessagesAround-wYKCHeA (JI)Lkotlinx/coroutines/flow/Flow;
+	public fun getMessagesBefore-wYKCHeA (JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
 	public fun getName ()Ljava/lang/String;
 	public fun getPermissionOverwrites ()Ljava/util/Set;
-	public fun getPermissionOverwritesForMember (Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/entity/PermissionOverwriteEntity;
-	public fun getPermissionOverwritesForRole (Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/entity/PermissionOverwriteEntity;
+	public fun getPermissionOverwritesForMember-IO-hELI (J)Ldev/kord/core/entity/PermissionOverwriteEntity;
+	public fun getPermissionOverwritesForRole-IO-hELI (J)Ldev/kord/core/entity/PermissionOverwriteEntity;
 	public fun getPinnedMessages ()Lkotlinx/coroutines/flow/Flow;
 	public fun getPosition (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getPublicArchivedThreads (Lkotlinx/datetime/Instant;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
@@ -8005,7 +8010,7 @@ public final class dev/kord/core/entity/channel/NewsChannel : dev/kord/core/beha
 	public fun getWebhooks ()Lkotlinx/coroutines/flow/Flow;
 	public fun hashCode ()I
 	public fun startPublicThread (Ljava/lang/String;Ldev/kord/common/entity/ArchiveDuration;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun startPublicThreadWithMessage (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/ArchiveDuration;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun startPublicThreadWithMessage-PHjaIKs (JLjava/lang/String;Ldev/kord/common/entity/ArchiveDuration;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun toString ()Ljava/lang/String;
 	public fun type (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun typeUntil (Lkotlin/time/TimeMark;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -8042,7 +8047,7 @@ public final class dev/kord/core/entity/channel/ResolvedChannel : dev/kord/core/
 	public fun fetchChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun fetchChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getData ()Ldev/kord/core/cache/data/ChannelData;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getMention ()Ljava/lang/String;
 	public final fun getName ()Ljava/lang/String;
@@ -8070,21 +8075,21 @@ public final class dev/kord/core/entity/channel/StageChannel : dev/kord/core/beh
 	public fun fetchChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getBitrate ()I
 	public fun getCategory ()Ldev/kord/core/behavior/channel/CategoryBehavior;
-	public fun getCategoryId ()Ldev/kord/common/entity/Snowflake;
+	public fun getCategoryId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public fun getData ()Ldev/kord/core/cache/data/ChannelData;
-	public fun getEffectivePermissions (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getEffectivePermissions-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public fun getGuildId-4_xYDEk ()J
 	public fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public fun getInvites ()Lkotlinx/coroutines/flow/Flow;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getMention ()Ljava/lang/String;
 	public fun getName ()Ljava/lang/String;
 	public fun getPermissionOverwrites ()Ljava/util/Set;
-	public fun getPermissionOverwritesForMember (Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/entity/PermissionOverwriteEntity;
-	public fun getPermissionOverwritesForRole (Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/entity/PermissionOverwriteEntity;
+	public fun getPermissionOverwritesForMember-IO-hELI (J)Ldev/kord/core/entity/PermissionOverwriteEntity;
+	public fun getPermissionOverwritesForRole-IO-hELI (J)Ldev/kord/core/entity/PermissionOverwriteEntity;
 	public fun getPosition (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getRawPosition ()I
 	public fun getStageInstance (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -8126,21 +8131,21 @@ public final class dev/kord/core/entity/channel/StoreChannel : dev/kord/core/beh
 	public fun fetchChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun fetchChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getCategory ()Ldev/kord/core/behavior/channel/CategoryBehavior;
-	public fun getCategoryId ()Ldev/kord/common/entity/Snowflake;
+	public fun getCategoryId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public fun getData ()Ldev/kord/core/cache/data/ChannelData;
-	public fun getEffectivePermissions (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getEffectivePermissions-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public fun getGuildId-4_xYDEk ()J
 	public fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public fun getInvites ()Lkotlinx/coroutines/flow/Flow;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getMention ()Ljava/lang/String;
 	public fun getName ()Ljava/lang/String;
 	public fun getPermissionOverwrites ()Ljava/util/Set;
-	public fun getPermissionOverwritesForMember (Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/entity/PermissionOverwriteEntity;
-	public fun getPermissionOverwritesForRole (Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/entity/PermissionOverwriteEntity;
+	public fun getPermissionOverwritesForMember-IO-hELI (J)Ldev/kord/core/entity/PermissionOverwriteEntity;
+	public fun getPermissionOverwritesForRole-IO-hELI (J)Ldev/kord/core/entity/PermissionOverwriteEntity;
 	public fun getPosition (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getRawPosition ()I
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
@@ -8172,38 +8177,38 @@ public final class dev/kord/core/entity/channel/TextChannel : dev/kord/core/beha
 	public synthetic fun compareTo (Ljava/lang/Object;)I
 	public fun createMessage (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun delete (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun deleteMessage (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun deleteMessage-9y3P_48 (JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun fetchChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun fetchChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getActiveThreads ()Lkotlinx/coroutines/flow/Flow;
 	public fun getCategory ()Ldev/kord/core/behavior/channel/CategoryBehavior;
-	public fun getCategoryId ()Ldev/kord/common/entity/Snowflake;
+	public fun getCategoryId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public fun getData ()Ldev/kord/core/cache/data/ChannelData;
-	public fun getEffectivePermissions (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getEffectivePermissions-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public fun getGuildId-4_xYDEk ()J
 	public fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public fun getInvites ()Lkotlinx/coroutines/flow/Flow;
-	public fun getJoinedPrivateArchivedThreads (Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getJoinedPrivateArchivedThreads-O4FuXRM (Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getLastMessage ()Ldev/kord/core/behavior/MessageBehavior;
 	public fun getLastMessage (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getLastMessageId ()Ldev/kord/common/entity/Snowflake;
+	public fun getLastMessageId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public fun getLastPinTimestamp ()Lkotlinx/datetime/Instant;
 	public fun getMention ()Ljava/lang/String;
-	public fun getMessage (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getMessageOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getMessage-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getMessageOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getMessages ()Lkotlinx/coroutines/flow/Flow;
-	public fun getMessagesAfter (Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public fun getMessagesAround (Ldev/kord/common/entity/Snowflake;I)Lkotlinx/coroutines/flow/Flow;
-	public fun getMessagesBefore (Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getMessagesAfter-wYKCHeA (JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getMessagesAround-wYKCHeA (JI)Lkotlinx/coroutines/flow/Flow;
+	public fun getMessagesBefore-wYKCHeA (JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
 	public fun getName ()Ljava/lang/String;
 	public fun getPermissionOverwrites ()Ljava/util/Set;
-	public fun getPermissionOverwritesForMember (Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/entity/PermissionOverwriteEntity;
-	public fun getPermissionOverwritesForRole (Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/entity/PermissionOverwriteEntity;
+	public fun getPermissionOverwritesForMember-IO-hELI (J)Ldev/kord/core/entity/PermissionOverwriteEntity;
+	public fun getPermissionOverwritesForRole-IO-hELI (J)Ldev/kord/core/entity/PermissionOverwriteEntity;
 	public fun getPinnedMessages ()Lkotlinx/coroutines/flow/Flow;
 	public fun getPosition (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getPrivateArchivedThreads (Lkotlinx/datetime/Instant;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
@@ -8218,7 +8223,7 @@ public final class dev/kord/core/entity/channel/TextChannel : dev/kord/core/beha
 	public final fun isNsfw ()Z
 	public fun startPrivateThread (Ljava/lang/String;Ldev/kord/common/entity/ArchiveDuration;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun startPublicThread (Ljava/lang/String;Ldev/kord/common/entity/ArchiveDuration;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun startPublicThreadWithMessage (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/ArchiveDuration;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun startPublicThreadWithMessage-PHjaIKs (JLjava/lang/String;Ldev/kord/common/entity/ArchiveDuration;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun toString ()Ljava/lang/String;
 	public fun type (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun typeUntil (Lkotlin/time/TimeMark;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -8257,34 +8262,34 @@ public final class dev/kord/core/entity/channel/ThreadParentChannel$DefaultImpls
 	public static fun compareTo (Ldev/kord/core/entity/channel/ThreadParentChannel;Ldev/kord/core/entity/Entity;)I
 	public static fun createMessage (Ldev/kord/core/entity/channel/ThreadParentChannel;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun delete (Ldev/kord/core/entity/channel/ThreadParentChannel;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun deleteMessage (Ldev/kord/core/entity/channel/ThreadParentChannel;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun deleteMessage-9y3P_48 (Ldev/kord/core/entity/channel/ThreadParentChannel;JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun fetchChannel (Ldev/kord/core/entity/channel/ThreadParentChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun fetchChannelOrNull (Ldev/kord/core/entity/channel/ThreadParentChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getActiveThreads (Ldev/kord/core/entity/channel/ThreadParentChannel;)Lkotlinx/coroutines/flow/Flow;
 	public static fun getCategory (Ldev/kord/core/entity/channel/ThreadParentChannel;)Ldev/kord/core/behavior/channel/CategoryBehavior;
-	public static fun getCategoryId (Ldev/kord/core/entity/channel/ThreadParentChannel;)Ldev/kord/common/entity/Snowflake;
-	public static fun getEffectivePermissions (Ldev/kord/core/entity/channel/ThreadParentChannel;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getCategoryId-eUG9VGM (Ldev/kord/core/entity/channel/ThreadParentChannel;)Ldev/kord/common/entity/Snowflake;
+	public static fun getEffectivePermissions-wYKCHeA (Ldev/kord/core/entity/channel/ThreadParentChannel;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getGuild (Ldev/kord/core/entity/channel/ThreadParentChannel;)Ldev/kord/core/behavior/GuildBehavior;
 	public static fun getGuild (Ldev/kord/core/entity/channel/ThreadParentChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getGuildId (Ldev/kord/core/entity/channel/ThreadParentChannel;)Ldev/kord/common/entity/Snowflake;
+	public static fun getGuildId-4_xYDEk (Ldev/kord/core/entity/channel/ThreadParentChannel;)J
 	public static fun getGuildOrNull (Ldev/kord/core/entity/channel/ThreadParentChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getId (Ldev/kord/core/entity/channel/ThreadParentChannel;)Ldev/kord/common/entity/Snowflake;
+	public static fun getId-4_xYDEk (Ldev/kord/core/entity/channel/ThreadParentChannel;)J
 	public static fun getInvites (Ldev/kord/core/entity/channel/ThreadParentChannel;)Lkotlinx/coroutines/flow/Flow;
 	public static fun getLastMessage (Ldev/kord/core/entity/channel/ThreadParentChannel;)Ldev/kord/core/behavior/MessageBehavior;
 	public static fun getLastMessage (Ldev/kord/core/entity/channel/ThreadParentChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getLastMessageId (Ldev/kord/core/entity/channel/ThreadParentChannel;)Ldev/kord/common/entity/Snowflake;
+	public static fun getLastMessageId-eUG9VGM (Ldev/kord/core/entity/channel/ThreadParentChannel;)Ldev/kord/common/entity/Snowflake;
 	public static fun getLastPinTimestamp (Ldev/kord/core/entity/channel/ThreadParentChannel;)Lkotlinx/datetime/Instant;
 	public static fun getMention (Ldev/kord/core/entity/channel/ThreadParentChannel;)Ljava/lang/String;
-	public static fun getMessage (Ldev/kord/core/entity/channel/ThreadParentChannel;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getMessageOrNull (Ldev/kord/core/entity/channel/ThreadParentChannel;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getMessage-wYKCHeA (Ldev/kord/core/entity/channel/ThreadParentChannel;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getMessageOrNull-wYKCHeA (Ldev/kord/core/entity/channel/ThreadParentChannel;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getMessages (Ldev/kord/core/entity/channel/ThreadParentChannel;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getMessagesAfter (Ldev/kord/core/entity/channel/ThreadParentChannel;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getMessagesAround (Ldev/kord/core/entity/channel/ThreadParentChannel;Ldev/kord/common/entity/Snowflake;I)Lkotlinx/coroutines/flow/Flow;
-	public static fun getMessagesBefore (Ldev/kord/core/entity/channel/ThreadParentChannel;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getMessagesAfter-wYKCHeA (Ldev/kord/core/entity/channel/ThreadParentChannel;JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getMessagesAround-wYKCHeA (Ldev/kord/core/entity/channel/ThreadParentChannel;JI)Lkotlinx/coroutines/flow/Flow;
+	public static fun getMessagesBefore-wYKCHeA (Ldev/kord/core/entity/channel/ThreadParentChannel;JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
 	public static fun getName (Ldev/kord/core/entity/channel/ThreadParentChannel;)Ljava/lang/String;
 	public static fun getPermissionOverwrites (Ldev/kord/core/entity/channel/ThreadParentChannel;)Ljava/util/Set;
-	public static fun getPermissionOverwritesForMember (Ldev/kord/core/entity/channel/ThreadParentChannel;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/entity/PermissionOverwriteEntity;
-	public static fun getPermissionOverwritesForRole (Ldev/kord/core/entity/channel/ThreadParentChannel;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/entity/PermissionOverwriteEntity;
+	public static fun getPermissionOverwritesForMember-IO-hELI (Ldev/kord/core/entity/channel/ThreadParentChannel;J)Ldev/kord/core/entity/PermissionOverwriteEntity;
+	public static fun getPermissionOverwritesForRole-IO-hELI (Ldev/kord/core/entity/channel/ThreadParentChannel;J)Ldev/kord/core/entity/PermissionOverwriteEntity;
 	public static fun getPinnedMessages (Ldev/kord/core/entity/channel/ThreadParentChannel;)Lkotlinx/coroutines/flow/Flow;
 	public static fun getPosition (Ldev/kord/core/entity/channel/ThreadParentChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getPublicArchivedThreads (Ldev/kord/core/entity/channel/ThreadParentChannel;Lkotlinx/datetime/Instant;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
@@ -8298,11 +8303,11 @@ public final class dev/kord/core/entity/channel/ThreadParentChannel$DefaultImpls
 }
 
 public abstract interface class dev/kord/core/entity/channel/TopGuildChannel : dev/kord/core/behavior/channel/TopGuildChannelBehavior, dev/kord/core/entity/channel/GuildChannel {
-	public abstract fun getEffectivePermissions (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getEffectivePermissions-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getGuildId-4_xYDEk ()J
 	public abstract fun getPermissionOverwrites ()Ljava/util/Set;
-	public abstract fun getPermissionOverwritesForMember (Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/entity/PermissionOverwriteEntity;
-	public abstract fun getPermissionOverwritesForRole (Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/entity/PermissionOverwriteEntity;
+	public abstract fun getPermissionOverwritesForMember-IO-hELI (J)Ldev/kord/core/entity/PermissionOverwriteEntity;
+	public abstract fun getPermissionOverwritesForRole-IO-hELI (J)Ldev/kord/core/entity/PermissionOverwriteEntity;
 	public abstract fun getRawPosition ()I
 	public abstract fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/entity/channel/TopGuildChannel;
 }
@@ -8315,17 +8320,17 @@ public final class dev/kord/core/entity/channel/TopGuildChannel$DefaultImpls {
 	public static fun delete (Ldev/kord/core/entity/channel/TopGuildChannel;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun fetchChannel (Ldev/kord/core/entity/channel/TopGuildChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun fetchChannelOrNull (Ldev/kord/core/entity/channel/TopGuildChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getEffectivePermissions (Ldev/kord/core/entity/channel/TopGuildChannel;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getEffectivePermissions-wYKCHeA (Ldev/kord/core/entity/channel/TopGuildChannel;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getGuild (Ldev/kord/core/entity/channel/TopGuildChannel;)Ldev/kord/core/behavior/GuildBehavior;
 	public static fun getGuild (Ldev/kord/core/entity/channel/TopGuildChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getGuildId (Ldev/kord/core/entity/channel/TopGuildChannel;)Ldev/kord/common/entity/Snowflake;
+	public static fun getGuildId-4_xYDEk (Ldev/kord/core/entity/channel/TopGuildChannel;)J
 	public static fun getGuildOrNull (Ldev/kord/core/entity/channel/TopGuildChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getId (Ldev/kord/core/entity/channel/TopGuildChannel;)Ldev/kord/common/entity/Snowflake;
+	public static fun getId-4_xYDEk (Ldev/kord/core/entity/channel/TopGuildChannel;)J
 	public static fun getMention (Ldev/kord/core/entity/channel/TopGuildChannel;)Ljava/lang/String;
 	public static fun getName (Ldev/kord/core/entity/channel/TopGuildChannel;)Ljava/lang/String;
 	public static fun getPermissionOverwrites (Ldev/kord/core/entity/channel/TopGuildChannel;)Ljava/util/Set;
-	public static fun getPermissionOverwritesForMember (Ldev/kord/core/entity/channel/TopGuildChannel;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/entity/PermissionOverwriteEntity;
-	public static fun getPermissionOverwritesForRole (Ldev/kord/core/entity/channel/TopGuildChannel;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/entity/PermissionOverwriteEntity;
+	public static fun getPermissionOverwritesForMember-IO-hELI (Ldev/kord/core/entity/channel/TopGuildChannel;J)Ldev/kord/core/entity/PermissionOverwriteEntity;
+	public static fun getPermissionOverwritesForRole-IO-hELI (Ldev/kord/core/entity/channel/TopGuildChannel;J)Ldev/kord/core/entity/PermissionOverwriteEntity;
 	public static fun getPosition (Ldev/kord/core/entity/channel/TopGuildChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getRawPosition (Ldev/kord/core/entity/channel/TopGuildChannel;)I
 	public static fun getType (Ldev/kord/core/entity/channel/TopGuildChannel;)Ldev/kord/common/entity/ChannelType;
@@ -8345,33 +8350,33 @@ public final class dev/kord/core/entity/channel/TopGuildMessageChannel$DefaultIm
 	public static fun compareTo (Ldev/kord/core/entity/channel/TopGuildMessageChannel;Ldev/kord/core/entity/Entity;)I
 	public static fun createMessage (Ldev/kord/core/entity/channel/TopGuildMessageChannel;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun delete (Ldev/kord/core/entity/channel/TopGuildMessageChannel;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun deleteMessage (Ldev/kord/core/entity/channel/TopGuildMessageChannel;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun deleteMessage-9y3P_48 (Ldev/kord/core/entity/channel/TopGuildMessageChannel;JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun fetchChannel (Ldev/kord/core/entity/channel/TopGuildMessageChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun fetchChannelOrNull (Ldev/kord/core/entity/channel/TopGuildMessageChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getCategory (Ldev/kord/core/entity/channel/TopGuildMessageChannel;)Ldev/kord/core/behavior/channel/CategoryBehavior;
-	public static fun getCategoryId (Ldev/kord/core/entity/channel/TopGuildMessageChannel;)Ldev/kord/common/entity/Snowflake;
-	public static fun getEffectivePermissions (Ldev/kord/core/entity/channel/TopGuildMessageChannel;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getCategoryId-eUG9VGM (Ldev/kord/core/entity/channel/TopGuildMessageChannel;)Ldev/kord/common/entity/Snowflake;
+	public static fun getEffectivePermissions-wYKCHeA (Ldev/kord/core/entity/channel/TopGuildMessageChannel;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getGuild (Ldev/kord/core/entity/channel/TopGuildMessageChannel;)Ldev/kord/core/behavior/GuildBehavior;
 	public static fun getGuild (Ldev/kord/core/entity/channel/TopGuildMessageChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getGuildId (Ldev/kord/core/entity/channel/TopGuildMessageChannel;)Ldev/kord/common/entity/Snowflake;
+	public static fun getGuildId-4_xYDEk (Ldev/kord/core/entity/channel/TopGuildMessageChannel;)J
 	public static fun getGuildOrNull (Ldev/kord/core/entity/channel/TopGuildMessageChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getId (Ldev/kord/core/entity/channel/TopGuildMessageChannel;)Ldev/kord/common/entity/Snowflake;
+	public static fun getId-4_xYDEk (Ldev/kord/core/entity/channel/TopGuildMessageChannel;)J
 	public static fun getInvites (Ldev/kord/core/entity/channel/TopGuildMessageChannel;)Lkotlinx/coroutines/flow/Flow;
 	public static fun getLastMessage (Ldev/kord/core/entity/channel/TopGuildMessageChannel;)Ldev/kord/core/behavior/MessageBehavior;
 	public static fun getLastMessage (Ldev/kord/core/entity/channel/TopGuildMessageChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getLastMessageId (Ldev/kord/core/entity/channel/TopGuildMessageChannel;)Ldev/kord/common/entity/Snowflake;
+	public static fun getLastMessageId-eUG9VGM (Ldev/kord/core/entity/channel/TopGuildMessageChannel;)Ldev/kord/common/entity/Snowflake;
 	public static fun getLastPinTimestamp (Ldev/kord/core/entity/channel/TopGuildMessageChannel;)Lkotlinx/datetime/Instant;
 	public static fun getMention (Ldev/kord/core/entity/channel/TopGuildMessageChannel;)Ljava/lang/String;
-	public static fun getMessage (Ldev/kord/core/entity/channel/TopGuildMessageChannel;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getMessageOrNull (Ldev/kord/core/entity/channel/TopGuildMessageChannel;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getMessage-wYKCHeA (Ldev/kord/core/entity/channel/TopGuildMessageChannel;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getMessageOrNull-wYKCHeA (Ldev/kord/core/entity/channel/TopGuildMessageChannel;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getMessages (Ldev/kord/core/entity/channel/TopGuildMessageChannel;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getMessagesAfter (Ldev/kord/core/entity/channel/TopGuildMessageChannel;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getMessagesAround (Ldev/kord/core/entity/channel/TopGuildMessageChannel;Ldev/kord/common/entity/Snowflake;I)Lkotlinx/coroutines/flow/Flow;
-	public static fun getMessagesBefore (Ldev/kord/core/entity/channel/TopGuildMessageChannel;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getMessagesAfter-wYKCHeA (Ldev/kord/core/entity/channel/TopGuildMessageChannel;JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getMessagesAround-wYKCHeA (Ldev/kord/core/entity/channel/TopGuildMessageChannel;JI)Lkotlinx/coroutines/flow/Flow;
+	public static fun getMessagesBefore-wYKCHeA (Ldev/kord/core/entity/channel/TopGuildMessageChannel;JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
 	public static fun getName (Ldev/kord/core/entity/channel/TopGuildMessageChannel;)Ljava/lang/String;
 	public static fun getPermissionOverwrites (Ldev/kord/core/entity/channel/TopGuildMessageChannel;)Ljava/util/Set;
-	public static fun getPermissionOverwritesForMember (Ldev/kord/core/entity/channel/TopGuildMessageChannel;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/entity/PermissionOverwriteEntity;
-	public static fun getPermissionOverwritesForRole (Ldev/kord/core/entity/channel/TopGuildMessageChannel;Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/entity/PermissionOverwriteEntity;
+	public static fun getPermissionOverwritesForMember-IO-hELI (Ldev/kord/core/entity/channel/TopGuildMessageChannel;J)Ldev/kord/core/entity/PermissionOverwriteEntity;
+	public static fun getPermissionOverwritesForRole-IO-hELI (Ldev/kord/core/entity/channel/TopGuildMessageChannel;J)Ldev/kord/core/entity/PermissionOverwriteEntity;
 	public static fun getPinnedMessages (Ldev/kord/core/entity/channel/TopGuildMessageChannel;)Lkotlinx/coroutines/flow/Flow;
 	public static fun getPosition (Ldev/kord/core/entity/channel/TopGuildMessageChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getRawPosition (Ldev/kord/core/entity/channel/TopGuildMessageChannel;)I
@@ -8395,37 +8400,37 @@ public final class dev/kord/core/entity/channel/VoiceChannel : dev/kord/core/beh
 	public synthetic fun compareTo (Ljava/lang/Object;)I
 	public fun createMessage (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun delete (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun deleteMessage (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun deleteMessage-9y3P_48 (JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun fetchChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun fetchChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getBitrate ()I
 	public fun getCategory ()Ldev/kord/core/behavior/channel/CategoryBehavior;
-	public fun getCategoryId ()Ldev/kord/common/entity/Snowflake;
+	public fun getCategoryId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public fun getData ()Ldev/kord/core/cache/data/ChannelData;
-	public fun getEffectivePermissions (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getEffectivePermissions-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public fun getGuildId-4_xYDEk ()J
 	public fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public fun getInvites ()Lkotlinx/coroutines/flow/Flow;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getLastMessage ()Ldev/kord/core/behavior/MessageBehavior;
 	public fun getLastMessage (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getLastMessageId ()Ldev/kord/common/entity/Snowflake;
+	public fun getLastMessageId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public fun getLastPinTimestamp ()Lkotlinx/datetime/Instant;
 	public fun getMention ()Ljava/lang/String;
-	public fun getMessage (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getMessageOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getMessage-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getMessageOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getMessages ()Lkotlinx/coroutines/flow/Flow;
-	public fun getMessagesAfter (Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public fun getMessagesAround (Ldev/kord/common/entity/Snowflake;I)Lkotlinx/coroutines/flow/Flow;
-	public fun getMessagesBefore (Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getMessagesAfter-wYKCHeA (JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getMessagesAround-wYKCHeA (JI)Lkotlinx/coroutines/flow/Flow;
+	public fun getMessagesBefore-wYKCHeA (JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
 	public fun getName ()Ljava/lang/String;
 	public fun getPermissionOverwrites ()Ljava/util/Set;
-	public fun getPermissionOverwritesForMember (Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/entity/PermissionOverwriteEntity;
-	public fun getPermissionOverwritesForRole (Ldev/kord/common/entity/Snowflake;)Ldev/kord/core/entity/PermissionOverwriteEntity;
+	public fun getPermissionOverwritesForMember-IO-hELI (J)Ldev/kord/core/entity/PermissionOverwriteEntity;
+	public fun getPermissionOverwritesForRole-IO-hELI (J)Ldev/kord/core/entity/PermissionOverwriteEntity;
 	public fun getPinnedMessages ()Lkotlinx/coroutines/flow/Flow;
 	public fun getPosition (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getRawPosition ()I
@@ -8475,9 +8480,9 @@ public final class dev/kord/core/entity/channel/WelcomeScreenChannel : dev/kord/
 	public fun fetchChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getData ()Ldev/kord/core/cache/data/WelcomeScreenChannelData;
 	public final fun getDescription ()Ljava/lang/String;
-	public final fun getEmojiId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getEmojiId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getEmojiName ()Ljava/lang/String;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getMention ()Ljava/lang/String;
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
@@ -8491,13 +8496,13 @@ public final class dev/kord/core/entity/channel/thread/DeletedThreadChannel : de
 	public final fun getData ()Ldev/kord/core/cache/data/ChannelData;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public final fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getKord ()Ldev/kord/core/Kord;
 	public final fun getParent ()Ldev/kord/core/behavior/channel/threads/ThreadParentChannelBehavior;
 	public final fun getParent (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getParentId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getParentId-4_xYDEk ()J
 	public final fun getParentOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
 	public final fun getType ()Ldev/kord/common/entity/ChannelType;
@@ -8508,7 +8513,7 @@ public final class dev/kord/core/entity/channel/thread/DeletedThreadChannel : de
 public final class dev/kord/core/entity/channel/thread/NewsChannelThread : dev/kord/core/entity/channel/thread/ThreadChannel {
 	public fun <init> (Ldev/kord/core/cache/data/ChannelData;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)V
 	public synthetic fun <init> (Ldev/kord/core/cache/data/ChannelData;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun addUser (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun addUser-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun asChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun asChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public synthetic fun bulkDelete (Ljava/lang/Iterable;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -8517,7 +8522,7 @@ public final class dev/kord/core/entity/channel/thread/NewsChannelThread : dev/k
 	public synthetic fun compareTo (Ljava/lang/Object;)I
 	public fun createMessage (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun delete (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun deleteMessage (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun deleteMessage-9y3P_48 (JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun fetchChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun fetchChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getArchiveTimestamp ()Lkotlinx/datetime/Instant;
@@ -8527,31 +8532,31 @@ public final class dev/kord/core/entity/channel/thread/NewsChannelThread : dev/k
 	public fun getDefaultAutoArchiveDuration ()Ldev/kord/common/entity/ArchiveDuration;
 	public fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public fun getGuildId-4_xYDEk ()J
 	public fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getLastMessage ()Ldev/kord/core/behavior/MessageBehavior;
 	public fun getLastMessage (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getLastMessageId ()Ldev/kord/common/entity/Snowflake;
+	public fun getLastMessageId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public fun getLastPinTimestamp ()Lkotlinx/datetime/Instant;
 	public fun getMember ()Ldev/kord/core/entity/channel/thread/ThreadMember;
 	public fun getMemberCount ()Ldev/kord/common/entity/optional/OptionalInt;
 	public fun getMembers ()Lkotlinx/coroutines/flow/Flow;
 	public fun getMention ()Ljava/lang/String;
-	public fun getMessage (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getMessage-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getMessageCount ()Ldev/kord/common/entity/optional/OptionalInt;
-	public fun getMessageOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getMessageOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getMessages ()Lkotlinx/coroutines/flow/Flow;
-	public fun getMessagesAfter (Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public fun getMessagesAround (Ldev/kord/common/entity/Snowflake;I)Lkotlinx/coroutines/flow/Flow;
-	public fun getMessagesBefore (Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getMessagesAfter-wYKCHeA (JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getMessagesAround-wYKCHeA (JI)Lkotlinx/coroutines/flow/Flow;
+	public fun getMessagesBefore-wYKCHeA (JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
 	public fun getName ()Ljava/lang/String;
 	public fun getOwner ()Ldev/kord/core/behavior/UserBehavior;
-	public fun getOwnerId ()Ldev/kord/common/entity/Snowflake;
+	public fun getOwnerId-4_xYDEk ()J
 	public fun getParent ()Ldev/kord/core/behavior/channel/threads/ThreadParentChannelBehavior;
 	public fun getParent (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getParentId ()Ldev/kord/common/entity/Snowflake;
+	public fun getParentId-4_xYDEk ()J
 	public fun getParentOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getPinnedMessages ()Lkotlinx/coroutines/flow/Flow;
 	public fun getRateLimitPerUser-FghU774 ()Lkotlin/time/Duration;
@@ -8562,7 +8567,7 @@ public final class dev/kord/core/entity/channel/thread/NewsChannelThread : dev/k
 	public fun isNsfw ()Z
 	public fun join (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun leave (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun removeUser (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun removeUser-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun type (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun typeUntil (Lkotlin/time/TimeMark;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun typeUntil (Lkotlinx/datetime/Instant;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -8583,7 +8588,7 @@ public final class dev/kord/core/entity/channel/thread/NewsChannelThread : dev/k
 public final class dev/kord/core/entity/channel/thread/TextChannelThread : dev/kord/core/entity/channel/thread/ThreadChannel {
 	public fun <init> (Ldev/kord/core/cache/data/ChannelData;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)V
 	public synthetic fun <init> (Ldev/kord/core/cache/data/ChannelData;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun addUser (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun addUser-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun asChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun asChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public synthetic fun bulkDelete (Ljava/lang/Iterable;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -8592,7 +8597,7 @@ public final class dev/kord/core/entity/channel/thread/TextChannelThread : dev/k
 	public synthetic fun compareTo (Ljava/lang/Object;)I
 	public fun createMessage (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun delete (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun deleteMessage (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun deleteMessage-9y3P_48 (JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun fetchChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun fetchChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getArchiveTimestamp ()Lkotlinx/datetime/Instant;
@@ -8602,31 +8607,31 @@ public final class dev/kord/core/entity/channel/thread/TextChannelThread : dev/k
 	public fun getDefaultAutoArchiveDuration ()Ldev/kord/common/entity/ArchiveDuration;
 	public fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public fun getGuildId-4_xYDEk ()J
 	public fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getLastMessage ()Ldev/kord/core/behavior/MessageBehavior;
 	public fun getLastMessage (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getLastMessageId ()Ldev/kord/common/entity/Snowflake;
+	public fun getLastMessageId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public fun getLastPinTimestamp ()Lkotlinx/datetime/Instant;
 	public fun getMember ()Ldev/kord/core/entity/channel/thread/ThreadMember;
 	public fun getMemberCount ()Ldev/kord/common/entity/optional/OptionalInt;
 	public fun getMembers ()Lkotlinx/coroutines/flow/Flow;
 	public fun getMention ()Ljava/lang/String;
-	public fun getMessage (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getMessage-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getMessageCount ()Ldev/kord/common/entity/optional/OptionalInt;
-	public fun getMessageOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getMessageOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getMessages ()Lkotlinx/coroutines/flow/Flow;
-	public fun getMessagesAfter (Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public fun getMessagesAround (Ldev/kord/common/entity/Snowflake;I)Lkotlinx/coroutines/flow/Flow;
-	public fun getMessagesBefore (Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getMessagesAfter-wYKCHeA (JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getMessagesAround-wYKCHeA (JI)Lkotlinx/coroutines/flow/Flow;
+	public fun getMessagesBefore-wYKCHeA (JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
 	public fun getName ()Ljava/lang/String;
 	public fun getOwner ()Ldev/kord/core/behavior/UserBehavior;
-	public fun getOwnerId ()Ldev/kord/common/entity/Snowflake;
+	public fun getOwnerId-4_xYDEk ()J
 	public fun getParent ()Ldev/kord/core/behavior/channel/threads/ThreadParentChannelBehavior;
 	public fun getParent (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getParentId ()Ldev/kord/common/entity/Snowflake;
+	public fun getParentId-4_xYDEk ()J
 	public fun getParentOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getPinnedMessages ()Lkotlinx/coroutines/flow/Flow;
 	public fun getRateLimitPerUser-FghU774 ()Lkotlin/time/Duration;
@@ -8639,7 +8644,7 @@ public final class dev/kord/core/entity/channel/thread/TextChannelThread : dev/k
 	public final fun isPrivate ()Z
 	public fun join (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun leave (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun removeUser (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun removeUser-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun type (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun typeUntil (Lkotlin/time/TimeMark;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun typeUntil (Lkotlinx/datetime/Instant;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -8666,8 +8671,8 @@ public abstract interface class dev/kord/core/entity/channel/thread/ThreadChanne
 	public abstract fun getMemberCount ()Ldev/kord/common/entity/optional/OptionalInt;
 	public abstract fun getMessageCount ()Ldev/kord/common/entity/optional/OptionalInt;
 	public abstract fun getOwner ()Ldev/kord/core/behavior/UserBehavior;
-	public abstract fun getOwnerId ()Ldev/kord/common/entity/Snowflake;
-	public abstract fun getParentId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getOwnerId-4_xYDEk ()J
+	public abstract fun getParentId-4_xYDEk ()J
 	public abstract fun getRateLimitPerUser-FghU774 ()Lkotlin/time/Duration;
 	public abstract fun isArchived ()Z
 	public abstract fun isLocked ()Z
@@ -8676,7 +8681,7 @@ public abstract interface class dev/kord/core/entity/channel/thread/ThreadChanne
 }
 
 public final class dev/kord/core/entity/channel/thread/ThreadChannel$DefaultImpls {
-	public static fun addUser (Ldev/kord/core/entity/channel/thread/ThreadChannel;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun addUser-wYKCHeA (Ldev/kord/core/entity/channel/thread/ThreadChannel;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun asChannel (Ldev/kord/core/entity/channel/thread/ThreadChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun asChannelOrNull (Ldev/kord/core/entity/channel/thread/ThreadChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun bulkDelete (Ldev/kord/core/entity/channel/thread/ThreadChannel;Ljava/lang/Iterable;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -8684,7 +8689,7 @@ public final class dev/kord/core/entity/channel/thread/ThreadChannel$DefaultImpl
 	public static fun compareTo (Ldev/kord/core/entity/channel/thread/ThreadChannel;Ldev/kord/core/entity/Entity;)I
 	public static fun createMessage (Ldev/kord/core/entity/channel/thread/ThreadChannel;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun delete (Ldev/kord/core/entity/channel/thread/ThreadChannel;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun deleteMessage (Ldev/kord/core/entity/channel/thread/ThreadChannel;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun deleteMessage-9y3P_48 (Ldev/kord/core/entity/channel/thread/ThreadChannel;JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun fetchChannel (Ldev/kord/core/entity/channel/thread/ThreadChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun fetchChannelOrNull (Ldev/kord/core/entity/channel/thread/ThreadChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getArchiveTimestamp (Ldev/kord/core/entity/channel/thread/ThreadChannel;)Lkotlinx/datetime/Instant;
@@ -8693,30 +8698,30 @@ public final class dev/kord/core/entity/channel/thread/ThreadChannel$DefaultImpl
 	public static fun getDefaultAutoArchiveDuration (Ldev/kord/core/entity/channel/thread/ThreadChannel;)Ldev/kord/common/entity/ArchiveDuration;
 	public static fun getGuild (Ldev/kord/core/entity/channel/thread/ThreadChannel;)Ldev/kord/core/behavior/GuildBehavior;
 	public static fun getGuild (Ldev/kord/core/entity/channel/thread/ThreadChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getGuildId (Ldev/kord/core/entity/channel/thread/ThreadChannel;)Ldev/kord/common/entity/Snowflake;
+	public static fun getGuildId-4_xYDEk (Ldev/kord/core/entity/channel/thread/ThreadChannel;)J
 	public static fun getGuildOrNull (Ldev/kord/core/entity/channel/thread/ThreadChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getId (Ldev/kord/core/entity/channel/thread/ThreadChannel;)Ldev/kord/common/entity/Snowflake;
+	public static fun getId-4_xYDEk (Ldev/kord/core/entity/channel/thread/ThreadChannel;)J
 	public static fun getLastMessage (Ldev/kord/core/entity/channel/thread/ThreadChannel;)Ldev/kord/core/behavior/MessageBehavior;
 	public static fun getLastMessage (Ldev/kord/core/entity/channel/thread/ThreadChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getLastMessageId (Ldev/kord/core/entity/channel/thread/ThreadChannel;)Ldev/kord/common/entity/Snowflake;
+	public static fun getLastMessageId-eUG9VGM (Ldev/kord/core/entity/channel/thread/ThreadChannel;)Ldev/kord/common/entity/Snowflake;
 	public static fun getLastPinTimestamp (Ldev/kord/core/entity/channel/thread/ThreadChannel;)Lkotlinx/datetime/Instant;
 	public static fun getMember (Ldev/kord/core/entity/channel/thread/ThreadChannel;)Ldev/kord/core/entity/channel/thread/ThreadMember;
 	public static fun getMemberCount (Ldev/kord/core/entity/channel/thread/ThreadChannel;)Ldev/kord/common/entity/optional/OptionalInt;
 	public static fun getMembers (Ldev/kord/core/entity/channel/thread/ThreadChannel;)Lkotlinx/coroutines/flow/Flow;
 	public static fun getMention (Ldev/kord/core/entity/channel/thread/ThreadChannel;)Ljava/lang/String;
-	public static fun getMessage (Ldev/kord/core/entity/channel/thread/ThreadChannel;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getMessage-wYKCHeA (Ldev/kord/core/entity/channel/thread/ThreadChannel;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getMessageCount (Ldev/kord/core/entity/channel/thread/ThreadChannel;)Ldev/kord/common/entity/optional/OptionalInt;
-	public static fun getMessageOrNull (Ldev/kord/core/entity/channel/thread/ThreadChannel;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getMessageOrNull-wYKCHeA (Ldev/kord/core/entity/channel/thread/ThreadChannel;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getMessages (Ldev/kord/core/entity/channel/thread/ThreadChannel;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getMessagesAfter (Ldev/kord/core/entity/channel/thread/ThreadChannel;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getMessagesAround (Ldev/kord/core/entity/channel/thread/ThreadChannel;Ldev/kord/common/entity/Snowflake;I)Lkotlinx/coroutines/flow/Flow;
-	public static fun getMessagesBefore (Ldev/kord/core/entity/channel/thread/ThreadChannel;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getMessagesAfter-wYKCHeA (Ldev/kord/core/entity/channel/thread/ThreadChannel;JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getMessagesAround-wYKCHeA (Ldev/kord/core/entity/channel/thread/ThreadChannel;JI)Lkotlinx/coroutines/flow/Flow;
+	public static fun getMessagesBefore-wYKCHeA (Ldev/kord/core/entity/channel/thread/ThreadChannel;JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
 	public static fun getName (Ldev/kord/core/entity/channel/thread/ThreadChannel;)Ljava/lang/String;
 	public static fun getOwner (Ldev/kord/core/entity/channel/thread/ThreadChannel;)Ldev/kord/core/behavior/UserBehavior;
-	public static fun getOwnerId (Ldev/kord/core/entity/channel/thread/ThreadChannel;)Ldev/kord/common/entity/Snowflake;
+	public static fun getOwnerId-4_xYDEk (Ldev/kord/core/entity/channel/thread/ThreadChannel;)J
 	public static fun getParent (Ldev/kord/core/entity/channel/thread/ThreadChannel;)Ldev/kord/core/behavior/channel/threads/ThreadParentChannelBehavior;
 	public static fun getParent (Ldev/kord/core/entity/channel/thread/ThreadChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getParentId (Ldev/kord/core/entity/channel/thread/ThreadChannel;)Ldev/kord/common/entity/Snowflake;
+	public static fun getParentId-4_xYDEk (Ldev/kord/core/entity/channel/thread/ThreadChannel;)J
 	public static fun getParentOrNull (Ldev/kord/core/entity/channel/thread/ThreadChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getPinnedMessages (Ldev/kord/core/entity/channel/thread/ThreadChannel;)Lkotlinx/coroutines/flow/Flow;
 	public static fun getRateLimitPerUser-FghU774 (Ldev/kord/core/entity/channel/thread/ThreadChannel;)Lkotlin/time/Duration;
@@ -8726,7 +8731,7 @@ public final class dev/kord/core/entity/channel/thread/ThreadChannel$DefaultImpl
 	public static fun isNsfw (Ldev/kord/core/entity/channel/thread/ThreadChannel;)Z
 	public static fun join (Ldev/kord/core/entity/channel/thread/ThreadChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun leave (Ldev/kord/core/entity/channel/thread/ThreadChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun removeUser (Ldev/kord/core/entity/channel/thread/ThreadChannel;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun removeUser-wYKCHeA (Ldev/kord/core/entity/channel/thread/ThreadChannel;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun type (Ldev/kord/core/entity/channel/thread/ThreadChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun typeUntil (Ldev/kord/core/entity/channel/thread/ThreadChannel;Lkotlin/time/TimeMark;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun typeUntil (Ldev/kord/core/entity/channel/thread/ThreadChannel;Lkotlinx/datetime/Instant;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -8736,27 +8741,27 @@ public final class dev/kord/core/entity/channel/thread/ThreadChannel$DefaultImpl
 public final class dev/kord/core/entity/channel/thread/ThreadMember : dev/kord/core/behavior/ThreadMemberBehavior {
 	public fun <init> (Ldev/kord/core/cache/data/ThreadMemberData;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)V
 	public synthetic fun <init> (Ldev/kord/core/cache/data/ThreadMemberData;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun asMember (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun asMemberOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun asMember-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun asMemberOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun asUser (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun asUserOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun compareTo (Ldev/kord/core/entity/Entity;)I
 	public synthetic fun compareTo (Ljava/lang/Object;)I
-	public fun fetchMember (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun fetchMemberOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun fetchMember-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun fetchMemberOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun fetchUser (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun fetchUserOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getData ()Ldev/kord/core/cache/data/ThreadMemberData;
 	public fun getDmChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getDmChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getFlags ()I
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public final fun getJoinTimestamp ()Lkotlinx/datetime/Instant;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getMention ()Ljava/lang/String;
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
 	public fun getThread (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getThreadId ()Ldev/kord/common/entity/Snowflake;
+	public fun getThreadId-4_xYDEk ()J
 	public fun getThreadOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public synthetic fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/UserBehavior;
 	public synthetic fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/entity/Strategizable;
@@ -8869,13 +8874,13 @@ public final class dev/kord/core/entity/interaction/ActionInteraction$DefaultImp
 	public static synthetic fun deferPublicMessage (Ldev/kord/core/entity/interaction/ActionInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun deferPublicResponse (Ldev/kord/core/entity/interaction/ActionInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun deferPublicResponseUnsafe (Ldev/kord/core/entity/interaction/ActionInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getApplicationId (Ldev/kord/core/entity/interaction/ActionInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getApplicationId-4_xYDEk (Ldev/kord/core/entity/interaction/ActionInteraction;)J
 	public static fun getChannel (Ldev/kord/core/entity/interaction/ActionInteraction;)Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public static fun getChannel (Ldev/kord/core/entity/interaction/ActionInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getChannelId (Ldev/kord/core/entity/interaction/ActionInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getChannelId-4_xYDEk (Ldev/kord/core/entity/interaction/ActionInteraction;)J
 	public static fun getChannelOrNull (Ldev/kord/core/entity/interaction/ActionInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getGuildLocale (Ldev/kord/core/entity/interaction/ActionInteraction;)Ldev/kord/common/Locale;
-	public static fun getId (Ldev/kord/core/entity/interaction/ActionInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getId-4_xYDEk (Ldev/kord/core/entity/interaction/ActionInteraction;)J
 	public static fun getLocale (Ldev/kord/core/entity/interaction/ActionInteraction;)Ldev/kord/common/Locale;
 	public static fun getOriginalInteractionResponse (Ldev/kord/core/entity/interaction/ActionInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getOriginalInteractionResponseOrNull (Ldev/kord/core/entity/interaction/ActionInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -8885,8 +8890,8 @@ public final class dev/kord/core/entity/interaction/ActionInteraction$DefaultImp
 }
 
 public abstract interface class dev/kord/core/entity/interaction/ApplicationCommandInteraction : dev/kord/core/behavior/interaction/ApplicationCommandInteractionBehavior, dev/kord/core/entity/interaction/ActionInteraction {
-	public abstract fun getInvokedCommandGuildId ()Ldev/kord/common/entity/Snowflake;
-	public abstract fun getInvokedCommandId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getInvokedCommandGuildId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getInvokedCommandId-4_xYDEk ()J
 	public abstract fun getInvokedCommandName ()Ljava/lang/String;
 	public abstract fun getInvokedCommandType ()Ldev/kord/common/entity/ApplicationCommandType;
 	public abstract fun getResolvedObjects ()Ldev/kord/core/entity/interaction/ResolvedObjects;
@@ -8901,15 +8906,15 @@ public final class dev/kord/core/entity/interaction/ApplicationCommandInteractio
 	public static synthetic fun deferPublicMessage (Ldev/kord/core/entity/interaction/ApplicationCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun deferPublicResponse (Ldev/kord/core/entity/interaction/ApplicationCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun deferPublicResponseUnsafe (Ldev/kord/core/entity/interaction/ApplicationCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getApplicationId (Ldev/kord/core/entity/interaction/ApplicationCommandInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getApplicationId-4_xYDEk (Ldev/kord/core/entity/interaction/ApplicationCommandInteraction;)J
 	public static fun getChannel (Ldev/kord/core/entity/interaction/ApplicationCommandInteraction;)Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public static fun getChannel (Ldev/kord/core/entity/interaction/ApplicationCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getChannelId (Ldev/kord/core/entity/interaction/ApplicationCommandInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getChannelId-4_xYDEk (Ldev/kord/core/entity/interaction/ApplicationCommandInteraction;)J
 	public static fun getChannelOrNull (Ldev/kord/core/entity/interaction/ApplicationCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getGuildLocale (Ldev/kord/core/entity/interaction/ApplicationCommandInteraction;)Ldev/kord/common/Locale;
-	public static fun getId (Ldev/kord/core/entity/interaction/ApplicationCommandInteraction;)Ldev/kord/common/entity/Snowflake;
-	public static fun getInvokedCommandGuildId (Ldev/kord/core/entity/interaction/ApplicationCommandInteraction;)Ldev/kord/common/entity/Snowflake;
-	public static fun getInvokedCommandId (Ldev/kord/core/entity/interaction/ApplicationCommandInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getId-4_xYDEk (Ldev/kord/core/entity/interaction/ApplicationCommandInteraction;)J
+	public static fun getInvokedCommandGuildId-eUG9VGM (Ldev/kord/core/entity/interaction/ApplicationCommandInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getInvokedCommandId-4_xYDEk (Ldev/kord/core/entity/interaction/ApplicationCommandInteraction;)J
 	public static fun getInvokedCommandName (Ldev/kord/core/entity/interaction/ApplicationCommandInteraction;)Ljava/lang/String;
 	public static fun getInvokedCommandType (Ldev/kord/core/entity/interaction/ApplicationCommandInteraction;)Ldev/kord/common/entity/ApplicationCommandType;
 	public static fun getLocale (Ldev/kord/core/entity/interaction/ApplicationCommandInteraction;)Ldev/kord/common/Locale;
@@ -8929,12 +8934,12 @@ public final class dev/kord/core/entity/interaction/ApplicationCommandInteractio
 }
 
 public final class dev/kord/core/entity/interaction/AttachmentOptionValue : dev/kord/core/entity/interaction/ResolvableOptionValue {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;ZLdev/kord/core/entity/Attachment;)V
+	public synthetic fun <init> (JZLdev/kord/core/entity/Attachment;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getFocused ()Z
 	public fun getResolvedObject ()Ldev/kord/core/entity/Attachment;
 	public synthetic fun getResolvedObject ()Ldev/kord/core/entity/Entity;
-	public fun getValue ()Ldev/kord/common/entity/Snowflake;
 	public synthetic fun getValue ()Ljava/lang/Object;
+	public fun getValue-4_xYDEk ()J
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -8946,15 +8951,15 @@ public abstract interface class dev/kord/core/entity/interaction/AutoCompleteInt
 
 public final class dev/kord/core/entity/interaction/AutoCompleteInteraction$DefaultImpls {
 	public static fun compareTo (Ldev/kord/core/entity/interaction/AutoCompleteInteraction;Ldev/kord/core/entity/Entity;)I
-	public static fun getApplicationId (Ldev/kord/core/entity/interaction/AutoCompleteInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getApplicationId-4_xYDEk (Ldev/kord/core/entity/interaction/AutoCompleteInteraction;)J
 	public static fun getChannel (Ldev/kord/core/entity/interaction/AutoCompleteInteraction;)Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public static fun getChannel (Ldev/kord/core/entity/interaction/AutoCompleteInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getChannelId (Ldev/kord/core/entity/interaction/AutoCompleteInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getChannelId-4_xYDEk (Ldev/kord/core/entity/interaction/AutoCompleteInteraction;)J
 	public static fun getChannelOrNull (Ldev/kord/core/entity/interaction/AutoCompleteInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getCommand (Ldev/kord/core/entity/interaction/AutoCompleteInteraction;)Ldev/kord/core/entity/interaction/InteractionCommand;
 	public static fun getFocusedOption (Ldev/kord/core/entity/interaction/AutoCompleteInteraction;)Ldev/kord/core/entity/interaction/StringOptionValue;
 	public static fun getGuildLocale (Ldev/kord/core/entity/interaction/AutoCompleteInteraction;)Ldev/kord/common/Locale;
-	public static fun getId (Ldev/kord/core/entity/interaction/AutoCompleteInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getId-4_xYDEk (Ldev/kord/core/entity/interaction/AutoCompleteInteraction;)J
 	public static fun getLocale (Ldev/kord/core/entity/interaction/AutoCompleteInteraction;)Ldev/kord/common/Locale;
 	public static fun getToken (Ldev/kord/core/entity/interaction/AutoCompleteInteraction;)Ljava/lang/String;
 	public static fun getType (Ldev/kord/core/entity/interaction/AutoCompleteInteraction;)Ldev/kord/common/entity/InteractionType;
@@ -8986,16 +8991,16 @@ public final class dev/kord/core/entity/interaction/ButtonInteraction$DefaultImp
 	public static fun deferPublicMessageUpdate (Ldev/kord/core/entity/interaction/ButtonInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun deferPublicResponse (Ldev/kord/core/entity/interaction/ButtonInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun deferPublicResponseUnsafe (Ldev/kord/core/entity/interaction/ButtonInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getApplicationId (Ldev/kord/core/entity/interaction/ButtonInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getApplicationId-4_xYDEk (Ldev/kord/core/entity/interaction/ButtonInteraction;)J
 	public static fun getChannel (Ldev/kord/core/entity/interaction/ButtonInteraction;)Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public static fun getChannel (Ldev/kord/core/entity/interaction/ButtonInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getChannelId (Ldev/kord/core/entity/interaction/ButtonInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getChannelId-4_xYDEk (Ldev/kord/core/entity/interaction/ButtonInteraction;)J
 	public static fun getChannelOrNull (Ldev/kord/core/entity/interaction/ButtonInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getComponent (Ldev/kord/core/entity/interaction/ButtonInteraction;)Ldev/kord/core/entity/component/ButtonComponent;
 	public static fun getComponentId (Ldev/kord/core/entity/interaction/ButtonInteraction;)Ljava/lang/String;
 	public static fun getComponentType (Ldev/kord/core/entity/interaction/ButtonInteraction;)Ldev/kord/common/entity/ComponentType;
 	public static fun getGuildLocale (Ldev/kord/core/entity/interaction/ButtonInteraction;)Ldev/kord/common/Locale;
-	public static fun getId (Ldev/kord/core/entity/interaction/ButtonInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getId-4_xYDEk (Ldev/kord/core/entity/interaction/ButtonInteraction;)J
 	public static fun getLocale (Ldev/kord/core/entity/interaction/ButtonInteraction;)Ldev/kord/common/Locale;
 	public static fun getMessage (Ldev/kord/core/entity/interaction/ButtonInteraction;)Ldev/kord/core/entity/Message;
 	public static fun getOriginalInteractionResponse (Ldev/kord/core/entity/interaction/ButtonInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -9006,12 +9011,12 @@ public final class dev/kord/core/entity/interaction/ButtonInteraction$DefaultImp
 }
 
 public final class dev/kord/core/entity/interaction/ChannelOptionValue : dev/kord/core/entity/interaction/ResolvableOptionValue {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;ZLdev/kord/core/entity/channel/ResolvedChannel;)V
+	public synthetic fun <init> (JZLdev/kord/core/entity/channel/ResolvedChannel;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getFocused ()Z
 	public synthetic fun getResolvedObject ()Ldev/kord/core/entity/Entity;
 	public fun getResolvedObject ()Ldev/kord/core/entity/channel/ResolvedChannel;
-	public fun getValue ()Ldev/kord/common/entity/Snowflake;
 	public synthetic fun getValue ()Ljava/lang/Object;
+	public fun getValue-4_xYDEk ()J
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -9028,16 +9033,16 @@ public final class dev/kord/core/entity/interaction/ChatInputCommandInteraction$
 	public static synthetic fun deferPublicMessage (Ldev/kord/core/entity/interaction/ChatInputCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun deferPublicResponse (Ldev/kord/core/entity/interaction/ChatInputCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun deferPublicResponseUnsafe (Ldev/kord/core/entity/interaction/ChatInputCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getApplicationId (Ldev/kord/core/entity/interaction/ChatInputCommandInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getApplicationId-4_xYDEk (Ldev/kord/core/entity/interaction/ChatInputCommandInteraction;)J
 	public static fun getChannel (Ldev/kord/core/entity/interaction/ChatInputCommandInteraction;)Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public static fun getChannel (Ldev/kord/core/entity/interaction/ChatInputCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getChannelId (Ldev/kord/core/entity/interaction/ChatInputCommandInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getChannelId-4_xYDEk (Ldev/kord/core/entity/interaction/ChatInputCommandInteraction;)J
 	public static fun getChannelOrNull (Ldev/kord/core/entity/interaction/ChatInputCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getCommand (Ldev/kord/core/entity/interaction/ChatInputCommandInteraction;)Ldev/kord/core/entity/interaction/InteractionCommand;
 	public static fun getGuildLocale (Ldev/kord/core/entity/interaction/ChatInputCommandInteraction;)Ldev/kord/common/Locale;
-	public static fun getId (Ldev/kord/core/entity/interaction/ChatInputCommandInteraction;)Ldev/kord/common/entity/Snowflake;
-	public static fun getInvokedCommandGuildId (Ldev/kord/core/entity/interaction/ChatInputCommandInteraction;)Ldev/kord/common/entity/Snowflake;
-	public static fun getInvokedCommandId (Ldev/kord/core/entity/interaction/ChatInputCommandInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getId-4_xYDEk (Ldev/kord/core/entity/interaction/ChatInputCommandInteraction;)J
+	public static fun getInvokedCommandGuildId-eUG9VGM (Ldev/kord/core/entity/interaction/ChatInputCommandInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getInvokedCommandId-4_xYDEk (Ldev/kord/core/entity/interaction/ChatInputCommandInteraction;)J
 	public static fun getInvokedCommandName (Ldev/kord/core/entity/interaction/ChatInputCommandInteraction;)Ljava/lang/String;
 	public static fun getInvokedCommandType (Ldev/kord/core/entity/interaction/ChatInputCommandInteraction;)Ldev/kord/common/entity/ApplicationCommandType;
 	public static fun getLocale (Ldev/kord/core/entity/interaction/ChatInputCommandInteraction;)Ldev/kord/common/Locale;
@@ -9069,15 +9074,15 @@ public final class dev/kord/core/entity/interaction/ComponentInteraction$Default
 	public static fun deferPublicMessageUpdate (Ldev/kord/core/entity/interaction/ComponentInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun deferPublicResponse (Ldev/kord/core/entity/interaction/ComponentInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun deferPublicResponseUnsafe (Ldev/kord/core/entity/interaction/ComponentInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getApplicationId (Ldev/kord/core/entity/interaction/ComponentInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getApplicationId-4_xYDEk (Ldev/kord/core/entity/interaction/ComponentInteraction;)J
 	public static fun getChannel (Ldev/kord/core/entity/interaction/ComponentInteraction;)Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public static fun getChannel (Ldev/kord/core/entity/interaction/ComponentInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getChannelId (Ldev/kord/core/entity/interaction/ComponentInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getChannelId-4_xYDEk (Ldev/kord/core/entity/interaction/ComponentInteraction;)J
 	public static fun getChannelOrNull (Ldev/kord/core/entity/interaction/ComponentInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getComponentId (Ldev/kord/core/entity/interaction/ComponentInteraction;)Ljava/lang/String;
 	public static fun getComponentType (Ldev/kord/core/entity/interaction/ComponentInteraction;)Ldev/kord/common/entity/ComponentType;
 	public static fun getGuildLocale (Ldev/kord/core/entity/interaction/ComponentInteraction;)Ldev/kord/common/Locale;
-	public static fun getId (Ldev/kord/core/entity/interaction/ComponentInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getId-4_xYDEk (Ldev/kord/core/entity/interaction/ComponentInteraction;)J
 	public static fun getLocale (Ldev/kord/core/entity/interaction/ComponentInteraction;)Ldev/kord/common/Locale;
 	public static fun getMessage (Ldev/kord/core/entity/interaction/ComponentInteraction;)Ldev/kord/core/entity/Message;
 	public static fun getOriginalInteractionResponse (Ldev/kord/core/entity/interaction/ComponentInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -9098,13 +9103,13 @@ public abstract interface class dev/kord/core/entity/interaction/DataInteraction
 
 public final class dev/kord/core/entity/interaction/DataInteraction$DefaultImpls {
 	public static fun compareTo (Ldev/kord/core/entity/interaction/DataInteraction;Ldev/kord/core/entity/Entity;)I
-	public static fun getApplicationId (Ldev/kord/core/entity/interaction/DataInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getApplicationId-4_xYDEk (Ldev/kord/core/entity/interaction/DataInteraction;)J
 	public static fun getChannel (Ldev/kord/core/entity/interaction/DataInteraction;)Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public static fun getChannel (Ldev/kord/core/entity/interaction/DataInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getChannelId (Ldev/kord/core/entity/interaction/DataInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getChannelId-4_xYDEk (Ldev/kord/core/entity/interaction/DataInteraction;)J
 	public static fun getChannelOrNull (Ldev/kord/core/entity/interaction/DataInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getGuildLocale (Ldev/kord/core/entity/interaction/DataInteraction;)Ldev/kord/common/Locale;
-	public static fun getId (Ldev/kord/core/entity/interaction/DataInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getId-4_xYDEk (Ldev/kord/core/entity/interaction/DataInteraction;)J
 	public static fun getLocale (Ldev/kord/core/entity/interaction/DataInteraction;)Ldev/kord/common/Locale;
 	public static fun getToken (Ldev/kord/core/entity/interaction/DataInteraction;)Ljava/lang/String;
 	public static fun getType (Ldev/kord/core/entity/interaction/DataInteraction;)Ldev/kord/common/entity/InteractionType;
@@ -9123,15 +9128,15 @@ public final class dev/kord/core/entity/interaction/GlobalApplicationCommandInte
 	public static synthetic fun deferPublicMessage (Ldev/kord/core/entity/interaction/GlobalApplicationCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun deferPublicResponse (Ldev/kord/core/entity/interaction/GlobalApplicationCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun deferPublicResponseUnsafe (Ldev/kord/core/entity/interaction/GlobalApplicationCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getApplicationId (Ldev/kord/core/entity/interaction/GlobalApplicationCommandInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getApplicationId-4_xYDEk (Ldev/kord/core/entity/interaction/GlobalApplicationCommandInteraction;)J
 	public static fun getChannel (Ldev/kord/core/entity/interaction/GlobalApplicationCommandInteraction;)Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public static fun getChannel (Ldev/kord/core/entity/interaction/GlobalApplicationCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getChannelId (Ldev/kord/core/entity/interaction/GlobalApplicationCommandInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getChannelId-4_xYDEk (Ldev/kord/core/entity/interaction/GlobalApplicationCommandInteraction;)J
 	public static fun getChannelOrNull (Ldev/kord/core/entity/interaction/GlobalApplicationCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getGuildLocale (Ldev/kord/core/entity/interaction/GlobalApplicationCommandInteraction;)Ldev/kord/common/Locale;
-	public static fun getId (Ldev/kord/core/entity/interaction/GlobalApplicationCommandInteraction;)Ldev/kord/common/entity/Snowflake;
-	public static fun getInvokedCommandGuildId (Ldev/kord/core/entity/interaction/GlobalApplicationCommandInteraction;)Ldev/kord/common/entity/Snowflake;
-	public static fun getInvokedCommandId (Ldev/kord/core/entity/interaction/GlobalApplicationCommandInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getId-4_xYDEk (Ldev/kord/core/entity/interaction/GlobalApplicationCommandInteraction;)J
+	public static fun getInvokedCommandGuildId-eUG9VGM (Ldev/kord/core/entity/interaction/GlobalApplicationCommandInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getInvokedCommandId-4_xYDEk (Ldev/kord/core/entity/interaction/GlobalApplicationCommandInteraction;)J
 	public static fun getInvokedCommandName (Ldev/kord/core/entity/interaction/GlobalApplicationCommandInteraction;)Ljava/lang/String;
 	public static fun getInvokedCommandType (Ldev/kord/core/entity/interaction/GlobalApplicationCommandInteraction;)Ldev/kord/common/entity/ApplicationCommandType;
 	public static fun getLocale (Ldev/kord/core/entity/interaction/GlobalApplicationCommandInteraction;)Ldev/kord/common/Locale;
@@ -9151,16 +9156,16 @@ public final class dev/kord/core/entity/interaction/GlobalAutoCompleteInteractio
 	public fun compareTo (Ldev/kord/core/entity/Entity;)I
 	public synthetic fun compareTo (Ljava/lang/Object;)I
 	public fun equals (Ljava/lang/Object;)Z
-	public fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
+	public fun getApplicationId-4_xYDEk ()J
 	public fun getChannel ()Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public fun getChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public fun getChannelId-4_xYDEk ()J
 	public fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getCommand ()Ldev/kord/core/entity/interaction/InteractionCommand;
 	public fun getData ()Ldev/kord/core/cache/data/InteractionData;
 	public fun getFocusedOption ()Ldev/kord/core/entity/interaction/StringOptionValue;
 	public fun getGuildLocale ()Ldev/kord/common/Locale;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getLocale ()Ldev/kord/common/Locale;
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
@@ -9197,10 +9202,10 @@ public final class dev/kord/core/entity/interaction/GlobalButtonInteraction : de
 	public fun deferPublicResponse (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun deferPublicResponseUnsafe (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun equals (Ljava/lang/Object;)Z
-	public fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
+	public fun getApplicationId-4_xYDEk ()J
 	public fun getChannel ()Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public fun getChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public fun getChannelId-4_xYDEk ()J
 	public fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getComponent ()Ldev/kord/core/entity/component/ButtonComponent;
 	public synthetic fun getComponent ()Ldev/kord/core/entity/component/Component;
@@ -9208,7 +9213,7 @@ public final class dev/kord/core/entity/interaction/GlobalButtonInteraction : de
 	public fun getComponentType ()Ldev/kord/common/entity/ComponentType;
 	public fun getData ()Ldev/kord/core/cache/data/InteractionData;
 	public fun getGuildLocale ()Ldev/kord/common/Locale;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getLocale ()Ldev/kord/common/Locale;
 	public fun getMessage ()Ldev/kord/core/entity/Message;
@@ -9247,17 +9252,17 @@ public final class dev/kord/core/entity/interaction/GlobalChatInputCommandIntera
 	public fun deferPublicResponse (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun deferPublicResponseUnsafe (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun equals (Ljava/lang/Object;)Z
-	public fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
+	public fun getApplicationId-4_xYDEk ()J
 	public fun getChannel ()Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public fun getChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public fun getChannelId-4_xYDEk ()J
 	public fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getCommand ()Ldev/kord/core/entity/interaction/InteractionCommand;
 	public fun getData ()Ldev/kord/core/cache/data/InteractionData;
 	public fun getGuildLocale ()Ldev/kord/common/Locale;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
-	public fun getInvokedCommandGuildId ()Ldev/kord/common/entity/Snowflake;
-	public fun getInvokedCommandId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
+	public fun getInvokedCommandGuildId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
+	public fun getInvokedCommandId-4_xYDEk ()J
 	public fun getInvokedCommandName ()Ljava/lang/String;
 	public fun getInvokedCommandType ()Ldev/kord/common/entity/ApplicationCommandType;
 	public fun getKord ()Ldev/kord/core/Kord;
@@ -9303,15 +9308,15 @@ public final class dev/kord/core/entity/interaction/GlobalComponentInteraction$D
 	public static fun deferPublicMessageUpdate (Ldev/kord/core/entity/interaction/GlobalComponentInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun deferPublicResponse (Ldev/kord/core/entity/interaction/GlobalComponentInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun deferPublicResponseUnsafe (Ldev/kord/core/entity/interaction/GlobalComponentInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getApplicationId (Ldev/kord/core/entity/interaction/GlobalComponentInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getApplicationId-4_xYDEk (Ldev/kord/core/entity/interaction/GlobalComponentInteraction;)J
 	public static fun getChannel (Ldev/kord/core/entity/interaction/GlobalComponentInteraction;)Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public static fun getChannel (Ldev/kord/core/entity/interaction/GlobalComponentInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getChannelId (Ldev/kord/core/entity/interaction/GlobalComponentInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getChannelId-4_xYDEk (Ldev/kord/core/entity/interaction/GlobalComponentInteraction;)J
 	public static fun getChannelOrNull (Ldev/kord/core/entity/interaction/GlobalComponentInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getComponentId (Ldev/kord/core/entity/interaction/GlobalComponentInteraction;)Ljava/lang/String;
 	public static fun getComponentType (Ldev/kord/core/entity/interaction/GlobalComponentInteraction;)Ldev/kord/common/entity/ComponentType;
 	public static fun getGuildLocale (Ldev/kord/core/entity/interaction/GlobalComponentInteraction;)Ldev/kord/common/Locale;
-	public static fun getId (Ldev/kord/core/entity/interaction/GlobalComponentInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getId-4_xYDEk (Ldev/kord/core/entity/interaction/GlobalComponentInteraction;)J
 	public static fun getLocale (Ldev/kord/core/entity/interaction/GlobalComponentInteraction;)Ldev/kord/common/Locale;
 	public static fun getMessage (Ldev/kord/core/entity/interaction/GlobalComponentInteraction;)Ldev/kord/core/entity/Message;
 	public static fun getOriginalInteractionResponse (Ldev/kord/core/entity/interaction/GlobalComponentInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -9329,13 +9334,13 @@ public abstract interface class dev/kord/core/entity/interaction/GlobalInteracti
 
 public final class dev/kord/core/entity/interaction/GlobalInteraction$DefaultImpls {
 	public static fun compareTo (Ldev/kord/core/entity/interaction/GlobalInteraction;Ldev/kord/core/entity/Entity;)I
-	public static fun getApplicationId (Ldev/kord/core/entity/interaction/GlobalInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getApplicationId-4_xYDEk (Ldev/kord/core/entity/interaction/GlobalInteraction;)J
 	public static fun getChannel (Ldev/kord/core/entity/interaction/GlobalInteraction;)Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public static fun getChannel (Ldev/kord/core/entity/interaction/GlobalInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getChannelId (Ldev/kord/core/entity/interaction/GlobalInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getChannelId-4_xYDEk (Ldev/kord/core/entity/interaction/GlobalInteraction;)J
 	public static fun getChannelOrNull (Ldev/kord/core/entity/interaction/GlobalInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getGuildLocale (Ldev/kord/core/entity/interaction/GlobalInteraction;)Ldev/kord/common/Locale;
-	public static fun getId (Ldev/kord/core/entity/interaction/GlobalInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getId-4_xYDEk (Ldev/kord/core/entity/interaction/GlobalInteraction;)J
 	public static fun getLocale (Ldev/kord/core/entity/interaction/GlobalInteraction;)Ldev/kord/common/Locale;
 	public static fun getToken (Ldev/kord/core/entity/interaction/GlobalInteraction;)Ljava/lang/String;
 	public static fun getType (Ldev/kord/core/entity/interaction/GlobalInteraction;)Ldev/kord/common/entity/InteractionType;
@@ -9354,16 +9359,16 @@ public final class dev/kord/core/entity/interaction/GlobalMessageCommandInteract
 	public fun deferPublicResponse (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun deferPublicResponseUnsafe (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun equals (Ljava/lang/Object;)Z
-	public fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
+	public fun getApplicationId-4_xYDEk ()J
 	public fun getChannel ()Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public fun getChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public fun getChannelId-4_xYDEk ()J
 	public fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getData ()Ldev/kord/core/cache/data/InteractionData;
 	public fun getGuildLocale ()Ldev/kord/common/Locale;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
-	public fun getInvokedCommandGuildId ()Ldev/kord/common/entity/Snowflake;
-	public fun getInvokedCommandId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
+	public fun getInvokedCommandGuildId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
+	public fun getInvokedCommandId-4_xYDEk ()J
 	public fun getInvokedCommandName ()Ljava/lang/String;
 	public fun getInvokedCommandType ()Ldev/kord/common/entity/ApplicationCommandType;
 	public fun getKord ()Ldev/kord/core/Kord;
@@ -9375,7 +9380,7 @@ public final class dev/kord/core/entity/interaction/GlobalMessageCommandInteract
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
 	public fun getTarget ()Ldev/kord/core/behavior/MessageBehavior;
 	public fun getTarget (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getTargetId ()Ldev/kord/common/entity/Snowflake;
+	public fun getTargetId-4_xYDEk ()J
 	public fun getTargetOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getToken ()Ljava/lang/String;
 	public fun getType ()Ldev/kord/common/entity/InteractionType;
@@ -9415,14 +9420,14 @@ public final class dev/kord/core/entity/interaction/GlobalModalSubmitInteraction
 	public fun deferPublicResponseUnsafe (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getActionRows ()Ljava/util/List;
-	public fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
+	public fun getApplicationId-4_xYDEk ()J
 	public fun getChannel ()Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public fun getChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public fun getChannelId-4_xYDEk ()J
 	public fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getData ()Ldev/kord/core/cache/data/InteractionData;
 	public fun getGuildLocale ()Ldev/kord/common/Locale;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getLocale ()Ldev/kord/common/Locale;
 	public fun getMessage ()Ldev/kord/core/entity/Message;
@@ -9464,10 +9469,10 @@ public final class dev/kord/core/entity/interaction/GlobalSelectMenuInteraction 
 	public fun deferPublicResponse (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun deferPublicResponseUnsafe (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun equals (Ljava/lang/Object;)Z
-	public fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
+	public fun getApplicationId-4_xYDEk ()J
 	public fun getChannel ()Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public fun getChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public fun getChannelId-4_xYDEk ()J
 	public fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public synthetic fun getComponent ()Ldev/kord/core/entity/component/Component;
 	public fun getComponent ()Ldev/kord/core/entity/component/SelectMenuComponent;
@@ -9475,7 +9480,7 @@ public final class dev/kord/core/entity/interaction/GlobalSelectMenuInteraction 
 	public fun getComponentType ()Ldev/kord/common/entity/ComponentType;
 	public fun getData ()Ldev/kord/core/cache/data/InteractionData;
 	public fun getGuildLocale ()Ldev/kord/common/Locale;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getLocale ()Ldev/kord/common/Locale;
 	public fun getMessage ()Ldev/kord/core/entity/Message;
@@ -9515,16 +9520,16 @@ public final class dev/kord/core/entity/interaction/GlobalUserCommandInteraction
 	public fun deferPublicResponse (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun deferPublicResponseUnsafe (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun equals (Ljava/lang/Object;)Z
-	public fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
+	public fun getApplicationId-4_xYDEk ()J
 	public fun getChannel ()Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public fun getChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public fun getChannelId-4_xYDEk ()J
 	public fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getData ()Ldev/kord/core/cache/data/InteractionData;
 	public fun getGuildLocale ()Ldev/kord/common/Locale;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
-	public fun getInvokedCommandGuildId ()Ldev/kord/common/entity/Snowflake;
-	public fun getInvokedCommandId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
+	public fun getInvokedCommandGuildId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
+	public fun getInvokedCommandId-4_xYDEk ()J
 	public fun getInvokedCommandName ()Ljava/lang/String;
 	public fun getInvokedCommandType ()Ldev/kord/common/entity/ApplicationCommandType;
 	public fun getKord ()Ldev/kord/core/Kord;
@@ -9535,7 +9540,7 @@ public final class dev/kord/core/entity/interaction/GlobalUserCommandInteraction
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
 	public fun getTarget ()Ldev/kord/core/behavior/UserBehavior;
 	public fun getTarget (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getTargetId ()Ldev/kord/common/entity/Snowflake;
+	public fun getTargetId-4_xYDEk ()J
 	public fun getTargetOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getToken ()Ljava/lang/String;
 	public fun getType ()Ldev/kord/common/entity/InteractionType;
@@ -9575,7 +9580,7 @@ public final class dev/kord/core/entity/interaction/GroupCommand : dev/kord/core
 	public fun getOptions ()Ljava/util/Map;
 	public fun getResolvedObjects ()Ldev/kord/core/entity/interaction/ResolvedObjects;
 	public fun getRoles ()Ljava/util/Map;
-	public fun getRootId ()Ldev/kord/common/entity/Snowflake;
+	public fun getRootId-4_xYDEk ()J
 	public fun getRootName ()Ljava/lang/String;
 	public fun getStrings ()Ljava/util/Map;
 	public fun getUsers ()Ljava/util/Map;
@@ -9594,19 +9599,19 @@ public final class dev/kord/core/entity/interaction/GuildApplicationCommandInter
 	public static fun deferPublicResponse (Ldev/kord/core/entity/interaction/GuildApplicationCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun deferPublicResponseUnsafe (Ldev/kord/core/entity/interaction/GuildApplicationCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getAppPermissions (Ldev/kord/core/entity/interaction/GuildApplicationCommandInteraction;)Ldev/kord/common/entity/Permissions;
-	public static fun getApplicationId (Ldev/kord/core/entity/interaction/GuildApplicationCommandInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getApplicationId-4_xYDEk (Ldev/kord/core/entity/interaction/GuildApplicationCommandInteraction;)J
 	public static fun getChannel (Ldev/kord/core/entity/interaction/GuildApplicationCommandInteraction;)Ldev/kord/core/behavior/channel/GuildMessageChannelBehavior;
 	public static fun getChannel (Ldev/kord/core/entity/interaction/GuildApplicationCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getChannelId (Ldev/kord/core/entity/interaction/GuildApplicationCommandInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getChannelId-4_xYDEk (Ldev/kord/core/entity/interaction/GuildApplicationCommandInteraction;)J
 	public static fun getChannelOrNull (Ldev/kord/core/entity/interaction/GuildApplicationCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getGuild (Ldev/kord/core/entity/interaction/GuildApplicationCommandInteraction;)Ldev/kord/core/behavior/GuildBehavior;
 	public static fun getGuild (Ldev/kord/core/entity/interaction/GuildApplicationCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getGuildId (Ldev/kord/core/entity/interaction/GuildApplicationCommandInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getGuildId-4_xYDEk (Ldev/kord/core/entity/interaction/GuildApplicationCommandInteraction;)J
 	public static fun getGuildLocale (Ldev/kord/core/entity/interaction/GuildApplicationCommandInteraction;)Ldev/kord/common/Locale;
 	public static fun getGuildOrNull (Ldev/kord/core/entity/interaction/GuildApplicationCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getId (Ldev/kord/core/entity/interaction/GuildApplicationCommandInteraction;)Ldev/kord/common/entity/Snowflake;
-	public static fun getInvokedCommandGuildId (Ldev/kord/core/entity/interaction/GuildApplicationCommandInteraction;)Ldev/kord/common/entity/Snowflake;
-	public static fun getInvokedCommandId (Ldev/kord/core/entity/interaction/GuildApplicationCommandInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getId-4_xYDEk (Ldev/kord/core/entity/interaction/GuildApplicationCommandInteraction;)J
+	public static fun getInvokedCommandGuildId-eUG9VGM (Ldev/kord/core/entity/interaction/GuildApplicationCommandInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getInvokedCommandId-4_xYDEk (Ldev/kord/core/entity/interaction/GuildApplicationCommandInteraction;)J
 	public static fun getInvokedCommandName (Ldev/kord/core/entity/interaction/GuildApplicationCommandInteraction;)Ljava/lang/String;
 	public static fun getInvokedCommandType (Ldev/kord/core/entity/interaction/GuildApplicationCommandInteraction;)Ldev/kord/common/entity/ApplicationCommandType;
 	public static fun getLocale (Ldev/kord/core/entity/interaction/GuildApplicationCommandInteraction;)Ldev/kord/common/Locale;
@@ -9628,21 +9633,21 @@ public final class dev/kord/core/entity/interaction/GuildAutoCompleteInteraction
 	public synthetic fun compareTo (Ljava/lang/Object;)I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getAppPermissions ()Ldev/kord/common/entity/Permissions;
-	public fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
+	public fun getApplicationId-4_xYDEk ()J
 	public fun getChannel ()Ldev/kord/core/behavior/channel/GuildMessageChannelBehavior;
 	public synthetic fun getChannel ()Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public fun getChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public fun getChannelId-4_xYDEk ()J
 	public fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getCommand ()Ldev/kord/core/entity/interaction/InteractionCommand;
 	public fun getData ()Ldev/kord/core/cache/data/InteractionData;
 	public fun getFocusedOption ()Ldev/kord/core/entity/interaction/StringOptionValue;
 	public fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public fun getGuildId-4_xYDEk ()J
 	public fun getGuildLocale ()Ldev/kord/common/Locale;
 	public fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getLocale ()Ldev/kord/common/Locale;
 	public fun getPermissions ()Ldev/kord/common/entity/Permissions;
@@ -9682,11 +9687,11 @@ public final class dev/kord/core/entity/interaction/GuildButtonInteraction : dev
 	public fun deferPublicResponseUnsafe (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getAppPermissions ()Ldev/kord/common/entity/Permissions;
-	public fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
+	public fun getApplicationId-4_xYDEk ()J
 	public fun getChannel ()Ldev/kord/core/behavior/channel/GuildMessageChannelBehavior;
 	public synthetic fun getChannel ()Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public fun getChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public fun getChannelId-4_xYDEk ()J
 	public fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getComponent ()Ldev/kord/core/entity/component/ButtonComponent;
 	public synthetic fun getComponent ()Ldev/kord/core/entity/component/Component;
@@ -9695,10 +9700,10 @@ public final class dev/kord/core/entity/interaction/GuildButtonInteraction : dev
 	public fun getData ()Ldev/kord/core/cache/data/InteractionData;
 	public fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public fun getGuildId-4_xYDEk ()J
 	public fun getGuildLocale ()Ldev/kord/common/Locale;
 	public fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getLocale ()Ldev/kord/common/Locale;
 	public fun getMessage ()Ldev/kord/core/entity/Message;
@@ -9740,22 +9745,22 @@ public final class dev/kord/core/entity/interaction/GuildChatInputCommandInterac
 	public fun deferPublicResponseUnsafe (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getAppPermissions ()Ldev/kord/common/entity/Permissions;
-	public fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
+	public fun getApplicationId-4_xYDEk ()J
 	public fun getChannel ()Ldev/kord/core/behavior/channel/GuildMessageChannelBehavior;
 	public synthetic fun getChannel ()Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public fun getChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public fun getChannelId-4_xYDEk ()J
 	public fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getCommand ()Ldev/kord/core/entity/interaction/InteractionCommand;
 	public fun getData ()Ldev/kord/core/cache/data/InteractionData;
 	public fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public fun getGuildId-4_xYDEk ()J
 	public fun getGuildLocale ()Ldev/kord/common/Locale;
 	public fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
-	public fun getInvokedCommandGuildId ()Ldev/kord/common/entity/Snowflake;
-	public fun getInvokedCommandId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
+	public fun getInvokedCommandGuildId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
+	public fun getInvokedCommandId-4_xYDEk ()J
 	public fun getInvokedCommandName ()Ljava/lang/String;
 	public fun getInvokedCommandType ()Ldev/kord/common/entity/ApplicationCommandType;
 	public fun getKord ()Ldev/kord/core/Kord;
@@ -9804,19 +9809,19 @@ public final class dev/kord/core/entity/interaction/GuildComponentInteraction$De
 	public static fun deferPublicResponse (Ldev/kord/core/entity/interaction/GuildComponentInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun deferPublicResponseUnsafe (Ldev/kord/core/entity/interaction/GuildComponentInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getAppPermissions (Ldev/kord/core/entity/interaction/GuildComponentInteraction;)Ldev/kord/common/entity/Permissions;
-	public static fun getApplicationId (Ldev/kord/core/entity/interaction/GuildComponentInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getApplicationId-4_xYDEk (Ldev/kord/core/entity/interaction/GuildComponentInteraction;)J
 	public static fun getChannel (Ldev/kord/core/entity/interaction/GuildComponentInteraction;)Ldev/kord/core/behavior/channel/GuildMessageChannelBehavior;
 	public static fun getChannel (Ldev/kord/core/entity/interaction/GuildComponentInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getChannelId (Ldev/kord/core/entity/interaction/GuildComponentInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getChannelId-4_xYDEk (Ldev/kord/core/entity/interaction/GuildComponentInteraction;)J
 	public static fun getChannelOrNull (Ldev/kord/core/entity/interaction/GuildComponentInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getComponentId (Ldev/kord/core/entity/interaction/GuildComponentInteraction;)Ljava/lang/String;
 	public static fun getComponentType (Ldev/kord/core/entity/interaction/GuildComponentInteraction;)Ldev/kord/common/entity/ComponentType;
 	public static fun getGuild (Ldev/kord/core/entity/interaction/GuildComponentInteraction;)Ldev/kord/core/behavior/GuildBehavior;
 	public static fun getGuild (Ldev/kord/core/entity/interaction/GuildComponentInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getGuildId (Ldev/kord/core/entity/interaction/GuildComponentInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getGuildId-4_xYDEk (Ldev/kord/core/entity/interaction/GuildComponentInteraction;)J
 	public static fun getGuildLocale (Ldev/kord/core/entity/interaction/GuildComponentInteraction;)Ldev/kord/common/Locale;
 	public static fun getGuildOrNull (Ldev/kord/core/entity/interaction/GuildComponentInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getId (Ldev/kord/core/entity/interaction/GuildComponentInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getId-4_xYDEk (Ldev/kord/core/entity/interaction/GuildComponentInteraction;)J
 	public static fun getLocale (Ldev/kord/core/entity/interaction/GuildComponentInteraction;)Ldev/kord/common/Locale;
 	public static fun getMessage (Ldev/kord/core/entity/interaction/GuildComponentInteraction;)Ldev/kord/core/entity/Message;
 	public static fun getOriginalInteractionResponse (Ldev/kord/core/entity/interaction/GuildComponentInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -9830,7 +9835,7 @@ public final class dev/kord/core/entity/interaction/GuildComponentInteraction$De
 
 public abstract interface class dev/kord/core/entity/interaction/GuildInteraction : dev/kord/core/behavior/interaction/GuildInteractionBehavior, dev/kord/core/entity/interaction/Interaction {
 	public abstract fun getAppPermissions ()Ldev/kord/common/entity/Permissions;
-	public abstract fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getGuildId-4_xYDEk ()J
 	public abstract fun getPermissions ()Ldev/kord/common/entity/Permissions;
 	public abstract fun getUser ()Ldev/kord/core/entity/Member;
 	public abstract fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/entity/interaction/GuildInteraction;
@@ -9839,17 +9844,17 @@ public abstract interface class dev/kord/core/entity/interaction/GuildInteractio
 public final class dev/kord/core/entity/interaction/GuildInteraction$DefaultImpls {
 	public static fun compareTo (Ldev/kord/core/entity/interaction/GuildInteraction;Ldev/kord/core/entity/Entity;)I
 	public static fun getAppPermissions (Ldev/kord/core/entity/interaction/GuildInteraction;)Ldev/kord/common/entity/Permissions;
-	public static fun getApplicationId (Ldev/kord/core/entity/interaction/GuildInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getApplicationId-4_xYDEk (Ldev/kord/core/entity/interaction/GuildInteraction;)J
 	public static fun getChannel (Ldev/kord/core/entity/interaction/GuildInteraction;)Ldev/kord/core/behavior/channel/GuildMessageChannelBehavior;
 	public static fun getChannel (Ldev/kord/core/entity/interaction/GuildInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getChannelId (Ldev/kord/core/entity/interaction/GuildInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getChannelId-4_xYDEk (Ldev/kord/core/entity/interaction/GuildInteraction;)J
 	public static fun getChannelOrNull (Ldev/kord/core/entity/interaction/GuildInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getGuild (Ldev/kord/core/entity/interaction/GuildInteraction;)Ldev/kord/core/behavior/GuildBehavior;
 	public static fun getGuild (Ldev/kord/core/entity/interaction/GuildInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getGuildId (Ldev/kord/core/entity/interaction/GuildInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getGuildId-4_xYDEk (Ldev/kord/core/entity/interaction/GuildInteraction;)J
 	public static fun getGuildLocale (Ldev/kord/core/entity/interaction/GuildInteraction;)Ldev/kord/common/Locale;
 	public static fun getGuildOrNull (Ldev/kord/core/entity/interaction/GuildInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getId (Ldev/kord/core/entity/interaction/GuildInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getId-4_xYDEk (Ldev/kord/core/entity/interaction/GuildInteraction;)J
 	public static fun getLocale (Ldev/kord/core/entity/interaction/GuildInteraction;)Ldev/kord/common/Locale;
 	public static fun getPermissions (Ldev/kord/core/entity/interaction/GuildInteraction;)Ldev/kord/common/entity/Permissions;
 	public static fun getToken (Ldev/kord/core/entity/interaction/GuildInteraction;)Ljava/lang/String;
@@ -9870,21 +9875,21 @@ public final class dev/kord/core/entity/interaction/GuildMessageCommandInteracti
 	public fun deferPublicResponseUnsafe (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getAppPermissions ()Ldev/kord/common/entity/Permissions;
-	public fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
+	public fun getApplicationId-4_xYDEk ()J
 	public fun getChannel ()Ldev/kord/core/behavior/channel/GuildMessageChannelBehavior;
 	public synthetic fun getChannel ()Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public fun getChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public fun getChannelId-4_xYDEk ()J
 	public fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getData ()Ldev/kord/core/cache/data/InteractionData;
 	public fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public fun getGuildId-4_xYDEk ()J
 	public fun getGuildLocale ()Ldev/kord/common/Locale;
 	public fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
-	public fun getInvokedCommandGuildId ()Ldev/kord/common/entity/Snowflake;
-	public fun getInvokedCommandId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
+	public fun getInvokedCommandGuildId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
+	public fun getInvokedCommandId-4_xYDEk ()J
 	public fun getInvokedCommandName ()Ljava/lang/String;
 	public fun getInvokedCommandType ()Ldev/kord/common/entity/ApplicationCommandType;
 	public fun getKord ()Ldev/kord/core/Kord;
@@ -9897,7 +9902,7 @@ public final class dev/kord/core/entity/interaction/GuildMessageCommandInteracti
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
 	public fun getTarget ()Ldev/kord/core/behavior/MessageBehavior;
 	public fun getTarget (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getTargetId ()Ldev/kord/common/entity/Snowflake;
+	public fun getTargetId-4_xYDEk ()J
 	public fun getTargetOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getToken ()Ljava/lang/String;
 	public fun getType ()Ldev/kord/common/entity/InteractionType;
@@ -9939,19 +9944,19 @@ public final class dev/kord/core/entity/interaction/GuildModalSubmitInteraction 
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getActionRows ()Ljava/util/List;
 	public fun getAppPermissions ()Ldev/kord/common/entity/Permissions;
-	public fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
+	public fun getApplicationId-4_xYDEk ()J
 	public fun getChannel ()Ldev/kord/core/behavior/channel/GuildMessageChannelBehavior;
 	public synthetic fun getChannel ()Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public fun getChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public fun getChannelId-4_xYDEk ()J
 	public fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getData ()Ldev/kord/core/cache/data/InteractionData;
 	public fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public fun getGuildId-4_xYDEk ()J
 	public fun getGuildLocale ()Ldev/kord/common/Locale;
 	public fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getLocale ()Ldev/kord/common/Locale;
 	public fun getMessage ()Ldev/kord/core/entity/Message;
@@ -9996,11 +10001,11 @@ public final class dev/kord/core/entity/interaction/GuildSelectMenuInteraction :
 	public fun deferPublicResponseUnsafe (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getAppPermissions ()Ldev/kord/common/entity/Permissions;
-	public fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
+	public fun getApplicationId-4_xYDEk ()J
 	public fun getChannel ()Ldev/kord/core/behavior/channel/GuildMessageChannelBehavior;
 	public synthetic fun getChannel ()Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public fun getChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public fun getChannelId-4_xYDEk ()J
 	public fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public synthetic fun getComponent ()Ldev/kord/core/entity/component/Component;
 	public fun getComponent ()Ldev/kord/core/entity/component/SelectMenuComponent;
@@ -10009,10 +10014,10 @@ public final class dev/kord/core/entity/interaction/GuildSelectMenuInteraction :
 	public fun getData ()Ldev/kord/core/cache/data/InteractionData;
 	public fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public fun getGuildId-4_xYDEk ()J
 	public fun getGuildLocale ()Ldev/kord/common/Locale;
 	public fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getLocale ()Ldev/kord/common/Locale;
 	public fun getMessage ()Ldev/kord/core/entity/Message;
@@ -10055,21 +10060,21 @@ public final class dev/kord/core/entity/interaction/GuildUserCommandInteraction 
 	public fun deferPublicResponseUnsafe (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getAppPermissions ()Ldev/kord/common/entity/Permissions;
-	public fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
+	public fun getApplicationId-4_xYDEk ()J
 	public fun getChannel ()Ldev/kord/core/behavior/channel/GuildMessageChannelBehavior;
 	public synthetic fun getChannel ()Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public fun getChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public fun getChannelId-4_xYDEk ()J
 	public fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getData ()Ldev/kord/core/cache/data/InteractionData;
 	public fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public fun getGuildId-4_xYDEk ()J
 	public fun getGuildLocale ()Ldev/kord/common/Locale;
 	public fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
-	public fun getInvokedCommandGuildId ()Ldev/kord/common/entity/Snowflake;
-	public fun getInvokedCommandId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
+	public fun getInvokedCommandGuildId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
+	public fun getInvokedCommandId-4_xYDEk ()J
 	public fun getInvokedCommandName ()Ljava/lang/String;
 	public fun getInvokedCommandType ()Ldev/kord/common/entity/ApplicationCommandType;
 	public fun getKord ()Ldev/kord/core/Kord;
@@ -10081,7 +10086,7 @@ public final class dev/kord/core/entity/interaction/GuildUserCommandInteraction 
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
 	public fun getTarget ()Ldev/kord/core/behavior/UserBehavior;
 	public fun getTarget (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getTargetId ()Ldev/kord/common/entity/Snowflake;
+	public fun getTargetId-4_xYDEk ()J
 	public fun getTargetOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getToken ()Ljava/lang/String;
 	public fun getType ()Ldev/kord/common/entity/InteractionType;
@@ -10116,11 +10121,11 @@ public final class dev/kord/core/entity/interaction/IntegerOptionValue : dev/kor
 
 public abstract interface class dev/kord/core/entity/interaction/Interaction : dev/kord/core/behavior/interaction/InteractionBehavior {
 	public static final field Companion Ldev/kord/core/entity/interaction/Interaction$Companion;
-	public abstract fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
-	public abstract fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getApplicationId-4_xYDEk ()J
+	public abstract fun getChannelId-4_xYDEk ()J
 	public abstract fun getData ()Ldev/kord/core/cache/data/InteractionData;
 	public abstract fun getGuildLocale ()Ldev/kord/common/Locale;
-	public abstract fun getId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getId-4_xYDEk ()J
 	public abstract fun getLocale ()Ldev/kord/common/Locale;
 	public abstract fun getToken ()Ljava/lang/String;
 	public abstract fun getType ()Ldev/kord/common/entity/InteractionType;
@@ -10136,13 +10141,13 @@ public final class dev/kord/core/entity/interaction/Interaction$Companion {
 
 public final class dev/kord/core/entity/interaction/Interaction$DefaultImpls {
 	public static fun compareTo (Ldev/kord/core/entity/interaction/Interaction;Ldev/kord/core/entity/Entity;)I
-	public static fun getApplicationId (Ldev/kord/core/entity/interaction/Interaction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getApplicationId-4_xYDEk (Ldev/kord/core/entity/interaction/Interaction;)J
 	public static fun getChannel (Ldev/kord/core/entity/interaction/Interaction;)Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public static fun getChannel (Ldev/kord/core/entity/interaction/Interaction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getChannelId (Ldev/kord/core/entity/interaction/Interaction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getChannelId-4_xYDEk (Ldev/kord/core/entity/interaction/Interaction;)J
 	public static fun getChannelOrNull (Ldev/kord/core/entity/interaction/Interaction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getGuildLocale (Ldev/kord/core/entity/interaction/Interaction;)Ldev/kord/common/Locale;
-	public static fun getId (Ldev/kord/core/entity/interaction/Interaction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getId-4_xYDEk (Ldev/kord/core/entity/interaction/Interaction;)J
 	public static fun getLocale (Ldev/kord/core/entity/interaction/Interaction;)Ldev/kord/common/Locale;
 	public static fun getToken (Ldev/kord/core/entity/interaction/Interaction;)Ljava/lang/String;
 	public static fun getType (Ldev/kord/core/entity/interaction/Interaction;)Ldev/kord/common/entity/InteractionType;
@@ -10161,7 +10166,7 @@ public abstract interface class dev/kord/core/entity/interaction/InteractionComm
 	public abstract fun getOptions ()Ljava/util/Map;
 	public abstract fun getResolvedObjects ()Ldev/kord/core/entity/interaction/ResolvedObjects;
 	public abstract fun getRoles ()Ljava/util/Map;
-	public abstract fun getRootId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getRootId-4_xYDEk ()J
 	public abstract fun getRootName ()Ljava/lang/String;
 	public abstract fun getStrings ()Ljava/util/Map;
 	public abstract fun getUsers ()Ljava/util/Map;
@@ -10177,7 +10182,7 @@ public final class dev/kord/core/entity/interaction/InteractionCommand$DefaultIm
 	public static fun getNumbers (Ldev/kord/core/entity/interaction/InteractionCommand;)Ljava/util/Map;
 	public static fun getResolvedObjects (Ldev/kord/core/entity/interaction/InteractionCommand;)Ldev/kord/core/entity/interaction/ResolvedObjects;
 	public static fun getRoles (Ldev/kord/core/entity/interaction/InteractionCommand;)Ljava/util/Map;
-	public static fun getRootId (Ldev/kord/core/entity/interaction/InteractionCommand;)Ldev/kord/common/entity/Snowflake;
+	public static fun getRootId-4_xYDEk (Ldev/kord/core/entity/interaction/InteractionCommand;)J
 	public static fun getRootName (Ldev/kord/core/entity/interaction/InteractionCommand;)Ljava/lang/String;
 	public static fun getStrings (Ldev/kord/core/entity/interaction/InteractionCommand;)Ljava/util/Map;
 	public static fun getUsers (Ldev/kord/core/entity/interaction/InteractionCommand;)Ljava/util/Map;
@@ -10188,7 +10193,7 @@ public final class dev/kord/core/entity/interaction/InteractionCommandKt {
 }
 
 public final class dev/kord/core/entity/interaction/MemberOptionValue : dev/kord/core/entity/interaction/UserOptionValue {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;ZLdev/kord/core/entity/Member;)V
+	public synthetic fun <init> (JZLdev/kord/core/entity/Member;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun getResolvedObject ()Ldev/kord/core/entity/Entity;
 	public fun getResolvedObject ()Ldev/kord/core/entity/Member;
 	public synthetic fun getResolvedObject ()Ldev/kord/core/entity/User;
@@ -10196,11 +10201,11 @@ public final class dev/kord/core/entity/interaction/MemberOptionValue : dev/kord
 }
 
 public final class dev/kord/core/entity/interaction/MentionableOptionValue : dev/kord/core/entity/interaction/ResolvableOptionValue {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;ZLdev/kord/core/entity/Entity;)V
+	public synthetic fun <init> (JZLdev/kord/core/entity/Entity;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getFocused ()Z
 	public fun getResolvedObject ()Ldev/kord/core/entity/Entity;
-	public fun getValue ()Ldev/kord/common/entity/Snowflake;
 	public synthetic fun getValue ()Ljava/lang/Object;
+	public fun getValue-4_xYDEk ()J
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -10208,7 +10213,7 @@ public abstract interface class dev/kord/core/entity/interaction/MessageCommandI
 	public abstract fun getMessages ()Ljava/util/Map;
 	public abstract fun getTarget ()Ldev/kord/core/behavior/MessageBehavior;
 	public abstract fun getTarget (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getTargetId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getTargetId-4_xYDEk ()J
 	public abstract fun getTargetOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/entity/interaction/MessageCommandInteraction;
 }
@@ -10221,15 +10226,15 @@ public final class dev/kord/core/entity/interaction/MessageCommandInteraction$De
 	public static synthetic fun deferPublicMessage (Ldev/kord/core/entity/interaction/MessageCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun deferPublicResponse (Ldev/kord/core/entity/interaction/MessageCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun deferPublicResponseUnsafe (Ldev/kord/core/entity/interaction/MessageCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getApplicationId (Ldev/kord/core/entity/interaction/MessageCommandInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getApplicationId-4_xYDEk (Ldev/kord/core/entity/interaction/MessageCommandInteraction;)J
 	public static fun getChannel (Ldev/kord/core/entity/interaction/MessageCommandInteraction;)Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public static fun getChannel (Ldev/kord/core/entity/interaction/MessageCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getChannelId (Ldev/kord/core/entity/interaction/MessageCommandInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getChannelId-4_xYDEk (Ldev/kord/core/entity/interaction/MessageCommandInteraction;)J
 	public static fun getChannelOrNull (Ldev/kord/core/entity/interaction/MessageCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getGuildLocale (Ldev/kord/core/entity/interaction/MessageCommandInteraction;)Ldev/kord/common/Locale;
-	public static fun getId (Ldev/kord/core/entity/interaction/MessageCommandInteraction;)Ldev/kord/common/entity/Snowflake;
-	public static fun getInvokedCommandGuildId (Ldev/kord/core/entity/interaction/MessageCommandInteraction;)Ldev/kord/common/entity/Snowflake;
-	public static fun getInvokedCommandId (Ldev/kord/core/entity/interaction/MessageCommandInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getId-4_xYDEk (Ldev/kord/core/entity/interaction/MessageCommandInteraction;)J
+	public static fun getInvokedCommandGuildId-eUG9VGM (Ldev/kord/core/entity/interaction/MessageCommandInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getInvokedCommandId-4_xYDEk (Ldev/kord/core/entity/interaction/MessageCommandInteraction;)J
 	public static fun getInvokedCommandName (Ldev/kord/core/entity/interaction/MessageCommandInteraction;)Ljava/lang/String;
 	public static fun getInvokedCommandType (Ldev/kord/core/entity/interaction/MessageCommandInteraction;)Ldev/kord/common/entity/ApplicationCommandType;
 	public static fun getLocale (Ldev/kord/core/entity/interaction/MessageCommandInteraction;)Ldev/kord/common/Locale;
@@ -10239,7 +10244,7 @@ public final class dev/kord/core/entity/interaction/MessageCommandInteraction$De
 	public static fun getResolvedObjects (Ldev/kord/core/entity/interaction/MessageCommandInteraction;)Ldev/kord/core/entity/interaction/ResolvedObjects;
 	public static fun getTarget (Ldev/kord/core/entity/interaction/MessageCommandInteraction;)Ldev/kord/core/behavior/MessageBehavior;
 	public static fun getTarget (Ldev/kord/core/entity/interaction/MessageCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getTargetId (Ldev/kord/core/entity/interaction/MessageCommandInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getTargetId-4_xYDEk (Ldev/kord/core/entity/interaction/MessageCommandInteraction;)J
 	public static fun getTargetOrNull (Ldev/kord/core/entity/interaction/MessageCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getToken (Ldev/kord/core/entity/interaction/MessageCommandInteraction;)Ljava/lang/String;
 	public static fun getType (Ldev/kord/core/entity/interaction/MessageCommandInteraction;)Ldev/kord/common/entity/InteractionType;
@@ -10267,13 +10272,13 @@ public final class dev/kord/core/entity/interaction/ModalSubmitInteraction$Defau
 	public static fun deferPublicResponse (Ldev/kord/core/entity/interaction/ModalSubmitInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun deferPublicResponseUnsafe (Ldev/kord/core/entity/interaction/ModalSubmitInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getActionRows (Ldev/kord/core/entity/interaction/ModalSubmitInteraction;)Ljava/util/List;
-	public static fun getApplicationId (Ldev/kord/core/entity/interaction/ModalSubmitInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getApplicationId-4_xYDEk (Ldev/kord/core/entity/interaction/ModalSubmitInteraction;)J
 	public static fun getChannel (Ldev/kord/core/entity/interaction/ModalSubmitInteraction;)Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public static fun getChannel (Ldev/kord/core/entity/interaction/ModalSubmitInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getChannelId (Ldev/kord/core/entity/interaction/ModalSubmitInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getChannelId-4_xYDEk (Ldev/kord/core/entity/interaction/ModalSubmitInteraction;)J
 	public static fun getChannelOrNull (Ldev/kord/core/entity/interaction/ModalSubmitInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getGuildLocale (Ldev/kord/core/entity/interaction/ModalSubmitInteraction;)Ldev/kord/common/Locale;
-	public static fun getId (Ldev/kord/core/entity/interaction/ModalSubmitInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getId-4_xYDEk (Ldev/kord/core/entity/interaction/ModalSubmitInteraction;)J
 	public static fun getLocale (Ldev/kord/core/entity/interaction/ModalSubmitInteraction;)Ldev/kord/common/Locale;
 	public static fun getMessage (Ldev/kord/core/entity/interaction/ModalSubmitInteraction;)Ldev/kord/core/entity/Message;
 	public static fun getModalId (Ldev/kord/core/entity/interaction/ModalSubmitInteraction;)Ljava/lang/String;
@@ -10326,12 +10331,12 @@ public final class dev/kord/core/entity/interaction/ResolvedObjects {
 }
 
 public final class dev/kord/core/entity/interaction/RoleOptionValue : dev/kord/core/entity/interaction/ResolvableOptionValue {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;ZLdev/kord/core/entity/Role;)V
+	public synthetic fun <init> (JZLdev/kord/core/entity/Role;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getFocused ()Z
 	public synthetic fun getResolvedObject ()Ldev/kord/core/entity/Entity;
 	public fun getResolvedObject ()Ldev/kord/core/entity/Role;
-	public fun getValue ()Ldev/kord/common/entity/Snowflake;
 	public synthetic fun getValue ()Ljava/lang/Object;
+	public fun getValue-4_xYDEk ()J
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -10349,7 +10354,7 @@ public final class dev/kord/core/entity/interaction/RootCommand : dev/kord/core/
 	public fun getOptions ()Ljava/util/Map;
 	public fun getResolvedObjects ()Ldev/kord/core/entity/interaction/ResolvedObjects;
 	public fun getRoles ()Ljava/util/Map;
-	public fun getRootId ()Ldev/kord/common/entity/Snowflake;
+	public fun getRootId-4_xYDEk ()J
 	public fun getRootName ()Ljava/lang/String;
 	public fun getStrings ()Ljava/util/Map;
 	public fun getUsers ()Ljava/util/Map;
@@ -10373,16 +10378,16 @@ public final class dev/kord/core/entity/interaction/SelectMenuInteraction$Defaul
 	public static fun deferPublicMessageUpdate (Ldev/kord/core/entity/interaction/SelectMenuInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun deferPublicResponse (Ldev/kord/core/entity/interaction/SelectMenuInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun deferPublicResponseUnsafe (Ldev/kord/core/entity/interaction/SelectMenuInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getApplicationId (Ldev/kord/core/entity/interaction/SelectMenuInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getApplicationId-4_xYDEk (Ldev/kord/core/entity/interaction/SelectMenuInteraction;)J
 	public static fun getChannel (Ldev/kord/core/entity/interaction/SelectMenuInteraction;)Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public static fun getChannel (Ldev/kord/core/entity/interaction/SelectMenuInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getChannelId (Ldev/kord/core/entity/interaction/SelectMenuInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getChannelId-4_xYDEk (Ldev/kord/core/entity/interaction/SelectMenuInteraction;)J
 	public static fun getChannelOrNull (Ldev/kord/core/entity/interaction/SelectMenuInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getComponent (Ldev/kord/core/entity/interaction/SelectMenuInteraction;)Ldev/kord/core/entity/component/SelectMenuComponent;
 	public static fun getComponentId (Ldev/kord/core/entity/interaction/SelectMenuInteraction;)Ljava/lang/String;
 	public static fun getComponentType (Ldev/kord/core/entity/interaction/SelectMenuInteraction;)Ldev/kord/common/entity/ComponentType;
 	public static fun getGuildLocale (Ldev/kord/core/entity/interaction/SelectMenuInteraction;)Ldev/kord/common/Locale;
-	public static fun getId (Ldev/kord/core/entity/interaction/SelectMenuInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getId-4_xYDEk (Ldev/kord/core/entity/interaction/SelectMenuInteraction;)J
 	public static fun getLocale (Ldev/kord/core/entity/interaction/SelectMenuInteraction;)Ldev/kord/common/Locale;
 	public static fun getMessage (Ldev/kord/core/entity/interaction/SelectMenuInteraction;)Ldev/kord/core/entity/Message;
 	public static fun getOriginalInteractionResponse (Ldev/kord/core/entity/interaction/SelectMenuInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -10416,7 +10421,7 @@ public final class dev/kord/core/entity/interaction/SubCommand : dev/kord/core/e
 	public fun getOptions ()Ljava/util/Map;
 	public fun getResolvedObjects ()Ldev/kord/core/entity/interaction/ResolvedObjects;
 	public fun getRoles ()Ljava/util/Map;
-	public fun getRootId ()Ldev/kord/common/entity/Snowflake;
+	public fun getRootId-4_xYDEk ()J
 	public fun getRootName ()Ljava/lang/String;
 	public fun getStrings ()Ljava/util/Map;
 	public fun getUsers ()Ljava/util/Map;
@@ -10425,7 +10430,7 @@ public final class dev/kord/core/entity/interaction/SubCommand : dev/kord/core/e
 public abstract interface class dev/kord/core/entity/interaction/UserCommandInteraction : dev/kord/core/entity/interaction/ApplicationCommandInteraction {
 	public abstract fun getTarget ()Ldev/kord/core/behavior/UserBehavior;
 	public abstract fun getTarget (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getTargetId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getTargetId-4_xYDEk ()J
 	public abstract fun getTargetOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getUsers ()Ljava/util/Map;
 	public abstract fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/entity/interaction/UserCommandInteraction;
@@ -10439,15 +10444,15 @@ public final class dev/kord/core/entity/interaction/UserCommandInteraction$Defau
 	public static synthetic fun deferPublicMessage (Ldev/kord/core/entity/interaction/UserCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun deferPublicResponse (Ldev/kord/core/entity/interaction/UserCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun deferPublicResponseUnsafe (Ldev/kord/core/entity/interaction/UserCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getApplicationId (Ldev/kord/core/entity/interaction/UserCommandInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getApplicationId-4_xYDEk (Ldev/kord/core/entity/interaction/UserCommandInteraction;)J
 	public static fun getChannel (Ldev/kord/core/entity/interaction/UserCommandInteraction;)Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public static fun getChannel (Ldev/kord/core/entity/interaction/UserCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getChannelId (Ldev/kord/core/entity/interaction/UserCommandInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getChannelId-4_xYDEk (Ldev/kord/core/entity/interaction/UserCommandInteraction;)J
 	public static fun getChannelOrNull (Ldev/kord/core/entity/interaction/UserCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getGuildLocale (Ldev/kord/core/entity/interaction/UserCommandInteraction;)Ldev/kord/common/Locale;
-	public static fun getId (Ldev/kord/core/entity/interaction/UserCommandInteraction;)Ldev/kord/common/entity/Snowflake;
-	public static fun getInvokedCommandGuildId (Ldev/kord/core/entity/interaction/UserCommandInteraction;)Ldev/kord/common/entity/Snowflake;
-	public static fun getInvokedCommandId (Ldev/kord/core/entity/interaction/UserCommandInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getId-4_xYDEk (Ldev/kord/core/entity/interaction/UserCommandInteraction;)J
+	public static fun getInvokedCommandGuildId-eUG9VGM (Ldev/kord/core/entity/interaction/UserCommandInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getInvokedCommandId-4_xYDEk (Ldev/kord/core/entity/interaction/UserCommandInteraction;)J
 	public static fun getInvokedCommandName (Ldev/kord/core/entity/interaction/UserCommandInteraction;)Ljava/lang/String;
 	public static fun getInvokedCommandType (Ldev/kord/core/entity/interaction/UserCommandInteraction;)Ldev/kord/common/entity/ApplicationCommandType;
 	public static fun getLocale (Ldev/kord/core/entity/interaction/UserCommandInteraction;)Ldev/kord/common/Locale;
@@ -10456,7 +10461,7 @@ public final class dev/kord/core/entity/interaction/UserCommandInteraction$Defau
 	public static fun getResolvedObjects (Ldev/kord/core/entity/interaction/UserCommandInteraction;)Ldev/kord/core/entity/interaction/ResolvedObjects;
 	public static fun getTarget (Ldev/kord/core/entity/interaction/UserCommandInteraction;)Ldev/kord/core/behavior/UserBehavior;
 	public static fun getTarget (Ldev/kord/core/entity/interaction/UserCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getTargetId (Ldev/kord/core/entity/interaction/UserCommandInteraction;)Ldev/kord/common/entity/Snowflake;
+	public static fun getTargetId-4_xYDEk (Ldev/kord/core/entity/interaction/UserCommandInteraction;)J
 	public static fun getTargetOrNull (Ldev/kord/core/entity/interaction/UserCommandInteraction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getToken (Ldev/kord/core/entity/interaction/UserCommandInteraction;)Ljava/lang/String;
 	public static fun getType (Ldev/kord/core/entity/interaction/UserCommandInteraction;)Ldev/kord/common/entity/InteractionType;
@@ -10465,19 +10470,19 @@ public final class dev/kord/core/entity/interaction/UserCommandInteraction$Defau
 }
 
 public class dev/kord/core/entity/interaction/UserOptionValue : dev/kord/core/entity/interaction/ResolvableOptionValue {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;ZLdev/kord/core/entity/User;)V
+	public synthetic fun <init> (JZLdev/kord/core/entity/User;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getFocused ()Z
 	public synthetic fun getResolvedObject ()Ldev/kord/core/entity/Entity;
 	public fun getResolvedObject ()Ldev/kord/core/entity/User;
-	public fun getValue ()Ldev/kord/common/entity/Snowflake;
 	public synthetic fun getValue ()Ljava/lang/Object;
+	public fun getValue-4_xYDEk ()J
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class dev/kord/core/entity/interaction/followup/EphemeralFollowupMessage : dev/kord/core/entity/interaction/followup/FollowupMessage, dev/kord/core/behavior/interaction/followup/EphemeralFollowupMessageBehavior {
-	public fun <init> (Ldev/kord/core/entity/Message;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/Message;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (Ldev/kord/core/entity/Message;JLjava/lang/String;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ldev/kord/core/entity/Message;JLjava/lang/String;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getApplicationId-4_xYDEk ()J
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
 	public fun getToken ()Ljava/lang/String;
@@ -10495,21 +10500,21 @@ public abstract class dev/kord/core/entity/interaction/followup/FollowupMessage 
 	public fun delete (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getChannel ()Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public fun getChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public fun getChannelId-4_xYDEk ()J
 	public fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public final fun getMessage ()Ldev/kord/core/entity/Message;
 	public abstract fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/entity/interaction/followup/FollowupMessage;
 }
 
 public final class dev/kord/core/entity/interaction/followup/FollowupMessageKt {
-	public static final fun FollowupMessage (Ldev/kord/core/entity/Message;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/core/Kord;)Ldev/kord/core/entity/interaction/followup/FollowupMessage;
+	public static final fun FollowupMessage-nMAJGj4 (Ldev/kord/core/entity/Message;JLjava/lang/String;Ldev/kord/core/Kord;)Ldev/kord/core/entity/interaction/followup/FollowupMessage;
 }
 
 public final class dev/kord/core/entity/interaction/followup/PublicFollowupMessage : dev/kord/core/entity/interaction/followup/FollowupMessage, dev/kord/core/behavior/interaction/followup/PublicFollowupMessageBehavior {
-	public fun <init> (Ldev/kord/core/entity/Message;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/Message;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (Ldev/kord/core/entity/Message;JLjava/lang/String;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ldev/kord/core/entity/Message;JLjava/lang/String;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getApplicationId-4_xYDEk ()J
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
 	public fun getToken ()Ljava/lang/String;
@@ -10521,9 +10526,9 @@ public final class dev/kord/core/entity/interaction/followup/PublicFollowupMessa
 }
 
 public final class dev/kord/core/entity/interaction/response/EphemeralMessageInteractionResponse : dev/kord/core/entity/interaction/response/MessageInteractionResponse, dev/kord/core/behavior/interaction/response/EphemeralMessageInteractionResponseBehavior {
-	public fun <init> (Ldev/kord/core/entity/Message;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/Message;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (Ldev/kord/core/entity/Message;JLjava/lang/String;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ldev/kord/core/entity/Message;JLjava/lang/String;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getApplicationId-4_xYDEk ()J
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
 	public fun getToken ()Ljava/lang/String;
@@ -10540,16 +10545,16 @@ public final class dev/kord/core/entity/interaction/response/EphemeralMessageInt
 public abstract class dev/kord/core/entity/interaction/response/MessageInteractionResponse : dev/kord/core/behavior/interaction/response/MessageInteractionResponseBehavior {
 	public synthetic fun <init> (Ldev/kord/core/entity/Message;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun delete (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getFollowupMessage (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getFollowupMessageOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getFollowupMessage-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getFollowupMessageOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getMessage ()Ldev/kord/core/entity/Message;
 	public abstract fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/entity/interaction/response/MessageInteractionResponse;
 }
 
 public final class dev/kord/core/entity/interaction/response/PublicMessageInteractionResponse : dev/kord/core/entity/interaction/response/MessageInteractionResponse, dev/kord/core/behavior/interaction/response/PublicMessageInteractionResponseBehavior {
-	public fun <init> (Ldev/kord/core/entity/Message;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/Message;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getApplicationId ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (Ldev/kord/core/entity/Message;JLjava/lang/String;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ldev/kord/core/entity/Message;JLjava/lang/String;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getApplicationId-4_xYDEk ()J
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
 	public fun getToken ()Ljava/lang/String;
@@ -10578,26 +10583,26 @@ public final class dev/kord/core/event/automoderation/AutoModerationActionExecut
 	public synthetic fun <init> (Ldev/kord/core/event/automoderation/data/AutoModerationActionExecutionEventData;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAction ()Ldev/kord/core/entity/automoderation/AutoModerationAction;
 	public final fun getAlertSystemMessage ()Ldev/kord/core/behavior/MessageBehavior;
-	public final fun getAlertSystemMessageId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getAlertSystemMessageId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getChannel ()Ldev/kord/core/behavior/channel/GuildMessageChannelBehavior;
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getContent ()Ljava/lang/String;
 	public fun getCustomContext ()Ljava/lang/Object;
 	public final fun getData ()Ldev/kord/core/event/automoderation/data/AutoModerationActionExecutionEventData;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public fun getGuildId-4_xYDEk ()J
 	public fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getMatchedContent ()Ljava/lang/String;
 	public final fun getMatchedKeyword ()Ljava/lang/String;
 	public final fun getMember ()Ldev/kord/core/behavior/MemberBehavior;
-	public final fun getMemberId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getMemberId-4_xYDEk ()J
 	public final fun getMessage ()Ldev/kord/core/behavior/MessageBehavior;
-	public final fun getMessageId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getMessageId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public fun getRule ()Ldev/kord/core/behavior/automoderation/TypedAutoModerationRuleBehavior;
-	public fun getRuleId ()Ldev/kord/common/entity/Snowflake;
+	public fun getRuleId-4_xYDEk ()J
 	public fun getShard ()I
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
 	public fun toString ()Ljava/lang/String;
@@ -10609,10 +10614,10 @@ public final class dev/kord/core/event/automoderation/AutoModerationActionExecut
 public abstract interface class dev/kord/core/event/automoderation/AutoModerationEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event {
 	public abstract fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public abstract fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getGuildId-4_xYDEk ()J
 	public abstract fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getRule ()Ldev/kord/core/behavior/automoderation/TypedAutoModerationRuleBehavior;
-	public abstract fun getRuleId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getRuleId-4_xYDEk ()J
 	public abstract fun toString ()Ljava/lang/String;
 	public abstract fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/event/automoderation/AutoModerationEvent;
 }
@@ -10625,9 +10630,9 @@ public final class dev/kord/core/event/automoderation/AutoModerationEvent$Defaul
 }
 
 public abstract interface class dev/kord/core/event/automoderation/AutoModerationRuleConfigurationEvent : dev/kord/core/event/automoderation/AutoModerationEvent {
-	public abstract fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getGuildId-4_xYDEk ()J
 	public abstract fun getRule ()Ldev/kord/core/entity/automoderation/AutoModerationRule;
-	public abstract fun getRuleId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getRuleId-4_xYDEk ()J
 	public abstract fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/event/automoderation/AutoModerationRuleConfigurationEvent;
 }
 
@@ -10635,9 +10640,9 @@ public final class dev/kord/core/event/automoderation/AutoModerationRuleConfigur
 	public static fun getGateway (Ldev/kord/core/event/automoderation/AutoModerationRuleConfigurationEvent;)Ldev/kord/gateway/Gateway;
 	public static fun getGuild (Ldev/kord/core/event/automoderation/AutoModerationRuleConfigurationEvent;)Ldev/kord/core/behavior/GuildBehavior;
 	public static fun getGuild (Ldev/kord/core/event/automoderation/AutoModerationRuleConfigurationEvent;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getGuildId (Ldev/kord/core/event/automoderation/AutoModerationRuleConfigurationEvent;)Ldev/kord/common/entity/Snowflake;
+	public static fun getGuildId-4_xYDEk (Ldev/kord/core/event/automoderation/AutoModerationRuleConfigurationEvent;)J
 	public static fun getGuildOrNull (Ldev/kord/core/event/automoderation/AutoModerationRuleConfigurationEvent;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getRuleId (Ldev/kord/core/event/automoderation/AutoModerationRuleConfigurationEvent;)Ldev/kord/common/entity/Snowflake;
+	public static fun getRuleId-4_xYDEk (Ldev/kord/core/event/automoderation/AutoModerationRuleConfigurationEvent;)J
 }
 
 public final class dev/kord/core/event/automoderation/AutoModerationRuleCreateEvent : dev/kord/core/event/automoderation/AutoModerationRuleConfigurationEvent {
@@ -10647,12 +10652,12 @@ public final class dev/kord/core/event/automoderation/AutoModerationRuleCreateEv
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public fun getGuildId-4_xYDEk ()J
 	public fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public synthetic fun getRule ()Ldev/kord/core/behavior/automoderation/TypedAutoModerationRuleBehavior;
 	public fun getRule ()Ldev/kord/core/entity/automoderation/AutoModerationRule;
-	public fun getRuleId ()Ldev/kord/common/entity/Snowflake;
+	public fun getRuleId-4_xYDEk ()J
 	public fun getShard ()I
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
 	public fun toString ()Ljava/lang/String;
@@ -10669,12 +10674,12 @@ public final class dev/kord/core/event/automoderation/AutoModerationRuleDeleteEv
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public fun getGuildId-4_xYDEk ()J
 	public fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public synthetic fun getRule ()Ldev/kord/core/behavior/automoderation/TypedAutoModerationRuleBehavior;
 	public fun getRule ()Ldev/kord/core/entity/automoderation/AutoModerationRule;
-	public fun getRuleId ()Ldev/kord/common/entity/Snowflake;
+	public fun getRuleId-4_xYDEk ()J
 	public fun getShard ()I
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
 	public fun toString ()Ljava/lang/String;
@@ -10691,13 +10696,13 @@ public final class dev/kord/core/event/automoderation/AutoModerationRuleUpdateEv
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public fun getGuildId-4_xYDEk ()J
 	public fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getOld ()Ldev/kord/core/entity/automoderation/AutoModerationRule;
 	public synthetic fun getRule ()Ldev/kord/core/behavior/automoderation/TypedAutoModerationRuleBehavior;
 	public fun getRule ()Ldev/kord/core/entity/automoderation/AutoModerationRule;
-	public fun getRuleId ()Ldev/kord/common/entity/Snowflake;
+	public fun getRuleId-4_xYDEk ()J
 	public fun getShard ()I
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
 	public fun toString ()Ljava/lang/String;
@@ -10709,34 +10714,34 @@ public final class dev/kord/core/event/automoderation/AutoModerationRuleUpdateEv
 
 public final class dev/kord/core/event/automoderation/data/AutoModerationActionExecutionEventData {
 	public static final field Companion Ldev/kord/core/event/automoderation/data/AutoModerationActionExecutionEventData$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/core/cache/data/AutoModerationActionData;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/AutoModerationRuleTriggerType;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/core/cache/data/AutoModerationActionData;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/AutoModerationRuleTriggerType;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/core/cache/data/AutoModerationActionData;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/AutoModerationRuleTriggerType;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/core/cache/data/AutoModerationActionData;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/AutoModerationRuleTriggerType;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/core/cache/data/AutoModerationActionData;JLdev/kord/common/entity/AutoModerationRuleTriggerType;JLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/core/cache/data/AutoModerationActionData;JLdev/kord/common/entity/AutoModerationRuleTriggerType;JLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component10 ()Ljava/lang/String;
 	public final fun component11 ()Ljava/lang/String;
 	public final fun component2 ()Ldev/kord/core/cache/data/AutoModerationActionData;
-	public final fun component3 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component3-4_xYDEk ()J
 	public final fun component4 ()Ldev/kord/common/entity/AutoModerationRuleTriggerType;
-	public final fun component5 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component5-4_xYDEk ()J
 	public final fun component6 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun component7 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun component8 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun component9 ()Ljava/lang/String;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/core/cache/data/AutoModerationActionData;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/AutoModerationRuleTriggerType;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ldev/kord/core/event/automoderation/data/AutoModerationActionExecutionEventData;
-	public static synthetic fun copy$default (Ldev/kord/core/event/automoderation/data/AutoModerationActionExecutionEventData;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/cache/data/AutoModerationActionData;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/AutoModerationRuleTriggerType;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ldev/kord/core/event/automoderation/data/AutoModerationActionExecutionEventData;
+	public final fun copy-6EMEGuc (JLdev/kord/core/cache/data/AutoModerationActionData;JLdev/kord/common/entity/AutoModerationRuleTriggerType;JLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ldev/kord/core/event/automoderation/data/AutoModerationActionExecutionEventData;
+	public static synthetic fun copy-6EMEGuc$default (Ldev/kord/core/event/automoderation/data/AutoModerationActionExecutionEventData;JLdev/kord/core/cache/data/AutoModerationActionData;JLdev/kord/common/entity/AutoModerationRuleTriggerType;JLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ldev/kord/core/event/automoderation/data/AutoModerationActionExecutionEventData;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAction ()Ldev/kord/core/cache/data/AutoModerationActionData;
 	public final fun getAlertSystemMessageId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun getChannelId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun getContent ()Ljava/lang/String;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public final fun getMatchedContent ()Ljava/lang/String;
 	public final fun getMatchedKeyword ()Ljava/lang/String;
 	public final fun getMessageId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
-	public final fun getRuleId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getRuleId-4_xYDEk ()J
 	public final fun getRuleTriggerType ()Ldev/kord/common/entity/AutoModerationRuleTriggerType;
-	public final fun getUserId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getUserId-4_xYDEk ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public static final fun write$Self (Ldev/kord/core/event/automoderation/data/AutoModerationActionExecutionEventData;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
@@ -10819,13 +10824,13 @@ public final class dev/kord/core/event/channel/ChannelPinsUpdateEvent : dev/kord
 	public synthetic fun <init> (Ldev/kord/core/event/channel/data/ChannelPinsUpdateEventData;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getChannel ()Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public final fun getChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-4_xYDEk ()J
 	public final fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getCustomContext ()Ljava/lang/Object;
 	public final fun getData ()Ldev/kord/core/event/channel/data/ChannelPinsUpdateEventData;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getLastPinTimestamp ()Lkotlinx/datetime/Instant;
 	public fun getShard ()I
@@ -11026,21 +11031,21 @@ public final class dev/kord/core/event/channel/TypingStartEvent : dev/kord/core/
 	public synthetic fun <init> (Ldev/kord/core/event/channel/data/TypingStartEventData;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getChannel ()Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public final fun getChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-4_xYDEk ()J
 	public final fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getCustomContext ()Ljava/lang/Object;
 	public final fun getData ()Ldev/kord/core/event/channel/data/TypingStartEventData;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
 	public final fun getStarted ()Lkotlinx/datetime/Instant;
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
 	public final fun getUser ()Ldev/kord/core/behavior/UserBehavior;
 	public final fun getUser (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getUserId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getUserId-4_xYDEk ()J
 	public final fun getUserOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun toString ()Ljava/lang/String;
 	public synthetic fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/entity/Strategizable;
@@ -11115,16 +11120,16 @@ public final class dev/kord/core/event/channel/VoiceChannelUpdateEvent : dev/kor
 
 public final class dev/kord/core/event/channel/data/ChannelPinsUpdateEventData {
 	public static final field Companion Ldev/kord/core/event/channel/data/ChannelPinsUpdateEventData$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (ILdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ldev/kord/common/entity/optional/OptionalSnowflake;JLdev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ldev/kord/common/entity/optional/OptionalSnowflake;JLdev/kord/common/entity/optional/Optional;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component2-4_xYDEk ()J
 	public final fun component3 ()Ldev/kord/common/entity/optional/Optional;
-	public final fun copy (Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/core/event/channel/data/ChannelPinsUpdateEventData;
-	public static synthetic fun copy$default (Ldev/kord/core/event/channel/data/ChannelPinsUpdateEventData;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/core/event/channel/data/ChannelPinsUpdateEventData;
+	public final fun copy-o5qqygM (Ldev/kord/common/entity/optional/OptionalSnowflake;JLdev/kord/common/entity/optional/Optional;)Ldev/kord/core/event/channel/data/ChannelPinsUpdateEventData;
+	public static synthetic fun copy-o5qqygM$default (Ldev/kord/core/event/channel/data/ChannelPinsUpdateEventData;Ldev/kord/common/entity/optional/OptionalSnowflake;JLdev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/core/event/channel/data/ChannelPinsUpdateEventData;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-4_xYDEk ()J
 	public final fun getGuildId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun getLastPinTimestamp ()Ldev/kord/common/entity/optional/Optional;
 	public fun hashCode ()I
@@ -11151,22 +11156,22 @@ public final class dev/kord/core/event/channel/data/ChannelPinsUpdateEventData$C
 
 public final class dev/kord/core/event/channel/data/TypingStartEventData {
 	public static final field Companion Ldev/kord/core/event/channel/data/TypingStartEventData$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/optional/OptionalSnowflake;JLkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/optional/OptionalSnowflake;JLkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component2 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
-	public final fun component3 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component3-4_xYDEk ()J
 	public final fun component4 ()Lkotlinx/datetime/Instant;
 	public final fun component5 ()Ldev/kord/common/entity/optional/Optional;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/core/event/channel/data/TypingStartEventData;
-	public static synthetic fun copy$default (Ldev/kord/core/event/channel/data/TypingStartEventData;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/Snowflake;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/core/event/channel/data/TypingStartEventData;
+	public final fun copy-AvpewP4 (JLdev/kord/common/entity/optional/OptionalSnowflake;JLkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/core/event/channel/data/TypingStartEventData;
+	public static synthetic fun copy-AvpewP4$default (Ldev/kord/core/event/channel/data/TypingStartEventData;JLdev/kord/common/entity/optional/OptionalSnowflake;JLkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/core/event/channel/data/TypingStartEventData;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-4_xYDEk ()J
 	public final fun getGuildId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun getMember ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getTimestamp ()Lkotlinx/datetime/Instant;
-	public final fun getUserId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getUserId-4_xYDEk ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public static final fun write$Self (Ldev/kord/core/event/channel/data/TypingStartEventData;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
@@ -11296,7 +11301,7 @@ public final class dev/kord/core/event/channel/thread/ThreadListSyncEvent : dev/
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public final fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getMembers ()Ljava/util/List;
@@ -11322,8 +11327,8 @@ public final class dev/kord/core/event/channel/thread/ThreadMembersUpdateEvent :
 	public fun getCustomContext ()Ljava/lang/Object;
 	public final fun getData ()Ldev/kord/core/cache/data/ThreadMembersUpdateEventData;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
+	public final fun getId-4_xYDEk ()J
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getMemberCount ()I
 	public final fun getRemovedMemberBehaviors ()Ljava/util/List;
@@ -11483,15 +11488,15 @@ public final class dev/kord/core/event/gateway/ResumedEvent : dev/kord/core/even
 }
 
 public final class dev/kord/core/event/guild/BanAddEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event {
-	public fun <init> (Ldev/kord/core/entity/User;Ldev/kord/common/entity/Snowflake;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/User;Ldev/kord/common/entity/Snowflake;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ldev/kord/core/entity/User;JILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ldev/kord/core/entity/User;JILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getBan (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getBanOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getCustomContext ()Ljava/lang/Object;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public final fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
@@ -11503,13 +11508,13 @@ public final class dev/kord/core/event/guild/BanAddEvent : dev/kord/core/entity/
 }
 
 public final class dev/kord/core/event/guild/BanRemoveEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event {
-	public fun <init> (Ldev/kord/core/entity/User;Ldev/kord/common/entity/Snowflake;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/User;Ldev/kord/common/entity/Snowflake;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ldev/kord/core/entity/User;JILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ldev/kord/core/entity/User;JILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getCustomContext ()Ljava/lang/Object;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public final fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
@@ -11521,14 +11526,14 @@ public final class dev/kord/core/event/guild/BanRemoveEvent : dev/kord/core/enti
 }
 
 public final class dev/kord/core/event/guild/EmojisUpdateEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/util/Set;Ljava/util/Set;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/util/Set;Ljava/util/Set;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/util/Set;Ljava/util/Set;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/util/Set;Ljava/util/Set;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getCustomContext ()Ljava/lang/Object;
 	public final fun getEmojis ()Ljava/util/Set;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public final fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getOld ()Ljava/util/Set;
@@ -11550,11 +11555,11 @@ public final class dev/kord/core/event/guild/GuildCreateEvent : dev/kord/core/ev
 }
 
 public final class dev/kord/core/event/guild/GuildDeleteEvent : dev/kord/core/event/Event {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;ZLdev/kord/core/entity/Guild;Ldev/kord/core/Kord;ILjava/lang/Object;)V
+	public synthetic fun <init> (JZLdev/kord/core/entity/Guild;Ldev/kord/core/Kord;ILjava/lang/Object;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getCustomContext ()Ljava/lang/Object;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/entity/Guild;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
 	public final fun getUnavailable ()Z
@@ -11572,16 +11577,16 @@ public final class dev/kord/core/event/guild/GuildScheduledEventCreateEvent : de
 	public final fun copy (Ldev/kord/core/entity/GuildScheduledEvent;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;)Ldev/kord/core/event/guild/GuildScheduledEventCreateEvent;
 	public static synthetic fun copy$default (Ldev/kord/core/event/guild/GuildScheduledEventCreateEvent;Ldev/kord/core/entity/GuildScheduledEvent;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;ILjava/lang/Object;)Ldev/kord/core/event/guild/GuildScheduledEventCreateEvent;
 	public fun equals (Ljava/lang/Object;)Z
-	public fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public fun getChannelId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getCustomContext ()Ljava/lang/Object;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public fun getGuildId-4_xYDEk ()J
 	public fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getScheduledEvent ()Ldev/kord/core/entity/GuildScheduledEvent;
-	public fun getScheduledEventId ()Ldev/kord/common/entity/Snowflake;
+	public fun getScheduledEventId-4_xYDEk ()J
 	public fun getShard ()I
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
 	public fun hashCode ()I
@@ -11602,16 +11607,16 @@ public final class dev/kord/core/event/guild/GuildScheduledEventDeleteEvent : de
 	public final fun copy (Ldev/kord/core/entity/GuildScheduledEvent;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;)Ldev/kord/core/event/guild/GuildScheduledEventDeleteEvent;
 	public static synthetic fun copy$default (Ldev/kord/core/event/guild/GuildScheduledEventDeleteEvent;Ldev/kord/core/entity/GuildScheduledEvent;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;ILjava/lang/Object;)Ldev/kord/core/event/guild/GuildScheduledEventDeleteEvent;
 	public fun equals (Ljava/lang/Object;)Z
-	public fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public fun getChannelId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getCustomContext ()Ljava/lang/Object;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public fun getGuildId-4_xYDEk ()J
 	public fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getScheduledEvent ()Ldev/kord/core/entity/GuildScheduledEvent;
-	public fun getScheduledEventId ()Ldev/kord/common/entity/Snowflake;
+	public fun getScheduledEventId-4_xYDEk ()J
 	public fun getShard ()I
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
 	public fun hashCode ()I
@@ -11622,24 +11627,24 @@ public final class dev/kord/core/event/guild/GuildScheduledEventDeleteEvent : de
 }
 
 public abstract interface class dev/kord/core/event/guild/GuildScheduledEventEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event {
-	public abstract fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getChannelId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public abstract fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getGuildId-4_xYDEk ()J
 	public abstract fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getScheduledEvent ()Ldev/kord/core/entity/GuildScheduledEvent;
-	public abstract fun getScheduledEventId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getScheduledEventId-4_xYDEk ()J
 	public abstract fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/event/guild/GuildScheduledEventEvent;
 }
 
 public final class dev/kord/core/event/guild/GuildScheduledEventEvent$DefaultImpls {
-	public static fun getChannelId (Ldev/kord/core/event/guild/GuildScheduledEventEvent;)Ldev/kord/common/entity/Snowflake;
+	public static fun getChannelId-eUG9VGM (Ldev/kord/core/event/guild/GuildScheduledEventEvent;)Ldev/kord/common/entity/Snowflake;
 	public static fun getChannelOrNull (Ldev/kord/core/event/guild/GuildScheduledEventEvent;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getGateway (Ldev/kord/core/event/guild/GuildScheduledEventEvent;)Ldev/kord/gateway/Gateway;
 	public static fun getGuild (Ldev/kord/core/event/guild/GuildScheduledEventEvent;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getGuildId (Ldev/kord/core/event/guild/GuildScheduledEventEvent;)Ldev/kord/common/entity/Snowflake;
+	public static fun getGuildId-4_xYDEk (Ldev/kord/core/event/guild/GuildScheduledEventEvent;)J
 	public static fun getGuildOrNull (Ldev/kord/core/event/guild/GuildScheduledEventEvent;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getScheduledEventId (Ldev/kord/core/event/guild/GuildScheduledEventEvent;)Ldev/kord/common/entity/Snowflake;
+	public static fun getScheduledEventId-4_xYDEk (Ldev/kord/core/event/guild/GuildScheduledEventEvent;)J
 }
 
 public final class dev/kord/core/event/guild/GuildScheduledEventUpdateEvent : dev/kord/core/event/guild/GuildScheduledEventEvent {
@@ -11654,17 +11659,17 @@ public final class dev/kord/core/event/guild/GuildScheduledEventUpdateEvent : de
 	public final fun copy (Ldev/kord/core/entity/GuildScheduledEvent;Ldev/kord/core/entity/GuildScheduledEvent;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;)Ldev/kord/core/event/guild/GuildScheduledEventUpdateEvent;
 	public static synthetic fun copy$default (Ldev/kord/core/event/guild/GuildScheduledEventUpdateEvent;Ldev/kord/core/entity/GuildScheduledEvent;Ldev/kord/core/entity/GuildScheduledEvent;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;ILjava/lang/Object;)Ldev/kord/core/event/guild/GuildScheduledEventUpdateEvent;
 	public fun equals (Ljava/lang/Object;)Z
-	public fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public fun getChannelId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getCustomContext ()Ljava/lang/Object;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public fun getGuildId-4_xYDEk ()J
 	public fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getOldEvent ()Ldev/kord/core/entity/GuildScheduledEvent;
 	public fun getScheduledEvent ()Ldev/kord/core/entity/GuildScheduledEvent;
-	public fun getScheduledEventId ()Ldev/kord/common/entity/Snowflake;
+	public fun getScheduledEventId-4_xYDEk ()J
 	public fun getShard ()I
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
 	public fun hashCode ()I
@@ -11675,33 +11680,33 @@ public final class dev/kord/core/event/guild/GuildScheduledEventUpdateEvent : de
 }
 
 public final class dev/kord/core/event/guild/GuildScheduledEventUserAddEvent : dev/kord/core/event/guild/GuildScheduledEventUserEvent {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
-	public final fun component3 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (JJJLdev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJJLdev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
+	public final fun component2-4_xYDEk ()J
+	public final fun component3-4_xYDEk ()J
 	public final fun component4 ()Ldev/kord/core/Kord;
 	public final fun component5 ()I
 	public final fun component6 ()Ljava/lang/Object;
 	public final fun component7 ()Ldev/kord/core/supplier/EntitySupplier;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;)Ldev/kord/core/event/guild/GuildScheduledEventUserAddEvent;
-	public static synthetic fun copy$default (Ldev/kord/core/event/guild/GuildScheduledEventUserAddEvent;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;ILjava/lang/Object;)Ldev/kord/core/event/guild/GuildScheduledEventUserAddEvent;
+	public final fun copy-tpBmEts (JJJLdev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;)Ldev/kord/core/event/guild/GuildScheduledEventUserAddEvent;
+	public static synthetic fun copy-tpBmEts$default (Ldev/kord/core/event/guild/GuildScheduledEventUserAddEvent;JJJLdev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;ILjava/lang/Object;)Ldev/kord/core/event/guild/GuildScheduledEventUserAddEvent;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getCustomContext ()Ljava/lang/Object;
 	public fun getEvent (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getEventOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public fun getGuildId-4_xYDEk ()J
 	public fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getMember (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getMemberOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getScheduledEventId ()Ldev/kord/common/entity/Snowflake;
+	public fun getScheduledEventId-4_xYDEk ()J
 	public fun getShard ()I
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
 	public fun getUser (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getUserId ()Ldev/kord/common/entity/Snowflake;
+	public fun getUserId-4_xYDEk ()J
 	public fun getUserOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -11714,13 +11719,13 @@ public abstract interface class dev/kord/core/event/guild/GuildScheduledEventUse
 	public abstract fun getEvent (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getEventOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getGuildId-4_xYDEk ()J
 	public abstract fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getMember (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getMemberOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getScheduledEventId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getScheduledEventId-4_xYDEk ()J
 	public abstract fun getUser (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getUserId ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getUserId-4_xYDEk ()J
 	public abstract fun getUserOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/event/guild/GuildScheduledEventUserEvent;
 }
@@ -11738,33 +11743,33 @@ public final class dev/kord/core/event/guild/GuildScheduledEventUserEvent$Defaul
 }
 
 public final class dev/kord/core/event/guild/GuildScheduledEventUserRemoveEvent : dev/kord/core/event/guild/GuildScheduledEventUserEvent {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
-	public final fun component3 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (JJJLdev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJJLdev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
+	public final fun component2-4_xYDEk ()J
+	public final fun component3-4_xYDEk ()J
 	public final fun component4 ()Ldev/kord/core/Kord;
 	public final fun component5 ()I
 	public final fun component6 ()Ljava/lang/Object;
 	public final fun component7 ()Ldev/kord/core/supplier/EntitySupplier;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;)Ldev/kord/core/event/guild/GuildScheduledEventUserRemoveEvent;
-	public static synthetic fun copy$default (Ldev/kord/core/event/guild/GuildScheduledEventUserRemoveEvent;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;ILjava/lang/Object;)Ldev/kord/core/event/guild/GuildScheduledEventUserRemoveEvent;
+	public final fun copy-tpBmEts (JJJLdev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;)Ldev/kord/core/event/guild/GuildScheduledEventUserRemoveEvent;
+	public static synthetic fun copy-tpBmEts$default (Ldev/kord/core/event/guild/GuildScheduledEventUserRemoveEvent;JJJLdev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;ILjava/lang/Object;)Ldev/kord/core/event/guild/GuildScheduledEventUserRemoveEvent;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getCustomContext ()Ljava/lang/Object;
 	public fun getEvent (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getEventOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public fun getGuildId-4_xYDEk ()J
 	public fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getMember (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getMemberOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getScheduledEventId ()Ldev/kord/common/entity/Snowflake;
+	public fun getScheduledEventId-4_xYDEk ()J
 	public fun getShard ()I
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
 	public fun getUser (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getUserId ()Ldev/kord/common/entity/Snowflake;
+	public fun getUserId-4_xYDEk ()J
 	public fun getUserOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -11785,13 +11790,13 @@ public final class dev/kord/core/event/guild/GuildUpdateEvent : dev/kord/core/ev
 }
 
 public final class dev/kord/core/event/guild/IntegrationsUpdateEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getCustomContext ()Ljava/lang/Object;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public final fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
@@ -11808,7 +11813,7 @@ public final class dev/kord/core/event/guild/InviteCreateEvent : dev/kord/core/e
 	public static synthetic fun delete$default (Ldev/kord/core/event/guild/InviteCreateEvent;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun getChannel ()Ldev/kord/core/behavior/channel/ChannelBehavior;
 	public final fun getChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-4_xYDEk ()J
 	public final fun getChannelOrNUll (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getCode ()Ljava/lang/String;
 	public final fun getCreatedAt ()Lkotlinx/datetime/Instant;
@@ -11816,11 +11821,11 @@ public final class dev/kord/core/event/guild/InviteCreateEvent : dev/kord/core/e
 	public final fun getData ()Ldev/kord/core/cache/data/InviteCreateData;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getInviter ()Ldev/kord/core/behavior/UserBehavior;
 	public final fun getInviterAsMemberOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getInviterId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getInviterId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getInviterMember ()Ldev/kord/core/behavior/MemberBehavior;
 	public final fun getInviterOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getKord ()Ldev/kord/core/Kord;
@@ -11833,7 +11838,7 @@ public final class dev/kord/core/event/guild/InviteCreateEvent : dev/kord/core/e
 	public final fun getTargetType ()Ldev/kord/common/entity/InviteTargetType;
 	public final fun getTargetUser ()Ldev/kord/core/behavior/UserBehavior;
 	public final fun getTargetUserAsMemberOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getTargetUserId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getTargetUserId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getTargetUserOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getUses ()I
 	public final fun isTemporary ()Z
@@ -11847,14 +11852,14 @@ public final class dev/kord/core/event/guild/InviteDeleteEvent : dev/kord/core/e
 	public synthetic fun <init> (Ldev/kord/core/cache/data/InviteDeleteData;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getChannel ()Ldev/kord/core/behavior/channel/ChannelBehavior;
 	public final fun getChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-4_xYDEk ()J
 	public final fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getCode ()Ljava/lang/String;
 	public fun getCustomContext ()Ljava/lang/Object;
 	public final fun getData ()Ldev/kord/core/cache/data/InviteDeleteData;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
@@ -11871,7 +11876,7 @@ public final class dev/kord/core/event/guild/MemberJoinEvent : dev/kord/core/ent
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public final fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getMember ()Ldev/kord/core/entity/Member;
@@ -11883,12 +11888,12 @@ public final class dev/kord/core/event/guild/MemberJoinEvent : dev/kord/core/ent
 }
 
 public final class dev/kord/core/event/guild/MemberLeaveEvent : dev/kord/core/event/Event {
-	public fun <init> (Ldev/kord/core/entity/User;Ldev/kord/core/entity/Member;Ldev/kord/common/entity/Snowflake;ILjava/lang/Object;)V
+	public synthetic fun <init> (Ldev/kord/core/entity/User;Ldev/kord/core/entity/Member;JILjava/lang/Object;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getCustomContext ()Ljava/lang/Object;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public final fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getOld ()Ldev/kord/core/entity/Member;
@@ -11904,7 +11909,7 @@ public final class dev/kord/core/event/guild/MemberUpdateEvent : dev/kord/core/e
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public final fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getMember ()Ldev/kord/core/entity/Member;
@@ -11926,7 +11931,7 @@ public final class dev/kord/core/event/guild/MembersChunkEvent : dev/kord/core/e
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public final fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getInvalidIds ()Ljava/util/Set;
 	public fun getKord ()Ldev/kord/core/Kord;
@@ -11941,14 +11946,14 @@ public final class dev/kord/core/event/guild/MembersChunkEvent : dev/kord/core/e
 }
 
 public final class dev/kord/core/event/guild/VoiceServerUpdateEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event {
-	public fun <init> (Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;)V
-	public synthetic fun <init> (Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;JLjava/lang/String;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;JLjava/lang/String;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getCustomContext ()Ljava/lang/Object;
 	public final fun getEndpoint ()Ljava/lang/String;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public final fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
@@ -11960,17 +11965,17 @@ public final class dev/kord/core/event/guild/VoiceServerUpdateEvent : dev/kord/c
 }
 
 public final class dev/kord/core/event/guild/WebhookUpdateEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLdev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLdev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getChannel ()Ldev/kord/core/behavior/channel/TopGuildMessageChannelBehavior;
 	public final fun getChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-4_xYDEk ()J
 	public final fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getCustomContext ()Ljava/lang/Object;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public final fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
@@ -12450,17 +12455,17 @@ public final class dev/kord/core/event/interaction/UserCommandUpdateEvent : dev/
 }
 
 public final class dev/kord/core/event/message/MessageBulkDeleteEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event {
-	public fun <init> (Ljava/util/Set;Ljava/util/Set;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;)V
-	public synthetic fun <init> (Ljava/util/Set;Ljava/util/Set;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/util/Set;Ljava/util/Set;JLdev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/util/Set;Ljava/util/Set;JLdev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getChannel ()Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public final fun getChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-4_xYDEk ()J
 	public final fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getCustomContext ()Ljava/lang/Object;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getMessageIds ()Ljava/util/Set;
 	public final fun getMessages ()Ljava/util/Set;
@@ -12472,12 +12477,12 @@ public final class dev/kord/core/event/message/MessageBulkDeleteEvent : dev/kord
 }
 
 public final class dev/kord/core/event/message/MessageCreateEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event {
-	public fun <init> (Ldev/kord/core/entity/Message;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/entity/Member;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;)V
 	public synthetic fun <init> (Ldev/kord/core/entity/Message;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/entity/Member;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ldev/kord/core/entity/Message;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/entity/Member;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getCustomContext ()Ljava/lang/Object;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getMember ()Ldev/kord/core/entity/Member;
 	public final fun getMessage ()Ldev/kord/core/entity/Message;
@@ -12489,20 +12494,20 @@ public final class dev/kord/core/event/message/MessageCreateEvent : dev/kord/cor
 }
 
 public final class dev/kord/core/event/message/MessageDeleteEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/entity/Message;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/entity/Message;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLdev/kord/common/entity/Snowflake;Ldev/kord/core/entity/Message;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLdev/kord/common/entity/Snowflake;Ldev/kord/core/entity/Message;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getChannel ()Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public final fun getChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-4_xYDEk ()J
 	public final fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getCustomContext ()Ljava/lang/Object;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getMessage ()Ldev/kord/core/entity/Message;
-	public final fun getMessageId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getMessageId-4_xYDEk ()J
 	public fun getShard ()I
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
 	public fun toString ()Ljava/lang/String;
@@ -12511,16 +12516,16 @@ public final class dev/kord/core/event/message/MessageDeleteEvent : dev/kord/cor
 }
 
 public final class dev/kord/core/event/message/MessageUpdateEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordPartialMessage;Ldev/kord/core/entity/Message;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordPartialMessage;Ldev/kord/core/entity/Message;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLdev/kord/common/entity/DiscordPartialMessage;Ldev/kord/core/entity/Message;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLdev/kord/common/entity/DiscordPartialMessage;Ldev/kord/core/entity/Message;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getChannel ()Ldev/kord/core/behavior/channel/MessageChannelBehavior;
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-4_xYDEk ()J
 	public fun getCustomContext ()Ljava/lang/Object;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getMessage ()Ldev/kord/core/behavior/MessageBehavior;
 	public final fun getMessage (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getMessageId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getMessageId-4_xYDEk ()J
 	public final fun getMessageOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getNew ()Ldev/kord/common/entity/DiscordPartialMessage;
 	public final fun getOld ()Ldev/kord/core/entity/Message;
@@ -12532,22 +12537,22 @@ public final class dev/kord/core/event/message/MessageUpdateEvent : dev/kord/cor
 }
 
 public final class dev/kord/core/event/message/ReactionAddEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/entity/ReactionEmoji;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/entity/ReactionEmoji;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJJLdev/kord/common/entity/Snowflake;Ldev/kord/core/entity/ReactionEmoji;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJJLdev/kord/common/entity/Snowflake;Ldev/kord/core/entity/ReactionEmoji;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getChannel ()Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public final fun getChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-4_xYDEk ()J
 	public final fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getCustomContext ()Ljava/lang/Object;
 	public final fun getEmoji ()Ldev/kord/core/entity/ReactionEmoji;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getMessage ()Ldev/kord/core/behavior/MessageBehavior;
 	public final fun getMessage (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getMessageId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getMessageId-4_xYDEk ()J
 	public final fun getMessageOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getShard ()I
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
@@ -12555,7 +12560,7 @@ public final class dev/kord/core/event/message/ReactionAddEvent : dev/kord/core/
 	public final fun getUser (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getUserAsMember ()Ldev/kord/core/behavior/MemberBehavior;
 	public final fun getUserAsMember (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getUserId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getUserId-4_xYDEk ()J
 	public final fun getUserOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun toString ()Ljava/lang/String;
 	public synthetic fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/entity/Strategizable;
@@ -12563,21 +12568,21 @@ public final class dev/kord/core/event/message/ReactionAddEvent : dev/kord/core/
 }
 
 public final class dev/kord/core/event/message/ReactionRemoveAllEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLdev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLdev/kord/common/entity/Snowflake;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getChannel ()Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public final fun getChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-4_xYDEk ()J
 	public final fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getCustomContext ()Ljava/lang/Object;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getMessage ()Ldev/kord/core/behavior/MessageBehavior;
 	public final fun getMessage (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getMessageId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getMessageId-4_xYDEk ()J
 	public final fun getMessageOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getShard ()I
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
@@ -12591,7 +12596,7 @@ public final class dev/kord/core/event/message/ReactionRemoveEmojiEvent : dev/ko
 	public synthetic fun <init> (Ldev/kord/core/cache/data/ReactionRemoveEmojiData;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getChannel ()Ldev/kord/core/behavior/channel/GuildMessageChannelBehavior;
 	public final fun getChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-4_xYDEk ()J
 	public final fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getCustomContext ()Ljava/lang/Object;
 	public final fun getData ()Ldev/kord/core/cache/data/ReactionRemoveEmojiData;
@@ -12599,12 +12604,12 @@ public final class dev/kord/core/event/message/ReactionRemoveEmojiEvent : dev/ko
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public final fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getMessage ()Ldev/kord/core/behavior/MessageBehavior;
 	public final fun getMessage (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getMessageId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getMessageId-4_xYDEk ()J
 	public final fun getMessageOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getShard ()I
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
@@ -12614,22 +12619,22 @@ public final class dev/kord/core/event/message/ReactionRemoveEmojiEvent : dev/ko
 }
 
 public final class dev/kord/core/event/message/ReactionRemoveEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/entity/ReactionEmoji;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/entity/ReactionEmoji;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJJLdev/kord/common/entity/Snowflake;Ldev/kord/core/entity/ReactionEmoji;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJJLdev/kord/common/entity/Snowflake;Ldev/kord/core/entity/ReactionEmoji;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getChannel ()Ldev/kord/core/behavior/channel/MessageChannelBehavior;
 	public final fun getChannel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-4_xYDEk ()J
 	public final fun getChannelOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getCustomContext ()Ljava/lang/Object;
 	public final fun getEmoji ()Ldev/kord/core/entity/ReactionEmoji;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getMessage ()Ldev/kord/core/behavior/MessageBehavior;
 	public final fun getMessage (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getMessageId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getMessageId-4_xYDEk ()J
 	public final fun getMessageOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getShard ()I
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
@@ -12637,7 +12642,7 @@ public final class dev/kord/core/event/message/ReactionRemoveEvent : dev/kord/co
 	public final fun getUser (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getUserAsMember ()Ldev/kord/core/behavior/MemberBehavior;
 	public final fun getUserAsMember (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getUserId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getUserId-4_xYDEk ()J
 	public final fun getUserOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun toString ()Ljava/lang/String;
 	public synthetic fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/entity/Strategizable;
@@ -12651,7 +12656,7 @@ public final class dev/kord/core/event/role/RoleCreateEvent : dev/kord/core/enti
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public final fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getRole ()Ldev/kord/core/entity/Role;
@@ -12663,17 +12668,17 @@ public final class dev/kord/core/event/role/RoleCreateEvent : dev/kord/core/enti
 }
 
 public final class dev/kord/core/event/role/RoleDeleteEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/entity/Role;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/entity/Role;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLdev/kord/core/entity/Role;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLdev/kord/core/entity/Role;Ldev/kord/core/Kord;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getCustomContext ()Ljava/lang/Object;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public final fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getRole ()Ldev/kord/core/entity/Role;
-	public final fun getRoleId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getRoleId-4_xYDEk ()J
 	public fun getShard ()I
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
 	public fun toString ()Ljava/lang/String;
@@ -12688,7 +12693,7 @@ public final class dev/kord/core/event/role/RoleUpdateEvent : dev/kord/core/enti
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public final fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getOld ()Ldev/kord/core/entity/Role;
@@ -12701,13 +12706,13 @@ public final class dev/kord/core/event/role/RoleUpdateEvent : dev/kord/core/enti
 }
 
 public final class dev/kord/core/event/user/PresenceUpdateEvent : dev/kord/core/entity/Strategizable, dev/kord/core/event/Event {
-	public fun <init> (Ldev/kord/core/entity/User;Ldev/kord/common/entity/DiscordPresenceUser;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/entity/Presence;Ldev/kord/core/entity/Presence;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;)V
-	public synthetic fun <init> (Ldev/kord/core/entity/User;Ldev/kord/common/entity/DiscordPresenceUser;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/entity/Presence;Ldev/kord/core/entity/Presence;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ldev/kord/core/entity/User;Ldev/kord/common/entity/DiscordPresenceUser;JLdev/kord/core/entity/Presence;Ldev/kord/core/entity/Presence;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ldev/kord/core/entity/User;Ldev/kord/common/entity/DiscordPresenceUser;JLdev/kord/core/entity/Presence;Ldev/kord/core/entity/Presence;ILjava/lang/Object;Ldev/kord/core/supplier/EntitySupplier;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getCustomContext ()Ljava/lang/Object;
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public final fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getMember ()Ldev/kord/core/behavior/MemberBehavior;
@@ -12756,30 +12761,30 @@ public final class dev/kord/core/exception/EntityNotFoundException : java/lang/E
 }
 
 public final class dev/kord/core/exception/EntityNotFoundException$Companion {
-	public final fun applicationCommandPermissionsNotFound (Ldev/kord/common/entity/Snowflake;)Ljava/lang/Void;
-	public final fun autoModerationRuleNotFound (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)Ljava/lang/Void;
-	public final fun banNotFound (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)Ljava/lang/Void;
-	public final fun emojiNotFound (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)Ljava/lang/Void;
-	public final fun entityNotFound (Ljava/lang/String;Ldev/kord/common/entity/Snowflake;)Ljava/lang/Void;
-	public final fun followupMessageNotFound (Ljava/lang/String;Ldev/kord/common/entity/Snowflake;)Ljava/lang/Void;
-	public final fun guildEntityNotFound (Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)Ljava/lang/Void;
-	public final fun guildNotFound (Ldev/kord/common/entity/Snowflake;)Ljava/lang/Void;
-	public final fun guildScheduledEventNotFound (Ldev/kord/common/entity/Snowflake;)Ljava/lang/Void;
+	public final fun applicationCommandPermissionsNotFound-IO-hELI (J)Ljava/lang/Void;
+	public final fun autoModerationRuleNotFound-Xcgsvs4 (JJ)Ljava/lang/Void;
+	public final fun banNotFound-Xcgsvs4 (JJ)Ljava/lang/Void;
+	public final fun emojiNotFound-Xcgsvs4 (JJ)Ljava/lang/Void;
+	public final fun entityNotFound-Vn1WZo8 (Ljava/lang/String;J)Ljava/lang/Void;
+	public final fun followupMessageNotFound-Vn1WZo8 (Ljava/lang/String;J)Ljava/lang/Void;
+	public final fun guildEntityNotFound-NW1KesY (Ljava/lang/String;JJ)Ljava/lang/Void;
+	public final fun guildNotFound-IO-hELI (J)Ljava/lang/Void;
+	public final fun guildScheduledEventNotFound-IO-hELI (J)Ljava/lang/Void;
 	public final fun interactionNotFound (Ljava/lang/String;)Ljava/lang/Void;
 	public final fun inviteNotFound (Ljava/lang/String;)Ljava/lang/Void;
-	public final fun memberNotFound (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)Ljava/lang/Void;
-	public final fun messageNotFound (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)Ljava/lang/Void;
-	public final fun roleNotFound (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)Ljava/lang/Void;
+	public final fun memberNotFound-Xcgsvs4 (JJ)Ljava/lang/Void;
+	public final fun messageNotFound-Xcgsvs4 (JJ)Ljava/lang/Void;
+	public final fun roleNotFound-Xcgsvs4 (JJ)Ljava/lang/Void;
 	public final fun selfNotFound ()Ljava/lang/Void;
-	public final fun stageInstanceNotFound (Ldev/kord/common/entity/Snowflake;)Ljava/lang/Void;
-	public final fun stickerNotFound (Ldev/kord/common/entity/Snowflake;)Ljava/lang/Void;
+	public final fun stageInstanceNotFound-IO-hELI (J)Ljava/lang/Void;
+	public final fun stickerNotFound-IO-hELI (J)Ljava/lang/Void;
 	public final fun templateNotFound (Ljava/lang/String;)Ljava/lang/Void;
-	public final fun userNotFound (Ldev/kord/common/entity/Snowflake;)Ljava/lang/Void;
-	public final fun webhookMessageNotFound (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)Ljava/lang/Void;
-	public static synthetic fun webhookMessageNotFound$default (Ldev/kord/core/exception/EntityNotFoundException$Companion;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;ILjava/lang/Object;)Ljava/lang/Void;
-	public final fun webhookNotFound (Ldev/kord/common/entity/Snowflake;)Ljava/lang/Void;
-	public final fun welcomeScreenNotFound (Ldev/kord/common/entity/Snowflake;)Ljava/lang/Void;
-	public final fun widgetNotFound (Ldev/kord/common/entity/Snowflake;)Ljava/lang/Void;
+	public final fun userNotFound-IO-hELI (J)Ljava/lang/Void;
+	public final fun webhookMessageNotFound-01M_kms (JLjava/lang/String;JLdev/kord/common/entity/Snowflake;)Ljava/lang/Void;
+	public static synthetic fun webhookMessageNotFound-01M_kms$default (Ldev/kord/core/exception/EntityNotFoundException$Companion;JLjava/lang/String;JLdev/kord/common/entity/Snowflake;ILjava/lang/Object;)Ljava/lang/Void;
+	public final fun webhookNotFound-IO-hELI (J)Ljava/lang/Void;
+	public final fun welcomeScreenNotFound-IO-hELI (J)Ljava/lang/Void;
+	public final fun widgetNotFound-IO-hELI (J)Ljava/lang/Void;
 }
 
 public final class dev/kord/core/exception/GatewayNotFoundException : java/lang/Exception {
@@ -12790,7 +12795,7 @@ public final class dev/kord/core/exception/GatewayNotFoundException : java/lang/
 }
 
 public final class dev/kord/core/exception/GatewayNotFoundException$Companion {
-	public final fun voiceConnectionGatewayNotFound (Ldev/kord/common/entity/Snowflake;)Ljava/lang/Void;
+	public final fun voiceConnectionGatewayNotFound-IO-hELI (J)Ljava/lang/Void;
 }
 
 public final class dev/kord/core/exception/KordInitializationException : java/lang/Exception {
@@ -12881,7 +12886,7 @@ public final class dev/kord/core/live/LiveGuild : dev/kord/core/live/AbstractLiv
 	public fun <init> (Ldev/kord/core/entity/Guild;Lkotlinx/coroutines/CoroutineScope;)V
 	public synthetic fun <init> (Ldev/kord/core/entity/Guild;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getGuild ()Ldev/kord/core/entity/Guild;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 }
 
 public final class dev/kord/core/live/LiveGuildKt {
@@ -12960,7 +12965,7 @@ public final class dev/kord/core/live/LiveKordEntity$DefaultImpls {
 public final class dev/kord/core/live/LiveMember : dev/kord/core/live/AbstractLiveKordEntity, dev/kord/core/entity/KordEntity {
 	public fun <init> (Ldev/kord/core/entity/Member;Lkotlinx/coroutines/CoroutineScope;)V
 	public synthetic fun <init> (Ldev/kord/core/entity/Member;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public final fun getMember ()Ldev/kord/core/entity/Member;
 }
 
@@ -12982,10 +12987,10 @@ public final class dev/kord/core/live/LiveMemberKt {
 }
 
 public final class dev/kord/core/live/LiveMessage : dev/kord/core/live/AbstractLiveKordEntity, dev/kord/core/entity/KordEntity {
-	public fun <init> (Ldev/kord/core/entity/Message;Ldev/kord/common/entity/Snowflake;Lkotlinx/coroutines/CoroutineScope;)V
 	public synthetic fun <init> (Ldev/kord/core/entity/Message;Ldev/kord/common/entity/Snowflake;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (Ldev/kord/core/entity/Message;Ldev/kord/common/entity/Snowflake;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getGuildId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public final fun getMessage ()Ldev/kord/core/entity/Message;
 }
 
@@ -13023,7 +13028,7 @@ public final class dev/kord/core/live/LiveMessageKt {
 public final class dev/kord/core/live/LiveRole : dev/kord/core/live/AbstractLiveKordEntity, dev/kord/core/entity/KordEntity {
 	public fun <init> (Ldev/kord/core/entity/Role;Lkotlinx/coroutines/CoroutineScope;)V
 	public synthetic fun <init> (Ldev/kord/core/entity/Role;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public final fun getRole ()Ldev/kord/core/entity/Role;
 }
 
@@ -13045,7 +13050,7 @@ public final class dev/kord/core/live/LiveRoleKt {
 public final class dev/kord/core/live/LiveUser : dev/kord/core/live/AbstractLiveKordEntity, dev/kord/core/entity/KordEntity {
 	public fun <init> (Ldev/kord/core/entity/User;Lkotlinx/coroutines/CoroutineScope;)V
 	public synthetic fun <init> (Ldev/kord/core/entity/User;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 	public final fun getUser ()Ldev/kord/core/entity/User;
 }
 
@@ -13063,7 +13068,7 @@ public final class dev/kord/core/live/channel/LiveCategory : dev/kord/core/live/
 	public synthetic fun <init> (Ldev/kord/core/entity/channel/Category;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getChannel ()Ldev/kord/core/entity/channel/Category;
 	public synthetic fun getChannel ()Ldev/kord/core/entity/channel/Channel;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 }
 
 public final class dev/kord/core/live/channel/LiveCategoryKt {
@@ -13130,7 +13135,7 @@ public final class dev/kord/core/live/channel/LiveDmChannel : dev/kord/core/live
 	public synthetic fun <init> (Ldev/kord/core/entity/channel/DmChannel;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun getChannel ()Ldev/kord/core/entity/channel/Channel;
 	public fun getChannel ()Ldev/kord/core/entity/channel/DmChannel;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 }
 
 public final class dev/kord/core/live/channel/LiveDmChannelKt {
@@ -13155,7 +13160,7 @@ public final class dev/kord/core/live/channel/LiveGuildChannel : dev/kord/core/l
 	public synthetic fun <init> (Ldev/kord/core/entity/channel/TopGuildChannel;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun getChannel ()Ldev/kord/core/entity/channel/Channel;
 	public fun getChannel ()Ldev/kord/core/entity/channel/TopGuildChannel;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 }
 
 public final class dev/kord/core/live/channel/LiveGuildChannelKt {
@@ -13180,7 +13185,7 @@ public final class dev/kord/core/live/channel/LiveGuildMessageChannel : dev/kord
 	public synthetic fun <init> (Ldev/kord/core/entity/channel/TopGuildMessageChannel;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun getChannel ()Ldev/kord/core/entity/channel/Channel;
 	public fun getChannel ()Ldev/kord/core/entity/channel/TopGuildMessageChannel;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 }
 
 public final class dev/kord/core/live/channel/LiveGuildMessageChannelKt {
@@ -13205,7 +13210,7 @@ public final class dev/kord/core/live/channel/LiveVoiceChannel : dev/kord/core/l
 	public synthetic fun <init> (Ldev/kord/core/entity/channel/VoiceChannel;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun getChannel ()Ldev/kord/core/entity/channel/Channel;
 	public fun getChannel ()Ldev/kord/core/entity/channel/VoiceChannel;
-	public fun getId ()Ldev/kord/common/entity/Snowflake;
+	public fun getId-4_xYDEk ()J
 }
 
 public final class dev/kord/core/live/channel/LiveVoiceChannelKt {
@@ -13233,227 +13238,227 @@ public final class dev/kord/core/live/exception/LiveCancellationException : java
 
 public final class dev/kord/core/supplier/CacheEntitySupplier : dev/kord/core/supplier/EntitySupplier {
 	public fun <init> (Ldev/kord/core/Kord;)V
-	public fun getActiveThreads (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public fun getApplicationCommandPermissions (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getApplicationCommandPermissionsOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getAutoModerationRule (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getAutoModerationRuleOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getAutoModerationRules (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public fun getChannel (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getChannelOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getChannelPins (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public fun getChannelWebhooks (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
+	public fun getActiveThreads-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public fun getApplicationCommandPermissions-SmFlTYk (JJJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getApplicationCommandPermissionsOrNull-SmFlTYk (JJJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getAutoModerationRule-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getAutoModerationRuleOrNull-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getAutoModerationRules-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public fun getChannel-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getChannelOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getChannelPins-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public fun getChannelWebhooks-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
 	public final fun getChannels ()Lkotlinx/coroutines/flow/Flow;
 	public fun getCurrentUserGuilds (Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public fun getEmoji (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getEmojiOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getEmojis (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public fun getFollowupMessage (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getFollowupMessageOrNull (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGlobalApplicationCommand (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGlobalApplicationCommandOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGlobalApplicationCommands (Ldev/kord/common/entity/Snowflake;Ljava/lang/Boolean;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuild (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildApplicationCommand (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildApplicationCommandOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildApplicationCommandPermissions (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuildApplicationCommands (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Boolean;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuildBan (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildBanOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildBans (Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuildChannels (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuildMembers (Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuildOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildPreview (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildPreviewOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildRoles (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuildScheduledEvent (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildScheduledEventMembers (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuildScheduledEventMembersAfter (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuildScheduledEventMembersBefore (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuildScheduledEventOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildScheduledEventUsers (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuildScheduledEventUsersAfter (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuildScheduledEventUsersBefore (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuildScheduledEvents (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuildSticker (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildStickerOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildStickers (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuildVoiceRegions (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuildWebhooks (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuildWidget (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildWidgetOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getEmoji-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getEmojiOrNull-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getEmojis-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public fun getFollowupMessage-IFX1TXc (JLjava/lang/String;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getFollowupMessageOrNull-IFX1TXc (JLjava/lang/String;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGlobalApplicationCommand-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGlobalApplicationCommandOrNull-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGlobalApplicationCommands-wYKCHeA (JLjava/lang/Boolean;)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuild-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGuildApplicationCommand-SmFlTYk (JJJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGuildApplicationCommandOrNull-SmFlTYk (JJJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGuildApplicationCommandPermissions-Xcgsvs4 (JJ)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuildApplicationCommands-U2evHYk (JJLjava/lang/Boolean;)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuildBan-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGuildBanOrNull-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGuildBans-wYKCHeA (JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuildChannels-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuildMembers-wYKCHeA (JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuildOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGuildPreview-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGuildPreviewOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGuildRoles-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuildScheduledEvent-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGuildScheduledEventMembers-U2evHYk (JJLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuildScheduledEventMembersAfter-SmFlTYk (JJJLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuildScheduledEventMembersBefore-SmFlTYk (JJJLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuildScheduledEventOrNull-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGuildScheduledEventUsers-U2evHYk (JJLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuildScheduledEventUsersAfter-SmFlTYk (JJJLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuildScheduledEventUsersBefore-SmFlTYk (JJJLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuildScheduledEvents-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuildSticker-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGuildStickerOrNull-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGuildStickers-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuildVoiceRegions-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuildWebhooks-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuildWidget-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGuildWidgetOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getGuilds ()Lkotlinx/coroutines/flow/Flow;
-	public fun getJoinedPrivateArchivedThreads (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public fun getMember (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getMemberOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getJoinedPrivateArchivedThreads-8GXc5so (JLdev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getMember-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getMemberOrNull-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getMembers ()Lkotlinx/coroutines/flow/Flow;
-	public fun getMessage (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getMessageOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getMessagesAfter (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public fun getMessagesAround (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;I)Lkotlinx/coroutines/flow/Flow;
-	public fun getMessagesBefore (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getMessage-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getMessageOrNull-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getMessagesAfter-U2evHYk (JJLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getMessagesAround-U2evHYk (JJI)Lkotlinx/coroutines/flow/Flow;
+	public fun getMessagesBefore-U2evHYk (JJLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
 	public fun getNitroStickerPacks ()Lkotlinx/coroutines/flow/Flow;
-	public fun getPrivateArchivedThreads (Ldev/kord/common/entity/Snowflake;Lkotlinx/datetime/Instant;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public fun getPublicArchivedThreads (Ldev/kord/common/entity/Snowflake;Lkotlinx/datetime/Instant;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getPrivateArchivedThreads-9y3P_48 (JLkotlinx/datetime/Instant;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getPublicArchivedThreads-9y3P_48 (JLkotlinx/datetime/Instant;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
 	public fun getRegions ()Lkotlinx/coroutines/flow/Flow;
-	public fun getRole (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getRole (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getRoleOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getRole-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getRole-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getRoleOrNull-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getRoles ()Lkotlinx/coroutines/flow/Flow;
 	public fun getSelf (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getSelfOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getStageInstance (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getStageInstanceOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getSticker (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getStickerOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getStageInstance-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getStageInstanceOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getSticker-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getStickerOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getTemplate (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getTemplateOrNull (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getTemplates (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public fun getThreadMembers (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public fun getUser (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getUserOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getTemplates-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public fun getThreadMembers-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public fun getUser-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getUserOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getUsers ()Lkotlinx/coroutines/flow/Flow;
-	public fun getWebhook (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getWebhookMessage (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getWebhookMessageOrNull (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getWebhookOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getWebhookWithToken (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getWebhookWithTokenOrNull (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getWebhook-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getWebhookMessage-k9QPuOU (JLjava/lang/String;JLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getWebhookMessageOrNull-k9QPuOU (JLjava/lang/String;JLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getWebhookOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getWebhookWithToken-9y3P_48 (JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getWebhookWithTokenOrNull-9y3P_48 (JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface class dev/kord/core/supplier/EntitySupplier {
-	public abstract fun getActiveThreads (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getApplicationCommandPermissions (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getApplicationCommandPermissionsOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getAutoModerationRule (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getAutoModerationRuleOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getAutoModerationRules (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getChannel (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getChannelOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getChannelPins (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getChannelWebhooks (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getActiveThreads-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getApplicationCommandPermissions-SmFlTYk (JJJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getApplicationCommandPermissionsOrNull-SmFlTYk (JJJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getAutoModerationRule-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getAutoModerationRuleOrNull-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getAutoModerationRules-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getChannel-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getChannelOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getChannelPins-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getChannelWebhooks-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
 	public abstract fun getCurrentUserGuilds (Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getEmoji (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getEmojiOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getEmojis (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getFollowupMessage (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getFollowupMessageOrNull (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getGlobalApplicationCommand (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getGlobalApplicationCommandOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getGlobalApplicationCommands (Ldev/kord/common/entity/Snowflake;Ljava/lang/Boolean;)Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getGuild (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getGuildApplicationCommand (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getGuildApplicationCommandOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getGuildApplicationCommandPermissions (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getGuildApplicationCommands (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Boolean;)Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getGuildBan (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getGuildBanOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getGuildBans (Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getGuildChannels (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getGuildMembers (Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getGuildOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getGuildPreview (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getGuildPreviewOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getGuildRoles (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getGuildScheduledEvent (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getGuildScheduledEventMembers (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getGuildScheduledEventMembersAfter (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getGuildScheduledEventMembersBefore (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getGuildScheduledEventOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getGuildScheduledEventUsers (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getGuildScheduledEventUsersAfter (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getGuildScheduledEventUsersBefore (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getGuildScheduledEvents (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getGuildSticker (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getGuildStickerOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getGuildStickers (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getGuildVoiceRegions (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getGuildWebhooks (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getGuildWidget (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getGuildWidgetOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getEmoji-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getEmojiOrNull-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getEmojis-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getFollowupMessage-IFX1TXc (JLjava/lang/String;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getFollowupMessageOrNull-IFX1TXc (JLjava/lang/String;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getGlobalApplicationCommand-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getGlobalApplicationCommandOrNull-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getGlobalApplicationCommands-wYKCHeA (JLjava/lang/Boolean;)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getGuild-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getGuildApplicationCommand-SmFlTYk (JJJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getGuildApplicationCommandOrNull-SmFlTYk (JJJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getGuildApplicationCommandPermissions-Xcgsvs4 (JJ)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getGuildApplicationCommands-U2evHYk (JJLjava/lang/Boolean;)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getGuildBan-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getGuildBanOrNull-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getGuildBans-wYKCHeA (JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getGuildChannels-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getGuildMembers-wYKCHeA (JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getGuildOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getGuildPreview-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getGuildPreviewOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getGuildRoles-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getGuildScheduledEvent-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getGuildScheduledEventMembers-U2evHYk (JJLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getGuildScheduledEventMembersAfter-SmFlTYk (JJJLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getGuildScheduledEventMembersBefore-SmFlTYk (JJJLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getGuildScheduledEventOrNull-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getGuildScheduledEventUsers-U2evHYk (JJLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getGuildScheduledEventUsersAfter-SmFlTYk (JJJLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getGuildScheduledEventUsersBefore-SmFlTYk (JJJLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getGuildScheduledEvents-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getGuildSticker-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getGuildStickerOrNull-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getGuildStickers-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getGuildVoiceRegions-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getGuildWebhooks-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getGuildWidget-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getGuildWidgetOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getGuilds ()Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getJoinedPrivateArchivedThreads (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getMember (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getMemberOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getMessage (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getMessageOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getMessagesAfter (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getMessagesAround (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;I)Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getMessagesBefore (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getJoinedPrivateArchivedThreads-8GXc5so (JLdev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getMember-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getMemberOrNull-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getMessage-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getMessageOrNull-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getMessagesAfter-U2evHYk (JJLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getMessagesAround-U2evHYk (JJI)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getMessagesBefore-U2evHYk (JJLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
 	public abstract fun getNitroStickerPacks ()Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getPrivateArchivedThreads (Ldev/kord/common/entity/Snowflake;Lkotlinx/datetime/Instant;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getPublicArchivedThreads (Ldev/kord/common/entity/Snowflake;Lkotlinx/datetime/Instant;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getPrivateArchivedThreads-9y3P_48 (JLkotlinx/datetime/Instant;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getPublicArchivedThreads-9y3P_48 (JLkotlinx/datetime/Instant;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
 	public abstract fun getRegions ()Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getRole (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getRoleOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getRole-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getRoleOrNull-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getSelf (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getSelfOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getStageInstance (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getStageInstanceOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getSticker (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getStickerOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getStageInstance-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getStageInstanceOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getSticker-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getStickerOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getTemplate (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getTemplateOrNull (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getTemplates (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getThreadMembers (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getUser (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getUserOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getWebhook (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getWebhookMessage (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getWebhookMessageOrNull (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getWebhookOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getWebhookWithToken (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getWebhookWithTokenOrNull (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getTemplates-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getThreadMembers-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getUser-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getUserOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getWebhook-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getWebhookMessage-k9QPuOU (JLjava/lang/String;JLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getWebhookMessageOrNull-k9QPuOU (JLjava/lang/String;JLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getWebhookOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getWebhookWithToken-9y3P_48 (JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getWebhookWithTokenOrNull-9y3P_48 (JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class dev/kord/core/supplier/EntitySupplier$DefaultImpls {
-	public static fun getApplicationCommandPermissions (Ldev/kord/core/supplier/EntitySupplier;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getAutoModerationRule (Ldev/kord/core/supplier/EntitySupplier;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getChannel (Ldev/kord/core/supplier/EntitySupplier;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getApplicationCommandPermissions-SmFlTYk (Ldev/kord/core/supplier/EntitySupplier;JJJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getAutoModerationRule-U2evHYk (Ldev/kord/core/supplier/EntitySupplier;JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getChannel-wYKCHeA (Ldev/kord/core/supplier/EntitySupplier;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getCurrentUserGuilds$default (Ldev/kord/core/supplier/EntitySupplier;Ljava/lang/Integer;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getEmoji (Ldev/kord/core/supplier/EntitySupplier;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getFollowupMessage (Ldev/kord/core/supplier/EntitySupplier;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getGlobalApplicationCommand (Ldev/kord/core/supplier/EntitySupplier;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getGlobalApplicationCommands$default (Ldev/kord/core/supplier/EntitySupplier;Ldev/kord/common/entity/Snowflake;Ljava/lang/Boolean;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getGuild (Ldev/kord/core/supplier/EntitySupplier;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getGuildApplicationCommand (Ldev/kord/core/supplier/EntitySupplier;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getGuildApplicationCommands$default (Ldev/kord/core/supplier/EntitySupplier;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Boolean;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getGuildBan (Ldev/kord/core/supplier/EntitySupplier;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getGuildBans$default (Ldev/kord/core/supplier/EntitySupplier;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
-	public static synthetic fun getGuildMembers$default (Ldev/kord/core/supplier/EntitySupplier;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getGuildPreview (Ldev/kord/core/supplier/EntitySupplier;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getGuildScheduledEvent (Ldev/kord/core/supplier/EntitySupplier;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getGuildScheduledEventMembers (Ldev/kord/core/supplier/EntitySupplier;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public static synthetic fun getGuildScheduledEventMembers$default (Ldev/kord/core/supplier/EntitySupplier;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
-	public static synthetic fun getGuildScheduledEventMembersAfter$default (Ldev/kord/core/supplier/EntitySupplier;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
-	public static synthetic fun getGuildScheduledEventMembersBefore$default (Ldev/kord/core/supplier/EntitySupplier;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getGuildScheduledEventUsers (Ldev/kord/core/supplier/EntitySupplier;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public static synthetic fun getGuildScheduledEventUsers$default (Ldev/kord/core/supplier/EntitySupplier;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
-	public static synthetic fun getGuildScheduledEventUsersAfter$default (Ldev/kord/core/supplier/EntitySupplier;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
-	public static synthetic fun getGuildScheduledEventUsersBefore$default (Ldev/kord/core/supplier/EntitySupplier;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getGuildSticker (Ldev/kord/core/supplier/EntitySupplier;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getGuildWidget (Ldev/kord/core/supplier/EntitySupplier;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getJoinedPrivateArchivedThreads$default (Ldev/kord/core/supplier/EntitySupplier;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getMember (Ldev/kord/core/supplier/EntitySupplier;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getMessage (Ldev/kord/core/supplier/EntitySupplier;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getMessagesAfter$default (Ldev/kord/core/supplier/EntitySupplier;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
-	public static synthetic fun getMessagesAround$default (Ldev/kord/core/supplier/EntitySupplier;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;IILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
-	public static synthetic fun getMessagesBefore$default (Ldev/kord/core/supplier/EntitySupplier;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
-	public static synthetic fun getPrivateArchivedThreads$default (Ldev/kord/core/supplier/EntitySupplier;Ldev/kord/common/entity/Snowflake;Lkotlinx/datetime/Instant;Ljava/lang/Integer;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
-	public static synthetic fun getPublicArchivedThreads$default (Ldev/kord/core/supplier/EntitySupplier;Ldev/kord/common/entity/Snowflake;Lkotlinx/datetime/Instant;Ljava/lang/Integer;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
-	public static fun getRole (Ldev/kord/core/supplier/EntitySupplier;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getEmoji-U2evHYk (Ldev/kord/core/supplier/EntitySupplier;JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getFollowupMessage-IFX1TXc (Ldev/kord/core/supplier/EntitySupplier;JLjava/lang/String;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getGlobalApplicationCommand-U2evHYk (Ldev/kord/core/supplier/EntitySupplier;JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getGlobalApplicationCommands-wYKCHeA$default (Ldev/kord/core/supplier/EntitySupplier;JLjava/lang/Boolean;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getGuild-wYKCHeA (Ldev/kord/core/supplier/EntitySupplier;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getGuildApplicationCommand-SmFlTYk (Ldev/kord/core/supplier/EntitySupplier;JJJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getGuildApplicationCommands-U2evHYk$default (Ldev/kord/core/supplier/EntitySupplier;JJLjava/lang/Boolean;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getGuildBan-U2evHYk (Ldev/kord/core/supplier/EntitySupplier;JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getGuildBans-wYKCHeA$default (Ldev/kord/core/supplier/EntitySupplier;JLjava/lang/Integer;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun getGuildMembers-wYKCHeA$default (Ldev/kord/core/supplier/EntitySupplier;JLjava/lang/Integer;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getGuildPreview-wYKCHeA (Ldev/kord/core/supplier/EntitySupplier;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getGuildScheduledEvent-U2evHYk (Ldev/kord/core/supplier/EntitySupplier;JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getGuildScheduledEventMembers-U2evHYk (Ldev/kord/core/supplier/EntitySupplier;JJLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun getGuildScheduledEventMembers-U2evHYk$default (Ldev/kord/core/supplier/EntitySupplier;JJLjava/lang/Integer;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun getGuildScheduledEventMembersAfter-SmFlTYk$default (Ldev/kord/core/supplier/EntitySupplier;JJJLjava/lang/Integer;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun getGuildScheduledEventMembersBefore-SmFlTYk$default (Ldev/kord/core/supplier/EntitySupplier;JJJLjava/lang/Integer;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getGuildScheduledEventUsers-U2evHYk (Ldev/kord/core/supplier/EntitySupplier;JJLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun getGuildScheduledEventUsers-U2evHYk$default (Ldev/kord/core/supplier/EntitySupplier;JJLjava/lang/Integer;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun getGuildScheduledEventUsersAfter-SmFlTYk$default (Ldev/kord/core/supplier/EntitySupplier;JJJLjava/lang/Integer;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun getGuildScheduledEventUsersBefore-SmFlTYk$default (Ldev/kord/core/supplier/EntitySupplier;JJJLjava/lang/Integer;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getGuildSticker-U2evHYk (Ldev/kord/core/supplier/EntitySupplier;JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getGuildWidget-wYKCHeA (Ldev/kord/core/supplier/EntitySupplier;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getJoinedPrivateArchivedThreads-8GXc5so$default (Ldev/kord/core/supplier/EntitySupplier;JLdev/kord/common/entity/Snowflake;Ljava/lang/Integer;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getMember-U2evHYk (Ldev/kord/core/supplier/EntitySupplier;JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getMessage-U2evHYk (Ldev/kord/core/supplier/EntitySupplier;JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getMessagesAfter-U2evHYk$default (Ldev/kord/core/supplier/EntitySupplier;JJLjava/lang/Integer;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun getMessagesAround-U2evHYk$default (Ldev/kord/core/supplier/EntitySupplier;JJIILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun getMessagesBefore-U2evHYk$default (Ldev/kord/core/supplier/EntitySupplier;JJLjava/lang/Integer;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun getPrivateArchivedThreads-9y3P_48$default (Ldev/kord/core/supplier/EntitySupplier;JLkotlinx/datetime/Instant;Ljava/lang/Integer;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun getPublicArchivedThreads-9y3P_48$default (Ldev/kord/core/supplier/EntitySupplier;JLkotlinx/datetime/Instant;Ljava/lang/Integer;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getRole-U2evHYk (Ldev/kord/core/supplier/EntitySupplier;JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getSelf (Ldev/kord/core/supplier/EntitySupplier;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getStageInstance (Ldev/kord/core/supplier/EntitySupplier;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getSticker (Ldev/kord/core/supplier/EntitySupplier;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getStageInstance-wYKCHeA (Ldev/kord/core/supplier/EntitySupplier;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getSticker-wYKCHeA (Ldev/kord/core/supplier/EntitySupplier;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun getTemplate (Ldev/kord/core/supplier/EntitySupplier;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getUser (Ldev/kord/core/supplier/EntitySupplier;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getWebhook (Ldev/kord/core/supplier/EntitySupplier;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun getWebhookMessage (Ldev/kord/core/supplier/EntitySupplier;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getWebhookMessage$default (Ldev/kord/core/supplier/EntitySupplier;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static synthetic fun getWebhookMessageOrNull$default (Ldev/kord/core/supplier/EntitySupplier;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static fun getWebhookWithToken (Ldev/kord/core/supplier/EntitySupplier;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getUser-wYKCHeA (Ldev/kord/core/supplier/EntitySupplier;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getWebhook-wYKCHeA (Ldev/kord/core/supplier/EntitySupplier;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun getWebhookMessage-k9QPuOU (Ldev/kord/core/supplier/EntitySupplier;JLjava/lang/String;JLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getWebhookMessage-k9QPuOU$default (Ldev/kord/core/supplier/EntitySupplier;JLjava/lang/String;JLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun getWebhookMessageOrNull-k9QPuOU$default (Ldev/kord/core/supplier/EntitySupplier;JLjava/lang/String;JLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static fun getWebhookWithToken-9y3P_48 (Ldev/kord/core/supplier/EntitySupplier;JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class dev/kord/core/supplier/EntitySupplyStrategy {
@@ -13476,189 +13481,189 @@ public final class dev/kord/core/supplier/FallbackEntitySupplierKt {
 
 public final class dev/kord/core/supplier/RestEntitySupplier : dev/kord/core/supplier/EntitySupplier {
 	public fun <init> (Ldev/kord/core/Kord;)V
-	public fun getActiveThreads (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public fun getApplicationCommandPermissions (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getApplicationCommandPermissionsOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getActiveThreads-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public fun getApplicationCommandPermissions-SmFlTYk (JJJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getApplicationCommandPermissionsOrNull-SmFlTYk (JJJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getApplicationInfo (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getAuditLogEntries (Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/AuditLogGetRequest;)Lkotlinx/coroutines/flow/Flow;
-	public final fun getAuditLogEntries (Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
-	public static synthetic fun getAuditLogEntries$default (Ldev/kord/core/supplier/RestEntitySupplier;Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/AuditLogGetRequest;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
-	public fun getAutoModerationRule (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getAutoModerationRuleOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getAutoModerationRules (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public fun getChannel (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getChannelOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getChannelPins (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public fun getChannelWebhooks (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
+	public final fun getAuditLogEntries-wYKCHeA (JLdev/kord/rest/json/request/AuditLogGetRequest;)Lkotlinx/coroutines/flow/Flow;
+	public final fun getAuditLogEntries-wYKCHeA (JLkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun getAuditLogEntries-wYKCHeA$default (Ldev/kord/core/supplier/RestEntitySupplier;JLdev/kord/rest/json/request/AuditLogGetRequest;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public fun getAutoModerationRule-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getAutoModerationRuleOrNull-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getAutoModerationRules-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public fun getChannel-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getChannelOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getChannelPins-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public fun getChannelWebhooks-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
 	public fun getCurrentUserGuilds (Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public fun getEmoji (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getEmojiOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getEmojis (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public fun getFollowupMessage (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getFollowupMessageOrNull (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGlobalApplicationCommand (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGlobalApplicationCommandOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGlobalApplicationCommands (Ldev/kord/common/entity/Snowflake;Ljava/lang/Boolean;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuild (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildApplicationCommand (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildApplicationCommandOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildApplicationCommandPermissions (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuildApplicationCommands (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Boolean;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuildBan (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildBanOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildBans (Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuildChannels (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuildMembers (Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuildOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildPreview (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildPreviewOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildRoles (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuildScheduledEvent (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildScheduledEventMembers (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuildScheduledEventMembersAfter (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuildScheduledEventMembersBefore (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuildScheduledEventOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildScheduledEventUsers (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuildScheduledEventUsersAfter (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuildScheduledEventUsersBefore (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuildScheduledEvents (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuildSticker (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildStickerOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildStickers (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuildVoiceRegions (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuildWebhooks (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public final fun getGuildWelcomeScreen (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildWelcomeScreenOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildWidget (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildWidgetOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getEmoji-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getEmojiOrNull-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getEmojis-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public fun getFollowupMessage-IFX1TXc (JLjava/lang/String;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getFollowupMessageOrNull-IFX1TXc (JLjava/lang/String;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGlobalApplicationCommand-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGlobalApplicationCommandOrNull-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGlobalApplicationCommands-wYKCHeA (JLjava/lang/Boolean;)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuild-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGuildApplicationCommand-SmFlTYk (JJJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGuildApplicationCommandOrNull-SmFlTYk (JJJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGuildApplicationCommandPermissions-Xcgsvs4 (JJ)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuildApplicationCommands-U2evHYk (JJLjava/lang/Boolean;)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuildBan-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGuildBanOrNull-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGuildBans-wYKCHeA (JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuildChannels-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuildMembers-wYKCHeA (JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuildOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGuildPreview-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGuildPreviewOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGuildRoles-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuildScheduledEvent-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGuildScheduledEventMembers-U2evHYk (JJLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuildScheduledEventMembersAfter-SmFlTYk (JJJLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuildScheduledEventMembersBefore-SmFlTYk (JJJLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuildScheduledEventOrNull-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGuildScheduledEventUsers-U2evHYk (JJLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuildScheduledEventUsersAfter-SmFlTYk (JJJLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuildScheduledEventUsersBefore-SmFlTYk (JJJLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuildScheduledEvents-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuildSticker-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGuildStickerOrNull-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGuildStickers-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuildVoiceRegions-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuildWebhooks-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public final fun getGuildWelcomeScreen-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getGuildWelcomeScreenOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGuildWidget-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGuildWidgetOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getGuilds ()Lkotlinx/coroutines/flow/Flow;
-	public final fun getInvite (Ljava/lang/String;ZZLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getInvite$default (Ldev/kord/core/supplier/RestEntitySupplier;Ljava/lang/String;ZZLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun getInviteOrNull (Ljava/lang/String;ZZLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getInviteOrNull$default (Ldev/kord/core/supplier/RestEntitySupplier;Ljava/lang/String;ZZLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public fun getJoinedPrivateArchivedThreads (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public final fun getInvite-ReOCJwE (Ljava/lang/String;ZZLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getInvite-ReOCJwE$default (Ldev/kord/core/supplier/RestEntitySupplier;Ljava/lang/String;ZZLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getInviteOrNull-ReOCJwE (Ljava/lang/String;ZZLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getInviteOrNull-ReOCJwE$default (Ldev/kord/core/supplier/RestEntitySupplier;Ljava/lang/String;ZZLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public fun getJoinedPrivateArchivedThreads-8GXc5so (JLdev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
 	public final fun getKord ()Ldev/kord/core/Kord;
-	public fun getMember (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getMemberOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getMessage (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getMessageOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getMessagesAfter (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public fun getMessagesAround (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;I)Lkotlinx/coroutines/flow/Flow;
-	public fun getMessagesBefore (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getMember-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getMemberOrNull-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getMessage-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getMessageOrNull-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getMessagesAfter-U2evHYk (JJLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getMessagesAround-U2evHYk (JJI)Lkotlinx/coroutines/flow/Flow;
+	public fun getMessagesBefore-U2evHYk (JJLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
 	public fun getNitroStickerPacks ()Lkotlinx/coroutines/flow/Flow;
-	public final fun getOriginalInteraction (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getOriginalInteractionOrNull (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getPrivateArchivedThreads (Ldev/kord/common/entity/Snowflake;Lkotlinx/datetime/Instant;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public fun getPublicArchivedThreads (Ldev/kord/common/entity/Snowflake;Lkotlinx/datetime/Instant;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public final fun getReactors (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/core/entity/ReactionEmoji;)Lkotlinx/coroutines/flow/Flow;
+	public final fun getOriginalInteraction-9y3P_48 (JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getOriginalInteractionOrNull-9y3P_48 (JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getPrivateArchivedThreads-9y3P_48 (JLkotlinx/datetime/Instant;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getPublicArchivedThreads-9y3P_48 (JLkotlinx/datetime/Instant;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public final fun getReactors-U2evHYk (JJLdev/kord/core/entity/ReactionEmoji;)Lkotlinx/coroutines/flow/Flow;
 	public fun getRegions ()Lkotlinx/coroutines/flow/Flow;
-	public fun getRole (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getRoleOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getRole-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getRoleOrNull-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getSelf (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getSelfOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getStageInstance (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getStageInstanceOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getSticker (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getStickerOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getStageInstance-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getStageInstanceOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getSticker-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getStickerOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getTemplate (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getTemplateOrNull (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getTemplates (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public fun getThreadMembers (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public fun getUser (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getUserOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getWebhook (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getWebhookMessage (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getWebhookMessageOrNull (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getWebhookOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getWebhookWithToken (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getWebhookWithTokenOrNull (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getTemplates-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public fun getThreadMembers-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public fun getUser-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getUserOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getWebhook-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getWebhookMessage-k9QPuOU (JLjava/lang/String;JLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getWebhookMessageOrNull-k9QPuOU (JLjava/lang/String;JLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getWebhookOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getWebhookWithToken-9y3P_48 (JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getWebhookWithTokenOrNull-9y3P_48 (JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class dev/kord/core/supplier/StoreEntitySupplier : dev/kord/core/supplier/EntitySupplier {
 	public fun <init> (Ldev/kord/core/supplier/EntitySupplier;Ldev/kord/cache/api/DataCache;)V
-	public fun getActiveThreads (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public fun getApplicationCommandPermissions (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getApplicationCommandPermissionsOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getAutoModerationRule (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getAutoModerationRuleOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getAutoModerationRules (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public fun getChannel (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getChannelOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getChannelPins (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public fun getChannelWebhooks (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
+	public fun getActiveThreads-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public fun getApplicationCommandPermissions-SmFlTYk (JJJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getApplicationCommandPermissionsOrNull-SmFlTYk (JJJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getAutoModerationRule-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getAutoModerationRuleOrNull-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getAutoModerationRules-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public fun getChannel-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getChannelOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getChannelPins-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public fun getChannelWebhooks-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
 	public fun getCurrentUserGuilds (Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public fun getEmoji (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getEmojiOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getEmojis (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public fun getFollowupMessage (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getFollowupMessageOrNull (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGlobalApplicationCommand (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGlobalApplicationCommandOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGlobalApplicationCommands (Ldev/kord/common/entity/Snowflake;Ljava/lang/Boolean;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuild (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildApplicationCommand (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildApplicationCommandOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildApplicationCommandPermissions (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuildApplicationCommands (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Boolean;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuildBan (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildBanOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildBans (Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuildChannels (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuildMembers (Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuildOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildPreview (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildPreviewOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildRoles (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuildScheduledEvent (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildScheduledEventMembers (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuildScheduledEventMembersAfter (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuildScheduledEventMembersBefore (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuildScheduledEventOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildScheduledEventUsers (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuildScheduledEventUsersAfter (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuildScheduledEventUsersBefore (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuildScheduledEvents (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuildSticker (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildStickerOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildStickers (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuildVoiceRegions (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuildWebhooks (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public fun getGuildWidget (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getGuildWidgetOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getEmoji-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getEmojiOrNull-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getEmojis-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public fun getFollowupMessage-IFX1TXc (JLjava/lang/String;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getFollowupMessageOrNull-IFX1TXc (JLjava/lang/String;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGlobalApplicationCommand-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGlobalApplicationCommandOrNull-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGlobalApplicationCommands-wYKCHeA (JLjava/lang/Boolean;)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuild-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGuildApplicationCommand-SmFlTYk (JJJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGuildApplicationCommandOrNull-SmFlTYk (JJJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGuildApplicationCommandPermissions-Xcgsvs4 (JJ)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuildApplicationCommands-U2evHYk (JJLjava/lang/Boolean;)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuildBan-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGuildBanOrNull-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGuildBans-wYKCHeA (JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuildChannels-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuildMembers-wYKCHeA (JLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuildOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGuildPreview-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGuildPreviewOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGuildRoles-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuildScheduledEvent-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGuildScheduledEventMembers-U2evHYk (JJLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuildScheduledEventMembersAfter-SmFlTYk (JJJLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuildScheduledEventMembersBefore-SmFlTYk (JJJLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuildScheduledEventOrNull-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGuildScheduledEventUsers-U2evHYk (JJLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuildScheduledEventUsersAfter-SmFlTYk (JJJLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuildScheduledEventUsersBefore-SmFlTYk (JJJLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuildScheduledEvents-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuildSticker-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGuildStickerOrNull-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGuildStickers-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuildVoiceRegions-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuildWebhooks-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public fun getGuildWidget-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getGuildWidgetOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getGuilds ()Lkotlinx/coroutines/flow/Flow;
-	public fun getJoinedPrivateArchivedThreads (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public fun getMember (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getMemberOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getMessage (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getMessageOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getMessagesAfter (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public fun getMessagesAround (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;I)Lkotlinx/coroutines/flow/Flow;
-	public fun getMessagesBefore (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getJoinedPrivateArchivedThreads-8GXc5so (JLdev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getMember-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getMemberOrNull-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getMessage-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getMessageOrNull-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getMessagesAfter-U2evHYk (JJLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getMessagesAround-U2evHYk (JJI)Lkotlinx/coroutines/flow/Flow;
+	public fun getMessagesBefore-U2evHYk (JJLjava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
 	public fun getNitroStickerPacks ()Lkotlinx/coroutines/flow/Flow;
-	public fun getPrivateArchivedThreads (Ldev/kord/common/entity/Snowflake;Lkotlinx/datetime/Instant;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public fun getPublicArchivedThreads (Ldev/kord/common/entity/Snowflake;Lkotlinx/datetime/Instant;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getPrivateArchivedThreads-9y3P_48 (JLkotlinx/datetime/Instant;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public fun getPublicArchivedThreads-9y3P_48 (JLkotlinx/datetime/Instant;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
 	public fun getRegions ()Lkotlinx/coroutines/flow/Flow;
-	public fun getRole (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getRoleOrNull (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getRole-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getRoleOrNull-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getSelf (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getSelfOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getStageInstance (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getStageInstanceOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getSticker (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getStickerOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getStageInstance-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getStageInstanceOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getSticker-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getStickerOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getTemplate (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getTemplateOrNull (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getTemplates (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public fun getThreadMembers (Ldev/kord/common/entity/Snowflake;)Lkotlinx/coroutines/flow/Flow;
-	public fun getUser (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getUserOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getWebhook (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getWebhookMessage (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getWebhookMessageOrNull (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getWebhookOrNull (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getWebhookWithToken (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getWebhookWithTokenOrNull (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getTemplates-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public fun getThreadMembers-IO-hELI (J)Lkotlinx/coroutines/flow/Flow;
+	public fun getUser-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getUserOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getWebhook-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getWebhookMessage-k9QPuOU (JLjava/lang/String;JLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getWebhookMessageOrNull-k9QPuOU (JLjava/lang/String;JLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getWebhookOrNull-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getWebhookWithToken-9y3P_48 (JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getWebhookWithTokenOrNull-9y3P_48 (JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/core/src/test/kotlin/BoxedSnowflake.kt
+++ b/core/src/test/kotlin/BoxedSnowflake.kt
@@ -1,0 +1,6 @@
+import dev.kord.common.entity.Snowflake
+
+/**
+ * A class that wraps a Snowflake, because you can't use `lateinit` with value classes
+ */
+data class BoxedSnowflake(val value: Snowflake)

--- a/core/src/test/kotlin/live/AbstractLiveEntityTest.kt
+++ b/core/src/test/kotlin/live/AbstractLiveEntityTest.kt
@@ -1,5 +1,6 @@
 package live
 
+import BoxedSnowflake
 import dev.kord.cache.api.DataCache
 import dev.kord.common.entity.Snowflake
 import dev.kord.core.ClientResources
@@ -76,14 +77,14 @@ abstract class AbstractLiveEntityTest<LIVE : AbstractLiveKordEntity> {
 
     protected lateinit var kord: Kord
 
-    protected lateinit var guildId: Snowflake
+    protected lateinit var guildId: BoxedSnowflake
 
     lateinit var live: LIVE
 
     @BeforeAll
     open fun onBeforeAll() = runBlocking {
         kord = createKord()
-        guildId = randomId()
+        guildId = BoxedSnowflake(randomId())
     }
 
     @AfterAll

--- a/core/src/test/kotlin/live/LiveGuildTest.kt
+++ b/core/src/test/kotlin/live/LiveGuildTest.kt
@@ -35,7 +35,7 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
             Guild(
                 kord = kord,
                 data = GuildData(
-                    id = guildId,
+                    id = guildId.value,
                     name = "",
                     ownerId = randomId(),
                     region = "",
@@ -61,11 +61,11 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
     fun `Check onEmojisUpdate is called when event is received`() {
         countdownContext(1) {
             live.onEmojisUpdate {
-                assertEquals(guildId, it.guildId)
+                assertEquals(guildId.value, it.guildId)
                 count()
             }
 
-            sendEventValidAndRandomId(guildId) {
+            sendEventValidAndRandomId(guildId.value) {
                 GuildEmojisUpdate(
                     DiscordUpdatedEmojis(
                         guildId = it,
@@ -81,11 +81,11 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
     fun `Check onIntegrationsUpdate is called when event is received`() {
         countdownContext(1) {
             live.onIntegrationsUpdate {
-                assertEquals(guildId, it.guildId)
+                assertEquals(guildId.value, it.guildId)
                 count()
             }
 
-            sendEventValidAndRandomId(guildId) {
+            sendEventValidAndRandomId(guildId.value) {
                 GuildIntegrationsUpdate(
                     DiscordGuildIntegrations(
                         guildId = it
@@ -100,11 +100,11 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
     fun `Check onBanAdd is called when event is received`() {
         countdownContext(1) {
             live.onBanAdd {
-                assertEquals(guildId, it.guildId)
+                assertEquals(guildId.value, it.guildId)
                 count()
             }
 
-            sendEventValidAndRandomId(guildId) {
+            sendEventValidAndRandomId(guildId.value) {
                 GuildBanAdd(
                     DiscordGuildBan(
                         guildId = it,
@@ -125,11 +125,11 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
     fun `Check onBanRemove is called when event is received`() {
         countdownContext(1) {
             live.onBanRemove {
-                assertEquals(guildId, it.guildId)
+                assertEquals(guildId.value, it.guildId)
                 count()
             }
 
-            sendEventValidAndRandomId(guildId) {
+            sendEventValidAndRandomId(guildId.value) {
                 GuildBanRemove(
                     DiscordGuildBan(
                         guildId = it,
@@ -150,11 +150,11 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
     fun `Check onPresenceUpdate is called when event is received`() {
         countdownContext(1) {
             live.onPresenceUpdate {
-                assertEquals(guildId, it.guildId)
+                assertEquals(guildId.value, it.guildId)
                 count()
             }
 
-            sendEventValidAndRandomId(guildId) {
+            sendEventValidAndRandomId(guildId.value) {
                 PresenceUpdate(
                     DiscordPresenceUpdate(
                         user = DiscordPresenceUser(
@@ -176,11 +176,11 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
     fun `Check onVoiceServerUpdate is called when event is received`() {
         countdownContext(1) {
             live.onVoiceServerUpdate {
-                assertEquals(guildId, it.guildId)
+                assertEquals(guildId.value, it.guildId)
                 count()
             }
 
-            sendEventValidAndRandomId(guildId) {
+            sendEventValidAndRandomId(guildId.value) {
                 VoiceServerUpdate(
                     DiscordVoiceServerUpdateData(
                         guildId = it,
@@ -197,11 +197,11 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
     fun `Check onVoiceStateUpdate is called when event is received`() {
         countdownContext(1) {
             live.onVoiceStateUpdate {
-                assertEquals(guildId, it.state.guildId)
+                assertEquals(guildId.value, it.state.guildId)
                 count()
             }
 
-            sendEventValidAndRandomId(guildId) {
+            sendEventValidAndRandomId(guildId.value) {
                 VoiceStateUpdate(
                     DiscordVoiceState(
                         guildId = it.optionalSnowflake(),
@@ -226,11 +226,11 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
     fun `Check onWebhookUpdate is called when event is received`() {
         countdownContext(1) {
             live.onWebhookUpdate {
-                assertEquals(guildId, it.guildId)
+                assertEquals(guildId.value, it.guildId)
                 count()
             }
 
-            sendEventValidAndRandomId(guildId) {
+            sendEventValidAndRandomId(guildId.value) {
                 WebhooksUpdate(
                     DiscordWebhooksUpdateData(
                         guildId = it,
@@ -246,11 +246,11 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
     fun `Check onRoleCreate is called when event is received`() {
         countdownContext(1) {
             live.onRoleCreate {
-                assertEquals(guildId, it.guildId)
+                assertEquals(guildId.value, it.guildId)
                 count()
             }
 
-            sendEventValidAndRandomId(guildId) {
+            sendEventValidAndRandomId(guildId.value) {
                 GuildRoleCreate(
                     DiscordGuildRole(
                         guildId = it,
@@ -277,11 +277,11 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
     fun `Check onRoleUpdate is called when event is received`() {
         countdownContext(1) {
             live.onRoleUpdate {
-                assertEquals(guildId, it.guildId)
+                assertEquals(guildId.value, it.guildId)
                 count()
             }
 
-            sendEventValidAndRandomId(guildId) {
+            sendEventValidAndRandomId(guildId.value) {
                 GuildRoleUpdate(
                     DiscordGuildRole(
                         guildId = it,
@@ -308,11 +308,11 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
     fun `Check onRoleDelete is called when event is received`() {
         countdownContext(1) {
             live.onRoleDelete {
-                assertEquals(guildId, it.guildId)
+                assertEquals(guildId.value, it.guildId)
                 count()
             }
 
-            sendEventValidAndRandomId(guildId) {
+            sendEventValidAndRandomId(guildId.value) {
                 GuildRoleDelete(
                     DiscordDeletedGuildRole(
                         guildId = it,
@@ -328,11 +328,11 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
     fun `Check onMemberJoin is called when event is received`() {
         countdownContext(1) {
             live.onMemberJoin {
-                assertEquals(guildId, it.guildId)
+                assertEquals(guildId.value, it.guildId)
                 count()
             }
 
-            sendEventValidAndRandomId(guildId) {
+            sendEventValidAndRandomId(guildId.value) {
                 GuildMemberAdd(
                     DiscordAddedGuildMember(
                         guildId = it,
@@ -359,11 +359,11 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
     fun `Check onMemberUpdate is called when event is received`() {
         countdownContext(1) {
             live.onMemberUpdate {
-                assertEquals(guildId, it.guildId)
+                assertEquals(guildId.value, it.guildId)
                 count()
             }
 
-            sendEventValidAndRandomId(guildId) {
+            sendEventValidAndRandomId(guildId.value) {
                 GuildMemberUpdate(
                     DiscordUpdatedGuildMember(
                         guildId = it,
@@ -386,11 +386,11 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
     fun `Check onMemberLeave is called when event is received`() {
         countdownContext(1) {
             live.onMemberLeave {
-                assertEquals(guildId, it.guildId)
+                assertEquals(guildId.value, it.guildId)
                 count()
             }
 
-            sendEventValidAndRandomId(guildId) {
+            sendEventValidAndRandomId(guildId.value) {
                 GuildMemberRemove(
                     DiscordRemovedGuildMember(
                         guildId = it,
@@ -413,11 +413,11 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
             val emojiExpected = ReactionEmoji.Unicode("\uD83D\uDC28")
 
             live.onReactionAdd {
-                assertEquals(guildId, it.guildId)
+                assertEquals(guildId.value, it.guildId)
                 count()
             }
 
-            sendEventValidAndRandomId(guildId) {
+            sendEventValidAndRandomId(guildId.value) {
                 MessageReactionAdd(
                     MessageReactionAddData(
                         messageId = randomId(),
@@ -439,7 +439,7 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
             val emojiOther = ReactionEmoji.Unicode("\uD83D\uDC3B")
 
             live.onReactionAdd(emojiExpected) {
-                assertEquals(guildId, it.guildId)
+                assertEquals(guildId.value, it.guildId)
                 assertEquals(emojiExpected, it.emoji)
                 count()
             }
@@ -456,8 +456,8 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
             )
 
             sendEventAndWait(createEvent(randomId(), emojiExpected))
-            sendEventAndWait(createEvent(guildId, emojiOther))
-            sendEvent(createEvent(guildId, emojiExpected))
+            sendEventAndWait(createEvent(guildId.value, emojiOther))
+            sendEvent(createEvent(guildId.value, emojiExpected))
         }
     }
 
@@ -467,12 +467,12 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
             val emojiExpected = ReactionEmoji.Unicode("\uD83D\uDC28")
 
             live.onReactionRemove {
-                assertEquals(guildId, it.guildId)
+                assertEquals(guildId.value, it.guildId)
                 assertEquals(emojiExpected, it.emoji)
                 count()
             }
 
-            sendEventValidAndRandomId(guildId) {
+            sendEventValidAndRandomId(guildId.value) {
                 MessageReactionRemove(
                     MessageReactionRemoveData(
                         messageId = randomId(),
@@ -494,7 +494,7 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
             val emojiOther = ReactionEmoji.Unicode("\uD83D\uDC3B")
 
             live.onReactionRemove(emojiExpected) {
-                assertEquals(guildId, it.guildId)
+                assertEquals(guildId.value, it.guildId)
                 assertEquals(emojiExpected, it.emoji)
                 count()
             }
@@ -511,8 +511,8 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
             )
 
             sendEventAndWait(createEvent(randomId(), emojiExpected))
-            sendEventAndWait(createEvent(guildId, emojiOther))
-            sendEvent(createEvent(guildId, emojiExpected))
+            sendEventAndWait(createEvent(guildId.value, emojiOther))
+            sendEvent(createEvent(guildId.value, emojiExpected))
         }
     }
 
@@ -520,11 +520,11 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
     fun `Check onReactionRemoveAll is called when event is received`() {
         countdownContext(1) {
             live.onReactionRemoveAll {
-                assertEquals(guildId, it.guildId)
+                assertEquals(guildId.value, it.guildId)
                 count()
             }
 
-            sendEventValidAndRandomId(guildId) {
+            sendEventValidAndRandomId(guildId.value) {
                 MessageReactionRemoveAll(
                     AllRemovedMessageReactions(
                         channelId = randomId(),
@@ -541,11 +541,11 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
     fun `Check onMessageCreate is called when event is received`() {
         countdownContext(1) {
             live.onMessageCreate {
-                assertEquals(guildId, it.guildId)
+                assertEquals(guildId.value, it.guildId)
                 count()
             }
 
-            sendEventValidAndRandomId(guildId) {
+            sendEventValidAndRandomId(guildId.value) {
                 MessageCreate(
                     DiscordMessage(
                         id = randomId(),
@@ -579,11 +579,11 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
     fun `Check onMessageUpdate is called when event is received`() {
         countdownContext(1) {
             live.onMessageUpdate {
-                assertEquals(guildId, it.new.guildId.value)
+                assertEquals(guildId.value, it.new.guildId.value)
                 count()
             }
 
-            sendEventValidAndRandomId(guildId) {
+            sendEventValidAndRandomId(guildId.value) {
                 MessageUpdate(
                     DiscordPartialMessage(
                         id = randomId(),
@@ -600,11 +600,11 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
     fun `Check onMessageDelete is called when event is received`() {
         countdownContext(1) {
             live.onMessageDelete {
-                assertEquals(guildId, it.guildId)
+                assertEquals(guildId.value, it.guildId)
                 count()
             }
 
-            sendEventValidAndRandomId(guildId) {
+            sendEventValidAndRandomId(guildId.value) {
                 MessageDelete(
                     DeletedMessage(
                         id = randomId(),
@@ -621,11 +621,11 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
     fun `Check onChannelCreate is called when event is received`() {
         countdownContext(1) {
             live.onChannelCreate {
-                assertEquals(guildId, it.channel.data.guildId.value)
+                assertEquals(guildId.value, it.channel.data.guildId.value)
                 count()
             }
 
-            sendEventValidAndRandomId(guildId) {
+            sendEventValidAndRandomId(guildId.value) {
                 ChannelCreate(
                     DiscordChannel(
                         id = randomId(),
@@ -642,11 +642,11 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
     fun `Check onChannelUpdate is called when event is received`() {
         countdownContext(1) {
             live.onChannelUpdate {
-                assertEquals(guildId, it.channel.data.guildId.value)
+                assertEquals(guildId.value, it.channel.data.guildId.value)
                 count()
             }
 
-            sendEventValidAndRandomId(guildId) {
+            sendEventValidAndRandomId(guildId.value) {
                 ChannelUpdate(
                     DiscordChannel(
                         id = randomId(),
@@ -663,11 +663,11 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
     fun `Check onChannelDelete is called when event is received`() {
         countdownContext(1) {
             live.onChannelDelete {
-                assertEquals(guildId, it.channel.data.guildId.value)
+                assertEquals(guildId.value, it.channel.data.guildId.value)
                 count()
             }
 
-            sendEventValidAndRandomId(guildId) {
+            sendEventValidAndRandomId(guildId.value) {
                 ChannelDelete(
                     DiscordChannel(
                         id = randomId(),
@@ -684,11 +684,11 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
     fun `Check onGuildCreate is called when event is received`() {
         countdownContext(1) {
             live.onGuildCreate {
-                assertEquals(guildId, it.guild.id)
+                assertEquals(guildId.value, it.guild.id)
                 count()
             }
 
-            sendEventValidAndRandomId(guildId) {
+            sendEventValidAndRandomId(guildId.value) {
                 GuildCreate(
                     DiscordGuild(
                         id = it,
@@ -728,11 +728,11 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
     fun `Check onGuildUpdate is called when event is received`() {
         countdownContext(1) {
             live.onGuildUpdate {
-                assertEquals(guildId, it.guild.id)
+                assertEquals(guildId.value, it.guild.id)
                 count()
             }
 
-            sendEventValidAndRandomId(guildId) {
+            sendEventValidAndRandomId(guildId.value) {
                 GuildUpdate(
                     DiscordGuild(
                         id = it,
@@ -774,11 +774,11 @@ class LiveGuildTest : AbstractLiveEntityTest<LiveGuild>() {
             live.coroutineContext.job.invokeOnCompletion {
                 it as LiveCancellationException
                 val event = it.event as GuildDeleteEvent
-                assertEquals(guildId, event.guildId)
+                assertEquals(guildId.value, event.guildId)
                 count()
             }
 
-            sendEventValidAndRandomIdCheckLiveActive(guildId) {
+            sendEventValidAndRandomIdCheckLiveActive(guildId.value) {
                 GuildDelete(
                     DiscordUnavailableGuild(
                         id = it,

--- a/core/src/test/kotlin/live/LiveKordEntityTest.kt
+++ b/core/src/test/kotlin/live/LiveKordEntityTest.kt
@@ -131,7 +131,7 @@ class LiveKordEntityTest : AbstractLiveEntityTest<LiveKordEntityTest.LiveEntityM
 
             val eventGuildBan = GuildBanAdd(
                 DiscordGuildBan(
-                    guildId = guildId,
+                    guildId = guildId.value,
                     user = DiscordUser(
                         id = randomId(),
                         username = "",
@@ -145,7 +145,7 @@ class LiveKordEntityTest : AbstractLiveEntityTest<LiveKordEntityTest.LiveEntityM
 
             val eventGuildDelete = GuildDelete(
                 DiscordUnavailableGuild(
-                    id = guildId
+                    id = guildId.value
                 ),
                 0
             )

--- a/core/src/test/kotlin/live/LiveMemberTest.kt
+++ b/core/src/test/kotlin/live/LiveMemberTest.kt
@@ -1,5 +1,6 @@
 package live
 
+import BoxedSnowflake
 import dev.kord.common.entity.*
 import dev.kord.common.entity.optional.Optional
 import dev.kord.core.cache.data.MemberData
@@ -33,12 +34,12 @@ import kotlin.test.assertEquals
 @Disabled
 class LiveMemberTest : AbstractLiveEntityTest<LiveMember>() {
 
-    private lateinit var userId: Snowflake
+    private lateinit var userId: BoxedSnowflake
 
     @BeforeAll
     override fun onBeforeAll() {
         super.onBeforeAll()
-        userId = randomId()
+        userId = BoxedSnowflake(randomId())
     }
 
     @BeforeTest
@@ -47,15 +48,15 @@ class LiveMemberTest : AbstractLiveEntityTest<LiveMember>() {
             Member(
                 kord = kord,
                 memberData = MemberData(
-                    userId = userId,
-                    guildId = guildId,
+                    userId = userId.value,
+                    guildId = guildId.value,
                     roles = emptyList(),
                     joinedAt = Instant.fromEpochMilliseconds(0),
                     premiumSince = Optional.Missing(),
                     avatar = Optional.Missing(),
                 ),
                 userData = UserData(
-                    id = userId,
+                    id = userId.value,
                     username = "",
                     discriminator = ""
                 )
@@ -67,11 +68,11 @@ class LiveMemberTest : AbstractLiveEntityTest<LiveMember>() {
     fun `Check onUpdate is called when event is received`() {
         countdownContext(1) {
             live.onUpdate {
-                assertEquals(userId, it.member.id)
+                assertEquals(userId.value, it.member.id)
                 count()
             }
 
-            sendEventValidAndRandomId(userId) {
+            sendEventValidAndRandomId(userId.value) {
                 GuildMemberUpdate(
                     DiscordUpdatedGuildMember(
                         guildId = randomId(),
@@ -96,11 +97,11 @@ class LiveMemberTest : AbstractLiveEntityTest<LiveMember>() {
             live.coroutineContext.job.invokeOnCompletion {
                 it as LiveCancellationException
                 val event = it.event as MemberLeaveEvent
-                assertEquals(userId, event.user.id)
+                assertEquals(userId.value, event.user.id)
                 count()
             }
 
-            sendEventValidAndRandomIdCheckLiveActive(userId) {
+            sendEventValidAndRandomIdCheckLiveActive(userId.value) {
                 GuildMemberRemove(
                     DiscordRemovedGuildMember(
                         guildId = randomId(),
@@ -123,11 +124,11 @@ class LiveMemberTest : AbstractLiveEntityTest<LiveMember>() {
             live.coroutineContext.job.invokeOnCompletion {
                 it as LiveCancellationException
                 val event = it.event as BanAddEvent
-                assertEquals(userId, event.user.id)
+                assertEquals(userId.value, event.user.id)
                 count()
             }
 
-            sendEventValidAndRandomIdCheckLiveActive(userId) {
+            sendEventValidAndRandomIdCheckLiveActive(userId.value) {
                 GuildBanAdd(
                     DiscordGuildBan(
                         guildId = randomId(),
@@ -150,11 +151,11 @@ class LiveMemberTest : AbstractLiveEntityTest<LiveMember>() {
             live.coroutineContext.job.invokeOnCompletion {
                 it as LiveCancellationException
                 val event = it.event as GuildDeleteEvent
-                assertEquals(guildId, event.guildId)
+                assertEquals(guildId.value, event.guildId)
                 count()
             }
 
-            sendEventValidAndRandomIdCheckLiveActive(guildId) {
+            sendEventValidAndRandomIdCheckLiveActive(guildId.value) {
                 GuildDelete(
                     DiscordUnavailableGuild(
                         id = it

--- a/core/src/test/kotlin/live/LiveMessageTest.kt
+++ b/core/src/test/kotlin/live/LiveMessageTest.kt
@@ -1,5 +1,6 @@
 package live
 
+import BoxedSnowflake
 import dev.kord.common.entity.*
 import dev.kord.core.cache.data.MessageData
 import dev.kord.core.cache.data.UserData
@@ -31,26 +32,26 @@ import kotlin.test.assertTrue
 @Disabled
 class LiveMessageTest : AbstractLiveEntityTest<LiveMessage>() {
 
-    private lateinit var messageId: Snowflake
+    private lateinit var messageId: BoxedSnowflake
 
-    private lateinit var channelId: Snowflake
+    private lateinit var channelId: BoxedSnowflake
 
     @BeforeAll
     override fun onBeforeAll() {
         super.onBeforeAll()
-        messageId = randomId()
-        channelId = randomId()
+        messageId = BoxedSnowflake(randomId())
+        channelId = BoxedSnowflake(randomId())
     }
 
     @BeforeTest
     fun onBefore() = runBlocking {
         live = LiveMessage(
-            guildId = guildId,
+            guildId = guildId.value,
             message = Message(
                 kord = kord,
                 data = MessageData(
-                    id = messageId,
-                    channelId = channelId,
+                    id = messageId.value,
+                    channelId = channelId.value,
                     author = UserData(
                         id = randomId(),
                         username = "",
@@ -77,12 +78,12 @@ class LiveMessageTest : AbstractLiveEntityTest<LiveMessage>() {
             val emojiExpected = ReactionEmoji.Unicode("\uD83D\uDC28")
 
             live.onReactionAdd {
-                assertEquals(messageId, it.messageId)
+                assertEquals(messageId.value, it.messageId)
                 assertEquals(emojiExpected, it.emoji)
                 count()
             }
 
-            sendEventValidAndRandomId(messageId) {
+            sendEventValidAndRandomId(messageId.value) {
                 MessageReactionAdd(
                     MessageReactionAddData(
                         messageId = it,
@@ -103,7 +104,7 @@ class LiveMessageTest : AbstractLiveEntityTest<LiveMessage>() {
             val emojiOther = ReactionEmoji.Unicode("\uD83D\uDC3B")
 
             live.onReactionAdd(emojiExpected) {
-                assertEquals(messageId, it.messageId)
+                assertEquals(messageId.value, it.messageId)
                 assertEquals(emojiExpected, it.emoji)
                 count()
             }
@@ -119,8 +120,8 @@ class LiveMessageTest : AbstractLiveEntityTest<LiveMessage>() {
             )
 
             sendEventAndWait(createEvent(randomId(), emojiExpected))
-            sendEventAndWait(createEvent(messageId, emojiOther))
-            sendEvent(createEvent(messageId, emojiExpected))
+            sendEventAndWait(createEvent(messageId.value, emojiOther))
+            sendEvent(createEvent(messageId.value, emojiExpected))
         }
     }
 
@@ -130,12 +131,12 @@ class LiveMessageTest : AbstractLiveEntityTest<LiveMessage>() {
             val emojiExpected = ReactionEmoji.Unicode("\uD83D\uDC28")
 
             live.onReactionRemove {
-                assertEquals(messageId, it.messageId)
+                assertEquals(messageId.value, it.messageId)
                 assertEquals(emojiExpected, it.emoji)
                 count()
             }
 
-            sendEventValidAndRandomId(messageId) {
+            sendEventValidAndRandomId(messageId.value) {
                 MessageReactionRemove(
                     MessageReactionRemoveData(
                         messageId = it,
@@ -156,7 +157,7 @@ class LiveMessageTest : AbstractLiveEntityTest<LiveMessage>() {
             val emojiOther = ReactionEmoji.Unicode("\uD83D\uDC3B")
 
             live.onReactionRemove(emojiExpected) {
-                assertEquals(messageId, it.messageId)
+                assertEquals(messageId.value, it.messageId)
                 assertEquals(emojiExpected, it.emoji)
                 count()
             }
@@ -172,8 +173,8 @@ class LiveMessageTest : AbstractLiveEntityTest<LiveMessage>() {
             )
 
             sendEvent(createEvent(randomId(), emojiExpected))
-            sendEvent(createEvent(messageId, emojiOther))
-            sendEvent(createEvent(messageId, emojiExpected))
+            sendEvent(createEvent(messageId.value, emojiOther))
+            sendEvent(createEvent(messageId.value, emojiExpected))
         }
     }
 
@@ -181,11 +182,11 @@ class LiveMessageTest : AbstractLiveEntityTest<LiveMessage>() {
     fun `Check onReactionRemoveAll is called when event is received`() {
         countdownContext(1) {
             live.onReactionRemoveAll {
-                assertEquals(messageId, it.messageId)
+                assertEquals(messageId.value, it.messageId)
                 count()
             }
 
-            sendEventValidAndRandomId(messageId) {
+            sendEventValidAndRandomId(messageId.value) {
                 MessageReactionRemoveAll(
                     AllRemovedMessageReactions(
                         channelId = randomId(),
@@ -201,11 +202,11 @@ class LiveMessageTest : AbstractLiveEntityTest<LiveMessage>() {
     fun `Check onUpdate is called when event is received`() {
         countdownContext(1) {
             live.onUpdate {
-                assertEquals(messageId, it.messageId)
+                assertEquals(messageId.value, it.messageId)
                 count()
             }
 
-            sendEventValidAndRandomId(messageId) {
+            sendEventValidAndRandomId(messageId.value) {
                 MessageUpdate(
                     DiscordPartialMessage(
                         id = it,
@@ -223,11 +224,11 @@ class LiveMessageTest : AbstractLiveEntityTest<LiveMessage>() {
             live.coroutineContext.job.invokeOnCompletion {
                 it as LiveCancellationException
                 val event = it.event as MessageDeleteEvent
-                assertEquals(messageId, event.messageId)
+                assertEquals(messageId.value, event.messageId)
                 count()
             }
 
-            sendEventValidAndRandomIdCheckLiveActive(messageId) {
+            sendEventValidAndRandomIdCheckLiveActive(messageId.value) {
                 MessageDelete(
                     DeletedMessage(
                         id = it,
@@ -245,11 +246,11 @@ class LiveMessageTest : AbstractLiveEntityTest<LiveMessage>() {
             live.coroutineContext.job.invokeOnCompletion {
                 it as LiveCancellationException
                 val event = it.event as MessageBulkDeleteEvent
-                assertTrue { messageId in event.messageIds }
+                assertTrue { messageId.value in event.messageIds }
                 count()
             }
 
-            sendEventValidAndRandomIdCheckLiveActive(messageId) {
+            sendEventValidAndRandomIdCheckLiveActive(messageId.value) {
                 MessageDeleteBulk(
                     BulkDeleteData(
                         ids = mutableListOf(it),
@@ -267,11 +268,11 @@ class LiveMessageTest : AbstractLiveEntityTest<LiveMessage>() {
             live.coroutineContext.job.invokeOnCompletion {
                 it as LiveCancellationException
                 val event = it.event as ChannelDeleteEvent
-                assertEquals(channelId, event.channel.id)
+                assertEquals(channelId.value, event.channel.id)
                 count()
             }
 
-            sendEventValidAndRandomIdCheckLiveActive(channelId) {
+            sendEventValidAndRandomIdCheckLiveActive(channelId.value) {
                 ChannelDelete(
                     DiscordChannel(
                         id = it,
@@ -289,11 +290,11 @@ class LiveMessageTest : AbstractLiveEntityTest<LiveMessage>() {
             live.coroutineContext.job.invokeOnCompletion {
                 it as LiveCancellationException
                 val event = it.event as GuildDeleteEvent
-                assertEquals(guildId, event.guildId)
+                assertEquals(guildId.value, event.guildId)
                 count()
             }
 
-            sendEventValidAndRandomIdCheckLiveActive(guildId) {
+            sendEventValidAndRandomIdCheckLiveActive(guildId.value) {
                 GuildDelete(
                     DiscordUnavailableGuild(
                         id = it

--- a/core/src/test/kotlin/live/LiveRoleTest.kt
+++ b/core/src/test/kotlin/live/LiveRoleTest.kt
@@ -1,5 +1,6 @@
 package live
 
+import BoxedSnowflake
 import dev.kord.common.entity.*
 import dev.kord.common.entity.optional.Optional
 import dev.kord.core.cache.data.RoleData
@@ -28,12 +29,12 @@ import kotlin.test.assertEquals
 @Disabled
 class LiveRoleTest : AbstractLiveEntityTest<LiveRole>() {
 
-    private lateinit var roleId: Snowflake
+    private lateinit var roleId: BoxedSnowflake
 
     @BeforeAll
     override fun onBeforeAll() {
         super.onBeforeAll()
-        roleId = randomId()
+        roleId = BoxedSnowflake(randomId())
     }
 
     @BeforeTest
@@ -42,8 +43,8 @@ class LiveRoleTest : AbstractLiveEntityTest<LiveRole>() {
             Role(
                 kord = kord,
                 data = RoleData(
-                    id = roleId,
-                    guildId = guildId,
+                    id = roleId.value,
+                    guildId = guildId.value,
                     name = "test",
                     color = 0,
                     hoisted = false,
@@ -62,11 +63,11 @@ class LiveRoleTest : AbstractLiveEntityTest<LiveRole>() {
     fun `Check onUpdate is called when event is received`() {
         countdownContext(1) {
             live.onUpdate {
-                assertEquals(roleId, it.role.id)
+                assertEquals(roleId.value, it.role.id)
                 count()
             }
 
-            sendEventValidAndRandomId(roleId) {
+            sendEventValidAndRandomId(roleId.value) {
                 GuildRoleUpdate(
                     DiscordGuildRole(
                         guildId = randomId(),
@@ -95,11 +96,11 @@ class LiveRoleTest : AbstractLiveEntityTest<LiveRole>() {
             live.coroutineContext.job.invokeOnCompletion {
                 it as LiveCancellationException
                 val event = it.event as RoleDeleteEvent
-                assertEquals(roleId, event.roleId)
+                assertEquals(roleId.value, event.roleId)
                 count()
             }
 
-            sendEventValidAndRandomIdCheckLiveActive(roleId) {
+            sendEventValidAndRandomIdCheckLiveActive(roleId.value) {
                 GuildRoleDelete(
                     DiscordDeletedGuildRole(
                         guildId = randomId(),
@@ -117,11 +118,11 @@ class LiveRoleTest : AbstractLiveEntityTest<LiveRole>() {
             live.coroutineContext.job.invokeOnCompletion {
                 it as LiveCancellationException
                 val event = it.event as GuildDeleteEvent
-                assertEquals(guildId, event.guildId)
+                assertEquals(guildId.value, event.guildId)
                 count()
             }
 
-            sendEventValidAndRandomIdCheckLiveActive(guildId) {
+            sendEventValidAndRandomIdCheckLiveActive(guildId.value) {
                 GuildDelete(
                     DiscordUnavailableGuild(
                         id = it

--- a/core/src/test/kotlin/live/LiveUserTest.kt
+++ b/core/src/test/kotlin/live/LiveUserTest.kt
@@ -1,5 +1,6 @@
 package live
 
+import BoxedSnowflake
 import dev.kord.common.entity.DiscordUser
 import dev.kord.common.entity.Snowflake
 import dev.kord.core.cache.data.UserData
@@ -23,12 +24,12 @@ import kotlin.test.assertEquals
 @Disabled
 class LiveUserTest : AbstractLiveEntityTest<LiveUser>() {
 
-    private lateinit var userId: Snowflake
+    private lateinit var userId: BoxedSnowflake
 
     @BeforeAll
     override fun onBeforeAll() {
         super.onBeforeAll()
-        userId = randomId()
+        userId = BoxedSnowflake(randomId())
     }
 
     @BeforeTest
@@ -37,7 +38,7 @@ class LiveUserTest : AbstractLiveEntityTest<LiveUser>() {
             user = User(
                 kord = kord,
                 data = UserData(
-                    id = userId,
+                    id = userId.value,
                     username = "",
                     discriminator = ""
                 )
@@ -49,11 +50,11 @@ class LiveUserTest : AbstractLiveEntityTest<LiveUser>() {
     fun `Check onUpdate is called when event is received`() {
         countdownContext(1) {
             live.onUpdate {
-                assertEquals(it.user.id, userId)
+                assertEquals(it.user.id, userId.value)
                 count()
             }
 
-            sendEventValidAndRandomId(userId) {
+            sendEventValidAndRandomId(userId.value) {
                 UserUpdate(
                     DiscordUser(
                         id = it,

--- a/core/src/test/kotlin/live/channel/LiveCategoryTest.kt
+++ b/core/src/test/kotlin/live/channel/LiveCategoryTest.kt
@@ -1,5 +1,6 @@
 package live.channel
 
+import BoxedSnowflake
 import dev.kord.common.entity.ChannelType
 import dev.kord.common.entity.DiscordChannel
 import dev.kord.common.entity.Snowflake
@@ -25,12 +26,12 @@ import kotlin.test.assertEquals
 @Disabled
 class LiveCategoryTest : LiveChannelTest<LiveCategory>() {
 
-    override lateinit var channelId: Snowflake
+    override lateinit var channelId: BoxedSnowflake
 
     @BeforeAll
     override fun onBeforeAll() {
         super.onBeforeAll()
-        channelId = randomId()
+        channelId = BoxedSnowflake(randomId())
     }
 
     @BeforeTest
@@ -39,9 +40,9 @@ class LiveCategoryTest : LiveChannelTest<LiveCategory>() {
             Category(
                 kord = kord,
                 data = ChannelData(
-                    id = channelId,
+                    id = channelId.value,
                     type = ChannelType.GuildCategory,
-                    guildId = guildId.optionalSnowflake()
+                    guildId = guildId.value.optionalSnowflake()
                 )
             )
         )
@@ -51,11 +52,11 @@ class LiveCategoryTest : LiveChannelTest<LiveCategory>() {
     fun `Check onUpdate is called when event is received`() {
         countdownContext(1) {
             live.onUpdate {
-                assertEquals(it.channel.id, channelId)
+                assertEquals(it.channel.id, channelId.value)
                 count()
             }
 
-            sendEventValidAndRandomId(channelId) {
+            sendEventValidAndRandomId(channelId.value) {
                 ChannelUpdate(
                     DiscordChannel(
                         id = it,

--- a/core/src/test/kotlin/live/channel/LiveChannelTest.kt
+++ b/core/src/test/kotlin/live/channel/LiveChannelTest.kt
@@ -1,5 +1,6 @@
 package live.channel
 
+import BoxedSnowflake
 import dev.kord.common.entity.ChannelType
 import dev.kord.common.entity.DiscordChannel
 import dev.kord.common.entity.DiscordUnavailableGuild
@@ -29,7 +30,7 @@ import kotlin.test.assertEquals
 @Disabled
 abstract class LiveChannelTest<LIVE : LiveChannel> : AbstractLiveEntityTest<LIVE>() {
 
-    protected abstract val channelId: Snowflake
+    protected abstract val channelId: BoxedSnowflake
 
     @Test
     fun `Check type of live entity corresponds to the channel type`() = runBlocking {
@@ -54,11 +55,11 @@ abstract class LiveChannelTest<LIVE : LiveChannel> : AbstractLiveEntityTest<LIVE
             live.coroutineContext.job.invokeOnCompletion {
                 it as LiveCancellationException
                 val event = it.event as ChannelDeleteEvent
-                assertEquals(channelId, event.channel.id)
+                assertEquals(channelId.value, event.channel.id)
                 count()
             }
 
-            sendEventValidAndRandomId(channelId) {
+            sendEventValidAndRandomId(channelId.value) {
                 ChannelDelete(
                     DiscordChannel(
                         id = it,
@@ -76,11 +77,11 @@ abstract class LiveChannelTest<LIVE : LiveChannel> : AbstractLiveEntityTest<LIVE
             live.coroutineContext.job.invokeOnCompletion {
                 it as LiveCancellationException
                 val event = it.event as GuildDeleteEvent
-                assertEquals(guildId, event.guildId)
+                assertEquals(guildId.value, event.guildId)
                 count()
             }
 
-            sendEventValidAndRandomIdCheckLiveActive(guildId) {
+            sendEventValidAndRandomIdCheckLiveActive(guildId.value) {
                 GuildDelete(
                     DiscordUnavailableGuild(
                         id = it

--- a/core/src/test/kotlin/live/channel/LiveDmChannelTest.kt
+++ b/core/src/test/kotlin/live/channel/LiveDmChannelTest.kt
@@ -1,5 +1,6 @@
 package live.channel
 
+import BoxedSnowflake
 import dev.kord.common.entity.ChannelType
 import dev.kord.common.entity.DiscordChannel
 import dev.kord.common.entity.Snowflake
@@ -25,12 +26,12 @@ import kotlin.test.assertEquals
 @Disabled
 class LiveDmChannelTest : LiveChannelTest<LiveDmChannel>() {
 
-    override lateinit var channelId: Snowflake
+    override lateinit var channelId: BoxedSnowflake
 
     @BeforeAll
     override fun onBeforeAll() {
         super.onBeforeAll()
-        channelId = randomId()
+        channelId = BoxedSnowflake(randomId())
     }
 
     @BeforeTest
@@ -39,9 +40,9 @@ class LiveDmChannelTest : LiveChannelTest<LiveDmChannel>() {
             DmChannel(
                 kord = kord,
                 data = ChannelData(
-                    id = channelId,
+                    id = channelId.value,
                     type = ChannelType.DM,
-                    guildId = guildId.optionalSnowflake()
+                    guildId = guildId.value.optionalSnowflake()
                 )
             )
         )
@@ -51,11 +52,11 @@ class LiveDmChannelTest : LiveChannelTest<LiveDmChannel>() {
     fun `Check onUpdate is called when event is received`() {
         countdownContext(1) {
             live.onUpdate {
-                assertEquals(it.channel.id, channelId)
+                assertEquals(it.channel.id, channelId.value)
                 count()
             }
 
-            sendEventValidAndRandomId(channelId) {
+            sendEventValidAndRandomId(channelId.value) {
                 ChannelUpdate(
                     DiscordChannel(
                         id = it,

--- a/core/src/test/kotlin/live/channel/LiveGuildChannelTest.kt
+++ b/core/src/test/kotlin/live/channel/LiveGuildChannelTest.kt
@@ -1,5 +1,6 @@
 package live.channel
 
+import BoxedSnowflake
 import dev.kord.common.entity.ChannelType
 import dev.kord.common.entity.DiscordChannel
 import dev.kord.common.entity.Snowflake
@@ -38,12 +39,12 @@ class LiveGuildChannelTest : LiveChannelTest<LiveGuildChannel>() {
         }
     }
 
-    override lateinit var channelId: Snowflake
+    override lateinit var channelId: BoxedSnowflake
 
     @BeforeAll
     override fun onBeforeAll() {
         super.onBeforeAll()
-        channelId = randomId()
+        channelId = BoxedSnowflake(randomId())
     }
 
     @BeforeTest
@@ -52,9 +53,9 @@ class LiveGuildChannelTest : LiveChannelTest<LiveGuildChannel>() {
             GuildChannelMock(
                 kord = kord,
                 data = ChannelData(
-                    id = channelId,
+                    id = channelId.value,
                     type = ChannelType.GuildText,
-                    guildId = guildId.optionalSnowflake()
+                    guildId = guildId.value.optionalSnowflake()
                 )
             )
         )
@@ -64,11 +65,11 @@ class LiveGuildChannelTest : LiveChannelTest<LiveGuildChannel>() {
     fun `Check onUpdate is called when event is received`() {
         countdownContext(1) {
             live.onUpdate {
-                assertEquals(it.channel.id, channelId)
+                assertEquals(it.channel.id, channelId.value)
                 count()
             }
 
-            sendEventValidAndRandomId(channelId) {
+            sendEventValidAndRandomId(channelId.value) {
                 ChannelUpdate(
                     DiscordChannel(
                         id = it,

--- a/core/src/test/kotlin/live/channel/LiveGuildTextTest.kt
+++ b/core/src/test/kotlin/live/channel/LiveGuildTextTest.kt
@@ -1,5 +1,6 @@
 package live.channel
 
+import BoxedSnowflake
 import dev.kord.common.entity.ChannelType
 import dev.kord.common.entity.DiscordChannel
 import dev.kord.common.entity.Snowflake
@@ -38,12 +39,12 @@ class LiveGuildTextTest : LiveChannelTest<LiveGuildChannel>() {
         }
     }
 
-    override lateinit var channelId: Snowflake
+    override lateinit var channelId: BoxedSnowflake
 
     @BeforeAll
     override fun onBeforeAll() {
         super.onBeforeAll()
-        channelId = randomId()
+        channelId = BoxedSnowflake(randomId())
     }
 
     @BeforeTest
@@ -52,9 +53,9 @@ class LiveGuildTextTest : LiveChannelTest<LiveGuildChannel>() {
             GuildChannelMock(
                 kord = kord,
                 data = ChannelData(
-                    id = channelId,
+                    id = channelId.value,
                     type = ChannelType.GuildText,
-                    guildId = guildId.optionalSnowflake()
+                    guildId = guildId.value.optionalSnowflake()
                 )
             )
         )
@@ -64,11 +65,11 @@ class LiveGuildTextTest : LiveChannelTest<LiveGuildChannel>() {
     fun `Check onUpdate is called when event is received`() {
         countdownContext(1) {
             live.onUpdate {
-                assertEquals(it.channel.id, channelId)
+                assertEquals(it.channel.id, channelId.value)
                 count()
             }
 
-            sendEventValidAndRandomId(channelId) {
+            sendEventValidAndRandomId(channelId.value) {
                 ChannelUpdate(
                     DiscordChannel(
                         id = it,

--- a/core/src/test/kotlin/live/channel/LiveVoiceChannelTest.kt
+++ b/core/src/test/kotlin/live/channel/LiveVoiceChannelTest.kt
@@ -1,5 +1,6 @@
 package live.channel
 
+import BoxedSnowflake
 import dev.kord.common.entity.ChannelType
 import dev.kord.common.entity.DiscordChannel
 import dev.kord.common.entity.Snowflake
@@ -25,12 +26,12 @@ import kotlin.test.assertEquals
 @Disabled
 class LiveVoiceChannelTest : LiveChannelTest<LiveVoiceChannel>() {
 
-    override lateinit var channelId: Snowflake
+    override lateinit var channelId: BoxedSnowflake
 
     @BeforeAll
     override fun onBeforeAll() {
         super.onBeforeAll()
-        channelId = randomId()
+        channelId = BoxedSnowflake(randomId())
     }
 
     @BeforeTest
@@ -39,9 +40,9 @@ class LiveVoiceChannelTest : LiveChannelTest<LiveVoiceChannel>() {
             VoiceChannel(
                 kord = kord,
                 data = ChannelData(
-                    id = channelId,
+                    id = channelId.value,
                     type = ChannelType.GuildVoice,
-                    guildId = guildId.optionalSnowflake()
+                    guildId = guildId.value.optionalSnowflake()
                 )
             )
         )
@@ -51,11 +52,11 @@ class LiveVoiceChannelTest : LiveChannelTest<LiveVoiceChannel>() {
     fun `Check onUpdate is called when event is received`() {
         countdownContext(1) {
             live.onUpdate {
-                assertEquals(it.channel.id, channelId)
+                assertEquals(it.channel.id, channelId.value)
                 count()
             }
 
-            sendEventValidAndRandomId(channelId) {
+            sendEventValidAndRandomId(channelId.value) {
                 ChannelUpdate(
                     DiscordChannel(
                         id = it,

--- a/core/src/test/kotlin/rest/RestTest.kt
+++ b/core/src/test/kotlin/rest/RestTest.kt
@@ -1,5 +1,6 @@
 package rest
 
+import BoxedSnowflake
 import dev.kord.common.Color
 import dev.kord.common.entity.*
 import dev.kord.core.Kord
@@ -49,21 +50,21 @@ class RestServiceTest {
     private lateinit var kord: Kord
 
     //created guild id
-    private lateinit var guildId: Snowflake
+    private lateinit var guildId: BoxedSnowflake
     private lateinit var guild: Guild
 
     //created channel id
-    private lateinit var channelId: Snowflake
+    private lateinit var channelId: BoxedSnowflake
     private lateinit var channel: TextChannel
 
 
-    private lateinit var userId: Snowflake
+    private lateinit var userId: BoxedSnowflake
 
     @BeforeAll
     fun setup() = runBlocking {
         kord = Kord.restOnly(token)
 
-        userId = kord.getSelf().id
+        userId = BoxedSnowflake(kord.getSelf().id)
     }
 
 
@@ -84,9 +85,9 @@ class RestServiceTest {
             explicitContentFilter = ExplicitContentFilter.AllMembers
         }
 
-        guildId = guild.id
+        guildId = BoxedSnowflake(guild.id)
 
-        this@RestServiceTest.guild = kord.getGuildOrThrow(guildId)
+        this@RestServiceTest.guild = kord.getGuildOrThrow(guildId.value)
 
         guild.edit {
             name = "Edited Guild Test"
@@ -116,7 +117,7 @@ class RestServiceTest {
                 to check if encoding is okay
             """.trimIndent()
         }
-        channelId = channel.id
+        channelId = BoxedSnowflake(channel.id)
         this@RestServiceTest.channel = channel
 
         guild.getChannelOf<TextChannel>(channel.id)
@@ -225,7 +226,7 @@ class RestServiceTest {
         guild.members.toList()
         //TODO add member to guild
 
-        guild.getMember(userId)
+        guild.getMember(userId.value)
 
         guild.editSelfNickname("Kord")
         //deleteGuildMember(guildId, user)
@@ -246,7 +247,7 @@ class RestServiceTest {
             name = "Edited role"
         }
 
-        val member = guild.getMember(userId)
+        val member = guild.getMember(userId.value)
         member.addRole(role.id)
         member.removeRole(role.id)
 
@@ -325,7 +326,7 @@ class RestServiceTest {
     @Order(19)
     fun `emojis in guilds`(): Unit = runBlocking {
         val emoji = guild.createEmoji("kord", imageBinary("images/kord.png")) {
-            roles.add(guildId)
+            roles.add(guildId.value)
         }
 
         emoji.edit { name = "edited" }

--- a/gateway/api/gateway.api
+++ b/gateway/api/gateway.api
@@ -279,34 +279,34 @@ public final class dev/kord/gateway/DefaultGatewayKt {
 
 public final class dev/kord/gateway/DiscordAutoModerationActionExecution {
 	public static final field Companion Ldev/kord/gateway/DiscordAutoModerationActionExecution$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordAutoModerationAction;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/AutoModerationRuleTriggerType;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordAutoModerationAction;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/AutoModerationRuleTriggerType;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordAutoModerationAction;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/AutoModerationRuleTriggerType;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordAutoModerationAction;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/AutoModerationRuleTriggerType;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/DiscordAutoModerationAction;JLdev/kord/common/entity/AutoModerationRuleTriggerType;JLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/DiscordAutoModerationAction;JLdev/kord/common/entity/AutoModerationRuleTriggerType;JLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component10 ()Ljava/lang/String;
 	public final fun component11 ()Ljava/lang/String;
 	public final fun component2 ()Ldev/kord/common/entity/DiscordAutoModerationAction;
-	public final fun component3 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component3-4_xYDEk ()J
 	public final fun component4 ()Ldev/kord/common/entity/AutoModerationRuleTriggerType;
-	public final fun component5 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component5-4_xYDEk ()J
 	public final fun component6 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun component7 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun component8 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun component9 ()Ljava/lang/String;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordAutoModerationAction;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/AutoModerationRuleTriggerType;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ldev/kord/gateway/DiscordAutoModerationActionExecution;
-	public static synthetic fun copy$default (Ldev/kord/gateway/DiscordAutoModerationActionExecution;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordAutoModerationAction;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/AutoModerationRuleTriggerType;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ldev/kord/gateway/DiscordAutoModerationActionExecution;
+	public final fun copy-6EMEGuc (JLdev/kord/common/entity/DiscordAutoModerationAction;JLdev/kord/common/entity/AutoModerationRuleTriggerType;JLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ldev/kord/gateway/DiscordAutoModerationActionExecution;
+	public static synthetic fun copy-6EMEGuc$default (Ldev/kord/gateway/DiscordAutoModerationActionExecution;JLdev/kord/common/entity/DiscordAutoModerationAction;JLdev/kord/common/entity/AutoModerationRuleTriggerType;JLdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ldev/kord/gateway/DiscordAutoModerationActionExecution;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAction ()Ldev/kord/common/entity/DiscordAutoModerationAction;
 	public final fun getAlertSystemMessageId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun getChannelId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun getContent ()Ljava/lang/String;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public final fun getMatchedContent ()Ljava/lang/String;
 	public final fun getMatchedKeyword ()Ljava/lang/String;
 	public final fun getMessageId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
-	public final fun getRuleId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getRuleId-4_xYDEk ()J
 	public final fun getRuleTriggerType ()Ldev/kord/common/entity/AutoModerationRuleTriggerType;
-	public final fun getUserId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getUserId-4_xYDEk ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public static final fun write$Self (Ldev/kord/gateway/DiscordAutoModerationActionExecution;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
@@ -331,9 +331,9 @@ public final class dev/kord/gateway/DiscordAutoModerationActionExecution$Compani
 public final class dev/kord/gateway/DiscordCreatedInvite {
 	public static final field Companion Ldev/kord/gateway/DiscordCreatedInvite$Companion;
 	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Lkotlin/time/Duration;ILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZILkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;JILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZIILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;JILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (JLjava/lang/String;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;JILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;JILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component10 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component11 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component12 ()Z
@@ -346,10 +346,10 @@ public final class dev/kord/gateway/DiscordCreatedInvite {
 	public final fun component7 ()I
 	public final fun component8 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component9 ()Ldev/kord/common/entity/optional/Optional;
-	public final fun copy-5ndHN30 (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;JILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZI)Ldev/kord/gateway/DiscordCreatedInvite;
-	public static synthetic fun copy-5ndHN30$default (Ldev/kord/gateway/DiscordCreatedInvite;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;JILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZIILjava/lang/Object;)Ldev/kord/gateway/DiscordCreatedInvite;
+	public final fun copy-68rp8C4 (JLjava/lang/String;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;JILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZI)Ldev/kord/gateway/DiscordCreatedInvite;
+	public static synthetic fun copy-68rp8C4$default (Ldev/kord/gateway/DiscordCreatedInvite;JLjava/lang/String;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;JILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ZIILjava/lang/Object;)Ldev/kord/gateway/DiscordCreatedInvite;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-4_xYDEk ()J
 	public final fun getCode ()Ljava/lang/String;
 	public final fun getCreatedAt ()Lkotlinx/datetime/Instant;
 	public final fun getGuildId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
@@ -385,16 +385,16 @@ public final class dev/kord/gateway/DiscordCreatedInvite$Companion {
 
 public final class dev/kord/gateway/DiscordDeletedInvite {
 	public static final field Companion Ldev/kord/gateway/DiscordDeletedInvite$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component2 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;)Ldev/kord/gateway/DiscordDeletedInvite;
-	public static synthetic fun copy$default (Ldev/kord/gateway/DiscordDeletedInvite;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;ILjava/lang/Object;)Ldev/kord/gateway/DiscordDeletedInvite;
+	public final fun copy-9y3P_48 (JLdev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;)Ldev/kord/gateway/DiscordDeletedInvite;
+	public static synthetic fun copy-9y3P_48$default (Ldev/kord/gateway/DiscordDeletedInvite;JLdev/kord/common/entity/optional/OptionalSnowflake;Ljava/lang/String;ILjava/lang/Object;)Ldev/kord/gateway/DiscordDeletedInvite;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-4_xYDEk ()J
 	public final fun getCode ()Ljava/lang/String;
 	public final fun getGuildId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public fun hashCode ()I
@@ -420,22 +420,22 @@ public final class dev/kord/gateway/DiscordDeletedInvite$Companion {
 
 public final class dev/kord/gateway/DiscordInviteUser {
 	public static final field Companion Ldev/kord/gateway/DiscordInviteUser$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun component6 ()Ldev/kord/common/entity/optional/Optional;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/gateway/DiscordInviteUser;
-	public static synthetic fun copy$default (Ldev/kord/gateway/DiscordInviteUser;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/gateway/DiscordInviteUser;
+	public final fun copy-vwSIg4A (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/gateway/DiscordInviteUser;
+	public static synthetic fun copy-vwSIg4A$default (Ldev/kord/gateway/DiscordInviteUser;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/gateway/DiscordInviteUser;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAvatar ()Ljava/lang/String;
 	public final fun getBot ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun getDiscriminator ()Ljava/lang/String;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getPublicFlags ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getUsername ()Ljava/lang/String;
 	public fun hashCode ()I
@@ -498,19 +498,19 @@ public final class dev/kord/gateway/DiscordPresence$Companion {
 
 public final class dev/kord/gateway/DiscordRemovedEmoji {
 	public static final field Companion Ldev/kord/gateway/DiscordRemovedEmoji$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/gateway/DiscordRemovedReactionEmoji;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/gateway/DiscordRemovedReactionEmoji;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
-	public final fun component3 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/gateway/DiscordRemovedReactionEmoji;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJJLdev/kord/gateway/DiscordRemovedReactionEmoji;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
+	public final fun component2-4_xYDEk ()J
+	public final fun component3-4_xYDEk ()J
 	public final fun component4 ()Ldev/kord/gateway/DiscordRemovedReactionEmoji;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/gateway/DiscordRemovedReactionEmoji;)Ldev/kord/gateway/DiscordRemovedEmoji;
-	public static synthetic fun copy$default (Ldev/kord/gateway/DiscordRemovedEmoji;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/gateway/DiscordRemovedReactionEmoji;ILjava/lang/Object;)Ldev/kord/gateway/DiscordRemovedEmoji;
+	public final fun copy-SmFlTYk (JJJLdev/kord/gateway/DiscordRemovedReactionEmoji;)Ldev/kord/gateway/DiscordRemovedEmoji;
+	public static synthetic fun copy-SmFlTYk$default (Ldev/kord/gateway/DiscordRemovedEmoji;JJJLdev/kord/gateway/DiscordRemovedReactionEmoji;ILjava/lang/Object;)Ldev/kord/gateway/DiscordRemovedEmoji;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-4_xYDEk ()J
 	public final fun getEmoji ()Ldev/kord/gateway/DiscordRemovedReactionEmoji;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
-	public final fun getMessageId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
+	public final fun getMessageId-4_xYDEk ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public static final fun write$Self (Ldev/kord/gateway/DiscordRemovedEmoji;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
@@ -534,14 +534,14 @@ public final class dev/kord/gateway/DiscordRemovedEmoji$Companion {
 
 public final class dev/kord/gateway/DiscordRemovedReactionEmoji {
 	public static final field Companion Ldev/kord/gateway/DiscordRemovedReactionEmoji$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun component2 ()Ljava/lang/String;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;)Ldev/kord/gateway/DiscordRemovedReactionEmoji;
-	public static synthetic fun copy$default (Ldev/kord/gateway/DiscordRemovedReactionEmoji;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;ILjava/lang/Object;)Ldev/kord/gateway/DiscordRemovedReactionEmoji;
+	public final fun copy-O4FuXRM (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;)Ldev/kord/gateway/DiscordRemovedReactionEmoji;
+	public static synthetic fun copy-O4FuXRM$default (Ldev/kord/gateway/DiscordRemovedReactionEmoji;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;ILjava/lang/Object;)Ldev/kord/gateway/DiscordRemovedReactionEmoji;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -566,18 +566,18 @@ public final class dev/kord/gateway/DiscordRemovedReactionEmoji$Companion {
 
 public final class dev/kord/gateway/DiscordThreadListSync {
 	public static final field Companion Ldev/kord/gateway/DiscordThreadListSync$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Ljava/util/List;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/optional/Optional;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/optional/Optional;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component2 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component3 ()Ljava/util/List;
 	public final fun component4 ()Ljava/util/List;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Ljava/util/List;)Ldev/kord/gateway/DiscordThreadListSync;
-	public static synthetic fun copy$default (Ldev/kord/gateway/DiscordThreadListSync;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Ldev/kord/gateway/DiscordThreadListSync;
+	public final fun copy-9VmEaQQ (JLdev/kord/common/entity/optional/Optional;Ljava/util/List;Ljava/util/List;)Ldev/kord/gateway/DiscordThreadListSync;
+	public static synthetic fun copy-9VmEaQQ$default (Ldev/kord/gateway/DiscordThreadListSync;JLdev/kord/common/entity/optional/Optional;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Ldev/kord/gateway/DiscordThreadListSync;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getChannelIds ()Ldev/kord/common/entity/optional/Optional;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public final fun getMembers ()Ljava/util/List;
 	public final fun getThreads ()Ljava/util/List;
 	public fun hashCode ()I
@@ -603,20 +603,20 @@ public final class dev/kord/gateway/DiscordThreadListSync$Companion {
 
 public final class dev/kord/gateway/DiscordThreadMembersUpdate {
 	public static final field Companion Ldev/kord/gateway/DiscordThreadMembersUpdate$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;ILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;ILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;ILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;ILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
+	public final fun component2-4_xYDEk ()J
 	public final fun component3 ()I
 	public final fun component4 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component5 ()Ldev/kord/common/entity/optional/Optional;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;ILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/gateway/DiscordThreadMembersUpdate;
-	public static synthetic fun copy$default (Ldev/kord/gateway/DiscordThreadMembersUpdate;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;ILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/gateway/DiscordThreadMembersUpdate;
+	public final fun copy-CJS6HZA (JJILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/gateway/DiscordThreadMembersUpdate;
+	public static synthetic fun copy-CJS6HZA$default (Ldev/kord/gateway/DiscordThreadMembersUpdate;JJILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/gateway/DiscordThreadMembersUpdate;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAddedMembers ()Ldev/kord/common/entity/optional/Optional;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
+	public final fun getId-4_xYDEk ()J
 	public final fun getMemberCount ()I
 	public final fun getRemovedMemberIds ()Ldev/kord/common/entity/optional/Optional;
 	public fun hashCode ()I
@@ -668,6 +668,11 @@ public final class dev/kord/gateway/Gateway$Companion {
 	public final fun none ()Ldev/kord/gateway/Gateway;
 }
 
+public final class dev/kord/gateway/Gateway$DefaultImpls {
+	public static synthetic fun stop (Ldev/kord/gateway/Gateway;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun stop$default (Ldev/kord/gateway/Gateway;Ldev/kord/gateway/WebSocketCloseReason;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
 public final class dev/kord/gateway/GatewayCloseCode : java/lang/Enum {
 	public static final field AlreadyAuthenticated Ldev/kord/gateway/GatewayCloseCode;
 	public static final field AuthenticationFailed Ldev/kord/gateway/GatewayCloseCode;
@@ -710,6 +715,22 @@ public final class dev/kord/gateway/GatewayConfiguration {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class dev/kord/gateway/GatewayConfiguration$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Ldev/kord/gateway/GatewayConfiguration$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/kord/gateway/GatewayConfiguration;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ldev/kord/gateway/GatewayConfiguration;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/kord/gateway/GatewayConfiguration$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class dev/kord/gateway/GatewayConfigurationBuilder {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/DiscordShard;Ldev/kord/gateway/DiscordPresence;ILdev/kord/gateway/Intents;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ldev/kord/common/entity/DiscordShard;Ldev/kord/gateway/DiscordPresence;ILdev/kord/gateway/Intents;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -731,11 +752,77 @@ public final class dev/kord/gateway/GatewayConfigurationBuilder {
 public final class dev/kord/gateway/GatewayKt {
 	public static final fun editPresence (Ldev/kord/gateway/Gateway;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun getGatewayOnLogger ()Lmu/KLogger;
-	public static final fun requestGuildMembers (Ldev/kord/gateway/Gateway;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun requestGuildMembers (Ldev/kord/gateway/Gateway;Ldev/kord/gateway/RequestGuildMembers;)Lkotlinx/coroutines/flow/Flow;
-	public static synthetic fun requestGuildMembers$default (Ldev/kord/gateway/Gateway;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun requestGuildMembers-o5qqygM (Ldev/kord/gateway/Gateway;JLkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun requestGuildMembers-o5qqygM$default (Ldev/kord/gateway/Gateway;JLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun start (Ldev/kord/gateway/Gateway;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun start$default (Ldev/kord/gateway/Gateway;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class dev/kord/gateway/GatewayResumeConfiguration {
+	public static final field Companion Ldev/kord/gateway/GatewayResumeConfiguration$Companion;
+	public synthetic fun <init> (ILdev/kord/gateway/GatewaySession;Ldev/kord/gateway/GatewayConfiguration;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ldev/kord/gateway/GatewaySession;Ldev/kord/gateway/GatewayConfiguration;)V
+	public final fun component1 ()Ldev/kord/gateway/GatewaySession;
+	public final fun component2 ()Ldev/kord/gateway/GatewayConfiguration;
+	public final fun copy (Ldev/kord/gateway/GatewaySession;Ldev/kord/gateway/GatewayConfiguration;)Ldev/kord/gateway/GatewayResumeConfiguration;
+	public static synthetic fun copy$default (Ldev/kord/gateway/GatewayResumeConfiguration;Ldev/kord/gateway/GatewaySession;Ldev/kord/gateway/GatewayConfiguration;ILjava/lang/Object;)Ldev/kord/gateway/GatewayResumeConfiguration;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSession ()Ldev/kord/gateway/GatewaySession;
+	public final fun getStartConfiguration ()Ldev/kord/gateway/GatewayConfiguration;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Ldev/kord/gateway/GatewayResumeConfiguration;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class dev/kord/gateway/GatewayResumeConfiguration$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Ldev/kord/gateway/GatewayResumeConfiguration$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/kord/gateway/GatewayResumeConfiguration;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ldev/kord/gateway/GatewayResumeConfiguration;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/kord/gateway/GatewayResumeConfiguration$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/kord/gateway/GatewaySession {
+	public static final field Companion Ldev/kord/gateway/GatewaySession$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;ILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;I)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()I
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;I)Ldev/kord/gateway/GatewaySession;
+	public static synthetic fun copy$default (Ldev/kord/gateway/GatewaySession;Ljava/lang/String;Ljava/lang/String;IILjava/lang/Object;)Ldev/kord/gateway/GatewaySession;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getResumeUrl ()Ljava/lang/String;
+	public final fun getSequence ()I
+	public final fun getSessionId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Ldev/kord/gateway/GatewaySession;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class dev/kord/gateway/GatewaySession$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Ldev/kord/gateway/GatewaySession$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/kord/gateway/GatewaySession;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ldev/kord/gateway/GatewaySession;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/kord/gateway/GatewaySession$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class dev/kord/gateway/GuildBanAdd : dev/kord/gateway/DispatchEvent {
@@ -870,22 +957,22 @@ public final class dev/kord/gateway/GuildMembersChunk : dev/kord/gateway/Dispatc
 
 public final class dev/kord/gateway/GuildMembersChunkData {
 	public static final field Companion Ldev/kord/gateway/GuildMembersChunkData$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/util/List;IILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/util/List;IILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/util/List;IILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/util/List;IILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/util/List;IILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/util/List;IILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component2 ()Ljava/util/List;
 	public final fun component3 ()I
 	public final fun component4 ()I
 	public final fun component5 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component6 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component7 ()Ldev/kord/common/entity/optional/Optional;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ljava/util/List;IILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/gateway/GuildMembersChunkData;
-	public static synthetic fun copy$default (Ldev/kord/gateway/GuildMembersChunkData;Ldev/kord/common/entity/Snowflake;Ljava/util/List;IILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/gateway/GuildMembersChunkData;
+	public final fun copy-7s8LgDc (JLjava/util/List;IILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/gateway/GuildMembersChunkData;
+	public static synthetic fun copy-7s8LgDc$default (Ldev/kord/gateway/GuildMembersChunkData;JLjava/util/List;IILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/gateway/GuildMembersChunkData;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getChunkCount ()I
 	public final fun getChunkIndex ()I
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public final fun getMembers ()Ljava/util/List;
 	public final fun getNonce ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getNotFound ()Ldev/kord/common/entity/optional/Optional;
@@ -1004,17 +1091,17 @@ public final class dev/kord/gateway/GuildScheduledEventUserAdd : dev/kord/gatewa
 
 public final class dev/kord/gateway/GuildScheduledEventUserMetadata {
 	public static final field Companion Ldev/kord/gateway/GuildScheduledEventUserMetadata$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
-	public final fun component3 ()Ldev/kord/common/entity/Snowflake;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)Ldev/kord/gateway/GuildScheduledEventUserMetadata;
-	public static synthetic fun copy$default (Ldev/kord/gateway/GuildScheduledEventUserMetadata;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;ILjava/lang/Object;)Ldev/kord/gateway/GuildScheduledEventUserMetadata;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
+	public final fun component2-4_xYDEk ()J
+	public final fun component3-4_xYDEk ()J
+	public final fun copy-9IY7LyE (JJJ)Ldev/kord/gateway/GuildScheduledEventUserMetadata;
+	public static synthetic fun copy-9IY7LyE$default (Ldev/kord/gateway/GuildScheduledEventUserMetadata;JJJILjava/lang/Object;)Ldev/kord/gateway/GuildScheduledEventUserMetadata;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
-	public final fun getGuildScheduledEventId ()Ldev/kord/common/entity/Snowflake;
-	public final fun getUserId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
+	public final fun getGuildScheduledEventId-4_xYDEk ()J
+	public final fun getUserId-4_xYDEk ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public static final fun write$Self (Ldev/kord/gateway/GuildScheduledEventUserMetadata;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
@@ -1568,19 +1655,19 @@ public final class dev/kord/gateway/Reconnect : dev/kord/gateway/Event {
 
 public final class dev/kord/gateway/RequestGuildMembers : dev/kord/gateway/Command {
 	public static final field Companion Ldev/kord/gateway/RequestGuildMembers$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component2 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component3 ()Ldev/kord/common/entity/optional/OptionalInt;
 	public final fun component4 ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun component5 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component6 ()Ldev/kord/common/entity/optional/Optional;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/gateway/RequestGuildMembers;
-	public static synthetic fun copy$default (Ldev/kord/gateway/RequestGuildMembers;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/gateway/RequestGuildMembers;
+	public final fun copy-vwSIg4A (JLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/gateway/RequestGuildMembers;
+	public static synthetic fun copy-vwSIg4A$default (Ldev/kord/gateway/RequestGuildMembers;JLdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/gateway/RequestGuildMembers;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public final fun getLimit ()Ldev/kord/common/entity/optional/OptionalInt;
 	public final fun getNonce ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getPresences ()Ldev/kord/common/entity/optional/OptionalBoolean;
@@ -1780,17 +1867,17 @@ public final class dev/kord/gateway/UpdateStatus$Companion {
 
 public final class dev/kord/gateway/UpdateVoiceStatus : dev/kord/gateway/Command {
 	public static final field Companion Ldev/kord/gateway/UpdateVoiceStatus$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;ZZLkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;ZZ)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;ZZLkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/Snowflake;ZZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
+	public final fun component2-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun component3 ()Z
 	public final fun component4 ()Z
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;ZZ)Ldev/kord/gateway/UpdateVoiceStatus;
-	public static synthetic fun copy$default (Ldev/kord/gateway/UpdateVoiceStatus;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;ZZILjava/lang/Object;)Ldev/kord/gateway/UpdateVoiceStatus;
+	public final fun copy-9T5RVU4 (JLdev/kord/common/entity/Snowflake;ZZ)Ldev/kord/gateway/UpdateVoiceStatus;
+	public static synthetic fun copy-9T5RVU4$default (Ldev/kord/gateway/UpdateVoiceStatus;JLdev/kord/common/entity/Snowflake;ZZILjava/lang/Object;)Ldev/kord/gateway/UpdateVoiceStatus;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public final fun getSelfDeaf ()Z
 	public final fun getSelfMute ()Z
 	public fun hashCode ()I
@@ -1853,6 +1940,19 @@ public final class dev/kord/gateway/VoiceStateUpdate : dev/kord/gateway/Dispatch
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class dev/kord/gateway/WebSocketCloseReason {
+	public fun <init> (SLjava/lang/String;)V
+	public final fun component1 ()S
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (SLjava/lang/String;)Ldev/kord/gateway/WebSocketCloseReason;
+	public static synthetic fun copy$default (Ldev/kord/gateway/WebSocketCloseReason;SLjava/lang/String;ILjava/lang/Object;)Ldev/kord/gateway/WebSocketCloseReason;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCode ()S
+	public final fun getMessage ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class dev/kord/gateway/WebhooksUpdate : dev/kord/gateway/DispatchEvent {
 	public fun <init> (Ldev/kord/common/entity/DiscordWebhooksUpdateData;Ljava/lang/Integer;)V
 	public final fun component1 ()Ldev/kord/common/entity/DiscordWebhooksUpdateData;
@@ -1896,15 +1996,15 @@ public final class dev/kord/gateway/builder/PresenceBuilder {
 }
 
 public final class dev/kord/gateway/builder/RequestGuildMembersBuilder {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;)V
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (JLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getGuildId-4_xYDEk ()J
 	public final fun getLimit ()Ljava/lang/Integer;
 	public final fun getNonce ()Ljava/lang/String;
 	public final fun getPresences ()Ljava/lang/Boolean;
 	public final fun getQuery ()Ljava/lang/String;
 	public final fun getUserIds ()Ljava/util/Set;
 	public final fun requestAllMembers ()V
-	public final fun setGuildId (Ldev/kord/common/entity/Snowflake;)V
+	public final fun setGuildId-IO-hELI (J)V
 	public final fun setLimit (Ljava/lang/Integer;)V
 	public final fun setNonce (Ljava/lang/String;)V
 	public final fun setPresences (Ljava/lang/Boolean;)V

--- a/rest/api/rest.api
+++ b/rest/api/rest.api
@@ -84,13 +84,13 @@ public abstract interface class dev/kord/rest/builder/RequestBuilder {
 public final class dev/kord/rest/builder/auditlog/AuditLogGetRequestBuilder : dev/kord/rest/builder/RequestBuilder {
 	public fun <init> ()V
 	public final fun getAction ()Ldev/kord/common/entity/AuditLogEvent;
-	public final fun getBefore ()Ldev/kord/common/entity/Snowflake;
+	public final fun getBefore-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getLimit ()Ljava/lang/Integer;
-	public final fun getUserId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getUserId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun setAction (Ldev/kord/common/entity/AuditLogEvent;)V
-	public final fun setBefore (Ldev/kord/common/entity/Snowflake;)V
+	public final fun setBefore-JTHp4pg (Ldev/kord/common/entity/Snowflake;)V
 	public final fun setLimit (Ljava/lang/Integer;)V
-	public final fun setUserId (Ldev/kord/common/entity/Snowflake;)V
+	public final fun setUserId-JTHp4pg (Ldev/kord/common/entity/Snowflake;)V
 	public fun toRequest ()Ldev/kord/rest/json/request/AuditLogGetRequest;
 	public synthetic fun toRequest ()Ljava/lang/Object;
 }
@@ -123,14 +123,14 @@ public final class dev/kord/rest/builder/automoderation/AutoModerationRuleBuilde
 	public static final fun anywhereKeyword (Ldev/kord/rest/builder/automoderation/KeywordAutoModerationRuleBuilder;Ljava/lang/String;)V
 	public static final fun blockMessage (Ldev/kord/rest/builder/automoderation/AutoModerationRuleBuilder;Lkotlin/jvm/functions/Function1;)V
 	public static synthetic fun blockMessage$default (Ldev/kord/rest/builder/automoderation/AutoModerationRuleBuilder;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
-	public static final fun exemptChannel (Ldev/kord/rest/builder/automoderation/AutoModerationRuleBuilder;Ldev/kord/common/entity/Snowflake;)V
-	public static final fun exemptRole (Ldev/kord/rest/builder/automoderation/AutoModerationRuleBuilder;Ldev/kord/common/entity/Snowflake;)V
+	public static final fun exemptChannel-Vn1WZo8 (Ldev/kord/rest/builder/automoderation/AutoModerationRuleBuilder;J)V
+	public static final fun exemptRole-Vn1WZo8 (Ldev/kord/rest/builder/automoderation/AutoModerationRuleBuilder;J)V
 	public static final fun keyword (Ldev/kord/rest/builder/automoderation/KeywordAutoModerationRuleBuilder;Ljava/lang/String;)V
 	public static final fun prefixKeyword (Ldev/kord/rest/builder/automoderation/KeywordAutoModerationRuleBuilder;Ljava/lang/String;)V
 	public static final fun preset (Ldev/kord/rest/builder/automoderation/KeywordPresetAutoModerationRuleBuilder;Ldev/kord/common/entity/AutoModerationRuleKeywordPresetType;)V
 	public static final fun regexPattern (Ldev/kord/rest/builder/automoderation/KeywordAutoModerationRuleBuilder;Ljava/lang/String;)V
-	public static final fun sendAlertMessage (Ldev/kord/rest/builder/automoderation/AutoModerationRuleBuilder;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;)V
-	public static synthetic fun sendAlertMessage$default (Ldev/kord/rest/builder/automoderation/AutoModerationRuleBuilder;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun sendAlertMessage-o5qqygM (Ldev/kord/rest/builder/automoderation/AutoModerationRuleBuilder;JLkotlin/jvm/functions/Function1;)V
+	public static synthetic fun sendAlertMessage-o5qqygM$default (Ldev/kord/rest/builder/automoderation/AutoModerationRuleBuilder;JLkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public static final fun suffixKeyword (Ldev/kord/rest/builder/automoderation/KeywordAutoModerationRuleBuilder;Ljava/lang/String;)V
 	public static final fun timeout-8Mi8wO0 (Ldev/kord/rest/builder/automoderation/TimeoutAutoModerationRuleBuilder;JLkotlin/jvm/functions/Function1;)V
 	public static synthetic fun timeout-8Mi8wO0$default (Ldev/kord/rest/builder/automoderation/TimeoutAutoModerationRuleBuilder;JLkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
@@ -291,12 +291,12 @@ public final class dev/kord/rest/builder/automoderation/MentionSpamAutoModeratio
 }
 
 public final class dev/kord/rest/builder/automoderation/SendAlertMessageAutoModerationActionBuilder : dev/kord/rest/builder/automoderation/AutoModerationActionBuilder {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;)V
+	public synthetic fun <init> (JLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun buildMetadata ()Ldev/kord/common/entity/optional/Optional;
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-4_xYDEk ()J
 	public fun getType ()Ldev/kord/common/entity/AutoModerationActionType$SendAlertMessage;
 	public synthetic fun getType ()Ldev/kord/common/entity/AutoModerationActionType;
-	public final fun setChannelId (Ldev/kord/common/entity/Snowflake;)V
+	public final fun setChannelId-IO-hELI (J)V
 }
 
 public abstract interface class dev/kord/rest/builder/automoderation/SpamAutoModerationRuleBuilder : dev/kord/rest/builder/automoderation/TypedAutoModerationRuleBuilder {
@@ -400,23 +400,23 @@ public final class dev/kord/rest/builder/channel/ChannelPermissionModifyBuilder 
 public final class dev/kord/rest/builder/channel/GuildChannelPositionModifyBuilder : dev/kord/rest/builder/RequestBuilder {
 	public fun <init> ()V
 	public final fun getSwaps ()Ljava/util/List;
-	public final fun move (Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;)V
 	public final fun move (Lkotlin/Pair;)V
 	public final fun move ([Lkotlin/Pair;)V
+	public final fun move-wYKCHeA (JLkotlin/jvm/functions/Function1;)V
 	public final fun setSwaps (Ljava/util/List;)V
 	public fun toRequest ()Ldev/kord/rest/json/request/GuildChannelPositionModifyRequest;
 	public synthetic fun toRequest ()Ljava/lang/Object;
 }
 
 public final class dev/kord/rest/builder/channel/GuildChannelSwapBuilder {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;)V
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (JLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getChannelId-4_xYDEk ()J
 	public final fun getLockPermissionsToParent ()Ljava/lang/Boolean;
-	public final fun getParentId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getParentId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getPosition ()Ljava/lang/Integer;
-	public final fun setChannelId (Ldev/kord/common/entity/Snowflake;)V
+	public final fun setChannelId-IO-hELI (J)V
 	public final fun setLockPermissionsToParent (Ljava/lang/Boolean;)V
-	public final fun setParentId (Ldev/kord/common/entity/Snowflake;)V
+	public final fun setParentId-JTHp4pg (Ldev/kord/common/entity/Snowflake;)V
 	public final fun setPosition (Ljava/lang/Integer;)V
 	public final fun toRequest ()Ldev/kord/rest/json/request/ChannelPositionSwapRequest;
 }
@@ -427,10 +427,10 @@ public final class dev/kord/rest/builder/channel/InviteCreateBuilder : dev/kord/
 	public final fun getMaxAge-FghU774 ()Lkotlin/time/Duration;
 	public final fun getMaxUses ()Ljava/lang/Integer;
 	public fun getReason ()Ljava/lang/String;
-	public final fun getTargetApplicationId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getTargetApplicationId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getTargetType ()Ldev/kord/common/entity/InviteTargetType;
-	public final synthetic fun getTargetUser ()Ldev/kord/common/entity/Snowflake;
-	public final fun getTargetUserId ()Ldev/kord/common/entity/Snowflake;
+	public final synthetic fun getTargetUser-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
+	public final fun getTargetUserId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getTemporary ()Ljava/lang/Boolean;
 	public final fun getUnique ()Ljava/lang/Boolean;
 	public final synthetic fun getUses ()Ljava/lang/Integer;
@@ -438,10 +438,10 @@ public final class dev/kord/rest/builder/channel/InviteCreateBuilder : dev/kord/
 	public final fun setMaxAge-BwNAW2A (Lkotlin/time/Duration;)V
 	public final fun setMaxUses (Ljava/lang/Integer;)V
 	public fun setReason (Ljava/lang/String;)V
-	public final fun setTargetApplicationId (Ldev/kord/common/entity/Snowflake;)V
+	public final fun setTargetApplicationId-JTHp4pg (Ldev/kord/common/entity/Snowflake;)V
 	public final fun setTargetType (Ldev/kord/common/entity/InviteTargetType;)V
-	public final synthetic fun setTargetUser (Ldev/kord/common/entity/Snowflake;)V
-	public final fun setTargetUserId (Ldev/kord/common/entity/Snowflake;)V
+	public final synthetic fun setTargetUser-JTHp4pg (Ldev/kord/common/entity/Snowflake;)V
+	public final fun setTargetUserId-JTHp4pg (Ldev/kord/common/entity/Snowflake;)V
 	public final fun setTemporary (Ljava/lang/Boolean;)V
 	public final fun setUnique (Ljava/lang/Boolean;)V
 	public final synthetic fun setUses (Ljava/lang/Integer;)V
@@ -455,7 +455,7 @@ public final class dev/kord/rest/builder/channel/NewsChannelCreateBuilder : dev/
 	public final fun getDefaultAutoArchiveDuration ()Ldev/kord/common/entity/ArchiveDuration;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getNsfw ()Ljava/lang/Boolean;
-	public final fun getParentId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getParentId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public fun getPermissionOverwrites ()Ljava/util/Set;
 	public final fun getPosition ()Ljava/lang/Integer;
 	public fun getReason ()Ljava/lang/String;
@@ -463,7 +463,7 @@ public final class dev/kord/rest/builder/channel/NewsChannelCreateBuilder : dev/
 	public final fun setDefaultAutoArchiveDuration (Ldev/kord/common/entity/ArchiveDuration;)V
 	public final fun setName (Ljava/lang/String;)V
 	public final fun setNsfw (Ljava/lang/Boolean;)V
-	public final fun setParentId (Ldev/kord/common/entity/Snowflake;)V
+	public final fun setParentId-JTHp4pg (Ldev/kord/common/entity/Snowflake;)V
 	public fun setPermissionOverwrites (Ljava/util/Set;)V
 	public final fun setPosition (Ljava/lang/Integer;)V
 	public fun setReason (Ljava/lang/String;)V
@@ -478,7 +478,7 @@ public final class dev/kord/rest/builder/channel/NewsChannelModifyBuilder : dev/
 	public final fun getDefaultAutoArchiveDuration ()Ldev/kord/common/entity/ArchiveDuration;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getNsfw ()Ljava/lang/Boolean;
-	public final fun getParentId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getParentId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public fun getPermissionOverwrites ()Ljava/util/Set;
 	public final fun getPosition ()Ljava/lang/Integer;
 	public final fun getRateLimitPerUser-FghU774 ()Lkotlin/time/Duration;
@@ -487,7 +487,7 @@ public final class dev/kord/rest/builder/channel/NewsChannelModifyBuilder : dev/
 	public final fun setDefaultAutoArchiveDuration (Ldev/kord/common/entity/ArchiveDuration;)V
 	public final fun setName (Ljava/lang/String;)V
 	public final fun setNsfw (Ljava/lang/Boolean;)V
-	public final fun setParentId (Ldev/kord/common/entity/Snowflake;)V
+	public final fun setParentId-JTHp4pg (Ldev/kord/common/entity/Snowflake;)V
 	public fun setPermissionOverwrites (Ljava/util/Set;)V
 	public final fun setPosition (Ljava/lang/Integer;)V
 	public final fun setRateLimitPerUser-BwNAW2A (Lkotlin/time/Duration;)V
@@ -498,7 +498,7 @@ public final class dev/kord/rest/builder/channel/NewsChannelModifyBuilder : dev/
 }
 
 public final class dev/kord/rest/builder/channel/PermissionOverwriteBuilder {
-	public fun <init> (Ldev/kord/common/entity/OverwriteType;Ldev/kord/common/entity/Snowflake;)V
+	public synthetic fun <init> (Ldev/kord/common/entity/OverwriteType;JLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAllowed ()Ldev/kord/common/entity/Permissions;
 	public final fun getDenied ()Ldev/kord/common/entity/Permissions;
 	public final fun setAllowed (Ldev/kord/common/entity/Permissions;)V
@@ -511,8 +511,8 @@ public abstract interface class dev/kord/rest/builder/channel/PermissionOverwrit
 }
 
 public final class dev/kord/rest/builder/channel/PermissionOverwritesBuilderKt {
-	public static final fun addMemberOverwrite (Ldev/kord/rest/builder/channel/PermissionOverwritesBuilder;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;)V
-	public static final fun addRoleOverwrite (Ldev/kord/rest/builder/channel/PermissionOverwritesBuilder;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;)V
+	public static final fun addMemberOverwrite-o5qqygM (Ldev/kord/rest/builder/channel/PermissionOverwritesBuilder;JLkotlin/jvm/functions/Function1;)V
+	public static final fun addRoleOverwrite-o5qqygM (Ldev/kord/rest/builder/channel/PermissionOverwritesBuilder;JLkotlin/jvm/functions/Function1;)V
 }
 
 public abstract interface class dev/kord/rest/builder/channel/PermissionOverwritesCreateBuilder : dev/kord/rest/builder/channel/PermissionOverwritesBuilder {
@@ -540,7 +540,7 @@ public final class dev/kord/rest/builder/channel/StageVoiceChannelModifyBuilder 
 	public fun addOverwrite (Ldev/kord/common/entity/Overwrite;)V
 	public final fun getBitrate ()Ljava/lang/Integer;
 	public final fun getName ()Ljava/lang/String;
-	public final fun getParentId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getParentId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public fun getPermissionOverwrites ()Ljava/util/Set;
 	public final fun getPosition ()Ljava/lang/Integer;
 	public fun getReason ()Ljava/lang/String;
@@ -548,7 +548,7 @@ public final class dev/kord/rest/builder/channel/StageVoiceChannelModifyBuilder 
 	public final fun getTopic ()Ljava/lang/String;
 	public final fun setBitrate (Ljava/lang/Integer;)V
 	public final fun setName (Ljava/lang/String;)V
-	public final fun setParentId (Ldev/kord/common/entity/Snowflake;)V
+	public final fun setParentId-JTHp4pg (Ldev/kord/common/entity/Snowflake;)V
 	public fun setPermissionOverwrites (Ljava/util/Set;)V
 	public final fun setPosition (Ljava/lang/Integer;)V
 	public fun setReason (Ljava/lang/String;)V
@@ -579,7 +579,7 @@ public final class dev/kord/rest/builder/channel/TextChannelCreateBuilder : dev/
 	public final fun getDefaultAutoArchiveDuration ()Ldev/kord/common/entity/ArchiveDuration;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getNsfw ()Ljava/lang/Boolean;
-	public final fun getParentId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getParentId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public fun getPermissionOverwrites ()Ljava/util/Set;
 	public final fun getPosition ()Ljava/lang/Integer;
 	public final fun getRateLimitPerUser-FghU774 ()Lkotlin/time/Duration;
@@ -588,7 +588,7 @@ public final class dev/kord/rest/builder/channel/TextChannelCreateBuilder : dev/
 	public final fun setDefaultAutoArchiveDuration (Ldev/kord/common/entity/ArchiveDuration;)V
 	public final fun setName (Ljava/lang/String;)V
 	public final fun setNsfw (Ljava/lang/Boolean;)V
-	public final fun setParentId (Ldev/kord/common/entity/Snowflake;)V
+	public final fun setParentId-JTHp4pg (Ldev/kord/common/entity/Snowflake;)V
 	public fun setPermissionOverwrites (Ljava/util/Set;)V
 	public final fun setPosition (Ljava/lang/Integer;)V
 	public final fun setRateLimitPerUser-BwNAW2A (Lkotlin/time/Duration;)V
@@ -604,7 +604,7 @@ public final class dev/kord/rest/builder/channel/TextChannelModifyBuilder : dev/
 	public final fun getDefaultAutoArchiveDuration ()Ldev/kord/common/entity/ArchiveDuration;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getNsfw ()Ljava/lang/Boolean;
-	public final fun getParentId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getParentId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public fun getPermissionOverwrites ()Ljava/util/Set;
 	public final fun getPosition ()Ljava/lang/Integer;
 	public final fun getRateLimitPerUser-FghU774 ()Lkotlin/time/Duration;
@@ -613,7 +613,7 @@ public final class dev/kord/rest/builder/channel/TextChannelModifyBuilder : dev/
 	public final fun setDefaultAutoArchiveDuration (Ldev/kord/common/entity/ArchiveDuration;)V
 	public final fun setName (Ljava/lang/String;)V
 	public final fun setNsfw (Ljava/lang/Boolean;)V
-	public final fun setParentId (Ldev/kord/common/entity/Snowflake;)V
+	public final fun setParentId-JTHp4pg (Ldev/kord/common/entity/Snowflake;)V
 	public fun setPermissionOverwrites (Ljava/util/Set;)V
 	public final fun setPosition (Ljava/lang/Integer;)V
 	public final fun setRateLimitPerUser-BwNAW2A (Lkotlin/time/Duration;)V
@@ -629,7 +629,7 @@ public final class dev/kord/rest/builder/channel/VoiceChannelCreateBuilder : dev
 	public final fun getBitrate ()Ljava/lang/Integer;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getNsfw ()Ljava/lang/Boolean;
-	public final fun getParentId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getParentId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public fun getPermissionOverwrites ()Ljava/util/Set;
 	public final fun getPosition ()Ljava/lang/Integer;
 	public fun getReason ()Ljava/lang/String;
@@ -637,7 +637,7 @@ public final class dev/kord/rest/builder/channel/VoiceChannelCreateBuilder : dev
 	public final fun setBitrate (Ljava/lang/Integer;)V
 	public final fun setName (Ljava/lang/String;)V
 	public final fun setNsfw (Ljava/lang/Boolean;)V
-	public final fun setParentId (Ldev/kord/common/entity/Snowflake;)V
+	public final fun setParentId-JTHp4pg (Ldev/kord/common/entity/Snowflake;)V
 	public fun setPermissionOverwrites (Ljava/util/Set;)V
 	public final fun setPosition (Ljava/lang/Integer;)V
 	public fun setReason (Ljava/lang/String;)V
@@ -652,7 +652,7 @@ public final class dev/kord/rest/builder/channel/VoiceChannelModifyBuilder : dev
 	public final fun getBitrate ()Ljava/lang/Integer;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getNsfw ()Ljava/lang/Boolean;
-	public final fun getParentId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getParentId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public fun getPermissionOverwrites ()Ljava/util/Set;
 	public final fun getPosition ()Ljava/lang/Integer;
 	public fun getReason ()Ljava/lang/String;
@@ -663,7 +663,7 @@ public final class dev/kord/rest/builder/channel/VoiceChannelModifyBuilder : dev
 	public final fun setBitrate (Ljava/lang/Integer;)V
 	public final fun setName (Ljava/lang/String;)V
 	public final fun setNsfw (Ljava/lang/Boolean;)V
-	public final fun setParentId (Ldev/kord/common/entity/Snowflake;)V
+	public final fun setParentId-JTHp4pg (Ldev/kord/common/entity/Snowflake;)V
 	public fun setPermissionOverwrites (Ljava/util/Set;)V
 	public final fun setPosition (Ljava/lang/Integer;)V
 	public fun setReason (Ljava/lang/String;)V
@@ -827,11 +827,11 @@ public final class dev/kord/rest/builder/component/TextInputBuilder : dev/kord/r
 
 public final class dev/kord/rest/builder/guild/CurrentVoiceStateModifyBuilder : dev/kord/rest/builder/RequestBuilder {
 	public fun <init> ()V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;)V
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (JLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getChannelId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getRequestToSpeakTimestamp ()Lkotlinx/datetime/Instant;
 	public final fun getSuppress ()Ljava/lang/Boolean;
-	public final fun setChannelId (Ldev/kord/common/entity/Snowflake;)V
+	public final fun setChannelId-JTHp4pg (Ldev/kord/common/entity/Snowflake;)V
 	public final fun setRequestToSpeakTimestamp (Lkotlinx/datetime/Instant;)V
 	public final fun setSuppress (Ljava/lang/Boolean;)V
 	public fun toRequest ()Ldev/kord/rest/json/request/CurrentVoiceStateModifyRequest;
@@ -866,10 +866,10 @@ public final class dev/kord/rest/builder/guild/EmojiModifyBuilder : dev/kord/res
 
 public final class dev/kord/rest/builder/guild/GuildCreateBuilder : dev/kord/rest/builder/RequestBuilder {
 	public fun <init> (Ljava/lang/String;)V
-	public final fun category (Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;)Ldev/kord/common/entity/Snowflake;
-	public static synthetic fun category$default (Ldev/kord/rest/builder/guild/GuildCreateBuilder;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/kord/common/entity/Snowflake;
+	public final fun category-L1BfQZs (Ljava/lang/String;JLkotlin/jvm/functions/Function1;)J
+	public static synthetic fun category-L1BfQZs$default (Ldev/kord/rest/builder/guild/GuildCreateBuilder;Ljava/lang/String;JLkotlin/jvm/functions/Function1;ILjava/lang/Object;)J
 	public final fun everyoneRole (Lkotlin/jvm/functions/Function1;)V
-	public final fun getAfkChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getAfkChannelId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getAfkTimeout-FghU774 ()Lkotlin/time/Duration;
 	public final fun getChannels ()Ljava/util/List;
 	public final fun getDefaultMessageNotificationLevel ()Ldev/kord/common/entity/DefaultMessageNotificationLevel;
@@ -880,14 +880,14 @@ public final class dev/kord/rest/builder/guild/GuildCreateBuilder : dev/kord/res
 	public final fun getRegion ()Ljava/lang/String;
 	public final fun getRoles ()Ljava/util/List;
 	public final fun getSnowflakeGenerator ()Ljava/util/Iterator;
-	public final fun getSystemChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getSystemChannelId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getVerificationLevel ()Ldev/kord/common/entity/VerificationLevel;
-	public final fun newUniqueSnowflake ()Ldev/kord/common/entity/Snowflake;
-	public final fun newsChannel (Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;)Ldev/kord/common/entity/Snowflake;
-	public static synthetic fun newsChannel$default (Ldev/kord/rest/builder/guild/GuildCreateBuilder;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/kord/common/entity/Snowflake;
-	public final fun role (Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;)Ldev/kord/common/entity/Snowflake;
-	public static synthetic fun role$default (Ldev/kord/rest/builder/guild/GuildCreateBuilder;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/kord/common/entity/Snowflake;
-	public final fun setAfkChannelId (Ldev/kord/common/entity/Snowflake;)V
+	public final fun newUniqueSnowflake-4_xYDEk ()J
+	public final fun newsChannel-L1BfQZs (Ljava/lang/String;JLkotlin/jvm/functions/Function1;)J
+	public static synthetic fun newsChannel-L1BfQZs$default (Ldev/kord/rest/builder/guild/GuildCreateBuilder;Ljava/lang/String;JLkotlin/jvm/functions/Function1;ILjava/lang/Object;)J
+	public final fun role-hI2Iy54 (JLkotlin/jvm/functions/Function1;)J
+	public static synthetic fun role-hI2Iy54$default (Ldev/kord/rest/builder/guild/GuildCreateBuilder;JLkotlin/jvm/functions/Function1;ILjava/lang/Object;)J
+	public final fun setAfkChannelId-JTHp4pg (Ldev/kord/common/entity/Snowflake;)V
 	public final fun setAfkTimeout-BwNAW2A (Lkotlin/time/Duration;)V
 	public final fun setDefaultMessageNotificationLevel (Ldev/kord/common/entity/DefaultMessageNotificationLevel;)V
 	public final fun setEveryoneRole (Ldev/kord/rest/builder/role/RoleCreateBuilder;)V
@@ -895,47 +895,47 @@ public final class dev/kord/rest/builder/guild/GuildCreateBuilder : dev/kord/res
 	public final fun setIcon (Ldev/kord/rest/Image;)V
 	public final fun setName (Ljava/lang/String;)V
 	public final fun setRegion (Ljava/lang/String;)V
-	public final fun setSystemChannelId (Ldev/kord/common/entity/Snowflake;)V
+	public final fun setSystemChannelId-JTHp4pg (Ldev/kord/common/entity/Snowflake;)V
 	public final fun setVerificationLevel (Ldev/kord/common/entity/VerificationLevel;)V
-	public final fun textChannel (Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;)Ldev/kord/common/entity/Snowflake;
-	public static synthetic fun textChannel$default (Ldev/kord/rest/builder/guild/GuildCreateBuilder;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/kord/common/entity/Snowflake;
+	public final fun textChannel-L1BfQZs (Ljava/lang/String;JLkotlin/jvm/functions/Function1;)J
+	public static synthetic fun textChannel-L1BfQZs$default (Ldev/kord/rest/builder/guild/GuildCreateBuilder;Ljava/lang/String;JLkotlin/jvm/functions/Function1;ILjava/lang/Object;)J
 	public fun toRequest ()Ldev/kord/rest/json/request/GuildCreateRequest;
 	public synthetic fun toRequest ()Ljava/lang/Object;
 }
 
 public final class dev/kord/rest/builder/guild/GuildModifyBuilder : dev/kord/rest/builder/AuditRequestBuilder {
 	public fun <init> ()V
-	public final fun getAfkChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getAfkChannelId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getAfkTimeout-FghU774 ()Lkotlin/time/Duration;
 	public final fun getBanner ()Ldev/kord/rest/Image;
 	public final fun getExplicitContentFilter ()Ldev/kord/common/entity/ExplicitContentFilter;
 	public final fun getIcon ()Ldev/kord/rest/Image;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getNotificationLevel ()Ldev/kord/common/entity/DefaultMessageNotificationLevel;
-	public final fun getOwnerId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getOwnerId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getPreferredLocale ()Ljava/util/Locale;
-	public final fun getPublicUpdatesChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getPublicUpdatesChannelId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public fun getReason ()Ljava/lang/String;
 	public final fun getRegion ()Ljava/lang/String;
-	public final fun getRulesChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getRulesChannelId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getSplash ()Ldev/kord/rest/Image;
-	public final fun getSystemChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getSystemChannelId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getVerificationLevel ()Ldev/kord/common/entity/VerificationLevel;
-	public final fun setAfkChannelId (Ldev/kord/common/entity/Snowflake;)V
+	public final fun setAfkChannelId-JTHp4pg (Ldev/kord/common/entity/Snowflake;)V
 	public final fun setAfkTimeout-BwNAW2A (Lkotlin/time/Duration;)V
 	public final fun setBanner (Ldev/kord/rest/Image;)V
 	public final fun setExplicitContentFilter (Ldev/kord/common/entity/ExplicitContentFilter;)V
 	public final fun setIcon (Ldev/kord/rest/Image;)V
 	public final fun setName (Ljava/lang/String;)V
 	public final fun setNotificationLevel (Ldev/kord/common/entity/DefaultMessageNotificationLevel;)V
-	public final fun setOwnerId (Ldev/kord/common/entity/Snowflake;)V
+	public final fun setOwnerId-JTHp4pg (Ldev/kord/common/entity/Snowflake;)V
 	public final fun setPreferredLocale (Ljava/util/Locale;)V
-	public final fun setPublicUpdatesChannelId (Ldev/kord/common/entity/Snowflake;)V
+	public final fun setPublicUpdatesChannelId-JTHp4pg (Ldev/kord/common/entity/Snowflake;)V
 	public fun setReason (Ljava/lang/String;)V
 	public final fun setRegion (Ljava/lang/String;)V
-	public final fun setRulesChannelId (Ldev/kord/common/entity/Snowflake;)V
+	public final fun setRulesChannelId-JTHp4pg (Ldev/kord/common/entity/Snowflake;)V
 	public final fun setSplash (Ldev/kord/rest/Image;)V
-	public final fun setSystemChannelId (Ldev/kord/common/entity/Snowflake;)V
+	public final fun setSystemChannelId-JTHp4pg (Ldev/kord/common/entity/Snowflake;)V
 	public final fun setVerificationLevel (Ldev/kord/common/entity/VerificationLevel;)V
 	public fun toRequest ()Ldev/kord/rest/json/request/GuildModifyRequest;
 	public synthetic fun toRequest ()Ljava/lang/Object;
@@ -943,10 +943,10 @@ public final class dev/kord/rest/builder/guild/GuildModifyBuilder : dev/kord/res
 
 public final class dev/kord/rest/builder/guild/GuildWidgetModifyBuilder : dev/kord/rest/builder/AuditRequestBuilder {
 	public fun <init> ()V
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getEnabled ()Ljava/lang/Boolean;
 	public fun getReason ()Ljava/lang/String;
-	public final fun setChannelId (Ldev/kord/common/entity/Snowflake;)V
+	public final fun setChannelId-JTHp4pg (Ldev/kord/common/entity/Snowflake;)V
 	public final fun setEnabled (Ljava/lang/Boolean;)V
 	public fun setReason (Ljava/lang/String;)V
 	public fun toRequest ()Ldev/kord/rest/json/request/GuildWidgetModifyRequest;
@@ -955,7 +955,7 @@ public final class dev/kord/rest/builder/guild/GuildWidgetModifyBuilder : dev/ko
 
 public final class dev/kord/rest/builder/guild/ScheduledEventCreateBuilder : dev/kord/rest/builder/AuditRequestBuilder {
 	public fun <init> (Ljava/lang/String;Ldev/kord/common/entity/GuildScheduledEventPrivacyLevel;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/ScheduledEntityType;)V
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getDescription ()Ljava/lang/String;
 	public final fun getEntityMetadata ()Ldev/kord/common/entity/GuildScheduledEventEntityMetadata;
 	public final fun getEntityType ()Ldev/kord/common/entity/ScheduledEntityType;
@@ -965,7 +965,7 @@ public final class dev/kord/rest/builder/guild/ScheduledEventCreateBuilder : dev
 	public fun getReason ()Ljava/lang/String;
 	public final fun getScheduledEndTime ()Lkotlinx/datetime/Instant;
 	public final fun getScheduledStartTime ()Lkotlinx/datetime/Instant;
-	public final fun setChannelId (Ldev/kord/common/entity/Snowflake;)V
+	public final fun setChannelId-JTHp4pg (Ldev/kord/common/entity/Snowflake;)V
 	public final fun setDescription (Ljava/lang/String;)V
 	public final fun setEntityMetadata (Ldev/kord/common/entity/GuildScheduledEventEntityMetadata;)V
 	public final fun setEntityType (Ldev/kord/common/entity/ScheduledEntityType;)V
@@ -992,24 +992,24 @@ public final class dev/kord/rest/builder/guild/StickerModifyBuilder : dev/kord/r
 }
 
 public final class dev/kord/rest/builder/guild/VoiceStateModifyBuilder : dev/kord/rest/builder/RequestBuilder {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;)V
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (JLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getChannelId-4_xYDEk ()J
 	public final fun getSuppress ()Ljava/lang/Boolean;
-	public final fun setChannelId (Ldev/kord/common/entity/Snowflake;)V
+	public final fun setChannelId-IO-hELI (J)V
 	public final fun setSuppress (Ljava/lang/Boolean;)V
 	public fun toRequest ()Ldev/kord/rest/json/request/VoiceStateModifyRequest;
 	public synthetic fun toRequest ()Ljava/lang/Object;
 }
 
 public final class dev/kord/rest/builder/guild/WelcomeScreenChannelBuilder : dev/kord/rest/builder/RequestBuilder {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;)V
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (JLjava/lang/String;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getChannelId-4_xYDEk ()J
 	public final fun getDescription ()Ljava/lang/String;
-	public final fun getEmojiId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getEmojiId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getEmojiName ()Ljava/lang/String;
-	public final fun setChannelId (Ldev/kord/common/entity/Snowflake;)V
+	public final fun setChannelId-IO-hELI (J)V
 	public final fun setDescription (Ljava/lang/String;)V
-	public final fun setEmojiId (Ldev/kord/common/entity/Snowflake;)V
+	public final fun setEmojiId-JTHp4pg (Ldev/kord/common/entity/Snowflake;)V
 	public final fun setEmojiName (Ljava/lang/String;)V
 	public fun toRequest ()Ldev/kord/common/entity/DiscordWelcomeScreenChannel;
 	public synthetic fun toRequest ()Ljava/lang/Object;
@@ -1027,7 +1027,7 @@ public final class dev/kord/rest/builder/guild/WelcomeScreenModifyBuilder : dev/
 	public final fun setWelcomeScreenChannels (Ljava/util/List;)V
 	public fun toRequest ()Ldev/kord/rest/json/request/GuildWelcomeScreenModifyRequest;
 	public synthetic fun toRequest ()Ljava/lang/Object;
-	public final fun welcomeChannel (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public final fun welcomeChannel-9y3P_48 (JLjava/lang/String;Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class dev/kord/rest/builder/integration/IntegrationModifyBuilder : dev/kord/rest/builder/AuditRequestBuilder {
@@ -1589,14 +1589,14 @@ public final class dev/kord/rest/builder/member/MemberModifyBuilder : dev/kord/r
 	public final fun getNickname ()Ljava/lang/String;
 	public fun getReason ()Ljava/lang/String;
 	public final fun getRoles ()Ljava/util/Set;
-	public final fun getVoiceChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getVoiceChannelId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun setCommunicationDisabledUntil (Lkotlinx/datetime/Instant;)V
 	public final fun setDeafened (Ljava/lang/Boolean;)V
 	public final fun setMuted (Ljava/lang/Boolean;)V
 	public final fun setNickname (Ljava/lang/String;)V
 	public fun setReason (Ljava/lang/String;)V
 	public final fun setRoles (Ljava/util/Set;)V
-	public final fun setVoiceChannelId (Ldev/kord/common/entity/Snowflake;)V
+	public final fun setVoiceChannelId-JTHp4pg (Ldev/kord/common/entity/Snowflake;)V
 	public fun toRequest ()Ldev/kord/rest/json/request/GuildMemberModifyRequest;
 	public synthetic fun toRequest ()Ljava/lang/Object;
 }
@@ -1818,13 +1818,13 @@ public final class dev/kord/rest/builder/message/create/UserMessageCreateBuilder
 	public fun getEmbeds ()Ljava/util/List;
 	public final fun getFailIfNotExists ()Ljava/lang/Boolean;
 	public fun getFiles ()Ljava/util/List;
-	public final fun getMessageReference ()Ldev/kord/common/entity/Snowflake;
+	public final fun getMessageReference-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getNonce ()Ljava/lang/String;
 	public fun getTts ()Ljava/lang/Boolean;
 	public fun setAllowedMentions (Ldev/kord/rest/builder/message/AllowedMentionsBuilder;)V
 	public fun setContent (Ljava/lang/String;)V
 	public final fun setFailIfNotExists (Ljava/lang/Boolean;)V
-	public final fun setMessageReference (Ldev/kord/common/entity/Snowflake;)V
+	public final fun setMessageReference-JTHp4pg (Ldev/kord/common/entity/Snowflake;)V
 	public final fun setNonce (Ljava/lang/String;)V
 	public fun setTts (Ljava/lang/Boolean;)V
 	public fun toRequest ()Ldev/kord/rest/json/request/MultipartMessageCreateRequest;
@@ -2026,7 +2026,7 @@ public final class dev/kord/rest/builder/role/RolePositionsModifyBuilder : dev/k
 
 public final class dev/kord/rest/builder/scheduled_events/ScheduledEventModifyBuilder : dev/kord/rest/builder/AuditRequestBuilder {
 	public fun <init> ()V
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getDescription ()Ljava/lang/String;
 	public final fun getEntityMetadata ()Ldev/kord/common/entity/GuildScheduledEventEntityMetadata;
 	public final fun getEntityType ()Ldev/kord/common/entity/ScheduledEntityType;
@@ -2037,7 +2037,7 @@ public final class dev/kord/rest/builder/scheduled_events/ScheduledEventModifyBu
 	public final fun getScheduledEndTime ()Lkotlinx/datetime/Instant;
 	public final fun getScheduledStartTime ()Lkotlinx/datetime/Instant;
 	public final fun getStatus ()Ldev/kord/common/entity/GuildScheduledEventStatus;
-	public final fun setChannelId (Ldev/kord/common/entity/Snowflake;)V
+	public final fun setChannelId-JTHp4pg (Ldev/kord/common/entity/Snowflake;)V
 	public final fun setDescription (Ljava/lang/String;)V
 	public final fun setEntityMetadata (Ldev/kord/common/entity/GuildScheduledEventEntityMetadata;)V
 	public final fun setEntityType (Ldev/kord/common/entity/ScheduledEntityType;)V
@@ -2053,13 +2053,13 @@ public final class dev/kord/rest/builder/scheduled_events/ScheduledEventModifyBu
 }
 
 public final class dev/kord/rest/builder/stage/StageInstanceCreateBuilder : dev/kord/rest/builder/AuditRequestBuilder {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;)V
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (JLjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getChannelId-4_xYDEk ()J
 	public final fun getPrivacyLevel ()Ldev/kord/common/entity/StageInstancePrivacyLevel;
 	public fun getReason ()Ljava/lang/String;
 	public final fun getSendStartNotification ()Ljava/lang/Boolean;
 	public final fun getTopic ()Ljava/lang/String;
-	public final fun setChannelId (Ldev/kord/common/entity/Snowflake;)V
+	public final fun setChannelId-IO-hELI (J)V
 	public final fun setPrivacyLevel (Ldev/kord/common/entity/StageInstancePrivacyLevel;)V
 	public fun setReason (Ljava/lang/String;)V
 	public final fun setSendStartNotification (Ljava/lang/Boolean;)V
@@ -2143,11 +2143,11 @@ public final class dev/kord/rest/builder/webhook/WebhookCreateBuilder : dev/kord
 public final class dev/kord/rest/builder/webhook/WebhookModifyBuilder : dev/kord/rest/builder/AuditRequestBuilder {
 	public fun <init> ()V
 	public final fun getAvatar ()Ldev/kord/rest/Image;
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getName ()Ljava/lang/String;
 	public fun getReason ()Ljava/lang/String;
 	public final fun setAvatar (Ldev/kord/rest/Image;)V
-	public final fun setChannelId (Ldev/kord/common/entity/Snowflake;)V
+	public final fun setChannelId-JTHp4pg (Ldev/kord/common/entity/Snowflake;)V
 	public final fun setName (Ljava/lang/String;)V
 	public fun setReason (Ljava/lang/String;)V
 	public fun toRequest ()Ldev/kord/rest/json/request/WebhookModifyRequest;
@@ -2427,20 +2427,19 @@ public final class dev/kord/rest/json/request/ApplicationCommandModifyRequest$Co
 }
 
 public final class dev/kord/rest/json/request/AuditLogGetRequest {
-	public fun <init> ()V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/AuditLogEvent;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)V
 	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/AuditLogEvent;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/AuditLogEvent;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun component2 ()Ldev/kord/common/entity/AuditLogEvent;
-	public final fun component3 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component3-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun component4 ()Ljava/lang/Integer;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/AuditLogEvent;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Ldev/kord/rest/json/request/AuditLogGetRequest;
-	public static synthetic fun copy$default (Ldev/kord/rest/json/request/AuditLogGetRequest;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/AuditLogEvent;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;ILjava/lang/Object;)Ldev/kord/rest/json/request/AuditLogGetRequest;
+	public final fun copy-7yaeFVE (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/AuditLogEvent;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Ldev/kord/rest/json/request/AuditLogGetRequest;
+	public static synthetic fun copy-7yaeFVE$default (Ldev/kord/rest/json/request/AuditLogGetRequest;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/AuditLogEvent;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;ILjava/lang/Object;)Ldev/kord/rest/json/request/AuditLogGetRequest;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAction ()Ldev/kord/common/entity/AuditLogEvent;
-	public final fun getBefore ()Ldev/kord/common/entity/Snowflake;
+	public final fun getBefore-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getLimit ()Ljava/lang/Integer;
-	public final fun getUserId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getUserId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -2598,13 +2597,13 @@ public final class dev/kord/rest/json/request/BulkDeleteRequest$Companion {
 
 public final class dev/kord/rest/json/request/ChannelFollowRequest {
 	public static final field Companion Ldev/kord/rest/json/request/ChannelFollowRequest$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;)Ldev/kord/rest/json/request/ChannelFollowRequest;
-	public static synthetic fun copy$default (Ldev/kord/rest/json/request/ChannelFollowRequest;Ldev/kord/common/entity/Snowflake;ILjava/lang/Object;)Ldev/kord/rest/json/request/ChannelFollowRequest;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
+	public final fun copy-IO-hELI (J)Ldev/kord/rest/json/request/ChannelFollowRequest;
+	public static synthetic fun copy-IO-hELI$default (Ldev/kord/rest/json/request/ChannelFollowRequest;JILjava/lang/Object;)Ldev/kord/rest/json/request/ChannelFollowRequest;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getWebhookChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getWebhookChannelId-4_xYDEk ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public static final fun write$Self (Ldev/kord/rest/json/request/ChannelFollowRequest;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
@@ -2771,19 +2770,19 @@ public final class dev/kord/rest/json/request/ChannelPermissionEditRequest$Compa
 
 public final class dev/kord/rest/json/request/ChannelPositionSwapRequest {
 	public static final field Companion Ldev/kord/rest/json/request/ChannelPositionSwapRequest$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalInt;Ljava/lang/Boolean;Ldev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalInt;Ljava/lang/Boolean;Ldev/kord/common/entity/Snowflake;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalInt;Ljava/lang/Boolean;Ldev/kord/common/entity/Snowflake;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalInt;Ljava/lang/Boolean;Ldev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/optional/OptionalInt;Ljava/lang/Boolean;Ldev/kord/common/entity/Snowflake;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/optional/OptionalInt;Ljava/lang/Boolean;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component2 ()Ldev/kord/common/entity/optional/OptionalInt;
 	public final fun component3 ()Ljava/lang/Boolean;
-	public final fun component4 ()Ldev/kord/common/entity/Snowflake;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalInt;Ljava/lang/Boolean;Ldev/kord/common/entity/Snowflake;)Ldev/kord/rest/json/request/ChannelPositionSwapRequest;
-	public static synthetic fun copy$default (Ldev/kord/rest/json/request/ChannelPositionSwapRequest;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalInt;Ljava/lang/Boolean;Ldev/kord/common/entity/Snowflake;ILjava/lang/Object;)Ldev/kord/rest/json/request/ChannelPositionSwapRequest;
+	public final fun component4-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
+	public final fun copy-2ldKgM0 (JLdev/kord/common/entity/optional/OptionalInt;Ljava/lang/Boolean;Ldev/kord/common/entity/Snowflake;)Ldev/kord/rest/json/request/ChannelPositionSwapRequest;
+	public static synthetic fun copy-2ldKgM0$default (Ldev/kord/rest/json/request/ChannelPositionSwapRequest;JLdev/kord/common/entity/optional/OptionalInt;Ljava/lang/Boolean;Ldev/kord/common/entity/Snowflake;ILjava/lang/Object;)Ldev/kord/rest/json/request/ChannelPositionSwapRequest;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getId-4_xYDEk ()J
 	public final fun getLockPermissions ()Ljava/lang/Boolean;
-	public final fun getParentId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getParentId-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getPosition ()Ldev/kord/common/entity/optional/OptionalInt;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -2910,13 +2909,13 @@ public final class dev/kord/rest/json/request/CurrentVoiceStateModifyRequest$Com
 
 public final class dev/kord/rest/json/request/DMCreateRequest {
 	public static final field Companion Ldev/kord/rest/json/request/DMCreateRequest$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;)Ldev/kord/rest/json/request/DMCreateRequest;
-	public static synthetic fun copy$default (Ldev/kord/rest/json/request/DMCreateRequest;Ldev/kord/common/entity/Snowflake;ILjava/lang/Object;)Ldev/kord/rest/json/request/DMCreateRequest;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
+	public final fun copy-IO-hELI (J)Ldev/kord/rest/json/request/DMCreateRequest;
+	public static synthetic fun copy-IO-hELI$default (Ldev/kord/rest/json/request/DMCreateRequest;JILjava/lang/Object;)Ldev/kord/rest/json/request/DMCreateRequest;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getUserId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getUserId-4_xYDEk ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public static final fun write$Self (Ldev/kord/rest/json/request/DMCreateRequest;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
@@ -3498,6 +3497,38 @@ public final class dev/kord/rest/json/request/GuildCreateRequest$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class dev/kord/rest/json/request/GuildEmbedModifyRequest {
+	public static final field Companion Ldev/kord/rest/json/request/GuildEmbedModifyRequest$Companion;
+	public synthetic fun <init> (IZLdev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (ZLdev/kord/common/entity/Snowflake;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
+	public final fun copy (ZLdev/kord/common/entity/Snowflake;)Ldev/kord/rest/json/request/GuildEmbedModifyRequest;
+	public static synthetic fun copy$default (Ldev/kord/rest/json/request/GuildEmbedModifyRequest;ZLdev/kord/common/entity/Snowflake;ILjava/lang/Object;)Ldev/kord/rest/json/request/GuildEmbedModifyRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getEnabled ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Ldev/kord/rest/json/request/GuildEmbedModifyRequest;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class dev/kord/rest/json/request/GuildEmbedModifyRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Ldev/kord/rest/json/request/GuildEmbedModifyRequest$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/kord/rest/json/request/GuildEmbedModifyRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ldev/kord/rest/json/request/GuildEmbedModifyRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/kord/rest/json/request/GuildEmbedModifyRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class dev/kord/rest/json/request/GuildFromTemplateCreateRequest {
 	public static final field Companion Ldev/kord/rest/json/request/GuildFromTemplateCreateRequest$Companion;
 	public synthetic fun <init> (ILjava/lang/String;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
@@ -3927,16 +3958,16 @@ public final class dev/kord/rest/json/request/GuildScheduledEventCreateRequest$C
 
 public final class dev/kord/rest/json/request/GuildScheduledEventUsersResponse {
 	public static final field Companion Ldev/kord/rest/json/request/GuildScheduledEventUsersResponse$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordUser;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordUser;Ldev/kord/common/entity/optional/Optional;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordUser;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordUser;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/DiscordUser;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/DiscordUser;Ldev/kord/common/entity/optional/Optional;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component2 ()Ldev/kord/common/entity/DiscordUser;
 	public final fun component3 ()Ldev/kord/common/entity/optional/Optional;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordUser;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/rest/json/request/GuildScheduledEventUsersResponse;
-	public static synthetic fun copy$default (Ldev/kord/rest/json/request/GuildScheduledEventUsersResponse;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/DiscordUser;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/rest/json/request/GuildScheduledEventUsersResponse;
+	public final fun copy-9y3P_48 (JLdev/kord/common/entity/DiscordUser;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/rest/json/request/GuildScheduledEventUsersResponse;
+	public static synthetic fun copy-9y3P_48$default (Ldev/kord/rest/json/request/GuildScheduledEventUsersResponse;JLdev/kord/common/entity/DiscordUser;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/rest/json/request/GuildScheduledEventUsersResponse;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getGuildScheduledEventId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildScheduledEventId-4_xYDEk ()J
 	public final fun getMember ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getUser ()Ldev/kord/common/entity/DiscordUser;
 	public fun hashCode ()I
@@ -4335,15 +4366,14 @@ public final class dev/kord/rest/json/request/InviteCreateRequest$Companion {
 }
 
 public final class dev/kord/rest/json/request/ListThreadsBySnowflakeRequest {
-	public fun <init> ()V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)V
 	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun component2 ()Ljava/lang/Integer;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Ldev/kord/rest/json/request/ListThreadsBySnowflakeRequest;
-	public static synthetic fun copy$default (Ldev/kord/rest/json/request/ListThreadsBySnowflakeRequest;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;ILjava/lang/Object;)Ldev/kord/rest/json/request/ListThreadsBySnowflakeRequest;
+	public final fun copy-O4FuXRM (Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Ldev/kord/rest/json/request/ListThreadsBySnowflakeRequest;
+	public static synthetic fun copy-O4FuXRM$default (Ldev/kord/rest/json/request/ListThreadsBySnowflakeRequest;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;ILjava/lang/Object;)Ldev/kord/rest/json/request/ListThreadsBySnowflakeRequest;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getBefore ()Ldev/kord/common/entity/Snowflake;
+	public final fun getBefore-eUG9VGM ()Ldev/kord/common/entity/Snowflake;
 	public final fun getLimit ()Ljava/lang/Integer;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -4659,17 +4689,17 @@ public final class dev/kord/rest/json/request/ScheduledEventModifyRequest$Compan
 
 public final class dev/kord/rest/json/request/StageInstanceCreateRequest {
 	public static final field Companion Ldev/kord/rest/json/request/StageInstanceCreateRequest$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component4 ()Ldev/kord/common/entity/optional/OptionalBoolean;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;)Ldev/kord/rest/json/request/StageInstanceCreateRequest;
-	public static synthetic fun copy$default (Ldev/kord/rest/json/request/StageInstanceCreateRequest;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;ILjava/lang/Object;)Ldev/kord/rest/json/request/StageInstanceCreateRequest;
+	public final fun copy-9VmEaQQ (JLjava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;)Ldev/kord/rest/json/request/StageInstanceCreateRequest;
+	public static synthetic fun copy-9VmEaQQ$default (Ldev/kord/rest/json/request/StageInstanceCreateRequest;JLjava/lang/String;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;ILjava/lang/Object;)Ldev/kord/rest/json/request/StageInstanceCreateRequest;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-4_xYDEk ()J
 	public final fun getPrivacyLevel ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getSendStartNotification ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun getTopic ()Ljava/lang/String;
@@ -4829,15 +4859,15 @@ public final class dev/kord/rest/json/request/UserAddDMRequest$Companion {
 
 public final class dev/kord/rest/json/request/VoiceStateModifyRequest {
 	public static final field Companion Ldev/kord/rest/json/request/VoiceStateModifyRequest$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/optional/OptionalBoolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLdev/kord/common/entity/optional/OptionalBoolean;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component2 ()Ldev/kord/common/entity/optional/OptionalBoolean;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;)Ldev/kord/rest/json/request/VoiceStateModifyRequest;
-	public static synthetic fun copy$default (Ldev/kord/rest/json/request/VoiceStateModifyRequest;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalBoolean;ILjava/lang/Object;)Ldev/kord/rest/json/request/VoiceStateModifyRequest;
+	public final fun copy-wYKCHeA (JLdev/kord/common/entity/optional/OptionalBoolean;)Ldev/kord/rest/json/request/VoiceStateModifyRequest;
+	public static synthetic fun copy-wYKCHeA$default (Ldev/kord/rest/json/request/VoiceStateModifyRequest;JLdev/kord/common/entity/optional/OptionalBoolean;ILjava/lang/Object;)Ldev/kord/rest/json/request/VoiceStateModifyRequest;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-4_xYDEk ()J
 	public final fun getSuppress ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -5191,17 +5221,49 @@ public final class dev/kord/rest/json/response/DiscordErrorResponse$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class dev/kord/rest/json/response/EmbedResponse {
+	public static final field Companion Ldev/kord/rest/json/response/EmbedResponse$Companion;
+	public synthetic fun <init> (IZLjava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (ZLjava/lang/String;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (ZLjava/lang/String;)Ldev/kord/rest/json/response/EmbedResponse;
+	public static synthetic fun copy$default (Ldev/kord/rest/json/response/EmbedResponse;ZLjava/lang/String;ILjava/lang/Object;)Ldev/kord/rest/json/response/EmbedResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChannelId ()Ljava/lang/String;
+	public final fun getEnabled ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Ldev/kord/rest/json/response/EmbedResponse;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class dev/kord/rest/json/response/EmbedResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Ldev/kord/rest/json/response/EmbedResponse$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/kord/rest/json/response/EmbedResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ldev/kord/rest/json/response/EmbedResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/kord/rest/json/response/EmbedResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class dev/kord/rest/json/response/FollowedChannelResponse {
 	public static final field Companion Ldev/kord/rest/json/response/FollowedChannelResponse$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)Ldev/kord/rest/json/response/FollowedChannelResponse;
-	public static synthetic fun copy$default (Ldev/kord/rest/json/response/FollowedChannelResponse;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;ILjava/lang/Object;)Ldev/kord/rest/json/response/FollowedChannelResponse;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
+	public final fun component2-4_xYDEk ()J
+	public final fun copy-Xcgsvs4 (JJ)Ldev/kord/rest/json/response/FollowedChannelResponse;
+	public static synthetic fun copy-Xcgsvs4$default (Ldev/kord/rest/json/response/FollowedChannelResponse;JJILjava/lang/Object;)Ldev/kord/rest/json/response/FollowedChannelResponse;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
-	public final fun getWebhookId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-4_xYDEk ()J
+	public final fun getWebhookId-4_xYDEk ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public static final fun write$Self (Ldev/kord/rest/json/response/FollowedChannelResponse;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
@@ -5581,6 +5643,21 @@ public final class dev/kord/rest/ratelimit/RequestResponse$GlobalRateLimit : dev
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class dev/kord/rest/ratelimit/RequestResponse$UnknownBucketRateLimit : dev/kord/rest/ratelimit/RequestResponse {
+	public synthetic fun <init> (Ldev/kord/rest/ratelimit/RateLimit;Lkotlinx/datetime/Instant;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ldev/kord/rest/ratelimit/RateLimit;
+	public final fun component2-Ad4v_Ag ()Lkotlinx/datetime/Instant;
+	public final fun copy-K94tdRY (Ldev/kord/rest/ratelimit/RateLimit;Lkotlinx/datetime/Instant;)Ldev/kord/rest/ratelimit/RequestResponse$UnknownBucketRateLimit;
+	public static synthetic fun copy-K94tdRY$default (Ldev/kord/rest/ratelimit/RequestResponse$UnknownBucketRateLimit;Ldev/kord/rest/ratelimit/RateLimit;Lkotlinx/datetime/Instant;ILjava/lang/Object;)Ldev/kord/rest/ratelimit/RequestResponse$UnknownBucketRateLimit;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getBucketKey-JBzVXgM ()Ljava/lang/String;
+	public fun getRateLimit ()Ldev/kord/rest/ratelimit/RateLimit;
+	public synthetic fun getReset-8536Nbg ()Lkotlinx/datetime/Instant;
+	public fun getReset-Ad4v_Ag ()Lkotlinx/datetime/Instant;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract interface class dev/kord/rest/ratelimit/RequestToken {
 	public abstract fun complete (Ldev/kord/rest/ratelimit/RequestResponse;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getCompleted ()Z
@@ -5728,10 +5805,10 @@ public final class dev/kord/rest/request/RequestBuilder {
 	public final fun getBaseUrl ()Ljava/lang/String;
 	public final fun getKeys ()Ljava/util/Map;
 	public final fun getRoute ()Ldev/kord/rest/route/Route;
-	public final fun parameter (Ljava/lang/String;Ldev/kord/common/entity/Snowflake;)V
 	public final fun parameter (Ljava/lang/String;Ljava/lang/Object;)V
-	public final fun set (Ljava/util/Map;Ldev/kord/rest/route/Route$Key;Ldev/kord/common/entity/Snowflake;)V
+	public final fun parameter-Vn1WZo8 (Ljava/lang/String;J)V
 	public final fun set (Ljava/util/Map;Ldev/kord/rest/route/Route$Key;Ljava/lang/String;)V
+	public final fun set-DGTxqCw (Ljava/util/Map;Ldev/kord/rest/route/Route$Key;J)V
 	public final fun setBaseUrl (Ljava/lang/String;)V
 	public final fun unencodedHeader (Ljava/lang/String;Ljava/lang/String;)V
 	public final fun urlEncodedHeader (Ljava/lang/String;Ljava/lang/String;)V
@@ -5817,33 +5894,33 @@ public final class dev/kord/rest/route/CdnUrl$UrlFormatBuilder {
 public final class dev/kord/rest/route/DiscordCdn {
 	public static final field INSTANCE Ldev/kord/rest/route/DiscordCdn;
 	public final fun defaultAvatar (I)Ldev/kord/rest/route/CdnUrl;
-	public final fun emoji (Ldev/kord/common/entity/Snowflake;)Ldev/kord/rest/route/CdnUrl;
-	public final fun memberAvatar (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;)Ldev/kord/rest/route/CdnUrl;
-	public final fun roleIcon (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;)Ldev/kord/rest/route/CdnUrl;
-	public final fun userAvatar (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;)Ldev/kord/rest/route/CdnUrl;
+	public final fun emoji-IO-hELI (J)Ldev/kord/rest/route/CdnUrl;
+	public final fun memberAvatar-U2evHYk (JJLjava/lang/String;)Ldev/kord/rest/route/CdnUrl;
+	public final fun roleIcon-wYKCHeA (JLjava/lang/String;)Ldev/kord/rest/route/CdnUrl;
+	public final fun userAvatar-wYKCHeA (JLjava/lang/String;)Ldev/kord/rest/route/CdnUrl;
 }
 
 public abstract interface class dev/kord/rest/route/Position {
 	public abstract fun getKey ()Ljava/lang/String;
-	public abstract fun getValue ()Ldev/kord/common/entity/Snowflake;
+	public abstract fun getValue-4_xYDEk ()J
 }
 
 public final class dev/kord/rest/route/Position$After : dev/kord/rest/route/Position$BeforeOrAfter {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;)V
+	public synthetic fun <init> (JLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getKey ()Ljava/lang/String;
-	public fun getValue ()Ldev/kord/common/entity/Snowflake;
+	public fun getValue-4_xYDEk ()J
 }
 
 public final class dev/kord/rest/route/Position$Around : dev/kord/rest/route/Position {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;)V
+	public synthetic fun <init> (JLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getKey ()Ljava/lang/String;
-	public fun getValue ()Ldev/kord/common/entity/Snowflake;
+	public fun getValue-4_xYDEk ()J
 }
 
 public final class dev/kord/rest/route/Position$Before : dev/kord/rest/route/Position$BeforeOrAfter {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;)V
+	public synthetic fun <init> (JLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getKey ()Ljava/lang/String;
-	public fun getValue ()Ldev/kord/common/entity/Snowflake;
+	public fun getValue-4_xYDEk ()J
 }
 
 public abstract interface class dev/kord/rest/route/Position$BeforeOrAfter : dev/kord/rest/route/Position {
@@ -6136,6 +6213,14 @@ public final class dev/kord/rest/route/Route$GuildCurrentUserNickPatch : dev/kor
 
 public final class dev/kord/rest/route/Route$GuildDelete : dev/kord/rest/route/Route {
 	public static final field INSTANCE Ldev/kord/rest/route/Route$GuildDelete;
+}
+
+public final class dev/kord/rest/route/Route$GuildEmbedGet : dev/kord/rest/route/Route {
+	public static final field INSTANCE Ldev/kord/rest/route/Route$GuildEmbedGet;
+}
+
+public final class dev/kord/rest/route/Route$GuildEmbedPatch : dev/kord/rest/route/Route {
+	public static final field INSTANCE Ldev/kord/rest/route/Route$GuildEmbedPatch;
 }
 
 public final class dev/kord/rest/route/Route$GuildEmojiDelete : dev/kord/rest/route/Route {
@@ -6637,294 +6722,294 @@ public final class dev/kord/rest/service/ApplicationService : dev/kord/rest/serv
 
 public final class dev/kord/rest/service/AuditLogService : dev/kord/rest/service/RestService {
 	public fun <init> (Ldev/kord/rest/request/RequestHandler;)V
-	public final fun getAuditLogs (Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/AuditLogGetRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getAuditLogs (Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getAuditLogs-9y3P_48 (JLdev/kord/rest/json/request/AuditLogGetRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getAuditLogs-9y3P_48 (JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class dev/kord/rest/service/AutoModerationService : dev/kord/rest/service/RestService {
 	public fun <init> (Ldev/kord/rest/request/RequestHandler;)V
-	public final fun createAutoModerationRule (Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/AutoModerationRuleCreateRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun createAutoModerationRule$default (Ldev/kord/rest/service/AutoModerationService;Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/AutoModerationRuleCreateRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun createKeywordAutoModerationRule (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/AutoModerationRuleEventType;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun createKeywordPresetAutoModerationRule (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/AutoModerationRuleEventType;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun createMentionSpamAutoModerationRule (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/AutoModerationRuleEventType;ILkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun createSpamAutoModerationRule (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/AutoModerationRuleEventType;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun deleteAutoModerationRule (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun deleteAutoModerationRule$default (Ldev/kord/rest/service/AutoModerationService;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun getAutoModerationRule (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun listAutoModerationRulesForGuild (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun modifyAutoModerationRule (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/AutoModerationRuleModifyRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun modifyAutoModerationRule$default (Ldev/kord/rest/service/AutoModerationService;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/AutoModerationRuleModifyRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun modifyKeywordAutoModerationRule (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun modifyKeywordPresetAutoModerationRule (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun modifyMentionSpamAutoModerationRule (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun modifySpamAutoModerationRule (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun modifyUntypedAutoModerationRule (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun createAutoModerationRule-9VmEaQQ (JLdev/kord/rest/json/request/AutoModerationRuleCreateRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun createAutoModerationRule-9VmEaQQ$default (Ldev/kord/rest/service/AutoModerationService;JLdev/kord/rest/json/request/AutoModerationRuleCreateRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun createKeywordAutoModerationRule-PHjaIKs (JLjava/lang/String;Ldev/kord/common/entity/AutoModerationRuleEventType;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun createKeywordPresetAutoModerationRule-PHjaIKs (JLjava/lang/String;Ldev/kord/common/entity/AutoModerationRuleEventType;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun createMentionSpamAutoModerationRule-vwSIg4A (JLjava/lang/String;Ldev/kord/common/entity/AutoModerationRuleEventType;ILkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun createSpamAutoModerationRule-PHjaIKs (JLjava/lang/String;Ldev/kord/common/entity/AutoModerationRuleEventType;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun deleteAutoModerationRule-Lfpyfds (JJLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteAutoModerationRule-Lfpyfds$default (Ldev/kord/rest/service/AutoModerationService;JJLjava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getAutoModerationRule-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun listAutoModerationRulesForGuild-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun modifyAutoModerationRule-CJS6HZA (JJLdev/kord/rest/json/request/AutoModerationRuleModifyRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun modifyAutoModerationRule-CJS6HZA$default (Ldev/kord/rest/service/AutoModerationService;JJLdev/kord/rest/json/request/AutoModerationRuleModifyRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun modifyKeywordAutoModerationRule-Lfpyfds (JJLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun modifyKeywordPresetAutoModerationRule-Lfpyfds (JJLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun modifyMentionSpamAutoModerationRule-Lfpyfds (JJLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun modifySpamAutoModerationRule-Lfpyfds (JJLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun modifyUntypedAutoModerationRule-Lfpyfds (JJLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class dev/kord/rest/service/ChannelService : dev/kord/rest/service/RestService {
 	public fun <init> (Ldev/kord/rest/request/RequestHandler;)V
-	public final fun addPinnedMessage (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun addPinnedMessage$default (Ldev/kord/rest/service/ChannelService;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun addToGroup (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/UserAddDMRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun addUserToThread (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun bulkDelete (Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/BulkDeleteRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun bulkDelete$default (Ldev/kord/rest/service/ChannelService;Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/BulkDeleteRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun createInvite (Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun createInvite$default (Ldev/kord/rest/service/ChannelService;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun createMessage (Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/MultipartMessageCreateRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun createMessage (Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun createReaction (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun crossPost (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun deleteAllReactions (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun deleteAllReactionsForEmoji (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun deleteChannel (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun deleteChannel$default (Ldev/kord/rest/service/ChannelService;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun deleteChannelPermission (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun deleteChannelPermission$default (Ldev/kord/rest/service/ChannelService;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun deleteMessage (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun deleteMessage$default (Ldev/kord/rest/service/ChannelService;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun deleteOwnReaction (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun deletePinnedMessage (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun deletePinnedMessage$default (Ldev/kord/rest/service/ChannelService;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun deleteReaction (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun editChannelPermissions (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/ChannelPermissionEditRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun editChannelPermissions$default (Ldev/kord/rest/service/ChannelService;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/ChannelPermissionEditRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun editMessage (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/MessageEditPatchRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun editMessage (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/MultipartMessagePatchRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun editMessage (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/MultipartWebhookEditMessageRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun editMessage (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun followNewsChannel (Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/ChannelFollowRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getChannel (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getChannelInvites (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getChannelPins (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getMessage (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getMessages (Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/route/Position;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getMessages$default (Ldev/kord/rest/service/ChannelService;Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/route/Position;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun getReactions (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/rest/route/Position$After;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getReactions$default (Ldev/kord/rest/service/ChannelService;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/rest/route/Position$After;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun joinThread (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun leaveThread (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun listJoinedPrivateArchivedThreads (Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/ListThreadsBySnowflakeRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun listPrivateArchivedThreads (Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/ListThreadsByTimestampRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun listPublicArchivedThreads (Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/ListThreadsByTimestampRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun listThreadMembers (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun patchChannel (Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/ChannelModifyPatchRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun patchChannel$default (Ldev/kord/rest/service/ChannelService;Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/ChannelModifyPatchRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun patchThread (Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/ChannelModifyPatchRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun patchThread$default (Ldev/kord/rest/service/ChannelService;Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/ChannelModifyPatchRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun putChannel (Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/ChannelModifyPutRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun putChannel$default (Ldev/kord/rest/service/ChannelService;Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/ChannelModifyPutRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun removeFromGroup (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun removeUserFromThread (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun startThread (Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/StartThreadRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun startThread (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/ArchiveDuration;Ldev/kord/common/entity/ChannelType;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun startThread$default (Ldev/kord/rest/service/ChannelService;Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/StartThreadRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static synthetic fun startThread$default (Ldev/kord/rest/service/ChannelService;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/ArchiveDuration;Ldev/kord/common/entity/ChannelType;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun startThreadWithMessage (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/StartThreadRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun startThreadWithMessage (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/ArchiveDuration;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun startThreadWithMessage$default (Ldev/kord/rest/service/ChannelService;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/StartThreadRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun triggerTypingIndicator (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun addPinnedMessage-Lfpyfds (JJLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun addPinnedMessage-Lfpyfds$default (Ldev/kord/rest/service/ChannelService;JJLjava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun addToGroup-Lfpyfds (JJLdev/kord/rest/json/request/UserAddDMRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun addUserToThread-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun bulkDelete-9VmEaQQ (JLdev/kord/rest/json/request/BulkDeleteRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun bulkDelete-9VmEaQQ$default (Ldev/kord/rest/service/ChannelService;JLdev/kord/rest/json/request/BulkDeleteRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun createInvite-9y3P_48 (JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun createInvite-9y3P_48$default (Ldev/kord/rest/service/ChannelService;JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun createMessage-9y3P_48 (JLdev/kord/rest/json/request/MultipartMessageCreateRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun createMessage-9y3P_48 (JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun createReaction-Lfpyfds (JJLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun crossPost-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun deleteAllReactions-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun deleteAllReactionsForEmoji-Lfpyfds (JJLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun deleteChannel-9y3P_48 (JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteChannel-9y3P_48$default (Ldev/kord/rest/service/ChannelService;JLjava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun deleteChannelPermission-Lfpyfds (JJLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteChannelPermission-Lfpyfds$default (Ldev/kord/rest/service/ChannelService;JJLjava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun deleteMessage-Lfpyfds (JJLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteMessage-Lfpyfds$default (Ldev/kord/rest/service/ChannelService;JJLjava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun deleteOwnReaction-Lfpyfds (JJLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun deletePinnedMessage-Lfpyfds (JJLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deletePinnedMessage-Lfpyfds$default (Ldev/kord/rest/service/ChannelService;JJLjava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun deleteReaction-duETn5c (JJJLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun editChannelPermissions-CJS6HZA (JJLdev/kord/rest/json/request/ChannelPermissionEditRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun editChannelPermissions-CJS6HZA$default (Ldev/kord/rest/service/ChannelService;JJLdev/kord/rest/json/request/ChannelPermissionEditRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun editMessage-Lfpyfds (JJLdev/kord/rest/json/request/MessageEditPatchRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun editMessage-Lfpyfds (JJLdev/kord/rest/json/request/MultipartMessagePatchRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun editMessage-Lfpyfds (JJLdev/kord/rest/json/request/MultipartWebhookEditMessageRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun editMessage-Lfpyfds (JJLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun followNewsChannel-9y3P_48 (JLdev/kord/rest/json/request/ChannelFollowRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getChannel-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getChannelInvites-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getChannelPins-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getMessage-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getMessages-9VmEaQQ (JLdev/kord/rest/route/Position;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getMessages-9VmEaQQ$default (Ldev/kord/rest/service/ChannelService;JLdev/kord/rest/route/Position;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getReactions-huMQfDM (JJLjava/lang/String;Ldev/kord/rest/route/Position$After;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getReactions-huMQfDM$default (Ldev/kord/rest/service/ChannelService;JJLjava/lang/String;Ldev/kord/rest/route/Position$After;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun joinThread-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun leaveThread-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun listJoinedPrivateArchivedThreads-9y3P_48 (JLdev/kord/rest/json/request/ListThreadsBySnowflakeRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun listPrivateArchivedThreads-9y3P_48 (JLdev/kord/rest/json/request/ListThreadsByTimestampRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun listPublicArchivedThreads-9y3P_48 (JLdev/kord/rest/json/request/ListThreadsByTimestampRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun listThreadMembers-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun patchChannel-9VmEaQQ (JLdev/kord/rest/json/request/ChannelModifyPatchRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun patchChannel-9VmEaQQ$default (Ldev/kord/rest/service/ChannelService;JLdev/kord/rest/json/request/ChannelModifyPatchRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun patchThread-9VmEaQQ (JLdev/kord/rest/json/request/ChannelModifyPatchRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun patchThread-9VmEaQQ$default (Ldev/kord/rest/service/ChannelService;JLdev/kord/rest/json/request/ChannelModifyPatchRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun putChannel-9VmEaQQ (JLdev/kord/rest/json/request/ChannelModifyPutRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun putChannel-9VmEaQQ$default (Ldev/kord/rest/service/ChannelService;JLdev/kord/rest/json/request/ChannelModifyPutRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun removeFromGroup-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun removeUserFromThread-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun startThread-9VmEaQQ (JLdev/kord/rest/json/request/StartThreadRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun startThread-9VmEaQQ$default (Ldev/kord/rest/service/ChannelService;JLdev/kord/rest/json/request/StartThreadRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun startThread-vwSIg4A (JLjava/lang/String;Ldev/kord/common/entity/ArchiveDuration;Ldev/kord/common/entity/ChannelType;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun startThread-vwSIg4A$default (Ldev/kord/rest/service/ChannelService;JLjava/lang/String;Ldev/kord/common/entity/ArchiveDuration;Ldev/kord/common/entity/ChannelType;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun startThreadWithMessage-CJS6HZA (JJLdev/kord/rest/json/request/StartThreadRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun startThreadWithMessage-CJS6HZA$default (Ldev/kord/rest/service/ChannelService;JJLdev/kord/rest/json/request/StartThreadRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun startThreadWithMessage-huMQfDM (JJLjava/lang/String;Ldev/kord/common/entity/ArchiveDuration;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun triggerTypingIndicator-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class dev/kord/rest/service/ChannelServiceKt {
-	public static final fun editMemberPermissions (Ldev/kord/rest/service/ChannelService;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun editRolePermission (Ldev/kord/rest/service/ChannelService;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun patchCategory (Ldev/kord/rest/service/ChannelService;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun patchNewsChannel (Ldev/kord/rest/service/ChannelService;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun patchStageVoiceChannel (Ldev/kord/rest/service/ChannelService;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final synthetic fun patchStoreChannel (Ldev/kord/rest/service/ChannelService;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun patchTextChannel (Ldev/kord/rest/service/ChannelService;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun patchVoiceChannel (Ldev/kord/rest/service/ChannelService;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun editMemberPermissions-5-xQWJg (Ldev/kord/rest/service/ChannelService;JJLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun editRolePermission-5-xQWJg (Ldev/kord/rest/service/ChannelService;JJLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun patchCategory-nMAJGj4 (Ldev/kord/rest/service/ChannelService;JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun patchNewsChannel-nMAJGj4 (Ldev/kord/rest/service/ChannelService;JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun patchStageVoiceChannel-nMAJGj4 (Ldev/kord/rest/service/ChannelService;JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final synthetic fun patchStoreChannel-nMAJGj4 (Ldev/kord/rest/service/ChannelService;JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun patchTextChannel-nMAJGj4 (Ldev/kord/rest/service/ChannelService;JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun patchVoiceChannel-nMAJGj4 (Ldev/kord/rest/service/ChannelService;JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class dev/kord/rest/service/EmojiService : dev/kord/rest/service/RestService {
 	public fun <init> (Ldev/kord/rest/request/RequestHandler;)V
-	public final fun createEmoji (Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/EmojiCreateRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun createEmoji (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/rest/Image;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun createEmoji$default (Ldev/kord/rest/service/EmojiService;Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/EmojiCreateRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static synthetic fun createEmoji$default (Ldev/kord/rest/service/EmojiService;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/rest/Image;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun deleteEmoji (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun deleteEmoji$default (Ldev/kord/rest/service/EmojiService;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun getEmoji (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getEmojis (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun modifyEmoji (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun createEmoji-9VmEaQQ (JLdev/kord/rest/json/request/EmojiCreateRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun createEmoji-9VmEaQQ$default (Ldev/kord/rest/service/EmojiService;JLdev/kord/rest/json/request/EmojiCreateRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun createEmoji-PHjaIKs (JLjava/lang/String;Ldev/kord/rest/Image;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun createEmoji-PHjaIKs$default (Ldev/kord/rest/service/EmojiService;JLjava/lang/String;Ldev/kord/rest/Image;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun deleteEmoji-Lfpyfds (JJLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteEmoji-Lfpyfds$default (Ldev/kord/rest/service/EmojiService;JJLjava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getEmoji-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getEmojis-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun modifyEmoji-Lfpyfds (JJLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class dev/kord/rest/service/GuildService : dev/kord/rest/service/RestService {
 	public fun <init> (Ldev/kord/rest/request/RequestHandler;)V
-	public final fun addGuildBan (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun addGuildMember (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun addRoleToGuildMember (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun addRoleToGuildMember$default (Ldev/kord/rest/service/GuildService;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun beginGuildPrune (Ldev/kord/common/entity/Snowflake;IZLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun beginGuildPrune$default (Ldev/kord/rest/service/GuildService;Ldev/kord/common/entity/Snowflake;IZLjava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun addGuildBan-Lfpyfds (JJLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun addGuildMember-CJS6HZA (JJLjava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun addRoleToGuildMember-duETn5c (JJJLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun addRoleToGuildMember-duETn5c$default (Ldev/kord/rest/service/GuildService;JJJLjava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun beginGuildPrune-PHjaIKs (JIZLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun beginGuildPrune-PHjaIKs$default (Ldev/kord/rest/service/GuildService;JIZLjava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun createGuild (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun createGuildChannel (Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/GuildChannelCreateRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun createGuildChannel$default (Ldev/kord/rest/service/GuildService;Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/GuildChannelCreateRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun createGuildIntegration (Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/GuildIntegrationCreateRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun createGuildRole (Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun createGuildRole$default (Ldev/kord/rest/service/GuildService;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun createScheduledEvent (Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/GuildScheduledEventCreateRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun createScheduledEvent$default (Ldev/kord/rest/service/GuildService;Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/GuildScheduledEventCreateRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun deleteGuild (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun deleteGuildBan (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun deleteGuildBan$default (Ldev/kord/rest/service/GuildService;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun deleteGuildIntegration (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun deleteGuildIntegration$default (Ldev/kord/rest/service/GuildService;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun deleteGuildMember (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun deleteGuildMember$default (Ldev/kord/rest/service/GuildService;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun deleteGuildRole (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun deleteGuildRole$default (Ldev/kord/rest/service/GuildService;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun deleteRoleFromGuildMember (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun deleteRoleFromGuildMember$default (Ldev/kord/rest/service/GuildService;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun deleteScheduledEvent (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuild (Ldev/kord/common/entity/Snowflake;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getGuild$default (Ldev/kord/rest/service/GuildService;Ldev/kord/common/entity/Snowflake;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun getGuildBan (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildBans (Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/route/Position$BeforeOrAfter;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getGuildBans$default (Ldev/kord/rest/service/GuildService;Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/route/Position$BeforeOrAfter;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun getGuildChannels (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildIntegrations (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildInvites (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildMember (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildMembers (Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/route/Position$After;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildMembers (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getGuildMembers$default (Ldev/kord/rest/service/GuildService;Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/route/Position$After;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static synthetic fun getGuildMembers$default (Ldev/kord/rest/service/GuildService;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun getGuildPreview (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildPruneCount (Ldev/kord/common/entity/Snowflake;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getGuildPruneCount$default (Ldev/kord/rest/service/GuildService;Ldev/kord/common/entity/Snowflake;ILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun getGuildRoles (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildVoiceRegions (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildWelcomeScreen (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildWidget (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getScheduledEvent (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getScheduledEventUsers (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/route/Position$BeforeOrAfter;Ljava/lang/Boolean;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getScheduledEventUsers$default (Ldev/kord/rest/service/GuildService;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/route/Position$BeforeOrAfter;Ljava/lang/Boolean;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun getScheduledEventUsersAfter (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Boolean;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getScheduledEventUsersAfter$default (Ldev/kord/rest/service/GuildService;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Boolean;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun getScheduledEventUsersBefore (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Boolean;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getScheduledEventUsersBefore$default (Ldev/kord/rest/service/GuildService;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Boolean;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun getVanityInvite (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun listActiveThreads (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun listScheduledEvents (Ldev/kord/common/entity/Snowflake;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun listScheduledEvents$default (Ldev/kord/rest/service/GuildService;Ldev/kord/common/entity/Snowflake;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun modifyCurrentUserNickname (Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/CurrentUserNicknameModifyRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun modifyCurrentUserNickname$default (Ldev/kord/rest/service/GuildService;Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/CurrentUserNicknameModifyRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun modifyCurrentVoiceState (Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/CurrentVoiceStateModifyRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun modifyGuild (Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun modifyGuildChannelPosition (Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun modifyGuildIntegration (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun modifyGuildMFALevel (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/MFALevel;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final synthetic fun modifyGuildMFALevel (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/MFALevel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun modifyGuildMFALevel$default (Ldev/kord/rest/service/GuildService;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/MFALevel;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun modifyGuildMember (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun modifyGuildRole (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun modifyGuildRolePosition (Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun modifyGuildWelcomeScreen (Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/GuildWelcomeScreenModifyRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun modifyGuildWelcomeScreen$default (Ldev/kord/rest/service/GuildService;Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/GuildWelcomeScreenModifyRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun modifyGuildWidget (Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/GuildWidgetModifyRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun modifyGuildWidget (Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun modifyGuildWidget$default (Ldev/kord/rest/service/GuildService;Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/GuildWidgetModifyRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun modifyScheduledEvent (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/ScheduledEventModifyRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun modifyScheduledEvent$default (Ldev/kord/rest/service/GuildService;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/ScheduledEventModifyRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun modifyVoiceState (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/VoiceStateModifyRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun syncGuildIntegration (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun createGuildChannel-9VmEaQQ (JLdev/kord/rest/json/request/GuildChannelCreateRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun createGuildChannel-9VmEaQQ$default (Ldev/kord/rest/service/GuildService;JLdev/kord/rest/json/request/GuildChannelCreateRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun createGuildIntegration-9y3P_48 (JLdev/kord/rest/json/request/GuildIntegrationCreateRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun createGuildRole-9y3P_48 (JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun createGuildRole-9y3P_48$default (Ldev/kord/rest/service/GuildService;JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun createScheduledEvent-9VmEaQQ (JLdev/kord/rest/json/request/GuildScheduledEventCreateRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun createScheduledEvent-9VmEaQQ$default (Ldev/kord/rest/service/GuildService;JLdev/kord/rest/json/request/GuildScheduledEventCreateRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun deleteGuild-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun deleteGuildBan-Lfpyfds (JJLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteGuildBan-Lfpyfds$default (Ldev/kord/rest/service/GuildService;JJLjava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun deleteGuildIntegration-Lfpyfds (JJLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteGuildIntegration-Lfpyfds$default (Ldev/kord/rest/service/GuildService;JJLjava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun deleteGuildMember-Lfpyfds (JJLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteGuildMember-Lfpyfds$default (Ldev/kord/rest/service/GuildService;JJLjava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun deleteGuildRole-Lfpyfds (JJLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteGuildRole-Lfpyfds$default (Ldev/kord/rest/service/GuildService;JJLjava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun deleteRoleFromGuildMember-duETn5c (JJJLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteRoleFromGuildMember-duETn5c$default (Ldev/kord/rest/service/GuildService;JJJLjava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun deleteScheduledEvent-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getGuild-9y3P_48 (JZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getGuild-9y3P_48$default (Ldev/kord/rest/service/GuildService;JZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getGuildBan-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getGuildBans-9VmEaQQ (JLdev/kord/rest/route/Position$BeforeOrAfter;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getGuildBans-9VmEaQQ$default (Ldev/kord/rest/service/GuildService;JLdev/kord/rest/route/Position$BeforeOrAfter;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getGuildChannels-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getGuildIntegrations-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getGuildInvites-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getGuildMember-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getGuildMembers-9VmEaQQ (JLdev/kord/rest/route/Position$After;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getGuildMembers-9VmEaQQ (JLjava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getGuildMembers-9VmEaQQ$default (Ldev/kord/rest/service/GuildService;JLdev/kord/rest/route/Position$After;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun getGuildMembers-9VmEaQQ$default (Ldev/kord/rest/service/GuildService;JLjava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getGuildPreview-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getGuildPruneCount-9y3P_48 (JILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getGuildPruneCount-9y3P_48$default (Ldev/kord/rest/service/GuildService;JILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getGuildRoles-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getGuildVoiceRegions-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getGuildWelcomeScreen-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getGuildWidget-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getScheduledEvent-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getScheduledEventUsers-huMQfDM (JJLdev/kord/rest/route/Position$BeforeOrAfter;Ljava/lang/Boolean;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getScheduledEventUsers-huMQfDM$default (Ldev/kord/rest/service/GuildService;JJLdev/kord/rest/route/Position$BeforeOrAfter;Ljava/lang/Boolean;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getScheduledEventUsersAfter-1Uz_rds (JJJLjava/lang/Boolean;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getScheduledEventUsersAfter-1Uz_rds$default (Ldev/kord/rest/service/GuildService;JJJLjava/lang/Boolean;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getScheduledEventUsersBefore-1Uz_rds (JJJLjava/lang/Boolean;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getScheduledEventUsersBefore-1Uz_rds$default (Ldev/kord/rest/service/GuildService;JJJLjava/lang/Boolean;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getVanityInvite-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun listActiveThreads-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun listScheduledEvents-9y3P_48 (JLjava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun listScheduledEvents-9y3P_48$default (Ldev/kord/rest/service/GuildService;JLjava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun modifyCurrentUserNickname-9VmEaQQ (JLdev/kord/rest/json/request/CurrentUserNicknameModifyRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun modifyCurrentUserNickname-9VmEaQQ$default (Ldev/kord/rest/service/GuildService;JLdev/kord/rest/json/request/CurrentUserNicknameModifyRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun modifyCurrentVoiceState-9y3P_48 (JLdev/kord/rest/json/request/CurrentVoiceStateModifyRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun modifyGuild-9y3P_48 (JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun modifyGuildChannelPosition-9y3P_48 (JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun modifyGuildIntegration-Lfpyfds (JJLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun modifyGuildMFALevel-9VmEaQQ (JLdev/kord/common/entity/MFALevel;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun modifyGuildMFALevel-9VmEaQQ$default (Ldev/kord/rest/service/GuildService;JLdev/kord/common/entity/MFALevel;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final synthetic fun modifyGuildMFALevel-9y3P_48 (JLdev/kord/common/entity/MFALevel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun modifyGuildMember-Lfpyfds (JJLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun modifyGuildRole-Lfpyfds (JJLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun modifyGuildRolePosition-9y3P_48 (JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun modifyGuildWelcomeScreen-9VmEaQQ (JLdev/kord/rest/json/request/GuildWelcomeScreenModifyRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun modifyGuildWelcomeScreen-9VmEaQQ$default (Ldev/kord/rest/service/GuildService;JLdev/kord/rest/json/request/GuildWelcomeScreenModifyRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun modifyGuildWidget-9VmEaQQ (JLdev/kord/rest/json/request/GuildWidgetModifyRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun modifyGuildWidget-9VmEaQQ$default (Ldev/kord/rest/service/GuildService;JLdev/kord/rest/json/request/GuildWidgetModifyRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun modifyGuildWidget-9y3P_48 (JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun modifyScheduledEvent-CJS6HZA (JJLdev/kord/rest/json/request/ScheduledEventModifyRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun modifyScheduledEvent-CJS6HZA$default (Ldev/kord/rest/service/GuildService;JJLdev/kord/rest/json/request/ScheduledEventModifyRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun modifyVoiceState-Lfpyfds (JJLdev/kord/rest/json/request/VoiceStateModifyRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun syncGuildIntegration-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class dev/kord/rest/service/GuildServiceKt {
-	public static final fun createCategory (Ldev/kord/rest/service/GuildService;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun createNewsChannel (Ldev/kord/rest/service/GuildService;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun createScheduledEvent (Ldev/kord/rest/service/GuildService;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/GuildScheduledEventPrivacyLevel;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/ScheduledEntityType;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun createScheduledEvent$default (Ldev/kord/rest/service/GuildService;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/GuildScheduledEventPrivacyLevel;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/ScheduledEntityType;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static final fun createTextChannel (Ldev/kord/rest/service/GuildService;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun createVoiceChannel (Ldev/kord/rest/service/GuildService;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun modifyCurrentVoiceState (Ldev/kord/rest/service/GuildService;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun modifyCurrentVoiceState (Ldev/kord/rest/service/GuildService;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun modifyGuildWelcomeScreen (Ldev/kord/rest/service/GuildService;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun modifyScheduledEvent (Ldev/kord/rest/service/GuildService;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun modifyVoiceState (Ldev/kord/rest/service/GuildService;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun createCategory-KRsW0wg (Ldev/kord/rest/service/GuildService;JLjava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun createNewsChannel-KRsW0wg (Ldev/kord/rest/service/GuildService;JLjava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun createScheduledEvent-HKDv9NQ (Ldev/kord/rest/service/GuildService;JLjava/lang/String;Ldev/kord/common/entity/GuildScheduledEventPrivacyLevel;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/ScheduledEntityType;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun createScheduledEvent-HKDv9NQ$default (Ldev/kord/rest/service/GuildService;JLjava/lang/String;Ldev/kord/common/entity/GuildScheduledEventPrivacyLevel;Lkotlinx/datetime/Instant;Ldev/kord/common/entity/ScheduledEntityType;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun createTextChannel-KRsW0wg (Ldev/kord/rest/service/GuildService;JLjava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun createVoiceChannel-KRsW0wg (Ldev/kord/rest/service/GuildService;JLjava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun modifyCurrentVoiceState-5-xQWJg (Ldev/kord/rest/service/GuildService;JJLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun modifyCurrentVoiceState-nMAJGj4 (Ldev/kord/rest/service/GuildService;JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun modifyGuildWelcomeScreen-nMAJGj4 (Ldev/kord/rest/service/GuildService;JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun modifyScheduledEvent-5-xQWJg (Ldev/kord/rest/service/GuildService;JJLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun modifyVoiceState-vnAI47A (Ldev/kord/rest/service/GuildService;JJJLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class dev/kord/rest/service/InteractionService : dev/kord/rest/service/RestService {
 	public fun <init> (Ldev/kord/rest/request/RequestHandler;)V
-	public final synthetic fun acknowledge (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun acknowledge$default (Ldev/kord/rest/service/InteractionService;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun createFollowupMessage (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/rest/json/request/MultipartFollowupMessageCreateRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun createFollowupMessage (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun createFollowupMessage$default (Ldev/kord/rest/service/InteractionService;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun createGlobalApplicationCommand (Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/ApplicationCommandCreateRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun createGlobalApplicationCommands (Ldev/kord/common/entity/Snowflake;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun createGlobalApplicationCommands (Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun createGlobalChatInputApplicationCommand (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun createGlobalChatInputApplicationCommand$default (Ldev/kord/rest/service/InteractionService;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun createGlobalMessageCommandApplicationCommand (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun createGlobalMessageCommandApplicationCommand$default (Ldev/kord/rest/service/InteractionService;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun createGlobalUserCommandApplicationCommand (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun createGlobalUserCommandApplicationCommand$default (Ldev/kord/rest/service/InteractionService;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun createGuildApplicationCommand (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/ApplicationCommandCreateRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun createGuildApplicationCommands (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun createGuildApplicationCommands (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun createGuildChatInputApplicationCommand (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun createGuildChatInputApplicationCommand$default (Ldev/kord/rest/service/InteractionService;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun createGuildMessageCommandApplicationCommand (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun createGuildMessageCommandApplicationCommand$default (Ldev/kord/rest/service/InteractionService;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun createGuildUserCommandApplicationCommand (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun createGuildUserCommandApplicationCommand$default (Ldev/kord/rest/service/InteractionService;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun createIntAutoCompleteInteractionResponse (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun createInteractionResponse (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/rest/json/request/InteractionResponseCreateRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun createInteractionResponse (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/rest/json/request/MultipartInteractionResponseCreateRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun createInteractionResponse (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun createInteractionResponse$default (Ldev/kord/rest/service/InteractionService;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun createModalInteractionResponse (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/DiscordModal;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun createModalInteractionResponse (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun createNumberAutoCompleteInteractionResponse (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun createStringAutoCompleteInteractionResponse (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun deferMessage (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun deferMessage$default (Ldev/kord/rest/service/InteractionService;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun deferMessageUpdate (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun deleteFollowupMessage (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun deleteGlobalApplicationCommand (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun deleteGuildApplicationCommand (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun deleteOriginalInteractionResponse (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getApplicationCommandPermissions (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getFollowupMessage (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGlobalApplicationCommands (Ldev/kord/common/entity/Snowflake;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getGlobalApplicationCommands$default (Ldev/kord/rest/service/InteractionService;Ldev/kord/common/entity/Snowflake;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun getGlobalCommand (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildApplicationCommandPermissions (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildApplicationCommands (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getGuildApplicationCommands$default (Ldev/kord/rest/service/InteractionService;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun getGuildCommand (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getInteractionResponse (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun modifyFollowupMessage (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/FollowupMessageModifyRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun modifyFollowupMessage (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/MultipartFollowupMessageModifyRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun modifyFollowupMessage (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun modifyFollowupMessage$default (Ldev/kord/rest/service/InteractionService;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun modifyGlobalApplicationCommand (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/ApplicationCommandModifyRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun modifyGlobalChatInputApplicationCommand (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun modifyGlobalMessageApplicationCommand (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun modifyGlobalUserApplicationCommand (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun modifyGuildApplicationCommand (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/ApplicationCommandModifyRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun modifyGuildChatInputApplicationCommand (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun modifyGuildMessageApplicationCommand (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun modifyGuildUserApplicationCommand (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun modifyInteractionResponse (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/rest/json/request/InteractionResponseModifyRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun modifyInteractionResponse (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/rest/json/request/MultipartInteractionResponseModifyRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun modifyInteractionResponse (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final synthetic fun acknowledge-9VmEaQQ (JLjava/lang/String;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun acknowledge-9VmEaQQ$default (Ldev/kord/rest/service/InteractionService;JLjava/lang/String;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun createFollowupMessage-9VmEaQQ (JLjava/lang/String;Ldev/kord/rest/json/request/MultipartFollowupMessageCreateRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun createFollowupMessage-PHjaIKs (JLjava/lang/String;ZLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun createFollowupMessage-PHjaIKs$default (Ldev/kord/rest/service/InteractionService;JLjava/lang/String;ZLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun createGlobalApplicationCommand-9y3P_48 (JLdev/kord/rest/json/request/ApplicationCommandCreateRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun createGlobalApplicationCommands-9y3P_48 (JLjava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun createGlobalApplicationCommands-9y3P_48 (JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun createGlobalChatInputApplicationCommand-PHjaIKs (JLjava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun createGlobalChatInputApplicationCommand-PHjaIKs$default (Ldev/kord/rest/service/InteractionService;JLjava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun createGlobalMessageCommandApplicationCommand-9VmEaQQ (JLjava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun createGlobalMessageCommandApplicationCommand-9VmEaQQ$default (Ldev/kord/rest/service/InteractionService;JLjava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun createGlobalUserCommandApplicationCommand-9VmEaQQ (JLjava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun createGlobalUserCommandApplicationCommand-9VmEaQQ$default (Ldev/kord/rest/service/InteractionService;JLjava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun createGuildApplicationCommand-Lfpyfds (JJLdev/kord/rest/json/request/ApplicationCommandCreateRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun createGuildApplicationCommands-Lfpyfds (JJLjava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun createGuildApplicationCommands-Lfpyfds (JJLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun createGuildChatInputApplicationCommand-huMQfDM (JJLjava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun createGuildChatInputApplicationCommand-huMQfDM$default (Ldev/kord/rest/service/InteractionService;JJLjava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun createGuildMessageCommandApplicationCommand-CJS6HZA (JJLjava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun createGuildMessageCommandApplicationCommand-CJS6HZA$default (Ldev/kord/rest/service/InteractionService;JJLjava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun createGuildUserCommandApplicationCommand-CJS6HZA (JJLjava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun createGuildUserCommandApplicationCommand-CJS6HZA$default (Ldev/kord/rest/service/InteractionService;JJLjava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun createIntAutoCompleteInteractionResponse-9VmEaQQ (JLjava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun createInteractionResponse-9VmEaQQ (JLjava/lang/String;Ldev/kord/rest/json/request/InteractionResponseCreateRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun createInteractionResponse-9VmEaQQ (JLjava/lang/String;Ldev/kord/rest/json/request/MultipartInteractionResponseCreateRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun createInteractionResponse-PHjaIKs (JLjava/lang/String;ZLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun createInteractionResponse-PHjaIKs$default (Ldev/kord/rest/service/InteractionService;JLjava/lang/String;ZLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun createModalInteractionResponse-9VmEaQQ (JLjava/lang/String;Ldev/kord/common/entity/DiscordModal;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun createModalInteractionResponse-vwSIg4A (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun createNumberAutoCompleteInteractionResponse-9VmEaQQ (JLjava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun createStringAutoCompleteInteractionResponse-9VmEaQQ (JLjava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun deferMessage-9VmEaQQ (JLjava/lang/String;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deferMessage-9VmEaQQ$default (Ldev/kord/rest/service/InteractionService;JLjava/lang/String;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun deferMessageUpdate-9y3P_48 (JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun deleteFollowupMessage-IFX1TXc (JLjava/lang/String;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun deleteGlobalApplicationCommand-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun deleteGuildApplicationCommand-SmFlTYk (JJJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun deleteOriginalInteractionResponse-9y3P_48 (JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getApplicationCommandPermissions-SmFlTYk (JJJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getFollowupMessage-IFX1TXc (JLjava/lang/String;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getGlobalApplicationCommands-9y3P_48 (JLjava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getGlobalApplicationCommands-9y3P_48$default (Ldev/kord/rest/service/InteractionService;JLjava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getGlobalCommand-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getGuildApplicationCommandPermissions-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getGuildApplicationCommands-Lfpyfds (JJLjava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getGuildApplicationCommands-Lfpyfds$default (Ldev/kord/rest/service/InteractionService;JJLjava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getGuildCommand-SmFlTYk (JJJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getInteractionResponse-9y3P_48 (JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun modifyFollowupMessage-AvpewP4 (JLjava/lang/String;JLdev/kord/rest/json/request/FollowupMessageModifyRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun modifyFollowupMessage-AvpewP4 (JLjava/lang/String;JLdev/kord/rest/json/request/MultipartFollowupMessageModifyRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun modifyFollowupMessage-AvpewP4 (JLjava/lang/String;JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun modifyFollowupMessage-AvpewP4$default (Ldev/kord/rest/service/InteractionService;JLjava/lang/String;JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun modifyGlobalApplicationCommand-Lfpyfds (JJLdev/kord/rest/json/request/ApplicationCommandModifyRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun modifyGlobalChatInputApplicationCommand-Lfpyfds (JJLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun modifyGlobalMessageApplicationCommand-Lfpyfds (JJLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun modifyGlobalUserApplicationCommand-Lfpyfds (JJLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun modifyGuildApplicationCommand-duETn5c (JJJLdev/kord/rest/json/request/ApplicationCommandModifyRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun modifyGuildChatInputApplicationCommand-duETn5c (JJJLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun modifyGuildMessageApplicationCommand-duETn5c (JJJLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun modifyGuildUserApplicationCommand-duETn5c (JJJLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun modifyInteractionResponse-9VmEaQQ (JLjava/lang/String;Ldev/kord/rest/json/request/InteractionResponseModifyRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun modifyInteractionResponse-9VmEaQQ (JLjava/lang/String;Ldev/kord/rest/json/request/MultipartInteractionResponseModifyRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun modifyInteractionResponse-9VmEaQQ (JLjava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class dev/kord/rest/service/InteractionServiceKt {
-	public static final fun interactionIdInteractionToken (Ldev/kord/rest/request/RequestBuilder;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;)V
+	public static final fun interactionIdInteractionToken-o5qqygM (Ldev/kord/rest/request/RequestBuilder;JLjava/lang/String;)V
 }
 
 public final class dev/kord/rest/service/InviteService : dev/kord/rest/service/RestService {
 	public fun <init> (Ldev/kord/rest/request/RequestHandler;)V
 	public final fun deleteInvite (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun deleteInvite$default (Ldev/kord/rest/service/InviteService;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun getInvite (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getInvite$default (Ldev/kord/rest/service/InviteService;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getInvite-ReOCJwE (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getInvite-ReOCJwE$default (Ldev/kord/rest/service/InviteService;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class dev/kord/rest/service/RestClient : dev/kord/rest/service/RestService {
@@ -6959,51 +7044,51 @@ public abstract class dev/kord/rest/service/RestService {
 
 public final class dev/kord/rest/service/StageInstanceService : dev/kord/rest/service/RestService {
 	public fun <init> (Ldev/kord/rest/request/RequestHandler;)V
-	public final fun createStageInstance (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun createStageInstance (Ldev/kord/rest/json/request/StageInstanceCreateRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun createStageInstance$default (Ldev/kord/rest/service/StageInstanceService;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun createStageInstance$default (Ldev/kord/rest/service/StageInstanceService;Ldev/kord/rest/json/request/StageInstanceCreateRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun deleteStageInstance (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun deleteStageInstance$default (Ldev/kord/rest/service/StageInstanceService;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun getStageInstance (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun modifyStageInstance (Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/StageInstanceModifyRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun modifyStageInstance (Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun modifyStageInstance$default (Ldev/kord/rest/service/StageInstanceService;Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/StageInstanceModifyRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final synthetic fun updateStageInstance (Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/StageInstanceUpdateRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun updateStageInstance$default (Ldev/kord/rest/service/StageInstanceService;Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/StageInstanceUpdateRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun createStageInstance-9VmEaQQ (JLjava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun createStageInstance-9VmEaQQ$default (Ldev/kord/rest/service/StageInstanceService;JLjava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun deleteStageInstance-9y3P_48 (JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteStageInstance-9y3P_48$default (Ldev/kord/rest/service/StageInstanceService;JLjava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getStageInstance-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun modifyStageInstance-9VmEaQQ (JLdev/kord/rest/json/request/StageInstanceModifyRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun modifyStageInstance-9VmEaQQ$default (Ldev/kord/rest/service/StageInstanceService;JLdev/kord/rest/json/request/StageInstanceModifyRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun modifyStageInstance-9y3P_48 (JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final synthetic fun updateStageInstance-9VmEaQQ (JLdev/kord/rest/json/request/StageInstanceUpdateRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun updateStageInstance-9VmEaQQ$default (Ldev/kord/rest/service/StageInstanceService;JLdev/kord/rest/json/request/StageInstanceUpdateRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class dev/kord/rest/service/StageInstanceServiceKt {
-	public static final synthetic fun createStageInstance (Ldev/kord/rest/service/StageInstanceService;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun createStageInstance$default (Ldev/kord/rest/service/StageInstanceService;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static final synthetic fun updateStageInstance (Ldev/kord/rest/service/StageInstanceService;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun updateStageInstance$default (Ldev/kord/rest/service/StageInstanceService;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final synthetic fun createStageInstance-KRsW0wg (Ldev/kord/rest/service/StageInstanceService;JLjava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun createStageInstance-KRsW0wg$default (Ldev/kord/rest/service/StageInstanceService;JLjava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final synthetic fun updateStageInstance-KRsW0wg (Ldev/kord/rest/service/StageInstanceService;JLjava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun updateStageInstance-KRsW0wg$default (Ldev/kord/rest/service/StageInstanceService;JLjava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class dev/kord/rest/service/StickerService : dev/kord/rest/service/RestService {
 	public fun <init> (Ldev/kord/rest/request/RequestHandler;)V
-	public final fun createGuildSticker (Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/MultipartGuildStickerCreateRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun deleteSticker (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildSticker (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildStickers (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun createGuildSticker-9y3P_48 (JLdev/kord/rest/json/request/MultipartGuildStickerCreateRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun deleteSticker-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getGuildSticker-U2evHYk (JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getGuildStickers-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getNitroStickerPacks (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getSticker (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun modifyGuildSticker (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/GuildStickerModifyRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun modifyGuildSticker (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getSticker-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun modifyGuildSticker-Lfpyfds (JJLdev/kord/rest/json/request/GuildStickerModifyRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun modifyGuildSticker-Lfpyfds (JJLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class dev/kord/rest/service/TemplateService : dev/kord/rest/service/RestService {
 	public fun <init> (Ldev/kord/rest/request/RequestHandler;)V
 	public final fun createGuildFromTemplate (Ljava/lang/String;Ldev/kord/rest/json/request/GuildFromTemplateCreateRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun createGuildFromTemplate (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun createGuildTemplate (Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/GuildTemplateCreateRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun createGuildTemplate (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun deleteGuildTemplate (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun createGuildTemplate-9VmEaQQ (JLjava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun createGuildTemplate-9y3P_48 (JLdev/kord/rest/json/request/GuildTemplateCreateRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun deleteGuildTemplate-9y3P_48 (JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getGuildTemplate (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildTemplates (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun modifyGuildTemplate (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/rest/json/request/GuildTemplateModifyRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun modifyGuildTemplate (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun syncGuildTemplate (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getGuildTemplates-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun modifyGuildTemplate-9VmEaQQ (JLjava/lang/String;Ldev/kord/rest/json/request/GuildTemplateModifyRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun modifyGuildTemplate-9VmEaQQ (JLjava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun syncGuildTemplate-9y3P_48 (JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class dev/kord/rest/service/UserService : dev/kord/rest/service/RestService {
@@ -7013,9 +7098,9 @@ public final class dev/kord/rest/service/UserService : dev/kord/rest/service/Res
 	public final fun getCurrentUser (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getCurrentUserGuilds (Ldev/kord/rest/route/Position$BeforeOrAfter;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getCurrentUserGuilds$default (Ldev/kord/rest/service/UserService;Ldev/kord/rest/route/Position$BeforeOrAfter;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun getUser (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getUser-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getUserConnections (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun leaveGuild (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun leaveGuild-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun modifyCurrentUser (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -7026,34 +7111,34 @@ public final class dev/kord/rest/service/VoiceService : dev/kord/rest/service/Re
 
 public final class dev/kord/rest/service/WebhookService : dev/kord/rest/service/RestService {
 	public fun <init> (Ldev/kord/rest/request/RequestHandler;)V
-	public final fun createWebhook (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun deleteWebhook (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun deleteWebhook$default (Ldev/kord/rest/service/WebhookService;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun deleteWebhookMessage (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun deleteWebhookMessage$default (Ldev/kord/rest/service/WebhookService;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun deleteWebhookWithToken (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun deleteWebhookWithToken$default (Ldev/kord/rest/service/WebhookService;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun editWebhookMessage (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun editWebhookMessage$default (Ldev/kord/rest/service/WebhookService;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun executeGithubWebhook (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/Boolean;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun executeGithubWebhook$default (Ldev/kord/rest/service/WebhookService;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/Boolean;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun executeSlackWebhook (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/Boolean;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun executeSlackWebhook$default (Ldev/kord/rest/service/WebhookService;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/Boolean;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun executeWebhook (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/Boolean;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun executeWebhook$default (Ldev/kord/rest/service/WebhookService;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/Boolean;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun getChannelWebhooks (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getGuildWebhooks (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getWebhook (Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getWebhookMessage (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getWebhookMessage$default (Ldev/kord/rest/service/WebhookService;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun getWebhookWithToken (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun modifyWebhook (Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun modifyWebhookWithToken (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun createWebhook-9VmEaQQ (JLjava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun deleteWebhook-9y3P_48 (JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteWebhook-9y3P_48$default (Ldev/kord/rest/service/WebhookService;JLjava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun deleteWebhookMessage-k9QPuOU (JLjava/lang/String;JLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteWebhookMessage-k9QPuOU$default (Ldev/kord/rest/service/WebhookService;JLjava/lang/String;JLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun deleteWebhookWithToken-9VmEaQQ (JLjava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteWebhookWithToken-9VmEaQQ$default (Ldev/kord/rest/service/WebhookService;JLjava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun editWebhookMessage-DaYwPxA (JLjava/lang/String;JLdev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun editWebhookMessage-DaYwPxA$default (Ldev/kord/rest/service/WebhookService;JLjava/lang/String;JLdev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun executeGithubWebhook-EF0f-hw (JLjava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/Boolean;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun executeGithubWebhook-EF0f-hw$default (Ldev/kord/rest/service/WebhookService;JLjava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/Boolean;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun executeSlackWebhook-EF0f-hw (JLjava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/Boolean;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun executeSlackWebhook-EF0f-hw$default (Ldev/kord/rest/service/WebhookService;JLjava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/Boolean;Ldev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun executeWebhook-qDtwSGI (JLjava/lang/String;Ljava/lang/Boolean;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun executeWebhook-qDtwSGI$default (Ldev/kord/rest/service/WebhookService;JLjava/lang/String;Ljava/lang/Boolean;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getChannelWebhooks-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getGuildWebhooks-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getWebhook-wYKCHeA (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getWebhookMessage-k9QPuOU (JLjava/lang/String;JLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getWebhookMessage-k9QPuOU$default (Ldev/kord/rest/service/WebhookService;JLjava/lang/String;JLdev/kord/common/entity/Snowflake;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getWebhookWithToken-9y3P_48 (JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun modifyWebhook-9y3P_48 (JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun modifyWebhookWithToken-9VmEaQQ (JLjava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class dev/kord/rest/service/WebhookServiceKt {
-	public static final fun webhookIdToken (Ldev/kord/rest/request/RequestBuilder;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;)V
-	public static final fun webhookIdTokenMessageIdThreadId (Ldev/kord/rest/request/RequestBuilder;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)V
-	public static final fun webhookIdTokenWaitThreadId (Ldev/kord/rest/request/RequestBuilder;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/Boolean;Ldev/kord/common/entity/Snowflake;)V
+	public static final fun webhookIdToken-o5qqygM (Ldev/kord/rest/request/RequestBuilder;JLjava/lang/String;)V
+	public static final fun webhookIdTokenMessageIdThreadId-f5OBm8s (Ldev/kord/rest/request/RequestBuilder;JLjava/lang/String;JLdev/kord/common/entity/Snowflake;)V
+	public static final fun webhookIdTokenWaitThreadId-Aiz6xR4 (Ldev/kord/rest/request/RequestBuilder;JLjava/lang/String;Ljava/lang/Boolean;Ldev/kord/common/entity/Snowflake;)V
 }
 

--- a/voice/api/voice.api
+++ b/voice/api/voice.api
@@ -207,6 +207,18 @@ public final class dev/kord/voice/EncryptionMode : java/lang/Enum {
 	public static fun values ()[Ldev/kord/voice/EncryptionMode;
 }
 
+public final class dev/kord/voice/EncryptionMode$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Ldev/kord/voice/EncryptionMode$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/kord/voice/EncryptionMode;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ldev/kord/voice/EncryptionMode;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
 public final class dev/kord/voice/EncryptionMode$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -293,43 +305,43 @@ public final class dev/kord/voice/VoiceConnection {
 	public final fun getVoiceGateway ()Ldev/kord/voice/gateway/VoiceGateway;
 	public final fun getVoiceGatewayConfiguration ()Ldev/kord/voice/gateway/VoiceGatewayConfiguration;
 	public final fun leave (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun move (Ldev/kord/common/entity/Snowflake;ZZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun move$default (Ldev/kord/voice/VoiceConnection;Ldev/kord/common/entity/Snowflake;ZZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun move-9VmEaQQ (JZZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun move-9VmEaQQ$default (Ldev/kord/voice/VoiceConnection;JZZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun setVoiceGatewayConfiguration (Ldev/kord/voice/gateway/VoiceGatewayConfiguration;)V
 	public final fun shutdown (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class dev/kord/voice/VoiceConnectionBuilder {
-	public fun <init> (Ldev/kord/gateway/Gateway;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;)V
+	public synthetic fun <init> (Ldev/kord/gateway/Gateway;JJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun audioProvider (Ldev/kord/voice/AudioProvider;)V
 	public final fun build (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun frameInterceptor (Ldev/kord/voice/FrameInterceptor;)V
 	public final fun getAudioProvider ()Ldev/kord/voice/AudioProvider;
 	public final fun getAudioSender ()Ldev/kord/voice/udp/AudioFrameSender;
-	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getChannelId-4_xYDEk ()J
 	public final fun getConnectionDetachDuration-UwyO8pc ()J
 	public final fun getFrameInterceptor ()Ldev/kord/voice/FrameInterceptor;
 	public final fun getGateway ()Ldev/kord/gateway/Gateway;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public final fun getNonceStrategy ()Ldev/kord/voice/encryption/strategies/NonceStrategy;
 	public final fun getReceiveVoice ()Z
 	public final fun getSelfDeaf ()Z
-	public final fun getSelfId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getSelfId-4_xYDEk ()J
 	public final fun getSelfMute ()Z
 	public final fun getStreams ()Ldev/kord/voice/streams/Streams;
 	public final fun getTimeout ()J
 	public final fun getUdpSocket ()Ldev/kord/voice/udp/VoiceUdpSocket;
 	public final fun setAudioProvider (Ldev/kord/voice/AudioProvider;)V
 	public final fun setAudioSender (Ldev/kord/voice/udp/AudioFrameSender;)V
-	public final fun setChannelId (Ldev/kord/common/entity/Snowflake;)V
+	public final fun setChannelId-IO-hELI (J)V
 	public final fun setConnectionDetachDuration-LRDsOJo (J)V
 	public final fun setFrameInterceptor (Ldev/kord/voice/FrameInterceptor;)V
 	public final fun setGateway (Ldev/kord/gateway/Gateway;)V
-	public final fun setGuildId (Ldev/kord/common/entity/Snowflake;)V
+	public final fun setGuildId-IO-hELI (J)V
 	public final fun setNonceStrategy (Ldev/kord/voice/encryption/strategies/NonceStrategy;)V
 	public final fun setReceiveVoice (Z)V
 	public final fun setSelfDeaf (Z)V
-	public final fun setSelfId (Ldev/kord/common/entity/Snowflake;)V
+	public final fun setSelfId-IO-hELI (J)V
 	public final fun setSelfMute (Z)V
 	public final fun setStreams (Ldev/kord/voice/streams/Streams;)V
 	public final fun setTimeout (J)V
@@ -338,23 +350,23 @@ public final class dev/kord/voice/VoiceConnectionBuilder {
 }
 
 public final class dev/kord/voice/VoiceConnectionData {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (JJLjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
+	public final fun component2-4_xYDEk ()J
 	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;)Ldev/kord/voice/VoiceConnectionData;
-	public static synthetic fun copy$default (Ldev/kord/voice/VoiceConnectionData;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;ILjava/lang/Object;)Ldev/kord/voice/VoiceConnectionData;
+	public final fun copy-U2evHYk (JJLjava/lang/String;)Ldev/kord/voice/VoiceConnectionData;
+	public static synthetic fun copy-U2evHYk$default (Ldev/kord/voice/VoiceConnectionData;JJLjava/lang/String;ILjava/lang/Object;)Ldev/kord/voice/VoiceConnectionData;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
-	public final fun getSelfId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
+	public final fun getSelfId-4_xYDEk ()J
 	public final fun getSessionId ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class dev/kord/voice/VoiceConnectionKt {
-	public static final fun VoiceConnection (Ldev/kord/gateway/Gateway;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun VoiceConnection$default (Ldev/kord/gateway/Gateway;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun VoiceConnection-vnAI47A (Ldev/kord/gateway/Gateway;JJJLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun VoiceConnection-vnAI47A$default (Ldev/kord/gateway/Gateway;JJJLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class dev/kord/voice/encryption/XSalsa20Poly1305Codec {
@@ -464,13 +476,13 @@ public final class dev/kord/voice/gateway/DefaultVoiceGateway : dev/kord/voice/g
 }
 
 public final class dev/kord/voice/gateway/DefaultVoiceGatewayBuilder {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;)V
+	public synthetic fun <init> (JJLjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun build ()Ldev/kord/voice/gateway/DefaultVoiceGateway;
 	public final fun getClient ()Lio/ktor/client/HttpClient;
 	public final fun getEventFlow ()Lkotlinx/coroutines/flow/MutableSharedFlow;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public final fun getReconnectRetry ()Ldev/kord/gateway/retry/Retry;
-	public final fun getSelfId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getSelfId-4_xYDEk ()J
 	public final fun getSessionId ()Ljava/lang/String;
 	public final fun setClient (Lio/ktor/client/HttpClient;)V
 	public final fun setEventFlow (Lkotlinx/coroutines/flow/MutableSharedFlow;)V
@@ -478,21 +490,21 @@ public final class dev/kord/voice/gateway/DefaultVoiceGatewayBuilder {
 }
 
 public final class dev/kord/voice/gateway/DefaultVoiceGatewayData {
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lio/ktor/client/HttpClient;Ldev/kord/gateway/retry/Retry;Lkotlinx/coroutines/flow/MutableSharedFlow;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (JJLjava/lang/String;Lio/ktor/client/HttpClient;Ldev/kord/gateway/retry/Retry;Lkotlinx/coroutines/flow/MutableSharedFlow;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
+	public final fun component2-4_xYDEk ()J
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Lio/ktor/client/HttpClient;
 	public final fun component5 ()Ldev/kord/gateway/retry/Retry;
 	public final fun component6 ()Lkotlinx/coroutines/flow/MutableSharedFlow;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lio/ktor/client/HttpClient;Ldev/kord/gateway/retry/Retry;Lkotlinx/coroutines/flow/MutableSharedFlow;)Ldev/kord/voice/gateway/DefaultVoiceGatewayData;
-	public static synthetic fun copy$default (Ldev/kord/voice/gateway/DefaultVoiceGatewayData;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lio/ktor/client/HttpClient;Ldev/kord/gateway/retry/Retry;Lkotlinx/coroutines/flow/MutableSharedFlow;ILjava/lang/Object;)Ldev/kord/voice/gateway/DefaultVoiceGatewayData;
+	public final fun copy-huMQfDM (JJLjava/lang/String;Lio/ktor/client/HttpClient;Ldev/kord/gateway/retry/Retry;Lkotlinx/coroutines/flow/MutableSharedFlow;)Ldev/kord/voice/gateway/DefaultVoiceGatewayData;
+	public static synthetic fun copy-huMQfDM$default (Ldev/kord/voice/gateway/DefaultVoiceGatewayData;JJLjava/lang/String;Lio/ktor/client/HttpClient;Ldev/kord/gateway/retry/Retry;Lkotlinx/coroutines/flow/MutableSharedFlow;ILjava/lang/Object;)Ldev/kord/voice/gateway/DefaultVoiceGatewayData;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getClient ()Lio/ktor/client/HttpClient;
 	public final fun getEventFlow ()Lkotlinx/coroutines/flow/MutableSharedFlow;
-	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildId-4_xYDEk ()J
 	public final fun getReconnectRetry ()Ldev/kord/gateway/retry/Retry;
-	public final fun getSelfId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getSelfId-4_xYDEk ()J
 	public final fun getSessionId ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -592,19 +604,19 @@ public final class dev/kord/voice/gateway/Hello$Companion {
 
 public final class dev/kord/voice/gateway/Identify : dev/kord/voice/gateway/Command {
 	public static final field Companion Ldev/kord/voice/gateway/Identify$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
-	public final fun component2 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLjava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
+	public final fun component2-4_xYDEk ()J
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;)Ldev/kord/voice/gateway/Identify;
-	public static synthetic fun copy$default (Ldev/kord/voice/gateway/Identify;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ldev/kord/voice/gateway/Identify;
+	public final fun copy-Lfpyfds (JJLjava/lang/String;Ljava/lang/String;)Ldev/kord/voice/gateway/Identify;
+	public static synthetic fun copy-Lfpyfds$default (Ldev/kord/voice/gateway/Identify;JJLjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ldev/kord/voice/gateway/Identify;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getServerId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getServerId-4_xYDEk ()J
 	public final fun getSessionId ()Ljava/lang/String;
 	public final fun getToken ()Ljava/lang/String;
-	public final fun getUserId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getUserId-4_xYDEk ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public static final fun write$Self (Ldev/kord/voice/gateway/Identify;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
@@ -682,15 +694,15 @@ public final class dev/kord/voice/gateway/Ready$Companion {
 
 public final class dev/kord/voice/gateway/Resume : dev/kord/voice/gateway/Command {
 	public static final field Companion Ldev/kord/voice/gateway/Resume$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;)Ldev/kord/voice/gateway/Resume;
-	public static synthetic fun copy$default (Ldev/kord/voice/gateway/Resume;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ldev/kord/voice/gateway/Resume;
+	public final fun copy-9y3P_48 (JLjava/lang/String;Ljava/lang/String;)Ldev/kord/voice/gateway/Resume;
+	public static synthetic fun copy-9y3P_48$default (Ldev/kord/voice/gateway/Resume;JLjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ldev/kord/voice/gateway/Resume;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getServerId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getServerId-4_xYDEk ()J
 	public final fun getSessionId ()Ljava/lang/String;
 	public final fun getToken ()Ljava/lang/String;
 	public fun hashCode ()I
@@ -854,16 +866,16 @@ public final class dev/kord/voice/gateway/SessionDescription$Companion {
 public final class dev/kord/voice/gateway/Speaking : dev/kord/voice/gateway/VoiceEvent {
 	public static final field Companion Ldev/kord/voice/gateway/Speaking$Companion;
 	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Lkotlin/UInt;Ldev/kord/voice/SpeakingFlags;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;ILdev/kord/voice/SpeakingFlags;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public synthetic fun <init> (JILdev/kord/voice/SpeakingFlags;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4_xYDEk ()J
 	public final fun component2-pVg5ArA ()I
 	public final fun component3 ()Ldev/kord/voice/SpeakingFlags;
-	public final fun copy-OsBMiQA (Ldev/kord/common/entity/Snowflake;ILdev/kord/voice/SpeakingFlags;)Ldev/kord/voice/gateway/Speaking;
-	public static synthetic fun copy-OsBMiQA$default (Ldev/kord/voice/gateway/Speaking;Ldev/kord/common/entity/Snowflake;ILdev/kord/voice/SpeakingFlags;ILjava/lang/Object;)Ldev/kord/voice/gateway/Speaking;
+	public final fun copy-jfKTBeE (JILdev/kord/voice/SpeakingFlags;)Ldev/kord/voice/gateway/Speaking;
+	public static synthetic fun copy-jfKTBeE$default (Ldev/kord/voice/gateway/Speaking;JILdev/kord/voice/SpeakingFlags;ILjava/lang/Object;)Ldev/kord/voice/gateway/Speaking;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getSpeaking ()Ldev/kord/voice/SpeakingFlags;
 	public final fun getSsrc-pVg5ArA ()I
-	public final fun getUserId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getUserId-4_xYDEk ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public static final fun write$Self (Ldev/kord/voice/gateway/Speaking;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V


### PR DESCRIPTION
Changes Snowflakes to be `value class` to reduce their memory footprint.

I know that this PR *probably* won't be merged because it is a huge binary change, so it would break everything. Anyhow, this PR is here so other users can implement this change in their own Kord fork, if they need it.

Related to #711

Sadly the constructor can't have `value.coerceIn(validValues)`, and we can't use a `interface` to "hide" the value class behind a `SnowflakeImpl` because, if you use interfaces, the class will be boxed. The failing tests are related to the missing `coerceIn` call.