### PR TITLE
Upgrade SLF4J to 2.0.x

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ ktor = "2.2.4" # https://github.com/ktorio/ktor
 kotlinx-coroutines = "1.6.4" # https://github.com/Kotlin/kotlinx.coroutines
 kotlinx-serialization = "1.5.0" # https://github.com/Kotlin/kotlinx.serialization
 kotlinx-datetime = "0.4.0" # https://github.com/Kotlin/kotlinx-datetime
-kotlin-logging = "3.0.5" # https://github.com/MicroUtils/kotlin-logging
+kotlin-logging = "3.0.5" # https://github.com/oshai/kotlin-logging
 kord-cache = { strictly = "[0.3.0, 0.4.0[", prefer = "latest.release" }
 
 # code generation

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ ktor = "2.2.4" # https://github.com/ktorio/ktor
 kotlinx-coroutines = "1.6.4" # https://github.com/Kotlin/kotlinx.coroutines
 kotlinx-serialization = "1.5.0" # https://github.com/Kotlin/kotlinx.serialization
 kotlinx-datetime = "0.4.0" # https://github.com/Kotlin/kotlinx-datetime
-kotlin-logging = "2.1.23" # https://github.com/MicroUtils/kotlin-logging
+kotlin-logging = "3.0.5" # https://github.com/MicroUtils/kotlin-logging
 kord-cache = { strictly = "[0.3.0, 0.4.0[", prefer = "latest.release" }
 
 # code generation
@@ -16,7 +16,7 @@ kotlinpoet = "1.12.0" # https://github.com/square/kotlinpoet
 # tests
 junit5 = "5.9.2" # https://github.com/junit-team/junit5
 mockk = "1.13.4" # https://github.com/mockk/mockk
-slf4j = "1.7.36" # https://www.slf4j.org
+slf4j = "2.0.7" # https://www.slf4j.org
 
 # plugins
 dokka = "1.8.10" # https://github.com/Kotlin/dokka


### PR DESCRIPTION
* [SLF4J](https://www.slf4j.org/) 1.7.36 -> 2.0.7
* [kotlin-logging](https://github.com/oshai/kotlin-logging) 2.1.23 -> 3.0.5

See https://www.slf4j.org/faq.html#changesInVersion200 for migration steps.
In most cases it should be enough to update the version of your logging provider (like slf4j-simple, logback or Log4j).