### PR TITLE
Fix various bugs in `DiscordBitSet`

### DIFF
--- a/common/src/test/kotlin/BitSetTests.kt
+++ b/common/src/test/kotlin/BitSetTests.kt
@@ -1,26 +1,58 @@
 import dev.kord.common.DiscordBitSet
-import org.junit.jupiter.api.Test
+import dev.kord.common.EmptyBitSet
+import kotlin.test.*
 
 class BitSetTests {
     @Test
-    fun `b contains a`() {
-        val a = DiscordBitSet(0b101)
-        val b = DiscordBitSet(0b111)
-        assert(a in b)
+    fun `a contains b and c`() {
+        val a = DiscordBitSet(0b111)
+        val b = DiscordBitSet(0b101)
+        val c = DiscordBitSet(0b101, 0)
+        assertTrue(b in a)
+        assertTrue(c in a)
     }
 
     @Test
-    fun `a equals b`() {
+    fun `a and b are equal and have the same hashCode`() {
         val a = DiscordBitSet(0b111, 0)
         val b = DiscordBitSet(0b111)
-        assert(a == b)
+        assertEquals(a, b)
+        assertEquals(a.hashCode(), b.hashCode())
     }
 
+    @Test
+    fun `a does not equal b`() {
+        val a = DiscordBitSet(0b111, 0)
+        val b = DiscordBitSet(0b111, 0b1)
+        assertNotEquals(a, b)
+    }
 
     @Test
-    fun `get a bit`() {
+    fun `get bits`() {
         val a = DiscordBitSet(0b101, 0)
-        assert(!a[1])
+        assertTrue(a[0])
+        assertFalse(a[1])
+        assertTrue(a[2])
+        for (i in 3..64) assertFalse(a[i])
+
+        val b = DiscordBitSet(1L shl 63)
+        for (i in 0..62) assertFalse(b[i])
+        assertTrue(b[63])
+    }
+
+    @Test
+    fun `set bits`() {
+        val a = EmptyBitSet()
+        for (i in 0..64) a[i] = true
+        assertEquals(DiscordBitSet(ULong.MAX_VALUE.toLong(), 1), a)
+
+        val b = EmptyBitSet()
+        b[1] = true
+        b[2] = true
+        b[5] = true
+        assertEquals(DiscordBitSet(0b100110), b)
+        b[2] = false
+        assertEquals(DiscordBitSet(0b100010), b)
     }
 
     @Test
@@ -30,13 +62,12 @@ class BitSetTests {
     }
 
     @Test
-    fun `add and remove a  bit`() {
+    fun `add and remove a bit`() {
         val a = DiscordBitSet(0b101, 0)
         a.add(DiscordBitSet(0b111))
         assert(a.value == 0b111.toString())
         a.remove(DiscordBitSet(0b001))
         assert(a.value == 0b110.toString())
-
     }
 
     @Test
@@ -44,7 +75,18 @@ class BitSetTests {
         val a = DiscordBitSet(0b101, 0)
         a.remove(DiscordBitSet(0b111))
         assert(a.value == "0")
-
     }
 
+    @Test
+    fun `binary works`() {
+        assertEquals("0", DiscordBitSet().binary)
+        assertEquals("0", DiscordBitSet(0).binary)
+        assertEquals("10011", DiscordBitSet(0b10011).binary)
+        assertEquals(
+            "110" +
+                "0000000000000000000000000000000000000000000000000000000000111001" +
+                "0000000000000000000000000000000000000000000000000000000000001011",
+            DiscordBitSet(0b1011, 0b111001, 0b110).binary,
+        )
+    }
 }


### PR DESCRIPTION
* `WIDTH` was defined to the width of a `Byte` not a `Long`, resulting in bugs in `size`, `get` and `set`

* `binary` just did some completely wrong things that I can't really describe

* `hashCode` could return different values for equal `DiscordBitSet`s (when they had different amounts of trailing zeros in the `data` array), breaking its general contract

* `equals` was comparing `this` with `this` and not `this` with `other`, which resulted in any two `DiscordBitSets` considered equal

* `contains` would erroneously return `false` if `other` did have more trailing zeros but would otherwise be contained

* `set` wasn't growing `data` correctly and also didn't unset bits properly