### PR TITLE
Use AtomicFU compiler plugin

### DIFF
--- a/common/src/main/kotlin/KordConfiguration.kt
+++ b/common/src/main/kotlin/KordConfiguration.kt
@@ -6,14 +6,8 @@ import kotlinx.atomicfu.atomic
 
 @KordExperimental
 public object KordConfiguration {
-    // not able to write it like `public var REST_VERSION: Int by atomic(10)` because of
-    // https://github.com/Kotlin/kotlinx.atomicfu/issues/186
-    // TODO use delegation when AtomicFU fixes this
 
     private const val REST_GATEWAY_DEFAULT = 10
-
-
-    private val REST = atomic(REST_GATEWAY_DEFAULT)
 
     /**
      * The [version of Discord's REST API](https://discord.com/developers/docs/reference#api-versioning) Kord uses.
@@ -22,14 +16,7 @@ public object KordConfiguration {
      */
     @KordExperimental
     @set:KordUnsafe
-    public var REST_VERSION: Int
-        get() = REST.value
-        set(value) {
-            REST.value = value
-        }
-
-
-    private val GATEWAY = atomic(REST_GATEWAY_DEFAULT)
+    public var REST_VERSION: Int by atomic(REST_GATEWAY_DEFAULT)
 
     /**
      * The
@@ -40,14 +27,7 @@ public object KordConfiguration {
      */
     @KordExperimental
     @set:KordUnsafe
-    public var GATEWAY_VERSION: Int
-        get() = GATEWAY.value
-        set(value) {
-            GATEWAY.value = value
-        }
-
-
-    private val VOICE = atomic(4)
+    public var GATEWAY_VERSION: Int by atomic(REST_GATEWAY_DEFAULT)
 
     /**
      * The
@@ -58,9 +38,5 @@ public object KordConfiguration {
      */
     @KordExperimental
     @set:KordUnsafe
-    public var VOICE_GATEWAY_VERSION: Int
-        get() = VOICE.value
-        set(value) {
-            VOICE.value = value
-        }
+    public var VOICE_GATEWAY_VERSION: Int by atomic(4)
 }

--- a/gateway/api/gateway.api
+++ b/gateway/api/gateway.api
@@ -1605,7 +1605,12 @@ public final class dev/kord/gateway/RequestGuildMembers$Companion {
 
 public final class dev/kord/gateway/RequestGuildMembers$Nonce {
 	public static final field INSTANCE Ldev/kord/gateway/RequestGuildMembers$Nonce;
+	public static final field counter$dev$VolatileWrapper Ldev/kord/gateway/RequestGuildMembers$Nonce$Counter$dev$VolatileWrapper;
 	public final fun new ()Ljava/lang/String;
+}
+
+public final class dev/kord/gateway/RequestGuildMembers$Nonce$Counter$dev$VolatileWrapper {
+	public fun <init> ()V
 }
 
 public final class dev/kord/gateway/Resume : dev/kord/gateway/Command {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,10 @@ org.gradle.jvmargs=-XX:MaxMetaspaceSize=1024m
 org.gradle.parallel=true
 kotlin.code.style=official
 
+# https://github.com/Kotlin/kotlinx-atomicfu#atomicfu-compiler-plugin
+kotlinx.atomicfu.enableJvmIrTransformation=true
+kotlinx.atomicfu.enableJsIrTransformation=true
+
 # remove when upgrading to gradle 8.0
 # https://docs.gradle.org/7.6/userguide/upgrading_version_7.html#strict-kotlin-dsl-precompiled-scripts-accessors
 systemProp.org.gradle.kotlin.dsl.precompiled.accessors.strict=true

--- a/rest/src/main/kotlin/ratelimit/AbstractRateLimiter.kt
+++ b/rest/src/main/kotlin/ratelimit/AbstractRateLimiter.kt
@@ -19,7 +19,7 @@ public abstract class AbstractRateLimiter internal constructor(public val clock:
     internal abstract val logger: KLogger
 
     internal val autoBanRateLimiter = IntervalRateLimiter(limit = 25000, interval = 10.minutes)
-    internal val globalSuspensionPoint = atomic(Reset(clock.now()))
+    private val globalSuspensionPoint = atomic(Reset(clock.now()))
     internal val buckets = ConcurrentHashMap<BucketKey, Bucket>()
     internal val routeBuckets = ConcurrentHashMap<RequestIdentifier, MutableSet<BucketKey>>()
 


### PR DESCRIPTION
It's supposed to be less fragile since it transforms Kotlin IR instead of JVM bytecode. E.g. it fixes https://github.com/Kotlin/kotlinx.atomicfu/issues/186 which allows simplifying `KordConfiguration`.

see https://github.com/Kotlin/kotlinx-atomicfu#atomicfu-compiler-plugin