### PR TITLE
Add `after` to audit log get

### DIFF
--- a/rest/api/rest.api
+++ b/rest/api/rest.api
@@ -84,10 +84,12 @@ public abstract interface class dev/kord/rest/builder/RequestBuilder {
 public final class dev/kord/rest/builder/auditlog/AuditLogGetRequestBuilder : dev/kord/rest/builder/RequestBuilder {
 	public fun <init> ()V
 	public final fun getAction ()Ldev/kord/common/entity/AuditLogEvent;
+	public final fun getAfter ()Ldev/kord/common/entity/Snowflake;
 	public final fun getBefore ()Ldev/kord/common/entity/Snowflake;
 	public final fun getLimit ()Ljava/lang/Integer;
 	public final fun getUserId ()Ldev/kord/common/entity/Snowflake;
 	public final fun setAction (Ldev/kord/common/entity/AuditLogEvent;)V
+	public final fun setAfter (Ldev/kord/common/entity/Snowflake;)V
 	public final fun setBefore (Ldev/kord/common/entity/Snowflake;)V
 	public final fun setLimit (Ljava/lang/Integer;)V
 	public final fun setUserId (Ldev/kord/common/entity/Snowflake;)V
@@ -2449,16 +2451,18 @@ public final class dev/kord/rest/json/request/ApplicationCommandModifyRequest$Co
 
 public final class dev/kord/rest/json/request/AuditLogGetRequest {
 	public fun <init> ()V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/AuditLogEvent;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/AuditLogEvent;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/AuditLogEvent;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)V
+	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/AuditLogEvent;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
 	public final fun component2 ()Ldev/kord/common/entity/AuditLogEvent;
 	public final fun component3 ()Ldev/kord/common/entity/Snowflake;
-	public final fun component4 ()Ljava/lang/Integer;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/AuditLogEvent;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Ldev/kord/rest/json/request/AuditLogGetRequest;
-	public static synthetic fun copy$default (Ldev/kord/rest/json/request/AuditLogGetRequest;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/AuditLogEvent;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;ILjava/lang/Object;)Ldev/kord/rest/json/request/AuditLogGetRequest;
+	public final fun component4 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component5 ()Ljava/lang/Integer;
+	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/AuditLogEvent;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;)Ldev/kord/rest/json/request/AuditLogGetRequest;
+	public static synthetic fun copy$default (Ldev/kord/rest/json/request/AuditLogGetRequest;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/AuditLogEvent;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/Integer;ILjava/lang/Object;)Ldev/kord/rest/json/request/AuditLogGetRequest;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAction ()Ldev/kord/common/entity/AuditLogEvent;
+	public final fun getAfter ()Ldev/kord/common/entity/Snowflake;
 	public final fun getBefore ()Ldev/kord/common/entity/Snowflake;
 	public final fun getLimit ()Ljava/lang/Integer;
 	public final fun getUserId ()Ldev/kord/common/entity/Snowflake;

--- a/rest/src/main/kotlin/builder/auditlog/AuditLogGetRequestBuilder.kt
+++ b/rest/src/main/kotlin/builder/auditlog/AuditLogGetRequestBuilder.kt
@@ -26,6 +26,11 @@ public class AuditLogGetRequestBuilder : RequestBuilder<AuditLogGetRequest> {
     public var before: Snowflake? = null
 
     /**
+     * The time, represented as a Snowflake, before which entries are no longer returned.
+     */
+    public var after: Snowflake? = null
+
+    /**
      * How many entries are returned.
      *
      * When used in a [direct rest request][AuditLogService.getAuditLogs]: default 50, minimum 1, maximum 100.
@@ -34,5 +39,5 @@ public class AuditLogGetRequestBuilder : RequestBuilder<AuditLogGetRequest> {
      */
     public var limit: Int? = null
 
-    override fun toRequest(): AuditLogGetRequest = AuditLogGetRequest(userId, action, before, limit)
+    override fun toRequest(): AuditLogGetRequest = AuditLogGetRequest(userId, action, before, after, limit)
 }

--- a/rest/src/main/kotlin/json/request/AuditLogGetRequest.kt
+++ b/rest/src/main/kotlin/json/request/AuditLogGetRequest.kt
@@ -7,5 +7,6 @@ public data class AuditLogGetRequest(
     val userId: Snowflake? = null,
     val action: AuditLogEvent? = null,
     val before: Snowflake? = null,
+    val after: Snowflake? = null,
     val limit: Int? = null,
 )

--- a/rest/src/main/kotlin/service/AuditLogService.kt
+++ b/rest/src/main/kotlin/service/AuditLogService.kt
@@ -28,6 +28,7 @@ public class AuditLogService(requestHandler: RequestHandler) : RestService(reque
         request.userId?.let { parameter("user_id", it) }
         request.action?.let { parameter("action_type", "${it.value}") }
         request.before?.let { parameter("before", it) }
+        request.after?.let { parameter("after", it) }
         request.limit?.let { parameter("limit", it) }
     }
 }


### PR DESCRIPTION
https://github.com/discord/discord-api-docs/commit/38f01b07531b672880e434692d215233e45eb0db