### PR TITLE
Update dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,21 +1,10 @@
-import org.gradle.api.tasks.wrapper.Wrapper.DistributionType.ALL
-
 plugins {
     org.jetbrains.dokka // for dokkaHtmlMultiModule task
 }
 
 repositories {
     mavenCentral()
-    // until Dokka 1.8.0 is released and we no longer need dev builds, see https://github.com/kordlib/kord/pull/755
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/dokka/dev")
 }
 
 group = Library.group
 version = Library.version
-
-// To upgrade Gradle, run the following command twice and commit all changes:
-// ./gradlew wrapper --gradle-version <version> --gradle-distribution-sha256-sum <checksum>
-// (use 'Complete (-all) ZIP Checksum' from https://gradle.org/release-checksums for <checksum>)
-tasks.wrapper {
-    distributionType = ALL
-}

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -4,8 +4,6 @@ plugins {
 
 repositories {
     mavenCentral()
-    // until Dokka 1.8.0 is released and we no longer need dev builds, see https://github.com/kordlib/kord/pull/755
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/dokka/dev")
 }
 
 dependencies {

--- a/buildSrc/src/main/kotlin/kord-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/kord-module.gradle.kts
@@ -15,8 +15,6 @@ plugins {
 
 repositories {
     mavenCentral()
-    // until Dokka 1.8.0 is released and we no longer need dev builds, see https://github.com/kordlib/kord/pull/755
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/dokka/dev")
 }
 
 kotlin {

--- a/common/src/main/kotlin/entity/DiscordNull.kt
+++ b/common/src/main/kotlin/entity/DiscordNull.kt
@@ -7,10 +7,20 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.buildClassSerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
+import kotlin.DeprecationLevel.WARNING
 
 /**
  * Type to represent a Discord value that can only be null. This class cannot be instantiated.
  */
+@Suppress("DEPRECATION")
+@Deprecated(
+    "This class is similar to 'Nothing' as it has no instances. The only reason it existed was to have a " +
+        "@Serializable version of 'Nothing'. However, since Kotlin 1.8.0 and kotlinx.serialization 1.5.0-RC " +
+        "'Nothing' is a serializable class. This means 'DiscordNull' isn't needed anymore and should be replaced " +
+        "with 'Nothing'.",
+    ReplaceWith("Nothing", imports = ["kotlin.Nothing"]),
+    level = WARNING,
+)
 @Serializable(with = DiscordNull.Serializer::class)
 public class DiscordNull private constructor() {
 

--- a/common/src/main/kotlin/entity/DiscordRole.kt
+++ b/common/src/main/kotlin/entity/DiscordRole.kt
@@ -30,13 +30,13 @@ public data class DiscordRoleTags(
     @SerialName("integration_id")
     val integrationId: OptionalSnowflake = OptionalSnowflake.Missing,
     @SerialName("premium_subscriber")
-    val premiumSubscriber: Optional<DiscordNull?> = Optional.Missing(),
+    val premiumSubscriber: Optional<Nothing?> = Optional.Missing(),
     @SerialName("subscription_listing_id")
     val subscriptionListingId: OptionalSnowflake = OptionalSnowflake.Missing,
     @SerialName("available_for_purchase")
-    val availableForPurchase: Optional<DiscordNull?> = Optional.Missing(),
+    val availableForPurchase: Optional<Nothing?> = Optional.Missing(),
     @SerialName("guild_connections")
-    val guildConnections: Optional<DiscordNull?> = Optional.Missing(),
+    val guildConnections: Optional<Nothing?> = Optional.Missing(),
 )
 
 @Serializable

--- a/gateway/src/main/kotlin/Event.kt
+++ b/gateway/src/main/kotlin/Event.kt
@@ -9,6 +9,7 @@ import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.NothingSerializer
 import kotlinx.serialization.builtins.nullable
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.descriptors.PrimitiveKind
@@ -27,20 +28,6 @@ private val jsonLogger = KotlinLogging.logger { }
 
 public sealed class DispatchEvent : Event() {
     public abstract val sequence: Int?
-}
-
-private object NullDecoder : KDeserializationStrategy<Nothing?> {
-    override val descriptor: SerialDescriptor
-        get() = PrimitiveSerialDescriptor("null", PrimitiveKind.STRING)
-
-    @OptIn(ExperimentalSerializationApi::class)
-    override fun deserialize(decoder: Decoder): Nothing? {
-        // decodeNull() doesn't consume the literal null therefore parsing doesn't end and in e.g. a heartbeat event
-        // the null gets parsed as a key
-        decoder.decodeNotNullMark()
-        return decoder.decodeNull()
-    }
-
 }
 
 public sealed class Event {
@@ -79,7 +66,8 @@ public sealed class Event {
                             OpCode.Dispatch -> getByDispatchEvent(index, this, eventName, sequence)
                             OpCode.Heartbeat -> decodeSerializableElement(descriptor, index, Heartbeat.serializer())
                             OpCode.HeartbeatACK -> {
-                                this.decodeSerializableElement(descriptor, index, NullDecoder)
+                                @Suppress("IMPLICIT_NOTHING_TYPE_ARGUMENT_IN_RETURN_POSITION")
+                                decodeNullableSerializableElement(descriptor, index, NothingSerializer())
                                 HeartbeatACK
                             }
                             OpCode.InvalidSession -> decodeSerializableElement(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,27 +1,27 @@
 [versions]
 
 # api dependencies
-kotlin = "1.8.0" # https://github.com/JetBrains/kotlin
-ktor = "2.2.1" # https://github.com/ktorio/ktor
+kotlin = "1.8.10" # https://github.com/JetBrains/kotlin
+ktor = "2.2.4" # https://github.com/ktorio/ktor
 kotlinx-coroutines = "1.6.4" # https://github.com/Kotlin/kotlinx.coroutines
-kotlinx-serialization = "1.4.1" # https://github.com/Kotlin/kotlinx.serialization
+kotlinx-serialization = "1.5.0" # https://github.com/Kotlin/kotlinx.serialization
 kotlinx-datetime = "0.4.0" # https://github.com/Kotlin/kotlinx-datetime
 kotlin-logging = "2.1.23" # https://github.com/MicroUtils/kotlin-logging
 kord-cache = { strictly = "[0.3.0, 0.4.0[", prefer = "latest.release" }
 
 # code generation
-ksp = "1.8.0-1.0.8" # https://github.com/google/ksp
+ksp = "1.8.10-1.0.9" # https://github.com/google/ksp
 kotlinpoet = "1.12.0" # https://github.com/square/kotlinpoet
 
 # tests
-junit5 = "5.9.1" # https://github.com/junit-team/junit5
-mockk = "1.13.2" # https://github.com/mockk/mockk
+junit5 = "5.9.2" # https://github.com/junit-team/junit5
+mockk = "1.13.4" # https://github.com/mockk/mockk
 slf4j = "1.7.36" # https://www.slf4j.org
 
 # plugins
-dokka = "1.8.0-dev-194" # https://github.com/Kotlin/dokka
-kotlinx-atomicfu = "0.19.0" # https://github.com/Kotlin/kotlinx-atomicfu
-binary-compatibility-validator = "0.12.1" # https://github.com/Kotlin/binary-compatibility-validator
+dokka = "1.8.10" # https://github.com/Kotlin/dokka
+kotlinx-atomicfu = "0.20.0" # https://github.com/Kotlin/kotlinx-atomicfu
+binary-compatibility-validator = "0.13.0" # https://github.com/Kotlin/binary-compatibility-validator
 buildconfig = "3.1.0" # https://github.com/gmazzo/gradle-buildconfig-plugin
 
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=f30b29580fe11719087d698da23f3b0f0d04031d8995f7dd8275a31f7674dc01
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip
+distributionSha256Sum=ff7bf6a86f09b9b2c40bb8f48b25fc19cf2b2664fd1d220cd7ab833ec758d0d7
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
* [Gradle](https://github.com/gradle/gradle) 8.0 -> 8.0.2
* [Kotlin](https://github.com/JetBrains/kotlin) 1.8.0 -> 1.8.10
* [KSP](https://github.com/google/ksp) 1.8.0-1.0.8 -> 1.8.10-1.0.9
* [Ktor](https://github.com/ktorio/ktor) 2.2.1 -> 2.2.4
* [kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization) 1.4.1 -> 1.5.0
* [Dokka](https://github.com/Kotlin/dokka) 1.8.0-dev-194 -> 1.8.10
* [AtomicFU](https://github.com/Kotlin/kotlinx-atomicfu) 0.19.0 -> 0.20.0
* [Binary compatibility validator](https://github.com/Kotlin/binary-compatibility-validator) 0.12.1 -> 0.13.0
* [JUnit 5](https://github.com/junit-team/junit5) 5.9.1 -> 5.9.2
* [MockK](https://github.com/mockk/mockk) 1.13.2 -> 1.13.4

The `wrapper` task is no longer configured to use the `all` [distribution type](https://docs.gradle.org/current/userguide/gradle_wrapper.html#sec:adding_wrapper). This results in smaller downloads (e.g. in CI) while still being able to inspect sources in IntelliJ (they are downloaded automatically).

`Nothing` is serializable since Kotlin 1.8.0 and [kotlinx.serialization 1.5.0-RC](https://github.com/Kotlin/kotlinx.serialization/releases/tag/v1.5.0-RC) which means `dev.kord.common.entity.DiscordNull` and `dev.kord.gateway.NullDecoder` are now obsolete.

https://github.com/Kotlin/dokka/issues/2796 was fixed with Dokka 1.8.10, which means the dev build used since #755 is no longer needed and the corresponding maven repository was removed from the build files.