### PR TITLE
Add `BlockMessageAutoModerationAction.customMessage`

### DIFF
--- a/common/api/common.api
+++ b/common/api/common.api
@@ -2573,15 +2573,17 @@ public final class dev/kord/common/entity/DiscordAutoModerationAction$Companion 
 public final class dev/kord/common/entity/DiscordAutoModerationActionMetadata {
 	public static final field Companion Ldev/kord/common/entity/DiscordAutoModerationActionMetadata$Companion;
 	public fun <init> ()V
-	public synthetic fun <init> (ILdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (ILdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)V
+	public synthetic fun <init> (Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun component2 ()Ldev/kord/common/entity/optional/Optional;
-	public final fun copy (Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/common/entity/DiscordAutoModerationActionMetadata;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordAutoModerationActionMetadata;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordAutoModerationActionMetadata;
+	public final fun component3 ()Ldev/kord/common/entity/optional/Optional;
+	public final fun copy (Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/common/entity/DiscordAutoModerationActionMetadata;
+	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordAutoModerationActionMetadata;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordAutoModerationActionMetadata;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getChannelId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
+	public final fun getCustomMessage ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getDurationSeconds ()Ldev/kord/common/entity/optional/Optional;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;

--- a/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/AutoModerationActionType.kt
+++ b/common/build/generated/ksp/main/kotlin/dev/kord/common/entity/AutoModerationActionType.kt
@@ -51,7 +51,9 @@ public sealed class AutoModerationActionType(
     ) : AutoModerationActionType(value)
 
     /**
-     * Blocks the content of a message according to the rule.
+     * Blocks a member's message and prevents it from being posted.
+     *
+     * A custom explanation can be specified and shown to members whenever their message is blocked.
      */
     public object BlockMessage : AutoModerationActionType(1)
 

--- a/common/src/main/kotlin/entity/AutoModeration.kt
+++ b/common/src/main/kotlin/entity/AutoModeration.kt
@@ -38,7 +38,11 @@
     kDoc = "The type of action.",
     docUrl = "https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-action-object-action-types",
     entries = [
-        Entry("BlockMessage", intValue = 1, kDoc = "Blocks the content of a message according to the rule."),
+        Entry(
+            "BlockMessage", intValue = 1,
+            kDoc = "Blocks a member's message and prevents it from being posted.\n\nA custom explanation can be " +
+                "specified and shown to members whenever their message is blocked.",
+        ),
         Entry("SendAlertMessage", intValue = 2, kDoc = "Logs user content to a specified channel."),
         Entry(
             "Timeout", intValue = 3,
@@ -107,7 +111,9 @@ public data class DiscordAutoModerationAction(
 @Serializable
 public data class DiscordAutoModerationActionMetadata(
     @SerialName("channel_id")
-    public val channelId: OptionalSnowflake = OptionalSnowflake.Missing,
+    val channelId: OptionalSnowflake = OptionalSnowflake.Missing,
     @SerialName("duration_seconds")
-    public val durationSeconds: Optional<DurationInSeconds> = Optional.Missing(),
+    val durationSeconds: Optional<DurationInSeconds> = Optional.Missing(),
+    @SerialName("custom_message")
+    val customMessage: Optional<String> = Optional.Missing(),
 )

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -2703,15 +2703,17 @@ public final class dev/kord/core/cache/data/AutoModerationActionData$Companion {
 public final class dev/kord/core/cache/data/AutoModerationActionMetadataData {
 	public static final field Companion Ldev/kord/core/cache/data/AutoModerationActionMetadataData$Companion;
 	public fun <init> ()V
-	public synthetic fun <init> (ILdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (ILdev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)V
+	public synthetic fun <init> (Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun component2 ()Ldev/kord/common/entity/optional/Optional;
-	public final fun copy (Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/core/cache/data/AutoModerationActionMetadataData;
-	public static synthetic fun copy$default (Ldev/kord/core/cache/data/AutoModerationActionMetadataData;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/core/cache/data/AutoModerationActionMetadataData;
+	public final fun component3 ()Ldev/kord/common/entity/optional/Optional;
+	public final fun copy (Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/core/cache/data/AutoModerationActionMetadataData;
+	public static synthetic fun copy$default (Ldev/kord/core/cache/data/AutoModerationActionMetadataData;Ldev/kord/common/entity/optional/OptionalSnowflake;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/core/cache/data/AutoModerationActionMetadataData;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getChannelId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
+	public final fun getCustomMessage ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getDurationSeconds ()Ldev/kord/common/entity/optional/Optional;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -7480,6 +7482,7 @@ public final class dev/kord/core/entity/automoderation/AutoModerationRuleKt {
 
 public final class dev/kord/core/entity/automoderation/BlockMessageAutoModerationAction : dev/kord/core/entity/automoderation/AutoModerationAction {
 	public fun <init> (Ldev/kord/core/cache/data/AutoModerationActionData;Ldev/kord/core/Kord;)V
+	public final fun getCustomMessage ()Ljava/lang/String;
 	public fun getType ()Ldev/kord/common/entity/AutoModerationActionType$BlockMessage;
 	public synthetic fun getType ()Ldev/kord/common/entity/AutoModerationActionType;
 	public fun toString ()Ljava/lang/String;

--- a/core/src/main/kotlin/cache/data/AutoModeration.kt
+++ b/core/src/main/kotlin/cache/data/AutoModeration.kt
@@ -85,8 +85,9 @@ public data class AutoModerationActionData(
 
 @Serializable
 public data class AutoModerationActionMetadataData(
-    public val channelId: OptionalSnowflake = OptionalSnowflake.Missing,
-    public val durationSeconds: Optional<DurationInSeconds> = Optional.Missing(),
+    val channelId: OptionalSnowflake = OptionalSnowflake.Missing,
+    val durationSeconds: Optional<DurationInSeconds> = Optional.Missing(),
+    val customMessage: Optional<String> = Optional.Missing(),
 ) {
     public companion object {
         public fun from(metadata: DiscordAutoModerationActionMetadata): AutoModerationActionMetadataData =
@@ -94,6 +95,7 @@ public data class AutoModerationActionMetadataData(
                 AutoModerationActionMetadataData(
                     channelId = channelId,
                     durationSeconds = durationSeconds,
+                    customMessage = customMessage,
                 )
             }
     }

--- a/core/src/main/kotlin/entity/automoderation/AutoModerationAction.kt
+++ b/core/src/main/kotlin/entity/automoderation/AutoModerationAction.kt
@@ -45,6 +45,9 @@ public class BlockMessageAutoModerationAction(
 
     override val type: BlockMessage get() = BlockMessage
 
+    /** Additional explanation that will be shown to members whenever their message is blocked. */
+    public val customMessage: String? get() = data.metadata.value?.customMessage?.value
+
     override fun toString(): String = "BlockMessageAutoModerationAction(data=$data)"
 }
 

--- a/rest/api/rest.api
+++ b/rest/api/rest.api
@@ -196,8 +196,10 @@ public abstract class dev/kord/rest/builder/automoderation/AutoModerationRuleMod
 
 public final class dev/kord/rest/builder/automoderation/BlockMessageAutoModerationActionBuilder : dev/kord/rest/builder/automoderation/AutoModerationActionBuilder {
 	public fun <init> ()V
+	public final fun getCustomMessage ()Ljava/lang/String;
 	public fun getType ()Ldev/kord/common/entity/AutoModerationActionType$BlockMessage;
 	public synthetic fun getType ()Ldev/kord/common/entity/AutoModerationActionType;
+	public final fun setCustomMessage (Ljava/lang/String;)V
 }
 
 public abstract interface class dev/kord/rest/builder/automoderation/KeywordAutoModerationRuleBuilder : dev/kord/rest/builder/automoderation/AllowedKeywordsAutoModerationRuleBuilder, dev/kord/rest/builder/automoderation/TimeoutAutoModerationRuleBuilder {

--- a/rest/src/main/kotlin/builder/automoderation/AutoModerationActionBuilder.kt
+++ b/rest/src/main/kotlin/builder/automoderation/AutoModerationActionBuilder.kt
@@ -7,6 +7,7 @@ import dev.kord.common.entity.DiscordAutoModerationAction
 import dev.kord.common.entity.DiscordAutoModerationActionMetadata
 import dev.kord.common.entity.Snowflake
 import dev.kord.common.entity.optional.Optional
+import dev.kord.common.entity.optional.delegate.delegate
 import dev.kord.common.entity.optional.optional
 import dev.kord.common.entity.optional.optionalSnowflake
 import dev.kord.rest.builder.RequestBuilder
@@ -31,10 +32,27 @@ public sealed class AutoModerationActionBuilder : RequestBuilder<DiscordAutoMode
 }
 
 /** An [AutoModerationActionBuilder] for building actions with type [BlockMessage]. */
-@Suppress("CanSealedSubClassBeObject") // keep it as a class in case we want to add more in the future
 @KordDsl
 public class BlockMessageAutoModerationActionBuilder : AutoModerationActionBuilder() {
+
     override val type: BlockMessage get() = BlockMessage
+
+    private var _customMessage: Optional<String> = Optional.Missing()
+
+    /**
+     * Additional explanation that will be shown to members whenever their message is blocked (maximum of 150
+     * characters).
+     */
+    public var customMessage: String? by ::_customMessage.delegate()
+
+    override fun buildMetadata(): Optional<DiscordAutoModerationActionMetadata> {
+        val customMessage = _customMessage
+        return if (customMessage is Optional.Value) {
+            DiscordAutoModerationActionMetadata(customMessage = customMessage).optional()
+        } else {
+            Optional.Missing()
+        }
+    }
 }
 
 /** An [AutoModerationActionBuilder] for building actions with type [SendAlertMessage]. */


### PR DESCRIPTION
The DSL for creating/editing `AutoModerationRule`s that have a `BlockMessageAutoModerationAction` with a `customMessage` looks like this:
```kotlin
val rule = guild.createKeywordAutoModerationRule("name") {
    keyword("cat")
    blockMessage { customMessage = "Stop posting about cats!" }
    enabled = true
}
val action = rule.actions.first() as BlockMessageAutoModerationAction
println(action.customMessage)
```

see https://github.com/discord/discord-api-docs/pull/5955