### PR TITLE
Deprecate `getGuild()` functions that call `getGuildOrNull()` under the hood

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -11025,6 +11025,7 @@ public final class dev/kord/core/event/channel/TypingStartEvent : dev/kord/core/
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public fun getShard ()I
 	public final fun getStarted ()Lkotlinx/datetime/Instant;
@@ -12452,6 +12453,7 @@ public final class dev/kord/core/event/message/MessageBulkDeleteEvent : dev/kord
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getMessageIds ()Ljava/util/Set;
 	public final fun getMessages ()Ljava/util/Set;
@@ -12469,6 +12471,7 @@ public final class dev/kord/core/event/message/MessageCreateEvent : dev/kord/cor
 	public fun getGateway ()Ldev/kord/gateway/Gateway;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getMember ()Ldev/kord/core/entity/Member;
 	public final fun getMessage ()Ldev/kord/core/entity/Message;
@@ -12491,6 +12494,7 @@ public final class dev/kord/core/event/message/MessageDeleteEvent : dev/kord/cor
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getMessage ()Ldev/kord/core/entity/Message;
 	public final fun getMessageId ()Ldev/kord/common/entity/Snowflake;
@@ -12535,6 +12539,7 @@ public final class dev/kord/core/event/message/ReactionAddEvent : dev/kord/core/
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getMessage ()Ldev/kord/core/behavior/MessageBehavior;
 	public final fun getMessage (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -12565,6 +12570,7 @@ public final class dev/kord/core/event/message/ReactionRemoveAllEvent : dev/kord
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getMessage ()Ldev/kord/core/behavior/MessageBehavior;
 	public final fun getMessage (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -12617,6 +12623,7 @@ public final class dev/kord/core/event/message/ReactionRemoveEvent : dev/kord/co
 	public final fun getGuild ()Ldev/kord/core/behavior/GuildBehavior;
 	public final fun getGuild (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getKord ()Ldev/kord/core/Kord;
 	public final fun getMessage ()Ldev/kord/core/behavior/MessageBehavior;
 	public final fun getMessage (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/core/src/main/kotlin/event/channel/TypingStartEvent.kt
+++ b/core/src/main/kotlin/event/channel/TypingStartEvent.kt
@@ -79,7 +79,20 @@ public class TypingStartEvent(
      *
      * @throws [RequestException] if anything went wrong during the request.
      */
+    @Deprecated(
+        "Deprecated in favour of getGuildOrNull() as it provides more clarity over the functionality",
+        ReplaceWith("getGuildOrNull()"),
+        DeprecationLevel.WARNING
+    )
     public suspend fun getGuild(): Guild? = guildId?.let { supplier.getGuildOrNull(it) }
+
+    /**
+     * Requests to get the guild this event was triggered in,
+     * returns null if the [Guild] isn't present.
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     */
+    public suspend fun getGuildOrNull(): Guild? = guildId?.let { supplier.getGuildOrNull(it) }
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): TypingStartEvent =
         TypingStartEvent(data, kord, shard, customContext, strategy.supply(kord))

--- a/core/src/main/kotlin/event/message/MessageBulkDeleteEvent.kt
+++ b/core/src/main/kotlin/event/message/MessageBulkDeleteEvent.kt
@@ -33,7 +33,14 @@ public class MessageBulkDeleteEvent(
 
     public suspend fun getChannelOrNull(): MessageChannel? = supplier.getChannelOfOrNull(channelId)
 
+    @Deprecated(
+        "Deprecated in favour of getGuildOrNull() as it provides more clarity over the functionality",
+        ReplaceWith("getGuildOrNull()"),
+        DeprecationLevel.WARNING
+    )
     public suspend fun getGuild(): Guild? = guildId?.let { supplier.getGuildOrNull(it) }
+
+    public suspend fun getGuildOrNull(): Guild? = guildId?.let { supplier.getGuildOrNull(it) }
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): MessageBulkDeleteEvent =
         MessageBulkDeleteEvent(messageIds, messages, channelId, guildId, kord, shard, customContext, strategy.supply(kord))

--- a/core/src/main/kotlin/event/message/MessageCreateEvent.kt
+++ b/core/src/main/kotlin/event/message/MessageCreateEvent.kt
@@ -28,7 +28,14 @@ public class MessageCreateEvent(
      *
      * @throws [RequestException] if anything went wrong during the request.
      */
+    @Deprecated(
+        "Deprecated in favour of getGuildOrNull() as it provides more clarity over the functionality",
+        ReplaceWith("getGuildOrNull()"),
+        DeprecationLevel.WARNING
+    )
     public suspend fun getGuild(): Guild? = guildId?.let { supplier.getGuildOrNull(it) }
+
+    public suspend fun getGuildOrNull(): Guild? = guildId?.let { supplier.getGuildOrNull(it) }
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): MessageCreateEvent =
         MessageCreateEvent(message, guildId, member, shard, customContext, strategy.supply(message.kord))

--- a/core/src/main/kotlin/event/message/MessageCreateEvent.kt
+++ b/core/src/main/kotlin/event/message/MessageCreateEvent.kt
@@ -35,6 +35,12 @@ public class MessageCreateEvent(
     )
     public suspend fun getGuild(): Guild? = guildId?.let { supplier.getGuildOrNull(it) }
 
+    /**
+     * Requests to get the guild this message was created in, if it was created in one,
+     * returns null if the [Guild] isn't present or the message was a [DM][DmChannel].
+     *
+     * @throws [RequestException] if anything went wrong during the request.
+     */
     public suspend fun getGuildOrNull(): Guild? = guildId?.let { supplier.getGuildOrNull(it) }
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): MessageCreateEvent =

--- a/core/src/main/kotlin/event/message/MessageDeleteEvent.kt
+++ b/core/src/main/kotlin/event/message/MessageDeleteEvent.kt
@@ -33,7 +33,14 @@ public class MessageDeleteEvent(
 
     public suspend fun getChannelOrNull(): MessageChannel? = supplier.getChannelOfOrNull(channelId)
 
+    @Deprecated(
+        "Deprecated in favour of getGuildOrNull() as it provides more clarity over the functionality",
+        ReplaceWith("getGuildOrNull()"),
+        DeprecationLevel.WARNING
+    )
     public suspend fun getGuild(): Guild? = guildId?.let { supplier.getGuildOrNull(it) }
+
+    public suspend fun getGuildOrNull(): Guild? = guildId?.let { supplier.getGuildOrNull(it) }
 
     override fun withStrategy(strategy: EntitySupplyStrategy<*>): MessageDeleteEvent =
         MessageDeleteEvent(messageId, channelId, guildId, message, kord, shard, customContext, strategy.supply(kord))

--- a/core/src/main/kotlin/event/message/ReactionAddEvent.kt
+++ b/core/src/main/kotlin/event/message/ReactionAddEvent.kt
@@ -41,7 +41,14 @@ public class ReactionAddEvent(
 
     public suspend fun getChannelOrNull(): MessageChannel? = supplier.getChannelOfOrNull(channelId)
 
+    @Deprecated(
+        "Deprecated in favour of getGuildOrNull() as it provides more clarity over the functionality",
+        ReplaceWith("getGuildOrNull()"),
+        DeprecationLevel.WARNING
+    )
     public suspend fun getGuild(): Guild? = guildId?.let { supplier.getGuildOrNull(it) }
+
+    public suspend fun getGuildOrNull(): Guild? = guildId?.let { supplier.getGuildOrNull(it) }
 
     public suspend fun getMessage(): Message = supplier.getMessage(channelId = channelId, messageId = messageId)
     public suspend fun getMessageOrNull(): Message? = supplier.getMessageOrNull(channelId = channelId, messageId = messageId)

--- a/core/src/main/kotlin/event/message/ReactionRemoveAllEvent.kt
+++ b/core/src/main/kotlin/event/message/ReactionRemoveAllEvent.kt
@@ -34,7 +34,14 @@ public class ReactionRemoveAllEvent(
     public suspend fun getChannel(): MessageChannel = supplier.getChannelOf(channelId)
     public suspend fun getChannelOrNull(): MessageChannel? = supplier.getChannelOfOrNull(channelId)
 
+    @Deprecated(
+        "Deprecated in favour of getGuildOrNull() as it provides more clarity over the functionality",
+        ReplaceWith("getGuildOrNull()"),
+        DeprecationLevel.WARNING
+    )
     public suspend fun getGuild(): Guild? = guildId?.let { supplier.getGuildOrNull(it) }
+
+    public suspend fun getGuildOrNull(): Guild? = guildId?.let { supplier.getGuildOrNull(it) }
 
     public suspend fun getMessage(): Message = supplier.getMessage(channelId = channelId, messageId = messageId)
     public suspend fun getMessageOrNull(): Message? = supplier.getMessageOrNull(channelId = channelId, messageId = messageId)

--- a/core/src/main/kotlin/event/message/ReactionRemoveEvent.kt
+++ b/core/src/main/kotlin/event/message/ReactionRemoveEvent.kt
@@ -41,7 +41,14 @@ public class ReactionRemoveEvent(
 
     public suspend fun getChannelOrNull(): MessageChannel? = supplier.getChannelOfOrNull(channelId)
 
+    @Deprecated(
+        "Deprecated in favour of getGuildOrNull() as it provides more clarity over the functionality",
+        ReplaceWith("getGuildOrNull()"),
+        DeprecationLevel.WARNING
+    )
     public suspend fun getGuild(): Guild? = guildId?.let { supplier.getGuildOrNull(it) }
+
+    public suspend fun getGuildOrNull(): Guild? = guildId?.let { supplier.getGuildOrNull(it) }
 
     public suspend fun getMessage(): Message = supplier.getMessage(channelId = channelId, messageId = messageId)
 


### PR DESCRIPTION
Replaces them with appropriately named variants that do the same thing