### PR TITLE
Improve `GenerateKordEnum` and `AnnotationArguments`

### DIFF
--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/GuildFeature.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/GuildFeature.kt
@@ -123,6 +123,17 @@ public sealed class GuildFeature(
     public object MemberVerificationGateEnabled : GuildFeature("MEMBER_VERIFICATION_GATE_ENABLED")
 
     /**
+     * Guild has enabled monetization.
+     */
+    @Deprecated(
+        level = DeprecationLevel.ERROR,
+        message = "Replaced by CreatorMonetizableProvisional.",
+        replaceWith = ReplaceWith(expression = "GuildFeature.CreatorMonetizableProvisional", imports
+                    = arrayOf("dev.kord.common.entitiy.GuildFeature")),
+    )
+    public object MonetizationEnabled : GuildFeature("MONETIZATION_ENABLED")
+
+    /**
      * Guild has increased custom sticker slots.
      */
     public object MoreStickers : GuildFeature("MORE_STICKERS")
@@ -141,6 +152,15 @@ public sealed class GuildFeature(
      * Guild can be previewed before joining via Membership Screening or the directory.
      */
     public object PreviewEnabled : GuildFeature("PREVIEW_ENABLED")
+
+    /**
+     * Guild has access to create private threads
+     */
+    @Deprecated(
+        level = DeprecationLevel.ERROR,
+        message = "Creating a private thread no longer requires the server to be boosted.",
+    )
+    public object PrivateThreads : GuildFeature("PRIVATE_THREADS")
 
     /**
      * Guild is able to set role icons.
@@ -182,26 +202,6 @@ public sealed class GuildFeature(
      * Guild has enabled the welcome screen.
      */
     public object WelcomeScreenEnabled : GuildFeature("WELCOME_SCREEN_ENABLED")
-
-    /**
-     * Guild has enabled monetization.
-     */
-    @Deprecated(
-        level = DeprecationLevel.ERROR,
-        message = "Replaced by CreatorMonetizableProvisional.",
-        replaceWith = ReplaceWith(expression = "GuildFeature.CreatorMonetizableProvisional", imports
-                    = arrayOf("dev.kord.common.entitiy.GuildFeature")),
-    )
-    public object MonetizationEnabled : GuildFeature("MONETIZATION_ENABLED")
-
-    /**
-     * Guild has access to create private threads
-     */
-    @Deprecated(
-        level = DeprecationLevel.ERROR,
-        message = "Creating a private thread no longer requires the server to be boosted.",
-    )
-    public object PrivateThreads : GuildFeature("PRIVATE_THREADS")
 
     internal object Serializer : KSerializer<GuildFeature> {
         public override val descriptor: SerialDescriptor =

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/StageInstancePrivacyLevel.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/StageInstancePrivacyLevel.kt
@@ -53,15 +53,15 @@ public sealed class StageInstancePrivacyLevel(
     ) : StageInstancePrivacyLevel(value)
 
     /**
-     * The Stage instance is visible to only guild members.
-     */
-    public object GuildOnly : StageInstancePrivacyLevel(2)
-
-    /**
      * The Stage instance is visible publicly.
      */
     @Deprecated(message = "Stages are no longer discoverable")
     public object Public : StageInstancePrivacyLevel(1)
+
+    /**
+     * The Stage instance is visible to only guild members.
+     */
+    public object GuildOnly : StageInstancePrivacyLevel(2)
 
     internal object NewSerializer : KSerializer<StageInstancePrivacyLevel> {
         public override val descriptor: SerialDescriptor =

--- a/common/src/commonMain/kotlin/entity/DiscordComponent.kt
+++ b/common/src/commonMain/kotlin/entity/DiscordComponent.kt
@@ -11,11 +11,13 @@
         Entry("RoleSelect", intValue = 6, kDoc = "Select menu for roles."),
         Entry("MentionableSelect", intValue = 7, kDoc = "Select menu for mentionables (users and roles)."),
         Entry("ChannelSelect", intValue = 8, kDoc = "Select menu for channels."),
-    ],
-    deprecatedEntries = [
-        Entry("SelectMenu", intValue = 3, kDoc = "A select menu for picking from choices.",
-            deprecationMessage = "Renamed by discord", replaceWith = ReplaceWith("StringSelect", "dev.kord.common.entity.ComponentType.StringSelect"),
-            deprecationLevel = DeprecationLevel.ERROR
+        Entry(
+            "SelectMenu", intValue = 3, kDoc = "A select menu for picking from choices.",
+            deprecated = Deprecated(
+                "Renamed by discord",
+                ReplaceWith("StringSelect", "dev.kord.common.entity.ComponentType.StringSelect"),
+                DeprecationLevel.ERROR
+            ),
         ),
     ],
 )

--- a/common/src/commonMain/kotlin/entity/DiscordGuild.kt
+++ b/common/src/commonMain/kotlin/entity/DiscordGuild.kt
@@ -115,12 +115,26 @@
             "MemberVerificationGateEnabled", stringValue = "MEMBER_VERIFICATION_GATE_ENABLED",
             kDoc = "Guild has enabled Membership Screening.",
         ),
+        Entry(
+            "MonetizationEnabled", stringValue = "MONETIZATION_ENABLED", kDoc = "Guild has enabled monetization.",
+            deprecated = Deprecated(
+                "Replaced by CreatorMonetizableProvisional.",
+                ReplaceWith("GuildFeature.CreatorMonetizableProvisional", "dev.kord.common.entitiy.GuildFeature"),
+                level = ERROR,
+            ),
+        ),
         Entry("MoreStickers", stringValue = "MORE_STICKERS", kDoc = "Guild has increased custom sticker slots."),
         Entry("News", stringValue = "NEWS", kDoc = "Guild has access to create announcement channels."),
         Entry("Partnered", stringValue = "PARTNERED", kDoc = "Guild is partnered."),
         Entry(
             "PreviewEnabled", stringValue = "PREVIEW_ENABLED",
             kDoc = "Guild can be previewed before joining via Membership Screening or the directory.",
+        ),
+        Entry(
+            "PrivateThreads", stringValue = "PRIVATE_THREADS", kDoc = "Guild has access to create private threads",
+            deprecated = Deprecated(
+                "Creating a private thread no longer requires the server to be boosted.", level = ERROR,
+            ),
         ),
         Entry("RoleIcons", stringValue = "ROLE_ICONS", kDoc = "Guild is able to set role icons."),
         Entry("RoleSubscriptionsAvailableForPurchase", stringValue = "ROLE_SUBSCRIPTIONS_AVAILABLE_FOR_PURCHASE",
@@ -142,21 +156,6 @@
         Entry(
             "WelcomeScreenEnabled", stringValue = "WELCOME_SCREEN_ENABLED",
             kDoc = "Guild has enabled the welcome screen.",
-        ),
-    ],
-    deprecatedEntries = [
-        Entry(
-            "MonetizationEnabled", stringValue = "MONETIZATION_ENABLED", kDoc = "Guild has enabled monetization.",
-            deprecationMessage = "Replaced by CreatorMonetizableProvisional.", deprecationLevel = ERROR,
-            replaceWith = ReplaceWith(
-                "GuildFeature.CreatorMonetizableProvisional",
-                imports = ["dev.kord.common.entitiy.GuildFeature"],
-            ),
-        ),
-        Entry(
-            "PrivateThreads", stringValue = "PRIVATE_THREADS", kDoc = "Guild has access to create private threads",
-            deprecationMessage = "Creating a private thread no longer requires the server to be boosted.",
-            deprecationLevel = ERROR,
         ),
     ],
 )

--- a/common/src/commonMain/kotlin/entity/DiscordStageInstance.kt
+++ b/common/src/commonMain/kotlin/entity/DiscordStageInstance.kt
@@ -3,13 +3,11 @@
     deprecatedSerializerName = "Serializer",
     docUrl = "https://discord.com/developers/docs/resources/stage-instance#stage-instance-object-privacy-level",
     entries = [
-        Entry("GuildOnly", intValue = 2, kDoc = "The Stage instance is visible to only guild members."),
-    ],
-    deprecatedEntries = [
         Entry(
             "Public", intValue = 1, kDoc = "The Stage instance is visible publicly.",
-            deprecationMessage = "Stages are no longer discoverable", deprecationLevel = WARNING,
+            deprecated = Deprecated("Stages are no longer discoverable", level = WARNING),
         ),
+        Entry("GuildOnly", intValue = 2, kDoc = "The Stage instance is visible to only guild members."),
     ],
 )
 

