### PR TITLE
Add git-hooks for apiCheck

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,10 +2,13 @@ import org.gradle.api.tasks.wrapper.Wrapper.DistributionType.ALL
 
 plugins {
     org.jetbrains.dokka // for dokkaHtmlMultiModule task
+    @Suppress("DSL_SCOPE_VIOLATION")
+    alias(libs.plugins.git.hooks)
 }
 
 repositories {
     mavenCentral()
+    gradlePluginPortal()
 }
 
 group = Library.group
@@ -16,4 +19,8 @@ version = Library.version
 // (use 'Complete (-all) ZIP Checksum' from https://gradle.org/release-checksums for <checksum>)
 tasks.wrapper {
     distributionType = ALL
+}
+
+gitHooks {
+    setHooks(mapOf("pre-commit" to "clean apiCheck"))
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ dokka = "1.7.20" # https://github.com/Kotlin/dokka
 kotlinx-atomicfu = "0.19.0" # https://github.com/Kotlin/kotlinx-atomicfu
 binary-compatibility-validator = "0.12.1" # https://github.com/Kotlin/binary-compatibility-validator
 buildconfig = "3.1.0" # https://github.com/gmazzo/gradle-buildconfig-plugin
-
+git-hooks = "0.0.2" # https://github.com/jakemarsden/git-hooks-gradle-plugin
 
 [libraries]
 
@@ -70,7 +70,6 @@ atomicfu-plugin = { module = "org.jetbrains.kotlinx:atomicfu-gradle-plugin", ver
 binary-compatibility-validator-plugin = { module = "org.jetbrains.kotlinx:binary-compatibility-validator", version.ref = "binary-compatibility-validator" }
 ksp-plugin = { module = "com.google.devtools.ksp:symbol-processing-gradle-plugin", version.ref = "ksp" }
 
-
 [bundles]
 
 ktor-client-serialization = ["ktor-client-content-negotiation", "ktor-serialization-kotlinx-json"]
@@ -91,3 +90,4 @@ pluginsForBuildSrc = [
 [plugins]
 
 buildconfig = { id = "com.github.gmazzo.buildconfig", version.ref = "buildconfig" }
+git-hooks = { id = "com.github.jakemarsden.git-hooks", version.ref = "git-hooks"}


### PR DESCRIPTION
This is entirely because I forget and others do too, so it just makes it easier to avoid random build failures. Not necessary, just useful imo