### PR TITLE
Stabilize `KordConfiguration` and `KordConstants`

### DIFF
--- a/common/api/common.api
+++ b/common/api/common.api
@@ -87,11 +87,15 @@ public final class dev/kord/common/KordConfiguration {
 
 public final class dev/kord/common/KordConstants {
 	public static final field INSTANCE Ldev/kord/common/KordConstants;
+	public final fun getCOMMIT_HASH ()Ljava/lang/String;
+	public final fun getGITHUB_URL ()Ljava/lang/String;
 	public final fun getKORD_COMMIT_HASH ()Ljava/lang/String;
 	public final fun getKORD_GITHUB_URL ()Ljava/lang/String;
 	public final fun getKORD_SHORT_COMMIT_HASH ()Ljava/lang/String;
 	public final fun getKORD_VERSION ()Ljava/lang/String;
+	public final fun getSHORT_COMMIT_HASH ()Ljava/lang/String;
 	public final fun getUSER_AGENT ()Ljava/lang/String;
+	public final fun getVERSION ()Ljava/lang/String;
 }
 
 public final class dev/kord/common/Locale {

--- a/common/src/main/kotlin/KordConfiguration.kt
+++ b/common/src/main/kotlin/KordConfiguration.kt
@@ -1,10 +1,8 @@
 package dev.kord.common
 
-import dev.kord.common.annotation.KordExperimental
 import dev.kord.common.annotation.KordUnsafe
 import kotlinx.atomicfu.atomic
 
-@KordExperimental
 public object KordConfiguration {
 
     private const val REST_GATEWAY_DEFAULT = 10
@@ -14,7 +12,6 @@ public object KordConfiguration {
      *
      * Changing this version might lead to errors since Kord is designed to work with the initially set version.
      */
-    @KordExperimental
     @set:KordUnsafe
     public var REST_VERSION: Int by atomic(REST_GATEWAY_DEFAULT)
 
@@ -25,7 +22,6 @@ public object KordConfiguration {
      *
      * Changing this version might lead to errors since Kord is designed to work with the initially set version.
      */
-    @KordExperimental
     @set:KordUnsafe
     public var GATEWAY_VERSION: Int by atomic(REST_GATEWAY_DEFAULT)
 
@@ -36,7 +32,6 @@ public object KordConfiguration {
      *
      * Changing this version might lead to errors since Kord is designed to work with the initially set version.
      */
-    @KordExperimental
     @set:KordUnsafe
     public var VOICE_GATEWAY_VERSION: Int by atomic(4)
 }

--- a/common/src/main/kotlin/KordConstants.kt
+++ b/common/src/main/kotlin/KordConstants.kt
@@ -4,27 +4,38 @@
 package dev.kord.common
 
 import dev.kord.common.annotation.KordExperimental
+import kotlin.DeprecationLevel.WARNING
 
-@KordExperimental
 public object KordConstants {
 
     /** Kord's version. */
-    @KordExperimental
-    public val KORD_VERSION: String = BUILD_CONFIG_GENERATED_LIBRARY_VERSION
+    public val VERSION: String = BUILD_CONFIG_GENERATED_LIBRARY_VERSION
 
     /** The hash of the commit from which this Kord version was built. */
-    @KordExperimental
-    public val KORD_COMMIT_HASH: String = BUILD_CONFIG_GENERATED_COMMIT_HASH
+    public val COMMIT_HASH: String = BUILD_CONFIG_GENERATED_COMMIT_HASH
 
-    /** Short variant of [KORD_COMMIT_HASH]. */
-    @KordExperimental
-    public val KORD_SHORT_COMMIT_HASH: String = BUILD_CONFIG_GENERATED_SHORT_COMMIT_HASH
+    /** Short variant of [COMMIT_HASH]. */
+    public val SHORT_COMMIT_HASH: String = BUILD_CONFIG_GENERATED_SHORT_COMMIT_HASH
 
     /** URL for Kord's GitHub repository. */
-    @KordExperimental
-    public val KORD_GITHUB_URL: String = "https://github.com/kordlib/kord"
+    public val GITHUB_URL: String = "https://github.com/kordlib/kord"
 
     /** Kord's value for the [User Agent header](https://discord.com/developers/docs/reference#user-agent). */
+    public val USER_AGENT: String = "DiscordBot ($GITHUB_URL, $VERSION)"
+
+    @Deprecated("Renamed to 'VERSION'.", ReplaceWith("KordConstants.VERSION"), level = WARNING)
     @KordExperimental
-    public val USER_AGENT: String = "DiscordBot ($KORD_GITHUB_URL, $KORD_VERSION)"
+    public val KORD_VERSION: String get() = VERSION
+
+    @Deprecated("Renamed to 'COMMIT_HASH'.", ReplaceWith("KordConstants.COMMIT_HASH"), level = WARNING)
+    @KordExperimental
+    public val KORD_COMMIT_HASH: String get() = COMMIT_HASH
+
+    @Deprecated("Renamed to 'SHORT_COMMIT_HASH'.", ReplaceWith("KordConstants.SHORT_COMMIT_HASH"), level = WARNING)
+    @KordExperimental
+    public val KORD_SHORT_COMMIT_HASH: String get() = SHORT_COMMIT_HASH
+
+    @Deprecated("Renamed to 'GITHUB_URL'.", ReplaceWith("KordConstants.GITHUB_URL"), level = WARNING)
+    @KordExperimental
+    public val KORD_GITHUB_URL: String get() = GITHUB_URL
 }


### PR DESCRIPTION
The following properties on `KordConstants` were renamed to remove the redundant `KORD_` prefix:

 * `KordConstants.KORD_VERSION` -> `KordConstants.VERSION`

 * `KordConstants.KORD_COMMIT_HASH` -> `KordConstants.COMMIT_HASH`

 * `KordConstants.KORD_SHORT_COMMIT_HASH` -> `KordConstants.SHORT_COMMIT_HASH`

 * `KordConstants.KORD_GITHUB_URL` -> `KordConstants.GITHUB_URL`