--- a/ksp-annotations/src/commonMain/kotlin/GenerateKordEnum.kt
+++ b/ksp-annotations/src/commonMain/kotlin/GenerateKordEnum.kt
@@ -5,7 +5,6 @@ import dev.kord.ksp.GenerateKordEnum.ValueType
 import dev.kord.ksp.GenerateKordEnum.ValueType.INT
 import dev.kord.ksp.GenerateKordEnum.ValueType.STRING
 import dev.kord.ksp.GenerateKordEnum.ValuesPropertyType.NONE
-import kotlin.DeprecationLevel.WARNING
 import kotlin.annotation.AnnotationRetention.SOURCE
 import kotlin.annotation.AnnotationTarget.FILE
 
@@ -18,16 +17,14 @@ annotation class GenerateKordEnum(
     val name: String,
     /** [ValueType] of the kord enum. */
     val valueType: ValueType,
+    /** URL to the Discord Developer Documentation for the kord enum. */
+    val docUrl: String,
     /** [Entries][Entry] of the kord enum. */
     val entries: Array<Entry>,
     /** KDoc for the kord enum (optional). */
     val kDoc: String = "",
-    /** Url to the Discord Developer Documentation for the kord enum (optional). */
-    val docUrl: String = "",
     /** Name of the value of the kord enum. */
     val valueName: String = "value",
-    /** [entries] of the kord enum that are [Deprecated]. [Entry.deprecationMessage] is required for these. */
-    val deprecatedEntries: Array<Entry> = [],
 
     // TODO remove eventually
     /** For migration purposes. */
@@ -46,26 +43,12 @@ annotation class GenerateKordEnum(
         /** Name of the entry. */
         val name: String,
         /** [Int] value of the entry. Only set this if [GenerateKordEnum.valueType] is [INT]. */
-        val intValue: Int = DEFAULT_INT_VALUE,
+        val intValue: Int = 0,
         /** [String] value of the entry. Only set this if [GenerateKordEnum.valueType] is [STRING]. */
-        val stringValue: String = DEFAULT_STRING_VALUE,
+        val stringValue: String = "",
         /** KDoc for the entry (optional). */
         val kDoc: String = "",
-        /** Whether to add `@KordExperimental` to this entry. */
-        val isKordExperimental: Boolean = false,
-        /** [Deprecated.message] for a [deprecated entry][GenerateKordEnum.deprecatedEntries]. */
-        val deprecationMessage: String = "",
-        /** [Deprecated.replaceWith] for a [deprecated entry][GenerateKordEnum.deprecatedEntries]. */
-        val replaceWith: ReplaceWith = ReplaceWith(""),
-        /** [Deprecated.level] for a [deprecated entry][GenerateKordEnum.deprecatedEntries]. */
-        val deprecationLevel: DeprecationLevel = WARNING,
-    ) {
-        companion object {
-            /** Default value for [intValue]. */
-            const val DEFAULT_INT_VALUE = Int.MIN_VALUE // probably won't appear anywhere
-
-            /** Default value for [stringValue]. */
-            const val DEFAULT_STRING_VALUE = ""
-        }
-    }
+        /** [Deprecated] annotation to mark this entry as deprecated. */
+        val deprecated: Deprecated = Deprecated(""),
+    )
 }

