### PR TITLE
Fix deprecation propagation for new select menus

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -8703,12 +8703,16 @@ public class dev/kord/core/entity/component/SelectMenuComponent : dev/kord/core/
 	public final fun getDisabled ()Z
 	public final fun getMaxValues ()I
 	public final fun getMinValues ()I
-	public fun getOptions ()Ljava/util/List;
+	public final fun getOptions ()Ljava/util/List;
 	public final fun getPlaceholder ()Ljava/lang/String;
 	public synthetic fun getType ()Ldev/kord/common/entity/ComponentType$SelectMenu;
 	public fun getType ()Ldev/kord/common/entity/ComponentType;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/kord/core/entity/component/SelectMenuComponentKt {
+	public static final fun getOptions (Ldev/kord/core/entity/component/StringSelectComponent;)Ljava/util/List;
 }
 
 public final class dev/kord/core/entity/component/SelectOption {
@@ -8726,7 +8730,6 @@ public final class dev/kord/core/entity/component/SelectOption {
 
 public final class dev/kord/core/entity/component/StringSelectComponent : dev/kord/core/entity/component/SelectMenuComponent {
 	public fun <init> (Ldev/kord/core/cache/data/ComponentData;)V
-	public fun getOptions ()Ljava/util/List;
 	public fun getType ()Ldev/kord/common/entity/ComponentType$StringSelect;
 	public synthetic fun getType ()Ldev/kord/common/entity/ComponentType;
 }

--- a/core/src/main/kotlin/entity/component/SelectMenuComponent.kt
+++ b/core/src/main/kotlin/entity/component/SelectMenuComponent.kt
@@ -48,10 +48,14 @@ public constructor(override val data: ComponentData) : Component {
         ReplaceWith(
             "(this as? StringSelectComponent)?.options ?: emptyList()",
             "dev.kord.core.entity.component.StringSelectComponent",
+            "dev.kord.core.entity.component.options",
         ),
         level = DeprecationLevel.WARNING,
     )
-    public open val options: List<SelectOption> get() = data.options.orEmpty().map { SelectOption(it) }
+    public val options: List<SelectOption> get() = _options
+
+    @Suppress("PropertyName")
+    internal val _options get() = data.options.orEmpty().map { SelectOption(it) }
 
     /**
      * The minimum amount of options that can be chosen, default `1`.
@@ -83,13 +87,12 @@ public constructor(override val data: ComponentData) : Component {
 
 public class StringSelectComponent(data: ComponentData) : SelectMenuComponent(data) {
     override val type: ComponentType.StringSelect get() = ComponentType.StringSelect
-
-    /**
-     * The possible options to choose from.
-     */
-    @Suppress("OVERRIDE_DEPRECATION")
-    public override val options: List<SelectOption> get() = data.options.orEmpty().map { SelectOption(it) }
 }
+
+// TODO replace with member in StringSelectComponent when SelectMenuComponent.options is removed
+/** The possible options to choose from. */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+public val StringSelectComponent.options: List<SelectOption> get() = _options
 
 public class UserSelectComponent(data: ComponentData) : SelectMenuComponent(data) {
     override val type: ComponentType.UserSelect get() = ComponentType.UserSelect

--- a/rest/api/rest.api
+++ b/rest/api/rest.api
@@ -781,7 +781,7 @@ public class dev/kord/rest/builder/component/SelectMenuBuilder : dev/kord/rest/b
 	protected fun buildOptions ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getAllowedValues ()Lkotlin/ranges/ClosedRange;
 	public final fun getCustomId ()Ljava/lang/String;
-	public fun getOptions ()Ljava/util/List;
+	public final fun getOptions ()Ljava/util/List;
 	public final fun getPlaceholder ()Ljava/lang/String;
 	protected fun getType ()Ldev/kord/common/entity/ComponentType;
 	public final fun option (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
@@ -793,8 +793,10 @@ public class dev/kord/rest/builder/component/SelectMenuBuilder : dev/kord/rest/b
 
 public final class dev/kord/rest/builder/component/SelectMenuBuilderKt {
 	public static final fun channelType (Ldev/kord/rest/builder/component/ChannelSelectBuilder;Ldev/kord/common/entity/ChannelType;)V
+	public static final fun getOptions (Ldev/kord/rest/builder/component/StringSelectBuilder;)Ljava/util/List;
 	public static final fun option (Ldev/kord/rest/builder/component/StringSelectBuilder;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public static synthetic fun option$default (Ldev/kord/rest/builder/component/StringSelectBuilder;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun setOptions (Ldev/kord/rest/builder/component/StringSelectBuilder;Ljava/util/List;)V
 }
 
 public final class dev/kord/rest/builder/component/SelectOptionBuilder {
@@ -814,8 +816,6 @@ public final class dev/kord/rest/builder/component/SelectOptionBuilder {
 
 public final class dev/kord/rest/builder/component/StringSelectBuilder : dev/kord/rest/builder/component/SelectMenuBuilder {
 	public fun <init> (Ljava/lang/String;)V
-	public fun getOptions ()Ljava/util/List;
-	public fun setOptions (Ljava/util/List;)V
 }
 
 public final class dev/kord/rest/builder/component/TextInputBuilder : dev/kord/rest/builder/component/ActionRowComponentBuilder {

--- a/rest/src/main/kotlin/builder/component/SelectMenuBuilder.kt
+++ b/rest/src/main/kotlin/builder/component/SelectMenuBuilder.kt
@@ -39,10 +39,16 @@ public constructor(public var customId: String) : ActionRowComponentBuilder() {
         ReplaceWith(
             "(this as? StringSelectBuilder)?.options ?: mutableListOf()",
             "dev.kord.rest.builder.component.StringSelectBuilder",
+            "dev.kord.rest.builder.component.options",
         ),
         level = DeprecationLevel.WARNING,
     )
-    public open val options: MutableList<SelectOptionBuilder> = mutableListOf()
+    @Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE")
+    @kotlin.internal.LowPriorityInOverloadResolution
+    public val options: MutableList<SelectOptionBuilder> get() = _options
+
+    @Suppress("PropertyName")
+    internal var _options = mutableListOf<SelectOptionBuilder>()
 
     /**
      * The range of values that can be accepted. Accepts any range between [0,25].
@@ -110,14 +116,17 @@ public constructor(public var customId: String) : ActionRowComponentBuilder() {
 public class StringSelectBuilder(customId: String) : SelectMenuBuilder(customId) {
     override val type: ComponentType get() = ComponentType.StringSelect
 
-    /**
-     * The choices in the select, max 25.
-     */
-    @Suppress("OVERRIDE_DEPRECATION")
-    override var options: MutableList<SelectOptionBuilder> = mutableListOf()
-
     override fun buildOptions(): Optional<List<DiscordSelectOption>> = Optional(options.map { it.build() })
 }
+
+// TODO replace with member in StringSelectBuilder when SelectMenuBuilder.options is removed
+/** The choices in the select, max 25. */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+public var StringSelectBuilder.options: MutableList<SelectOptionBuilder>
+    get() = _options
+    set(value) {
+        _options = value
+    }
 
 /**
  * Adds a new option to the select menu with the given [label] and [value] that can be configured by the [builder].


### PR DESCRIPTION
The deprecations for `SelectMenuBuilder.options` and `SelectMenuComponent.options` were propagated to the overrides in `StringSelectBuilder` and `StringSelectComponent` when a user of Kord didn't have progressive mode enabled.

To fix this, extensions are provided instead.

The changes in the public API are binary incompatible compared to #707 but not compared to 0.8.0-M17 so only snapshot users can be affected.

see #707, https://youtrack.jetbrains.com/issue/KT-47902 and https://discord.com/channels/556525343595298817/587324906702766226/1042799716745879643