### PR TITLE
Clean up

### DIFF
--- a/buildSrc/src/main/kotlin/Documentation.kt
+++ b/buildSrc/src/main/kotlin/Documentation.kt
@@ -3,6 +3,9 @@ import org.jetbrains.dokka.gradle.AbstractDokkaLeafTask
 import java.net.URL
 
 fun AbstractDokkaLeafTask.applyKordDokkaOptions() {
+
+    moduleName = "kord-${project.name}"
+
     failOnWarning = true
 
     dokkaSourceSets.configureEach {

--- a/buildSrc/src/main/kotlin/kord-publishing.gradle.kts
+++ b/buildSrc/src/main/kotlin/kord-publishing.gradle.kts
@@ -42,7 +42,7 @@ publishing {
                 licenses {
                     license {
                         name = "MIT"
-                        url = "http://opensource.org/licenses/MIT"
+                        url = "https://opensource.org/licenses/MIT"
                     }
                 }
 

--- a/common/src/commonMain/kotlin/entity/AuditLog.kt
+++ b/common/src/commonMain/kotlin/entity/AuditLog.kt
@@ -182,7 +182,7 @@ public data class AuditLogChange<T>(
     val key: AuditLogChangeKey<T>,
 ) {
 
-    internal class Serializer<T>(val ser: KSerializer<T>) : KSerializer<AuditLogChange<T>> {
+    internal class Serializer<T>(private val ser: KSerializer<T>) : KSerializer<AuditLogChange<T>> {
         override val descriptor: SerialDescriptor = buildClassSerialDescriptor("Kord.AuditLogChange", ser.descriptor) {
             element<JsonElement>("new_value")
             element<JsonElement>("old_value")

--- a/common/src/commonMain/kotlin/entity/DiscordComponent.kt
+++ b/common/src/commonMain/kotlin/entity/DiscordComponent.kt
@@ -105,9 +105,10 @@ public sealed class DiscordComponent {
         override fun selectDeserializer(element: JsonElement): KSerializer<out DiscordComponent> {
             val componentType = element.jsonObject["type"]?.jsonPrimitive?.intOrNull ?: error("Missing component type ID!")
 
-            return when (componentType) {
-                ComponentType.TextInput.value -> DiscordTextInputComponent.serializer()
-                else -> DiscordChatComponent.serializer()
+            return if (componentType == ComponentType.TextInput.value) {
+                DiscordTextInputComponent.serializer()
+            } else {
+                DiscordChatComponent.serializer()
             }
         }
     }

--- a/common/src/commonTest/kotlin/entity/optional/OptionalBooleanTest.kt
+++ b/common/src/commonTest/kotlin/entity/optional/OptionalBooleanTest.kt
@@ -41,7 +41,7 @@ internal class OptionalBooleanTest {
     }
 
     @Serializable
-    private class ValueOptionalEntity(@Suppress("unused") val value: OptionalBoolean = OptionalBoolean.Missing)
+    private class ValueOptionalEntity(val value: OptionalBoolean = OptionalBoolean.Missing)
 
     @Test
     @JsName("test3")

--- a/common/src/commonTest/kotlin/entity/optional/OptionalIntTest.kt
+++ b/common/src/commonTest/kotlin/entity/optional/OptionalIntTest.kt
@@ -40,7 +40,7 @@ internal class OptionalIntTest {
     }
 
     @Serializable
-    class ValueOptionalEntity(@Suppress("unused") val value: OptionalInt = OptionalInt.Missing)
+    class ValueOptionalEntity(val value: OptionalInt = OptionalInt.Missing)
 
     @Test
     @JsName("test3")

--- a/common/src/commonTest/kotlin/entity/optional/OptionalLongTest.kt
+++ b/common/src/commonTest/kotlin/entity/optional/OptionalLongTest.kt
@@ -26,7 +26,7 @@ internal class OptionalLongTest {
 
 
     @Serializable
-    class NullOptionalEntity(@Suppress("unused") val value: OptionalLong = OptionalLong.Missing)
+    class NullOptionalEntity(val value: OptionalLong = OptionalLong.Missing)
 
     @Test
     @JsName("test2")
@@ -42,7 +42,7 @@ internal class OptionalLongTest {
 
 
     @Serializable
-    class ValueOptionalEntity(@Suppress("unused") val value: OptionalLong = OptionalLong.Missing)
+    class ValueOptionalEntity(val value: OptionalLong = OptionalLong.Missing)
 
     @Test
     @JsName("test3")

--- a/common/src/commonTest/kotlin/entity/optional/OptionalSnowflakeTest.kt
+++ b/common/src/commonTest/kotlin/entity/optional/OptionalSnowflakeTest.kt
@@ -28,7 +28,7 @@ internal class OptionalSnowflakeTest {
 
 
     @Serializable
-    class NullOptionalEntity(@Suppress("unused") val value: OptionalSnowflake = OptionalSnowflake.Missing)
+    class NullOptionalEntity(val value: OptionalSnowflake = OptionalSnowflake.Missing)
 
     @Test
     @JsName("test2")
@@ -43,7 +43,7 @@ internal class OptionalSnowflakeTest {
 
 
     @Serializable
-    class ValueOptionalEntity(@Suppress("unused") val value: OptionalSnowflake = OptionalSnowflake.Missing)
+    class ValueOptionalEntity(val value: OptionalSnowflake = OptionalSnowflake.Missing)
 
     @Test
     @JsName("test3")

--- a/core/live-tests/src/commonTest/kotlin/regression/CacheMissRegression.kt
+++ b/core/live-tests/src/commonTest/kotlin/regression/CacheMissRegression.kt
@@ -46,9 +46,9 @@ private val parser = Json {
 
 object FakeGateway : Gateway {
 
-    val deferred = CompletableDeferred<Unit>()
+    private val deferred = CompletableDeferred<Unit>()
 
-    override val events: SharedFlow<Event> = MutableSharedFlow<Event>()
+    override val events: SharedFlow<Event> = MutableSharedFlow()
 
     override val ping: StateFlow<Duration?> = MutableStateFlow(null)
 
@@ -66,7 +66,7 @@ object FakeGateway : Gateway {
     override val coroutineContext: CoroutineContext = SupervisorJob() + EmptyCoroutineContext
 }
 
-class CrashingHandler(val client: HttpClient, override val token: String) : RequestHandler {
+class CrashingHandler(private val client: HttpClient, override val token: String) : RequestHandler {
     override suspend fun <B : Any, R> handle(request: Request<B, R>): R {
         if (request.route != Route.CurrentUserGet) throw IllegalStateException("shouldn't do a request")
         val response = client.request {

--- a/core/src/commonMain/kotlin/Util.kt
+++ b/core/src/commonMain/kotlin/Util.kt
@@ -27,7 +27,6 @@ import kotlinx.datetime.Instant
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 import kotlin.reflect.KClass
-import kotlinx.coroutines.flow.firstOrNull as coroutinesFirstOrNull
 
 internal inline fun <T> catchNotFound(block: () -> T): T? {
     contract {
@@ -66,7 +65,7 @@ internal fun <T : Comparable<T>> Flow<T>.sorted(): Flow<T> = flow {
  * The flow's collection is cancelled when a match is found.
  */
 internal suspend inline fun <T : Any> Flow<T>.any(crossinline predicate: suspend (T) -> Boolean): Boolean =
-    coroutinesFirstOrNull { predicate(it) } != null
+    firstOrNull { predicate(it) } != null
 
 /**
  * The non-terminal operator that returns a new flow that will emit values of the second [flow] only after the first

--- a/core/src/commonMain/kotlin/behavior/GuildBehavior.kt
+++ b/core/src/commonMain/kotlin/behavior/GuildBehavior.kt
@@ -54,7 +54,6 @@ import dev.kord.rest.request.RestRequestException
 import dev.kord.rest.service.*
 import kotlinx.coroutines.flow.*
 import kotlinx.datetime.Instant
-import kotlin.contracts.InvocationKind
 import kotlin.contracts.InvocationKind.EXACTLY_ONCE
 import kotlin.contracts.contract
 
@@ -695,7 +694,7 @@ public suspend inline fun GuildBehavior.createChatInputCommand(
     description: String,
     builder: ChatInputCreateBuilder.() -> Unit = {},
 ): GuildChatInputCommand {
-    contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
+    contract { callsInPlace(builder, EXACTLY_ONCE) }
     return kord.createGuildChatInputCommand(id, name, description, builder)
 }
 
@@ -704,7 +703,7 @@ public suspend inline fun GuildBehavior.createMessageCommand(
     name: String,
     builder: MessageCommandCreateBuilder.() -> Unit = {},
 ): GuildMessageCommand {
-    contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
+    contract { callsInPlace(builder, EXACTLY_ONCE) }
     return kord.createGuildMessageCommand(id, name, builder)
 }
 
@@ -713,7 +712,7 @@ public suspend inline fun GuildBehavior.createUserCommand(
     name: String,
     builder: UserCommandCreateBuilder.() -> Unit = {},
 ): GuildUserCommand {
-    contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
+    contract { callsInPlace(builder, EXACTLY_ONCE) }
     return kord.createGuildUserCommand(id, name, builder)
 }
 
@@ -721,7 +720,7 @@ public suspend inline fun GuildBehavior.createUserCommand(
 public suspend inline fun GuildBehavior.createApplicationCommands(
     builder: GuildMultiApplicationCommandBuilder.() -> Unit
 ): Flow<GuildApplicationCommand> {
-    contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
+    contract { callsInPlace(builder, EXACTLY_ONCE) }
     return kord.createGuildApplicationCommands(id, builder)
 }
 
@@ -734,7 +733,7 @@ public suspend inline fun GuildBehavior.createApplicationCommands(
  */
 public suspend inline fun GuildBehavior.edit(builder: GuildModifyBuilder.() -> Unit): Guild {
     contract {
-        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+        callsInPlace(builder, EXACTLY_ONCE)
     }
     val response = kord.rest.guild.modifyGuild(id, builder)
     val data = GuildData.from(response)
@@ -748,7 +747,7 @@ public suspend inline fun GuildBehavior.createEmoji(
     builder: EmojiCreateBuilder.() -> Unit = {}
 ): GuildEmoji {
     contract {
-        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+        callsInPlace(builder, EXACTLY_ONCE)
     }
     val discordEmoji = kord.rest.emoji.createEmoji(guildId = id, name, image, builder)
     return GuildEmoji(EmojiData.from(guildId = id, id = discordEmoji.id!!, discordEmoji), kord)
@@ -767,7 +766,7 @@ public suspend inline fun GuildBehavior.createTextChannel(
     builder: TextChannelCreateBuilder.() -> Unit = {}
 ): TextChannel {
     contract {
-        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+        callsInPlace(builder, EXACTLY_ONCE)
     }
     val response = kord.rest.guild.createTextChannel(id, name, builder)
     val data = ChannelData.from(response)
@@ -779,7 +778,7 @@ public suspend inline fun GuildBehavior.createForumChannel(
     name: String,
     builder: ForumChannelCreateBuilder.() -> Unit = {}
 ): ForumChannel  {
-    contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
+    contract { callsInPlace(builder, EXACTLY_ONCE) }
     val response = kord.rest.guild.createForumChannel(id, name, builder)
     val data = ChannelData.from(response)
     return Channel.from(data, kord) as ForumChannel
@@ -797,7 +796,7 @@ public suspend inline fun GuildBehavior.createVoiceChannel(
     builder: VoiceChannelCreateBuilder.() -> Unit = {}
 ): VoiceChannel {
     contract {
-        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+        callsInPlace(builder, EXACTLY_ONCE)
     }
     val response = kord.rest.guild.createVoiceChannel(id, name, builder)
     val data = ChannelData.from(response)
@@ -817,7 +816,7 @@ public suspend inline fun GuildBehavior.createNewsChannel(
     builder: NewsChannelCreateBuilder.() -> Unit = {}
 ): NewsChannel {
     contract {
-        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+        callsInPlace(builder, EXACTLY_ONCE)
     }
     val response = kord.rest.guild.createNewsChannel(id, name, builder)
     val data = ChannelData.from(response)
@@ -838,7 +837,7 @@ public suspend inline fun GuildBehavior.createCategory(
     builder: CategoryCreateBuilder.() -> Unit = {}
 ): Category {
     contract {
-        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+        callsInPlace(builder, EXACTLY_ONCE)
     }
     val response = kord.rest.guild.createCategory(id, name, builder)
     val data = ChannelData.from(response)
@@ -853,7 +852,7 @@ public suspend inline fun GuildBehavior.createCategory(
  */
 public suspend inline fun GuildBehavior.swapChannelPositions(builder: GuildChannelPositionModifyBuilder.() -> Unit) {
     contract {
-        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+        callsInPlace(builder, EXACTLY_ONCE)
     }
     kord.rest.guild.modifyGuildChannelPosition(id, builder)
 }
@@ -870,7 +869,7 @@ public suspend inline fun GuildBehavior.swapChannelPositions(builder: GuildChann
  */
 public suspend inline fun GuildBehavior.swapRolePositions(builder: RolePositionsModifyBuilder.() -> Unit): Flow<Role> {
     contract {
-        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+        callsInPlace(builder, EXACTLY_ONCE)
     }
     val response = kord.rest.guild.modifyGuildRolePosition(id, builder)
     return response.asFlow().map { RoleData.from(id, it) }.map { Role(it, kord) }
@@ -886,7 +885,7 @@ public suspend inline fun GuildBehavior.swapRolePositions(builder: RolePositions
  */
 public suspend inline fun GuildBehavior.createRole(builder: RoleCreateBuilder.() -> Unit = {}): Role {
     contract {
-        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+        callsInPlace(builder, EXACTLY_ONCE)
     }
     val response = kord.rest.guild.createGuildRole(id, builder)
     val data = RoleData.from(id, response)
@@ -901,7 +900,7 @@ public suspend inline fun GuildBehavior.createRole(builder: RoleCreateBuilder.()
  */
 public suspend inline fun GuildBehavior.ban(userId: Snowflake, builder: BanCreateBuilder.() -> Unit) {
     contract {
-        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+        callsInPlace(builder, EXACTLY_ONCE)
     }
     kord.rest.guild.addGuildBan(guildId = id, userId = userId, builder = builder)
 }
@@ -935,7 +934,7 @@ public suspend inline fun <reified T : GuildChannel> GuildBehavior.getChannelOfO
 }
 
 public suspend inline fun GuildBehavior.editWidget(builder: GuildWidgetModifyBuilder.() -> Unit): GuildWidget {
-    contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
+    contract { callsInPlace(builder, EXACTLY_ONCE) }
     return GuildWidget(GuildWidgetData.from(kord.rest.guild.modifyGuildWidget(id, builder)), id, kord)
 }
 
@@ -955,7 +954,7 @@ public suspend inline fun GuildBehavior.editWidget(builder: GuildWidgetModifyBui
  *  ```
  */
 public inline fun GuildBehavior.getAuditLogEntries(builder: AuditLogGetRequestBuilder.() -> Unit = {}): Flow<AuditLogEntry> {
-    contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
+    contract { callsInPlace(builder, EXACTLY_ONCE) }
     return kord.with(rest).getAuditLogEntries(id, builder).map { AuditLogEntry(it, kord) }
 }
 
@@ -978,7 +977,7 @@ public inline fun GuildBehavior.getAuditLogEntries(builder: AuditLogGetRequestBu
  */
 @PrivilegedIntent
 public inline fun GuildBehavior.requestMembers(builder: RequestGuildMembersBuilder.() -> Unit = { requestAllMembers() }): Flow<MembersChunkEvent> {
-    contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
+    contract { callsInPlace(builder, EXACTLY_ONCE) }
     val request = RequestGuildMembersBuilder(id).apply(builder).toRequest()
     return requestMembers(request)
 }
@@ -993,7 +992,7 @@ public suspend fun GuildBehavior.createScheduledEvent(
     entityType: ScheduledEntityType,
     builder: ScheduledEventCreateBuilder.() -> Unit
 ): GuildScheduledEvent {
-    contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
+    contract { callsInPlace(builder, EXACTLY_ONCE) }
 
     val event = kord.rest.guild.createScheduledEvent(id, name, privacyLevel, scheduledStartTime, entityType, builder)
     val data = GuildScheduledEventData.from(event)

--- a/core/src/commonMain/kotlin/cache/data/ApplicationCommandData.kt
+++ b/core/src/commonMain/kotlin/cache/data/ApplicationCommandData.kt
@@ -98,7 +98,6 @@ public class ApplicationCommandGroupData(
     public val subCommands: List<ApplicationCommandSubcommandData>
 )
 
-@Suppress("FunctionName")
 public fun ApplicationCommandGroupData(data: ApplicationCommandOptionData): ApplicationCommandGroupData {
     return ApplicationCommandGroupData(
         data.name,
@@ -139,7 +138,6 @@ public data class ApplicationCommandParameterData(
 )
 
 
-@Suppress("FunctionName")
 public fun ApplicationCommandParameterData(data: ApplicationCommandOptionData): ApplicationCommandParameterData {
     return ApplicationCommandParameterData(
         data.name,

--- a/core/src/commonMain/kotlin/entity/component/SelectMenuComponent.kt
+++ b/core/src/commonMain/kotlin/entity/component/SelectMenuComponent.kt
@@ -25,7 +25,7 @@ public open class SelectMenuComponent
 )
 public constructor(override val data: ComponentData) : Component {
 
-    @Suppress("DEPRECATION", "INAPPLICABLE_JVM_NAME")
+    @Suppress("INAPPLICABLE_JVM_NAME")
     @Deprecated("Binary compatibility", level = DeprecationLevel.HIDDEN)
     @get:JvmName("getType")
     public open val type0: ComponentType.SelectMenu get() = ComponentType.SelectMenu

--- a/core/src/commonMain/kotlin/gateway/handler/GuildEventHandler.kt
+++ b/core/src/commonMain/kotlin/gateway/handler/GuildEventHandler.kt
@@ -4,6 +4,7 @@ import dev.kord.cache.api.DataCache
 import dev.kord.cache.api.put
 import dev.kord.cache.api.putAll
 import dev.kord.cache.api.query
+import dev.kord.common.entity.DiscordGuild
 import dev.kord.common.entity.optional.optionalSnowflake
 import dev.kord.common.entity.optional.orEmpty
 import dev.kord.core.Kord
@@ -19,7 +20,6 @@ import dev.kord.gateway.*
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.singleOrNull
 import kotlinx.coroutines.flow.toSet
-import dev.kord.common.entity.DiscordGuild as GatewayGuild
 import dev.kord.core.event.Event as CoreEvent
 
 internal class GuildEventHandler : BaseGatewayEventHandler() {
@@ -55,7 +55,7 @@ internal class GuildEventHandler : BaseGatewayEventHandler() {
             else -> null
         }
 
-    private suspend fun GatewayGuild.cache(cache: DataCache) {
+    private suspend fun DiscordGuild.cache(cache: DataCache) {
         for (member in members.orEmpty()) {
             cache.put(MemberData.from(member.user.value!!.id, id, member))
             cache.put(UserData.from(member.user.value!!))

--- a/core/src/commonTest/kotlin/live/AbstractLiveEntityTest.kt
+++ b/core/src/commonTest/kotlin/live/AbstractLiveEntityTest.kt
@@ -51,7 +51,7 @@ abstract class AbstractLiveEntityTest<LIVE : AbstractLiveKordEntity> {
         override suspend fun stop() {}
     }
 
-    class CounterAtomicLatch() {
+    class CounterAtomicLatch {
         private val channel = Channel<Unit>()
 
         private val received = atomic(0)

--- a/core/src/jvmTest/kotlin/behavior/channel/ChannelBehaviorTest.kt
+++ b/core/src/jvmTest/kotlin/behavior/channel/ChannelBehaviorTest.kt
@@ -3,7 +3,6 @@ package dev.kord.core.behavior.channel
 import dev.kord.core.equality.ChannelEqualityTest
 import dev.kord.core.mockKord
 
-@Suppress("DELEGATED_MEMBER_HIDES_SUPERTYPE_OVERRIDE")
 internal class ChannelBehaviorTest : ChannelEqualityTest<ChannelBehavior> by ChannelEqualityTest({ id ->
     val kord = mockKord()
     ChannelBehavior(id = id, kord = kord)

--- a/core/src/jvmTest/kotlin/behavior/channel/MessageChannelBehaviorTest.kt
+++ b/core/src/jvmTest/kotlin/behavior/channel/MessageChannelBehaviorTest.kt
@@ -3,7 +3,6 @@ package dev.kord.core.behavior.channel
 import dev.kord.core.equality.ChannelEqualityTest
 import dev.kord.core.mockKord
 
-@Suppress("DELEGATED_MEMBER_HIDES_SUPERTYPE_OVERRIDE")
 internal class MessageChannelBehaviorTest : ChannelEqualityTest<MessageChannelBehavior> by ChannelEqualityTest({ id ->
     val kord = mockKord()
     MessageChannelBehavior(id = id, kord = kord)

--- a/core/src/jvmTest/kotlin/entity/channel/CategoryTest.kt
+++ b/core/src/jvmTest/kotlin/entity/channel/CategoryTest.kt
@@ -10,6 +10,4 @@ import dev.kord.core.mockKord
 internal class CategoryTest : GuildChannelEqualityTest<Category> by GuildChannelEqualityTest ({ id, guildId ->
     val kord = mockKord()
     Category(ChannelData(id, guildId = guildId.optionalSnowflake(), type = ChannelType.GuildCategory), kord)
-}) {
-
-}
+})

--- a/core/src/jvmTest/kotlin/interaction/CommandTypesTest.kt
+++ b/core/src/jvmTest/kotlin/interaction/CommandTypesTest.kt
@@ -15,29 +15,29 @@ import kotlin.test.assertIs
 
 
 class CommandsTypeTests {
-    val arg = buildJsonObject {
+    private val arg = buildJsonObject {
         put("type", ApplicationCommandOptionType.Integer.type)
         put("name", "argument")
         put("value", 1)
     }
-    val root = buildJsonObject {
+    private val root = buildJsonObject {
         put("id", "792107855418490901")
         put("name", "root")
         putJsonArray("options") { add(arg) }
     }
-    val partialSubCommand = buildJsonObject {
+    private val partialSubCommand = buildJsonObject {
         put("type", ApplicationCommandOptionType.SubCommand.type)
         put("name", "subCommand")
         putJsonArray("options") { add(arg) }
     }
-    val subCommand =
+    private val subCommand =
         buildJsonObject {
             putJsonArray("options") { add(partialSubCommand) }
             put("name", "root")
             put("id", "792107855418490901")
         }
 
-    val group = buildJsonObject {
+    private val group = buildJsonObject {
 
         putJsonArray("options") {
             addJsonObject {

--- a/gateway/src/commonMain/kotlin/Gateway.kt
+++ b/gateway/src/commonMain/kotlin/Gateway.kt
@@ -4,7 +4,6 @@ import dev.kord.common.entity.Snowflake
 import dev.kord.common.entity.optional.Optional
 import dev.kord.gateway.builder.PresenceBuilder
 import dev.kord.gateway.builder.RequestGuildMembersBuilder
-import io.ktor.util.logging.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.*

--- a/gateway/src/commonTest/kotlin/DefaultGatewayTest.kt
+++ b/gateway/src/commonTest/kotlin/DefaultGatewayTest.kt
@@ -4,13 +4,8 @@ import dev.kord.common.entity.ActivityType
 import dev.kord.common.entity.DiscordBotActivity
 import dev.kord.common.entity.PresenceStatus
 import dev.kord.common.ratelimit.IntervalRateLimiter
-import dev.kord.gateway.*
 import dev.kord.gateway.retry.LinearRetry
 import dev.kord.test.getEnv
-import io.ktor.client.*
-import io.ktor.client.plugins.contentnegotiation.*
-import io.ktor.client.plugins.websocket.*
-import io.ktor.serialization.kotlinx.json.*
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope

--- a/rest/src/commonMain/kotlin/builder/component/SelectMenuBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/component/SelectMenuBuilder.kt
@@ -27,7 +27,7 @@ public open class SelectMenuBuilder
     "This will be made a sealed class in the future, please stop using this constructor. You can instead use the " +
             "constructor of one of the subtypes.",
     ReplaceWith("StringSelectBuilder(customId)", "dev.kord.rest.builder.component.StringSelectBuilder"),
-    level = DeprecationLevel.ERROR,
+    level = ERROR,
 )
 public constructor(public var customId: String) : ActionRowComponentBuilder() {
 
@@ -41,7 +41,7 @@ public constructor(public var customId: String) : ActionRowComponentBuilder() {
             "dev.kord.rest.builder.component.StringSelectBuilder",
             "dev.kord.rest.builder.component.options",
         ),
-        level = DeprecationLevel.ERROR,
+        level = ERROR,
     )
     @Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE")
     @kotlin.internal.LowPriorityInOverloadResolution

--- a/rest/src/commonMain/kotlin/builder/message/EmbedBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/message/EmbedBuilder.kt
@@ -17,7 +17,6 @@ import kotlinx.datetime.Instant
  * Inline Markdown links are supported in in all description-like fields.
  */
 @KordDsl
-@Suppress("unused")
 public class EmbedBuilder : RequestBuilder<EmbedRequest> {
     public companion object {
         /**

--- a/rest/src/commonMain/kotlin/request/HttpUtils.kt
+++ b/rest/src/commonMain/kotlin/request/HttpUtils.kt
@@ -1,5 +1,3 @@
-@file:Suppress("unused")
-
 package dev.kord.rest.request
 
 import dev.kord.rest.ratelimit.BucketKey

--- a/rest/src/commonMain/kotlin/request/RestRequestException.kt
+++ b/rest/src/commonMain/kotlin/request/RestRequestException.kt
@@ -3,7 +3,7 @@ package dev.kord.rest.request
 import dev.kord.common.exception.RequestException
 import dev.kord.rest.json.response.DiscordErrorResponse
 import dev.kord.rest.service.RestService
-import io.ktor.client.statement.HttpResponse as KtorResponse
+import io.ktor.client.statement.HttpResponse
 
 private fun formatRestRequestExceptionMessage(status: HttpStatus, error: DiscordErrorResponse?): String {
     val statusCode = status.code
@@ -34,7 +34,7 @@ public data class HttpStatus(val code: Int, val message: String)
  * Implementation of the [RestRequestException] for [RestServices][RestService] using Ktor.
  */
 public class KtorRequestException(
-    @Suppress("MemberVisibilityCanBePrivate") public val httpResponse: KtorResponse,
+    @Suppress("MemberVisibilityCanBePrivate") public val httpResponse: HttpResponse,
     request: Request<*, *>,
     discordError: DiscordErrorResponse?,
 ) : RestRequestException(request, HttpStatus(httpResponse.status.value, httpResponse.status.description), discordError)

--- a/rest/src/commonMain/kotlin/service/ChannelService.kt
+++ b/rest/src/commonMain/kotlin/service/ChannelService.kt
@@ -4,13 +4,14 @@ import dev.kord.common.entity.*
 import dev.kord.common.entity.optional.orEmpty
 import dev.kord.rest.builder.channel.*
 import dev.kord.rest.builder.channel.thread.StartForumThreadBuilder
-import dev.kord.rest.builder.channel.thread.StartThreadWithMessageBuilder
 import dev.kord.rest.builder.channel.thread.StartThreadBuilder
+import dev.kord.rest.builder.channel.thread.StartThreadWithMessageBuilder
 import dev.kord.rest.builder.message.create.UserMessageCreateBuilder
 import dev.kord.rest.builder.message.modify.UserMessageModifyBuilder
 import dev.kord.rest.json.request.*
 import dev.kord.rest.json.response.FollowedChannelResponse
 import dev.kord.rest.json.response.ListThreadsResponse
+import dev.kord.rest.request.RequestBuilder
 import dev.kord.rest.request.RequestHandler
 import dev.kord.rest.request.auditLogReason
 import dev.kord.rest.route.Position
@@ -398,34 +399,28 @@ public class ChannelService(requestHandler: RequestHandler) : RestService(reques
         channelId: Snowflake,
         request: ListThreadsByTimestampRequest,
     ): ListThreadsResponse = call(Route.PublicArchivedThreadsGet) {
-        keys[Route.ChannelId] = channelId
-        val before = request.before
-        val limit = request.limit
-        if (before != null) parameter("before", before)
-        if (limit != null) parameter("limit", limit)
+        listThreadsConfig(channelId, request.before, request.limit)
     }
 
     public suspend fun listPrivateArchivedThreads(
         channelId: Snowflake,
         request: ListThreadsByTimestampRequest,
     ): ListThreadsResponse = call(Route.PrivateArchivedThreadsGet) {
-        keys[Route.ChannelId] = channelId
-        val before = request.before
-        val limit = request.limit
-        if (before != null) parameter("before", before)
-        if (limit != null) parameter("limit", limit)
+        listThreadsConfig(channelId, request.before, request.limit)
     }
 
     public suspend fun listJoinedPrivateArchivedThreads(
         channelId: Snowflake,
         request: ListThreadsBySnowflakeRequest,
     ): ListThreadsResponse = call(Route.JoinedPrivateArchivedThreadsGet) {
-        keys[Route.ChannelId] = channelId
-        val before = request.before
-        val limit = request.limit
-        if (before != null) parameter("before", before)
-        if (limit != null) parameter("limit", limit)
+        listThreadsConfig(channelId, request.before, request.limit)
     }
+}
+
+private fun RequestBuilder<ListThreadsResponse>.listThreadsConfig(channelId: Snowflake, before: Any?, limit: Int?) {
+    keys[Route.ChannelId] = channelId
+    if (before != null) parameter("before", before)
+    if (limit != null) parameter("limit", limit)
 }
 
 public suspend inline fun ChannelService.patchTextChannel(

--- a/rest/src/commonTest/kotlin/json/AuditLogResponseTest.kt
+++ b/rest/src/commonTest/kotlin/json/AuditLogResponseTest.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.json.Json
 import kotlin.js.JsName
 import kotlin.test.Test
 
-object AuditLogResponseTest {
+class AuditLogResponseTest {
 
     @Test
     @JsName("test1")

--- a/rest/src/commonTest/kotlin/ratelimit/TestClock.kt
+++ b/rest/src/commonTest/kotlin/ratelimit/TestClock.kt
@@ -6,6 +6,6 @@ import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlin.time.Duration.Companion.milliseconds
 
-class TestClock(val instant: Instant, val scope: TestScope) : Clock {
+class TestClock(private val instant: Instant, private val scope: TestScope) : Clock {
     override fun now(): Instant = instant + scope.currentTime.milliseconds
 }

--- a/voice/src/main/kotlin/SpeakingFlag.kt
+++ b/voice/src/main/kotlin/SpeakingFlag.kt
@@ -56,7 +56,7 @@ public class SpeakingFlags internal constructor(public val code: Int) {
         }
     }
 
-    public class Builder(internal var code: Int = 0) {
+    public class Builder(private var code: Int = 0) {
         public operator fun SpeakingFlag.unaryPlus() {
             this@Builder.code = this@Builder.code or code
         }

--- a/voice/src/main/kotlin/udp/AudioFrameSender.kt
+++ b/voice/src/main/kotlin/udp/AudioFrameSender.kt
@@ -5,7 +5,6 @@ package dev.kord.voice.udp
 import dev.kord.common.annotation.KordVoice
 import dev.kord.voice.FrameInterceptorConfiguration
 import io.ktor.network.sockets.*
-import io.ktor.util.network.*
 
 @KordVoice
 public data class AudioFrameSenderConfiguration(

--- a/voice/src/main/kotlin/udp/RTPPacket.kt
+++ b/voice/src/main/kotlin/udp/RTPPacket.kt
@@ -23,7 +23,6 @@ internal const val RTP_HEADER_LENGTH = 12
  * - SSRCs are stored as UInt (4 bytes) not long.
  * - And most notably, the extension header is not exactly after the RTP header. Discord instead encrypts it along with the payload...
  */
-@Suppress("ArrayInDataClass")
 @OptIn(ExperimentalUnsignedTypes::class)
 public data class RTPPacket(
     val paddingBytes: UByte,


### PR DESCRIPTION
* Remove pointless import aliases

* Prefix Dokka modules with 'kord-'
  This aligns the Dokka documentation with the artifact names (see [`buildSrc/src/main/kotlin/kord-publishing.gradle.kts`](https://github.com/kordlib/kord/blob/57b186c0ee11d696a8ffa2c4301e55856e7468e4/buildSrc/src/main/kotlin/kord-publishing.gradle.kts#L18))

* Fix some findings of Inspect Code in IntelliJ