--- a/ksp-processors/src/main/kotlin/KSPUtils.kt
+++ b/ksp-processors/src/main/kotlin/KSPUtils.kt
@@ -1,7 +1,10 @@
 package dev.kord.ksp
 
+import com.google.devtools.ksp.findActualType
+import com.google.devtools.ksp.isDefault
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.ClassKind.ENUM_ENTRY
 import kotlin.reflect.KProperty1
 
 internal inline fun <reified A : Annotation> Resolver.getSymbolsWithAnnotation(inDepth: Boolean = false) =
@@ -11,26 +14,46 @@ internal fun Resolver.getNewClasses() = getNewFiles().flatMap { it.declarations.
 
 internal inline fun <reified A : Annotation> KSAnnotation.isOfType() = isOfType(A::class.qualifiedName!!)
 
-internal fun KSAnnotation.isOfType(qualifiedName: String) =
-    shortName.asString() == qualifiedName.substringAfterLast('.')
-        && annotationType.resolve().declaration.qualifiedName?.asString() == qualifiedName
+internal fun KSAnnotation.isOfType(qualifiedName: String) = annotationType.resolve()
+    .declaration.let { if (it is KSTypeAlias) it.findActualType() else it }
+    .qualifiedName?.asString() == qualifiedName
 
-internal class AnnotationArguments private constructor(private val map: Map<String, Any?>) {
-    private inline fun <reified V : Any> get(parameter: KProperty1<out Annotation, V>) = map[parameter.name] as V?
+internal class AnnotationArguments<A : Annotation> private constructor(
+    private val arguments: Map<String, KSValueArgument>,
+) {
+    private fun getArgument(parameter: KProperty1<A, Any>) = arguments.getValue(parameter.name)
+    private val KProperty1<A, Any>.value get() = getArgument(this).value
 
-    internal inline fun <reified V : Any> getSafe(parameter: KProperty1<out Annotation, V>) =
-        get(parameter) ?: error("Missing required parameter: $parameter")
+    fun isDefault(parameter: KProperty1<A, Any>) = getArgument(parameter).isDefault()
 
-    // https://github.com/google/ksp/issues/885
-    internal inline fun <reified V : Any> getOrDefault(parameter: KProperty1<out Annotation, V>, defaultValue: V) =
-        get(parameter) ?: defaultValue
+    // can't return non-nullable values because of https://github.com/google/ksp/issues/885
+    operator fun get(parameter: KProperty1<A, Int>) = parameter.value as Int?
+    operator fun get(parameter: KProperty1<A, String>) = parameter.value as String?
+    operator fun get(parameter: KProperty1<A, Annotation>) = parameter.value as KSAnnotation?
+    inline operator fun <reified E : Enum<E>> get(parameter: KProperty1<A, E>) =
+        (parameter.value as KSType?)?.toEnumEntry<E>()
 
-    internal fun getRaw(parameter: KProperty1<out Annotation, Any>) = map[parameter.name]
+    @JvmName("getStrings")
+    operator fun get(parameter: KProperty1<A, Array<out String>>) =
+        @Suppress("UNCHECKED_CAST") (parameter.value as List<String>?)
 
-    internal companion object {
-        internal val KSAnnotation.annotationArguments
-            get() = AnnotationArguments(arguments.associate { it.name!!.getShortName() to it.value })
+    @JvmName("getAnnotations")
+    operator fun get(parameter: KProperty1<A, Array<out Annotation>>) =
+        @Suppress("UNCHECKED_CAST") (parameter.value as List<KSAnnotation>?)
+
+    companion object {
+        fun <A : Annotation> KSAnnotation.arguments() =
+            AnnotationArguments<A>(arguments.associateBy { it.name!!.asString() })
     }
+}
+
+/** Maps [KSType] to an entry of the enum class [E]. */
+private inline fun <reified E : Enum<E>> KSType.toEnumEntry(): E {
+    val decl = declaration
+    require(decl is KSClassDeclaration && decl.classKind == ENUM_ENTRY)
+    val name = decl.qualifiedName!!
+    require(name.getQualifier() == E::class.qualifiedName)
+    return enumValueOf(name.getShortName())
 }
 
 @Suppress("RecursivePropertyAccessor")

--- a/ksp-processors/src/main/kotlin/kordenum/KordEnum.kt
+++ b/ksp-processors/src/main/kotlin/kordenum/KordEnum.kt
@@ -2,47 +2,36 @@ package dev.kord.ksp.kordenum
 
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.symbol.KSAnnotation
-import com.google.devtools.ksp.symbol.KSType
-import dev.kord.ksp.AnnotationArguments.Companion.annotationArguments
+import dev.kord.ksp.AnnotationArguments.Companion.arguments
 import dev.kord.ksp.GenerateKordEnum
 import dev.kord.ksp.GenerateKordEnum.ValueType
 import dev.kord.ksp.GenerateKordEnum.ValueType.INT
 import dev.kord.ksp.GenerateKordEnum.ValueType.STRING
 import dev.kord.ksp.GenerateKordEnum.ValuesPropertyType
 import dev.kord.ksp.GenerateKordEnum.ValuesPropertyType.NONE
-import dev.kord.ksp.GenerateKordEnum.ValuesPropertyType.SET
 import dev.kord.ksp.kordenum.KordEnum.Entry
-import kotlin.DeprecationLevel.*
-
-private val NATURAL_ORDER: Comparator<Comparable<*>> = compareBy { it }
+import kotlin.DeprecationLevel.WARNING
 
 /** Mapping of [GenerateKordEnum] that is easier to work with in [KordEnumProcessor]. */
 internal class KordEnum(
     val name: String,
     val kDoc: String?,
-    val docUrl: String?,
+    val docUrl: String,
     val valueType: ValueType,
     val valueName: String,
     val entries: List<Entry>,
-    val deprecatedEntries: List<Entry>,
 
     // for migration purposes, TODO remove eventually
     val valuesPropertyName: String?,
     val valuesPropertyType: ValuesPropertyType,
     val deprecatedSerializerName: String?,
 ) {
-    internal class Entry(
+    class Entry(
         val name: String,
         val kDoc: String?,
         val value: Comparable<*>,
-        val isKordExperimental: Boolean,
-        val isDeprecated: Boolean,
-        val deprecationMessage: String,
-        val replaceWith: ReplaceWith,
-        val deprecationLevel: DeprecationLevel,
-    ) : Comparable<Entry> {
-        override fun compareTo(other: Entry) = with(NATURAL_ORDER) { compare(value, other.value) }
-    }
+        val deprecated: Deprecated?,
+    )
 }
 
 /**
@@ -51,18 +40,17 @@ internal class KordEnum(
  * Returns `null` if mapping fails.
  */
 internal fun KSAnnotation.toKordEnumOrNull(logger: KSPLogger): KordEnum? {
-    val args = annotationArguments
+    val args = arguments<GenerateKordEnum>()
 
-    val name = args.getSafe(GenerateKordEnum::name)
-    val valueType = args.getRaw(GenerateKordEnum::valueType).toValueType()
-    val entries = args.getRaw(GenerateKordEnum::entries) as List<*>
-    val kDoc = args.getOrDefault(GenerateKordEnum::kDoc, "").toKDoc()
-    val docUrl = args.getOrDefault(GenerateKordEnum::docUrl, "").ifBlank { null }
-    val valueName = args.getOrDefault(GenerateKordEnum::valueName, "value")
-    val deprecatedEntries = args.getRaw(GenerateKordEnum::deprecatedEntries) as List<*>? ?: emptyList<Any>()
+    val name = args[GenerateKordEnum::name]!!
+    val valueType = args[GenerateKordEnum::valueType]!!
+    val docUrl = args[GenerateKordEnum::docUrl]!!
+    val entries = args[GenerateKordEnum::entries]!!
+    val kDoc = args[GenerateKordEnum::kDoc]?.toKDoc()
+    val valueName = args[GenerateKordEnum::valueName] ?: "value"
 
-    val valuesPropertyName = args.getOrDefault(GenerateKordEnum::valuesPropertyName, "").ifEmpty { null }
-    val valuesPropertyType = args.getRaw(GenerateKordEnum::valuesPropertyType)?.toValuesPropertyType() ?: NONE
+    val valuesPropertyName = args[GenerateKordEnum::valuesPropertyName]?.ifEmpty { null }
+    val valuesPropertyType = args[GenerateKordEnum::valuesPropertyType] ?: NONE
     if (valuesPropertyName != null) {
         if (valuesPropertyType == NONE) {
             logger.error("Didn't specify valuesPropertyType", symbol = this)
@@ -74,114 +62,77 @@ internal fun KSAnnotation.toKordEnumOrNull(logger: KSPLogger): KordEnum? {
             return null
         }
     }
-    val deprecatedSerializerName = args.getOrDefault(GenerateKordEnum::deprecatedSerializerName, "").ifEmpty { null }
+    val deprecatedSerializerName = args[GenerateKordEnum::deprecatedSerializerName]?.ifEmpty { null }
+
+    val mappedEntries = entries
+        .mapNotNull { it.toEntryOrNull(valueType, logger) }
+        .takeIf { it.size == entries.size } ?: return null // there were errors while mapping entries
 
     return KordEnum(
-        name, kDoc, docUrl, valueType, valueName,
-        entries.map { it.toEntryOrNull(valueType, isDeprecated = false, logger) ?: return null },
-        deprecatedEntries.map { it.toEntryOrNull(valueType, isDeprecated = true, logger) ?: return null },
+        name, kDoc, docUrl, valueType, valueName, mappedEntries,
 
         valuesPropertyName, valuesPropertyType, deprecatedSerializerName,
     )
 }
 
-/** Maps [KSType] to [ValueType]. */
-private fun Any?.toValueType() = when (val name = (this as KSType).declaration.qualifiedName?.asString()) {
-    "dev.kord.ksp.GenerateKordEnum.ValueType.INT" -> INT
-    "dev.kord.ksp.GenerateKordEnum.ValueType.STRING" -> STRING
-    else -> error("Unknown GenerateKordEnum.ValueType: $name")
-}
-
-private fun Any?.toKDoc() = (this as String).trimIndent().ifBlank { null }
-
-/** Maps [KSType] to [ValuesPropertyType]. */
-private fun Any?.toValuesPropertyType() = when (val name = (this as KSType).declaration.qualifiedName?.asString()) {
-    "dev.kord.ksp.GenerateKordEnum.ValuesPropertyType.NONE" -> NONE
-    "dev.kord.ksp.GenerateKordEnum.ValuesPropertyType.SET" -> SET
-    else -> error("Unknown GenerateKordEnum.ValuesPropertyType: $name")
-}
+private fun String.toKDoc() = trimIndent().ifBlank { null }
 
 /**
  * Maps [KSAnnotation] for [GenerateKordEnum.Entry] to [Entry].
  *
  * Returns `null` if mapping fails.
  */
-private fun Any?.toEntryOrNull(valueType: ValueType, isDeprecated: Boolean, logger: KSPLogger): Entry? {
-    val args = (this as KSAnnotation).annotationArguments
+private fun KSAnnotation.toEntryOrNull(valueType: ValueType, logger: KSPLogger): Entry? {
+    val args = arguments<GenerateKordEnum.Entry>()
 
-    val name = args.getSafe(GenerateKordEnum.Entry::name)
-    val intValue = args.getOrDefault(GenerateKordEnum.Entry::intValue, GenerateKordEnum.Entry.DEFAULT_INT_VALUE)
-    val stringValue = args.getOrDefault(GenerateKordEnum.Entry::stringValue, GenerateKordEnum.Entry.DEFAULT_STRING_VALUE)
-    val kDoc = args.getOrDefault(GenerateKordEnum.Entry::kDoc, "").toKDoc()
-    val isKordExperimental = args.getOrDefault(GenerateKordEnum.Entry::isKordExperimental, false)
-    val deprecationMessage = args.getOrDefault(GenerateKordEnum.Entry::deprecationMessage, "")
-    val replaceWith = args.getRaw(GenerateKordEnum.Entry::replaceWith)?.toReplaceWith() ?: ReplaceWith("", imports = emptyArray())
-    val deprecationLevel = args.getRaw(GenerateKordEnum.Entry::deprecationLevel)?.toDeprecationLevel() ?: WARNING
+    val name = args[GenerateKordEnum.Entry::name]!!
+    val kDoc = args[GenerateKordEnum.Entry::kDoc]?.toKDoc()
+    val deprecated = args[GenerateKordEnum.Entry::deprecated]?.toDeprecated()
+        .takeUnless { args.isDefault(GenerateKordEnum.Entry::deprecated) }
 
     val value = when (valueType) {
         INT -> {
-            if (stringValue != GenerateKordEnum.Entry.DEFAULT_STRING_VALUE) {
+            if (!args.isDefault(GenerateKordEnum.Entry::stringValue)) {
                 logger.error("Specified stringValue for valueType $valueType", symbol = this)
                 return null
             }
-            if (intValue == GenerateKordEnum.Entry.DEFAULT_INT_VALUE) {
+            if (args.isDefault(GenerateKordEnum.Entry::intValue)) {
                 logger.error("Didn't specify intValue for valueType $valueType", symbol = this)
                 return null
             }
-
-            intValue
+            args[GenerateKordEnum.Entry::intValue]!!
         }
         STRING -> {
-            if (intValue != GenerateKordEnum.Entry.DEFAULT_INT_VALUE) {
+            if (!args.isDefault(GenerateKordEnum.Entry::intValue)) {
                 logger.error("Specified intValue for valueType $valueType", symbol = this)
                 return null
             }
-            if (stringValue == GenerateKordEnum.Entry.DEFAULT_STRING_VALUE) {
+            if (args.isDefault(GenerateKordEnum.Entry::stringValue)) {
                 logger.error("Didn't specify stringValue for valueType $valueType", symbol = this)
                 return null
             }
-
-            stringValue
+            args[GenerateKordEnum.Entry::stringValue]!!
         }
     }
 
-    if (isDeprecated) {
-        if (deprecationMessage.isBlank()) {
-            logger.error("deprecationMessage is required", symbol = this)
-            return null
-        }
-    } else {
-        if (deprecationMessage.isNotEmpty()) {
-            logger.error("deprecationMessage is not allowed", symbol = this)
-            return null
-        }
-        if (replaceWith.expression.isNotEmpty() || replaceWith.imports.isNotEmpty()) {
-            logger.error("replaceWith is not allowed", symbol = this)
-            return null
-        }
-        if (deprecationLevel != WARNING) {
-            logger.error("deprecationLevel is not allowed", symbol = this)
-            return null
-        }
-    }
+    return Entry(name, kDoc, value, deprecated)
+}
 
-    return Entry(name, kDoc, value, isKordExperimental, isDeprecated, deprecationMessage, replaceWith, deprecationLevel)
+/** Maps [KSAnnotation] to [Deprecated]. */
+private fun KSAnnotation.toDeprecated(): Deprecated {
+    val args = arguments<Deprecated>()
+    return Deprecated(
+        message = args[Deprecated::message]!!,
+        replaceWith = args[Deprecated::replaceWith]?.toReplaceWith() ?: ReplaceWith("", imports = emptyArray()),
+        level = args[Deprecated::level] ?: WARNING,
+    )
 }
 
 /** Maps [KSAnnotation] to [ReplaceWith]. */
-private fun Any?.toReplaceWith(): ReplaceWith {
-    val args = (this as KSAnnotation).annotationArguments
-
-    val expression = args.getSafe(ReplaceWith::expression)
-    val imports = @Suppress("UNCHECKED_CAST") (args.getRaw(ReplaceWith::imports) as List<String>)
-
-    return ReplaceWith(expression, *imports.toTypedArray())
-}
-
-/** Maps [KSType] to [DeprecationLevel]. */
-private fun Any?.toDeprecationLevel() = when (val name = (this as KSType).declaration.qualifiedName?.asString()) {
-    "kotlin.DeprecationLevel.WARNING" -> WARNING
-    "kotlin.DeprecationLevel.ERROR" -> ERROR
-    "kotlin.DeprecationLevel.HIDDEN" -> HIDDEN
-    else -> error("Unknown DeprecationLevel: $name")
+private fun KSAnnotation.toReplaceWith(): ReplaceWith {
+    val args = arguments<ReplaceWith>()
+    return ReplaceWith(
+        expression = args[ReplaceWith::expression]!!,
+        imports = args[ReplaceWith::imports]!!.toTypedArray(),
+    )
 }


### PR DESCRIPTION
The `GenerateKordEnum` annotation was simplified by using a single array for both normal and deprecated entries.

`AnnotationArguments` is now more type-safe and allows checking if a default is used for a parameter.