### PR TITLE
Fix `MessageChannelBehavior.typeUntil`

### DIFF
--- a/core/src/main/kotlin/behavior/channel/MessageChannelBehavior.kt
+++ b/core/src/main/kotlin/behavior/channel/MessageChannelBehavior.kt
@@ -238,7 +238,7 @@ public interface MessageChannelBehavior : ChannelBehavior, Strategizable {
      * @throws [RestRequestException] if something went wrong during the request.
      */
     public suspend fun typeUntil(instant: Instant) {
-        while (instant < Clock.System.now()) {
+        while (Clock.System.now() < instant) {
             type()
             delay(8.seconds) //bracing ourselves for some network delays
         }


### PR DESCRIPTION
If the instant was less than the current instant, it was triggering typing indicators forever. If the instant was greater than or equal to the current instant, it was not triggering the typing indicator at all.