### PR TITLE
Add `KeywordAutoModerationRule.allowedKeywords`

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -7526,6 +7526,7 @@ public final class dev/kord/core/entity/automoderation/KeywordAutoModerationRule
 	public fun <init> (Ldev/kord/core/cache/data/AutoModerationRuleData;Ldev/kord/core/Kord;Ldev/kord/core/supplier/EntitySupplier;)V
 	public fun asAutoModerationRule (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun asAutoModerationRuleOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getAllowedKeywords ()Ljava/util/List;
 	public final fun getKeywords ()Ljava/util/List;
 	public final fun getRegexPatterns ()Ljava/util/List;
 	public fun getTriggerType ()Ldev/kord/common/entity/AutoModerationRuleTriggerType$Keyword;

--- a/core/src/main/kotlin/entity/automoderation/AutoModerationRule.kt
+++ b/core/src/main/kotlin/entity/automoderation/AutoModerationRule.kt
@@ -121,9 +121,9 @@ public class KeywordAutoModerationRule(data: AutoModerationRuleData, kord: Kord,
     /**
      * Substrings which will be searched for in content.
      *
-     * A keyword can be a phrase which contains multiple words. Wildcard symbols can be used to customize how each
-     * keyword will be matched. See
-     * [keyword matching strategies](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-keyword-matching-strategies).
+     * A keyword can be a phrase which contains multiple words.
+     * [Wildcard symbols](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-keyword-matching-strategies)
+     * can be used to customize how each keyword will be matched.
      */
     public val keywords: List<String> get() = data.triggerMetadata.keywordFilter.orEmpty()
 
@@ -133,6 +133,15 @@ public class KeywordAutoModerationRule(data: AutoModerationRuleData, kord: Kord,
      * Only Rust flavored regex is currently supported.
      */
     public val regexPatterns: List<String> get() = data.triggerMetadata.regexPatterns.orEmpty()
+
+    /**
+     * Substrings which should not trigger the rule.
+     *
+     * A keyword can be a phrase which contains multiple words.
+     * [Wildcard symbols](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-keyword-matching-strategies)
+     * can be used to customize how each keyword will be matched.
+     */
+    public val allowedKeywords: List<String> get() = data.triggerMetadata.allowList.orEmpty()
 
     override suspend fun asAutoModerationRuleOrNull(): KeywordAutoModerationRule = this
     override suspend fun asAutoModerationRule(): KeywordAutoModerationRule = this
@@ -166,9 +175,11 @@ public class KeywordPresetAutoModerationRule(data: AutoModerationRuleData, kord:
     public val presets: List<AutoModerationRuleKeywordPresetType> get() = data.triggerMetadata.presets.orEmpty()
 
     /**
-     * Substrings which will be exempt from triggering the [presets].
+     * Substrings which should not trigger the rule.
      *
      * A keyword can be a phrase which contains multiple words.
+     * [Wildcard symbols](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-keyword-matching-strategies)
+     * can be used to customize how each keyword will be matched.
      */
     public val allowedKeywords: List<String> get() = data.triggerMetadata.allowList.orEmpty()
 

--- a/rest/api/rest.api
+++ b/rest/api/rest.api
@@ -95,6 +95,11 @@ public final class dev/kord/rest/builder/auditlog/AuditLogGetRequestBuilder : de
 	public synthetic fun toRequest ()Ljava/lang/Object;
 }
 
+public abstract interface class dev/kord/rest/builder/automoderation/AllowedKeywordsAutoModerationRuleBuilder : dev/kord/rest/builder/automoderation/TypedAutoModerationRuleBuilder {
+	public abstract fun getAllowedKeywords ()Ljava/util/List;
+	public abstract fun setAllowedKeywords (Ljava/util/List;)V
+}
+
 public abstract class dev/kord/rest/builder/automoderation/AutoModerationActionBuilder : dev/kord/rest/builder/RequestBuilder {
 	protected fun buildMetadata ()Ldev/kord/common/entity/optional/Optional;
 	public abstract fun getType ()Ldev/kord/common/entity/AutoModerationActionType;
@@ -119,7 +124,11 @@ public abstract interface class dev/kord/rest/builder/automoderation/AutoModerat
 }
 
 public final class dev/kord/rest/builder/automoderation/AutoModerationRuleBuilderKt {
-	public static final fun allowKeyword (Ldev/kord/rest/builder/automoderation/KeywordPresetAutoModerationRuleBuilder;Ljava/lang/String;)V
+	public static final fun allowAnywhereKeyword (Ldev/kord/rest/builder/automoderation/AllowedKeywordsAutoModerationRuleBuilder;Ljava/lang/String;)V
+	public static final fun allowKeyword (Ldev/kord/rest/builder/automoderation/AllowedKeywordsAutoModerationRuleBuilder;Ljava/lang/String;)V
+	public static final synthetic fun allowKeyword (Ldev/kord/rest/builder/automoderation/KeywordPresetAutoModerationRuleBuilder;Ljava/lang/String;)V
+	public static final fun allowPrefixKeyword (Ldev/kord/rest/builder/automoderation/AllowedKeywordsAutoModerationRuleBuilder;Ljava/lang/String;)V
+	public static final fun allowSuffixKeyword (Ldev/kord/rest/builder/automoderation/AllowedKeywordsAutoModerationRuleBuilder;Ljava/lang/String;)V
 	public static final fun anywhereKeyword (Ldev/kord/rest/builder/automoderation/KeywordAutoModerationRuleBuilder;Ljava/lang/String;)V
 	public static final fun blockMessage (Ldev/kord/rest/builder/automoderation/AutoModerationRuleBuilder;Lkotlin/jvm/functions/Function1;)V
 	public static synthetic fun blockMessage$default (Ldev/kord/rest/builder/automoderation/AutoModerationRuleBuilder;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
@@ -189,7 +198,7 @@ public final class dev/kord/rest/builder/automoderation/BlockMessageAutoModerati
 	public synthetic fun getType ()Ldev/kord/common/entity/AutoModerationActionType;
 }
 
-public abstract interface class dev/kord/rest/builder/automoderation/KeywordAutoModerationRuleBuilder : dev/kord/rest/builder/automoderation/TimeoutAutoModerationRuleBuilder {
+public abstract interface class dev/kord/rest/builder/automoderation/KeywordAutoModerationRuleBuilder : dev/kord/rest/builder/automoderation/AllowedKeywordsAutoModerationRuleBuilder, dev/kord/rest/builder/automoderation/TimeoutAutoModerationRuleBuilder {
 	public abstract fun getKeywords ()Ljava/util/List;
 	public abstract fun getRegexPatterns ()Ljava/util/List;
 	public abstract fun getTriggerType ()Ldev/kord/common/entity/AutoModerationRuleTriggerType$Keyword;
@@ -204,30 +213,32 @@ public final class dev/kord/rest/builder/automoderation/KeywordAutoModerationRul
 public final class dev/kord/rest/builder/automoderation/KeywordAutoModerationRuleCreateBuilder : dev/kord/rest/builder/automoderation/AutoModerationRuleCreateBuilder, dev/kord/rest/builder/automoderation/KeywordAutoModerationRuleBuilder {
 	public fun <init> (Ljava/lang/String;Ldev/kord/common/entity/AutoModerationRuleEventType;)V
 	public synthetic fun buildTriggerMetadata ()Ldev/kord/common/entity/optional/Optional;
+	public fun getAllowedKeywords ()Ljava/util/List;
 	public fun getKeywords ()Ljava/util/List;
 	public fun getRegexPatterns ()Ljava/util/List;
 	public fun getTriggerType ()Ldev/kord/common/entity/AutoModerationRuleTriggerType$Keyword;
 	public synthetic fun getTriggerType ()Ldev/kord/common/entity/AutoModerationRuleTriggerType;
+	public fun setAllowedKeywords (Ljava/util/List;)V
 	public fun setKeywords (Ljava/util/List;)V
 	public fun setRegexPatterns (Ljava/util/List;)V
 }
 
 public final class dev/kord/rest/builder/automoderation/KeywordAutoModerationRuleModifyBuilder : dev/kord/rest/builder/automoderation/AutoModerationRuleModifyBuilder, dev/kord/rest/builder/automoderation/KeywordAutoModerationRuleBuilder {
 	public fun <init> ()V
+	public fun getAllowedKeywords ()Ljava/util/List;
 	public fun getKeywords ()Ljava/util/List;
 	public fun getRegexPatterns ()Ljava/util/List;
 	public fun getTriggerType ()Ldev/kord/common/entity/AutoModerationRuleTriggerType$Keyword;
 	public synthetic fun getTriggerType ()Ldev/kord/common/entity/AutoModerationRuleTriggerType;
+	public fun setAllowedKeywords (Ljava/util/List;)V
 	public fun setKeywords (Ljava/util/List;)V
 	public fun setRegexPatterns (Ljava/util/List;)V
 }
 
-public abstract interface class dev/kord/rest/builder/automoderation/KeywordPresetAutoModerationRuleBuilder : dev/kord/rest/builder/automoderation/TypedAutoModerationRuleBuilder {
+public abstract interface class dev/kord/rest/builder/automoderation/KeywordPresetAutoModerationRuleBuilder : dev/kord/rest/builder/automoderation/AllowedKeywordsAutoModerationRuleBuilder {
 	public abstract fun assignPresets (Ljava/util/List;)V
-	public abstract fun getAllowedKeywords ()Ljava/util/List;
 	public abstract fun getPresets ()Ljava/util/List;
 	public abstract fun getTriggerType ()Ldev/kord/common/entity/AutoModerationRuleTriggerType$KeywordPreset;
-	public abstract fun setAllowedKeywords (Ljava/util/List;)V
 }
 
 public final class dev/kord/rest/builder/automoderation/KeywordPresetAutoModerationRuleBuilder$DefaultImpls {

--- a/rest/src/main/kotlin/builder/automoderation/AutoModerationRuleBuilder.kt
+++ b/rest/src/main/kotlin/builder/automoderation/AutoModerationRuleBuilder.kt
@@ -9,6 +9,7 @@ import dev.kord.common.entity.AutoModerationRuleTriggerType.*
 import dev.kord.common.entity.Permission.ModerateMembers
 import dev.kord.common.entity.Snowflake
 import dev.kord.rest.builder.AuditBuilder
+import kotlin.DeprecationLevel.HIDDEN
 import kotlin.contracts.InvocationKind.EXACTLY_ONCE
 import kotlin.contracts.contract
 import kotlin.time.Duration
@@ -130,26 +131,86 @@ public inline fun TimeoutAutoModerationRuleBuilder.timeout(
 }
 
 
+/** An [AutoModerationRuleBuilder] for building rules that can have [allowedKeywords]. */
+@KordDsl
+public sealed interface AllowedKeywordsAutoModerationRuleBuilder : TypedAutoModerationRuleBuilder {
+
+    /**
+     * Substrings which should not trigger the rule.
+     *
+     * A keyword can be a phrase which contains multiple words.
+     * [Wildcard symbols](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-keyword-matching-strategies)
+     * can be used to customize how each keyword will be matched. Each keyword must be 30 characters or less.
+     */
+    public var allowedKeywords: MutableList<String>?
+}
+
+/**
+ * Add a [keyword] to [allowedKeywords][AllowedKeywordsAutoModerationRuleBuilder.allowedKeywords].
+ *
+ * A keyword can be a phrase which contains multiple words.
+ * [Wildcard symbols](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-keyword-matching-strategies)
+ * can be used to customize how each keyword will be matched. Each keyword must be 30 characters or less.
+ */
+public fun AllowedKeywordsAutoModerationRuleBuilder.allowKeyword(keyword: String) {
+    allowedKeywords?.add(keyword) ?: run { allowedKeywords = mutableListOf(keyword) }
+}
+
+/**
+ * Add a [keyword] with keyword matching strategy
+ * [Prefix](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-keyword-matching-strategies)
+ * to [allowedKeywords][AllowedKeywordsAutoModerationRuleBuilder.allowedKeywords].
+ *
+ * A keyword can be a phrase which contains multiple words. Each keyword must be 30 characters or less.
+ */
+public fun AllowedKeywordsAutoModerationRuleBuilder.allowPrefixKeyword(keyword: String) {
+    allowKeyword("$keyword*")
+}
+
+/**
+ * Add a [keyword] with keyword matching strategy
+ * [Suffix](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-keyword-matching-strategies)
+ * to [allowedKeywords][AllowedKeywordsAutoModerationRuleBuilder.allowedKeywords].
+ *
+ * A keyword can be a phrase which contains multiple words. Each keyword must be 30 characters or less.
+ */
+public fun AllowedKeywordsAutoModerationRuleBuilder.allowSuffixKeyword(keyword: String) {
+    allowKeyword("*$keyword")
+}
+
+/**
+ * Add a [keyword] with keyword matching strategy
+ * [Anywhere](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-keyword-matching-strategies)
+ * to [allowedKeywords][AllowedKeywordsAutoModerationRuleBuilder.allowedKeywords].
+ *
+ * A keyword can be a phrase which contains multiple words. Each keyword must be 30 characters or less.
+ */
+public fun AllowedKeywordsAutoModerationRuleBuilder.allowAnywhereKeyword(keyword: String) {
+    allowKeyword("*$keyword*")
+}
+
+
 /** An [AutoModerationRuleBuilder] for building rules with trigger type [Keyword]. */
 @KordDsl
-public sealed interface KeywordAutoModerationRuleBuilder : TimeoutAutoModerationRuleBuilder {
+public sealed interface KeywordAutoModerationRuleBuilder :
+    TimeoutAutoModerationRuleBuilder,
+    AllowedKeywordsAutoModerationRuleBuilder {
 
     override val triggerType: Keyword get() = Keyword
 
     /**
      * Substrings which will be searched for in content (maximum of 1000).
      *
-     * A keyword can be a phrase which contains multiple words. Wildcard symbols can be used to customize how each
-     * keyword will be matched. See
-     * [keyword matching strategies](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-keyword-matching-strategies).
-     * Each keyword must be 30 characters or less.
+     * A keyword can be a phrase which contains multiple words.
+     * [Wildcard symbols](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-keyword-matching-strategies)
+     * can be used to customize how each keyword will be matched. Each keyword must be 30 characters or less.
      */
     public var keywords: MutableList<String>?
 
     /**
      * Regular expression patterns which will be matched against content (maximum of 10).
      *
-     * Only Rust flavored regex is currently supported. Each regex pattern must be 75 characters or less.
+     * Only Rust flavored regex is currently supported. Each regex pattern must be 260 characters or less.
      */
     public var regexPatterns: MutableList<String>?
 }
@@ -157,10 +218,9 @@ public sealed interface KeywordAutoModerationRuleBuilder : TimeoutAutoModeration
 /**
  * Add a [keyword] to [keywords][KeywordAutoModerationRuleBuilder.keywords] (maximum of 1000).
  *
- * A keyword can be a phrase which contains multiple words. Wildcard symbols can be used to customize how each
- * keyword will be matched. See
- * [keyword matching strategies](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-keyword-matching-strategies).
- * Each keyword must be 30 characters or less.
+ * A keyword can be a phrase which contains multiple words.
+ * [Wildcard symbols](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-keyword-matching-strategies)
+ * can be used to customize how each keyword will be matched. Each keyword must be 30 characters or less.
  */
 public fun KeywordAutoModerationRuleBuilder.keyword(keyword: String) {
     keywords?.add(keyword) ?: run { keywords = mutableListOf(keyword) }
@@ -202,7 +262,7 @@ public fun KeywordAutoModerationRuleBuilder.anywhereKeyword(keyword: String) {
 /**
  * Add a [pattern] to [regexPatterns][KeywordAutoModerationRuleBuilder.regexPatterns] (maximum of 10).
  *
- * Only Rust flavored regex is currently supported. Each regex pattern must be 75 characters or less.
+ * Only Rust flavored regex is currently supported. Each regex pattern must be 260 characters or less.
  */
 public fun KeywordAutoModerationRuleBuilder.regexPattern(pattern: String) {
     regexPatterns?.add(pattern) ?: run { regexPatterns = mutableListOf(pattern) }
@@ -218,7 +278,7 @@ public sealed interface SpamAutoModerationRuleBuilder : TypedAutoModerationRuleB
 
 /** An [AutoModerationRuleBuilder] for building rules with trigger type [KeywordPreset]. */
 @KordDsl
-public sealed interface KeywordPresetAutoModerationRuleBuilder : TypedAutoModerationRuleBuilder {
+public sealed interface KeywordPresetAutoModerationRuleBuilder : AllowedKeywordsAutoModerationRuleBuilder {
 
     override val triggerType: KeywordPreset get() = KeywordPreset
 
@@ -230,13 +290,6 @@ public sealed interface KeywordPresetAutoModerationRuleBuilder : TypedAutoModera
      * [KeywordPresetAutoModerationRuleBuilder].
      */
     public fun assignPresets(presets: MutableList<AutoModerationRuleKeywordPresetType>)
-
-    /**
-     * Substrings which will be exempt from triggering the [presets] (maximum of 1000).
-     *
-     * A keyword can be a phrase which contains multiple words. Each keyword must be 30 characters or less.
-     */
-    public var allowedKeywords: MutableList<String>?
 }
 
 /** Add a [preset] to [presets][KeywordPresetAutoModerationRuleBuilder.presets]. */
@@ -244,11 +297,11 @@ public fun KeywordPresetAutoModerationRuleBuilder.preset(preset: AutoModerationR
     presets?.add(preset) ?: assignPresets(mutableListOf(preset))
 }
 
-/**
- * Add a [keyword] to [allowedKeywords][KeywordPresetAutoModerationRuleBuilder.allowedKeywords] (maximum of 1000).
- *
- * A keyword can be a phrase which contains multiple words. Each keyword must be 30 characters or less.
- */
+@Deprecated(
+    "Binary compatibility, an extension with the same name and parameter is now available on the " +
+            "'AllowedKeywordsAutoModerationRuleBuilder' supertype of 'KeywordPresetAutoModerationRuleBuilder'.",
+    level = HIDDEN,
+)
 public fun KeywordPresetAutoModerationRuleBuilder.allowKeyword(keyword: String) {
     allowedKeywords?.add(keyword) ?: run { allowedKeywords = mutableListOf(keyword) }
 }

--- a/rest/src/main/kotlin/builder/automoderation/AutoModerationRuleCreateBuilder.kt
+++ b/rest/src/main/kotlin/builder/automoderation/AutoModerationRuleCreateBuilder.kt
@@ -71,11 +71,15 @@ public class KeywordAutoModerationRuleCreateBuilder(
     private var _regexPatterns: Optional<MutableList<String>> = Optional.Missing()
     override var regexPatterns: MutableList<String>? by ::_regexPatterns.delegate()
 
+    private var _allowedKeywords: Optional<MutableList<String>> = Optional.Missing()
+    override var allowedKeywords: MutableList<String>? by ::_allowedKeywords.delegate()
+
     // one of keywords or regexPatterns is required, don't bother to send missing trigger metadata if both are missing
     override fun buildTriggerMetadata(): Optional.Value<DiscordAutoModerationRuleTriggerMetadata> =
         DiscordAutoModerationRuleTriggerMetadata(
             keywordFilter = _keywords.mapCopy(),
             regexPatterns = _regexPatterns.mapCopy(),
+            allowList = _allowedKeywords.mapCopy(),
         ).optional()
 }
 

--- a/rest/src/main/kotlin/builder/automoderation/AutoModerationRuleModifyBuilder.kt
+++ b/rest/src/main/kotlin/builder/automoderation/AutoModerationRuleModifyBuilder.kt
@@ -85,13 +85,18 @@ public class KeywordAutoModerationRuleModifyBuilder :
     private var _regexPatterns: Optional<MutableList<String>> = Optional.Missing()
     override var regexPatterns: MutableList<String>? by ::_regexPatterns.delegate()
 
+    private var _allowedKeywords: Optional<MutableList<String>> = Optional.Missing()
+    override var allowedKeywords: MutableList<String>? by ::_allowedKeywords.delegate()
+
     override fun buildTriggerMetadata(): Optional<DiscordAutoModerationRuleTriggerMetadata> {
         val keywords = _keywords
         val regexPatterns = _regexPatterns
-        return ifAnyPresent(keywords, regexPatterns) {
+        val allowedKeywords = _allowedKeywords
+        return ifAnyPresent(keywords, regexPatterns, allowedKeywords) {
             DiscordAutoModerationRuleTriggerMetadata(
                 keywordFilter = keywords.mapCopy(),
                 regexPatterns = regexPatterns.mapCopy(),
+                allowList = allowedKeywords.mapCopy(),
             )
         }
     }


### PR DESCRIPTION
The DSL for creating/editing `KeywordAutoModerationRule`s with `allowedKeywords` looks like this:
```kotlin
val rule = guild.createKeywordAutoModerationRule("name") {
    anywhereKeyword("cat")
    allowPrefixKeyword("black cat")
    timeout(10.minutes)
    enabled = true
}
println(rule.allowedKeywords)
```

Since [allow list keywords can contain wildcard symbols now](https://github.com/discord/discord-api-docs/pull/5644#discussion_r1029473648), the `allowPrefixKeyword`, `allowSuffixKeyword` and `allowAnywhereKeyword` extensions were added to `AllowedKeywordsAutoModerationRuleBuilder` to be consistent with the extensions for `KeywordAutoModerationRuleBuilder`.

The documentation for regex pattern max length was also updated.

see https://github.com/discord/discord-api-docs/pull/5670, https://github.com/discord/discord-api-docs/pull/5672 and https://github.com/discord/discord-api-docs/pull/5673