### PR TITLE
Allow modifying `GuildOnboarding`

### DIFF
--- a/common/api/common.api
+++ b/common/api/common.api
@@ -4121,18 +4121,20 @@ public final class dev/kord/common/entity/DiscordGuildMember$Companion {
 
 public final class dev/kord/common/entity/DiscordGuildOnboarding {
 	public static final field Companion Ldev/kord/common/entity/DiscordGuildOnboarding$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/util/List;Ljava/util/List;ZLkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/util/List;Ljava/util/List;Z)V
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ljava/util/List;Ljava/util/List;ZLdev/kord/common/entity/OnboardingMode;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ldev/kord/common/entity/Snowflake;Ljava/util/List;Ljava/util/List;ZLdev/kord/common/entity/OnboardingMode;)V
 	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
 	public final fun component2 ()Ljava/util/List;
 	public final fun component3 ()Ljava/util/List;
 	public final fun component4 ()Z
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ljava/util/List;Ljava/util/List;Z)Ldev/kord/common/entity/DiscordGuildOnboarding;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordGuildOnboarding;Ldev/kord/common/entity/Snowflake;Ljava/util/List;Ljava/util/List;ZILjava/lang/Object;)Ldev/kord/common/entity/DiscordGuildOnboarding;
+	public final fun component5 ()Ldev/kord/common/entity/OnboardingMode;
+	public final fun copy (Ldev/kord/common/entity/Snowflake;Ljava/util/List;Ljava/util/List;ZLdev/kord/common/entity/OnboardingMode;)Ldev/kord/common/entity/DiscordGuildOnboarding;
+	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordGuildOnboarding;Ldev/kord/common/entity/Snowflake;Ljava/util/List;Ljava/util/List;ZLdev/kord/common/entity/OnboardingMode;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordGuildOnboarding;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDefaultChannelIds ()Ljava/util/List;
 	public final fun getEnabled ()Z
 	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getMode ()Ldev/kord/common/entity/OnboardingMode;
 	public final fun getPrompts ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -7892,6 +7894,32 @@ public final class dev/kord/common/entity/NsfwLevel$Safe : dev/kord/common/entit
 
 public final class dev/kord/common/entity/NsfwLevel$Unknown : dev/kord/common/entity/NsfwLevel {
 	public fun <init> (I)V
+}
+
+public abstract class dev/kord/common/entity/OnboardingMode {
+	public static final field Companion Ldev/kord/common/entity/OnboardingMode$Companion;
+	public synthetic fun <init> (ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()I
+	public final fun hashCode ()I
+	public final fun toString ()Ljava/lang/String;
+}
+
+public final class dev/kord/common/entity/OnboardingMode$Advanced : dev/kord/common/entity/OnboardingMode {
+	public static final field INSTANCE Ldev/kord/common/entity/OnboardingMode$Advanced;
+}
+
+public final class dev/kord/common/entity/OnboardingMode$Companion {
+	public final fun from (I)Ldev/kord/common/entity/OnboardingMode;
+	public final fun getEntries ()Ljava/util/List;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/kord/common/entity/OnboardingMode$Default : dev/kord/common/entity/OnboardingMode {
+	public static final field INSTANCE Ldev/kord/common/entity/OnboardingMode$Default;
+}
+
+public final class dev/kord/common/entity/OnboardingMode$Unknown : dev/kord/common/entity/OnboardingMode {
 }
 
 public abstract class dev/kord/common/entity/OnboardingPromptType {

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/OnboardingMode.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/OnboardingMode.kt
@@ -1,0 +1,91 @@
+// THIS FILE IS AUTO-GENERATED, DO NOT EDIT!
+@file:Suppress(names = arrayOf("IncorrectFormatting", "ReplaceArrayOfWithLiteral",
+                "SpellCheckingInspection", "GrazieInspection"))
+
+package dev.kord.common.entity
+
+import kotlin.LazyThreadSafetyMode.PUBLICATION
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+/**
+ * Defines the criteria used to satisfy Onboarding constraints that are required for enabling.
+ *
+ * See [OnboardingMode]s in the
+ * [Discord Developer Documentation](https://discord.com/developers/docs/resources/guild#guild-onboarding-object-onboarding-mode).
+ */
+@Serializable(with = OnboardingMode.Serializer::class)
+public sealed class OnboardingMode(
+    /**
+     * The raw value used by Discord.
+     */
+    public val `value`: Int,
+) {
+    final override fun equals(other: Any?): Boolean = this === other ||
+            (other is OnboardingMode && this.value == other.value)
+
+    final override fun hashCode(): Int = value.hashCode()
+
+    final override fun toString(): String =
+            if (this is Unknown) "OnboardingMode.Unknown(value=$value)"
+            else "OnboardingMode.${this::class.simpleName}"
+
+    /**
+     * An unknown [OnboardingMode].
+     *
+     * This is used as a fallback for [OnboardingMode]s that haven't been added to Kord yet.
+     */
+    public class Unknown internal constructor(
+        `value`: Int,
+    ) : OnboardingMode(value)
+
+    /**
+     * Counts only Default Channels towards constraints.
+     */
+    public object Default : OnboardingMode(0)
+
+    /**
+     * Counts Default Channels and Questions towards constraints.
+     */
+    public object Advanced : OnboardingMode(1)
+
+    internal object Serializer : KSerializer<OnboardingMode> {
+        override val descriptor: SerialDescriptor =
+                PrimitiveSerialDescriptor("dev.kord.common.entity.OnboardingMode",
+                PrimitiveKind.INT)
+
+        override fun serialize(encoder: Encoder, `value`: OnboardingMode) {
+            encoder.encodeInt(value.value)
+        }
+
+        override fun deserialize(decoder: Decoder): OnboardingMode = from(decoder.decodeInt())
+    }
+
+    public companion object {
+        /**
+         * A [List] of all known [OnboardingMode]s.
+         */
+        public val entries: List<OnboardingMode> by lazy(mode = PUBLICATION) {
+            listOf(
+                Default,
+                Advanced,
+            )
+        }
+
+
+        /**
+         * Returns an instance of [OnboardingMode] with [OnboardingMode.value] equal to the
+         * specified [value].
+         */
+        public fun from(`value`: Int): OnboardingMode = when (value) {
+            0 -> Default
+            1 -> Advanced
+            else -> Unknown(value)
+        }
+    }
+}

--- a/common/src/commonMain/kotlin/entity/DiscordGuildOnboarding.kt
+++ b/common/src/commonMain/kotlin/entity/DiscordGuildOnboarding.kt
@@ -1,4 +1,14 @@
 @file:Generate(
+    INT_KORD_ENUM, name = "OnboardingMode", unknownConstructorWasPublic = false,
+    kDoc = "Defines the criteria used to satisfy Onboarding constraints that are required for enabling.",
+    docUrl = "https://discord.com/developers/docs/resources/guild#guild-onboarding-object-onboarding-mode",
+    entries = [
+        Entry("Default", intValue = 0, kDoc = "Counts only Default Channels towards constraints."),
+        Entry("Advanced", intValue = 1, kDoc = "Counts Default Channels and Questions towards constraints."),
+    ],
+)
+
+@file:Generate(
     INT_KORD_ENUM, name = "OnboardingPromptType",
     docUrl = "https://discord.com/developers/docs/resources/guild#guild-onboarding-object-prompt-types",
     entries = [
@@ -21,6 +31,7 @@ public data class DiscordGuildOnboarding(
     val prompts: List<DiscordOnboardingPrompt>,
     @SerialName("default_channel_ids") val defaultChannelIds: List<Snowflake>,
     val enabled: Boolean,
+    val mode: OnboardingMode,
 )
 
 @Serializable

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -421,6 +421,7 @@ public final class dev/kord/core/behavior/GuildBehaviorKt {
 	public static final fun createVoiceChannel (Ldev/kord/core/behavior/GuildBehavior;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun createVoiceChannel$default (Ldev/kord/core/behavior/GuildBehavior;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun edit (Ldev/kord/core/behavior/GuildBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun editOnboarding (Ldev/kord/core/behavior/GuildBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun editWidget (Ldev/kord/core/behavior/GuildBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun getAuditLogEntries (Ldev/kord/core/behavior/GuildBehavior;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun getAuditLogEntries$default (Ldev/kord/core/behavior/GuildBehavior;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
@@ -6388,6 +6389,7 @@ public final class dev/kord/core/entity/GuildOnboarding : dev/kord/core/KordObje
 	public final fun getGuildId ()Ldev/kord/common/entity/Snowflake;
 	public final fun getGuildOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getKord ()Ldev/kord/core/Kord;
+	public final fun getMode ()Ldev/kord/common/entity/OnboardingMode;
 	public final fun getPrompts ()Ljava/util/List;
 	public fun getSupplier ()Ldev/kord/core/supplier/EntitySupplier;
 	public final fun isEnabled ()Z

--- a/core/src/commonMain/kotlin/behavior/GuildBehavior.kt
+++ b/core/src/commonMain/kotlin/behavior/GuildBehavior.kt
@@ -5,6 +5,7 @@ import dev.kord.common.annotation.KordExperimental
 import dev.kord.common.entity.*
 import dev.kord.common.entity.AutoModerationRuleEventType.MessageSend
 import dev.kord.common.entity.Permission.ManageGuild
+import dev.kord.common.entity.Permission.ManageRoles
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.unwrap
 import dev.kord.common.exception.RequestException
@@ -966,6 +967,21 @@ public suspend inline fun <reified T : GuildChannel> GuildBehavior.getChannelOfO
 public suspend inline fun GuildBehavior.editWidget(builder: GuildWidgetModifyBuilder.() -> Unit): GuildWidget {
     contract { callsInPlace(builder, EXACTLY_ONCE) }
     return GuildWidget(GuildWidgetData.from(kord.rest.guild.modifyGuildWidget(id, builder)), id, kord)
+}
+
+/**
+ * Requests to edit the [GuildOnboarding] object of the guild and returns the edited onboarding object.
+ *
+ * This requires the [ManageGuild] and [ManageRoles] permissions.
+ *
+ * @throws RestRequestException if something went wrong during the request.
+ */
+public suspend inline fun GuildBehavior.editOnboarding(
+    builder: GuildOnboardingModifyBuilder.() -> Unit,
+): GuildOnboarding {
+    contract { callsInPlace(builder, EXACTLY_ONCE) }
+    val onboarding = kord.rest.guild.modifyGuildOnboarding(guildId = id, builder)
+    return GuildOnboarding(onboarding, kord)
 }
 
 /**

--- a/core/src/commonMain/kotlin/entity/GuildOnboarding.kt
+++ b/core/src/commonMain/kotlin/entity/GuildOnboarding.kt
@@ -45,6 +45,9 @@ public class GuildOnboarding(
     /** Whether onboarding is enabled in the [guild]. */
     public val isEnabled: Boolean get() = data.enabled
 
+    /** Current [mode][OnboardingMode] of onboarding. */
+    public val mode: OnboardingMode get() = data.mode
+
     /**
      * Requests the [Guild] this onboarding is part of.
      *

--- a/ksp-annotations/src/commonMain/kotlin/Generate.kt
+++ b/ksp-annotations/src/commonMain/kotlin/Generate.kt
@@ -29,6 +29,7 @@ annotation class Generate(
     val hadFlagsProperty: Boolean = false,
     val flagsPropertyWasSet: Boolean = false,
     val builderHadFlagsFunction: Boolean = false,
+    val unknownConstructorWasPublic: Boolean = true,
 ) {
     enum class EntityType { INT_KORD_ENUM, STRING_KORD_ENUM, INT_FLAGS, BIT_SET_FLAGS }
 

--- a/ksp-processors/src/main/kotlin/generation/GenerationEntity.kt
+++ b/ksp-processors/src/main/kotlin/generation/GenerationEntity.kt
@@ -26,6 +26,7 @@ internal sealed class GenerationEntity(
     class KordEnum(
         name: String, kDoc: String?, docUrl: String, valueName: String, entries: List<Entry>,
         override val valueType: ValueType,
+        val unknownConstructorWasPublic: Boolean,
     ) : GenerationEntity(name, kDoc, docUrl, valueName, entries) {
         enum class ValueType : GenerationEntity.ValueType { INT, STRING }
     }
@@ -72,7 +73,7 @@ internal fun Generate.toGenerationEntityOrNull(logger: KSPLogger, annotation: KS
             Generate::wasEnum, Generate::collectionWasDataClass, Generate::hadFlagsProperty,
             Generate::flagsPropertyWasSet, Generate::builderHadFlagsFunction,
         )
-        INT_FLAGS, BIT_SET_FLAGS -> true
+        INT_FLAGS, BIT_SET_FLAGS -> areNotSpecified(Generate::unknownConstructorWasPublic)
     }
 
     val mappedEntries = (entries zip args[Generate::entries]!!).mapNotNull { (entry, annotation) ->
@@ -84,8 +85,12 @@ internal fun Generate.toGenerationEntityOrNull(logger: KSPLogger, annotation: KS
     } else {
         val kDoc = kDoc.toKDoc()
         when (entityType) {
-            INT_KORD_ENUM -> KordEnum(name, kDoc, docUrl, valueName, mappedEntries, KordEnum.ValueType.INT)
-            STRING_KORD_ENUM -> KordEnum(name, kDoc, docUrl, valueName, mappedEntries, KordEnum.ValueType.STRING)
+            INT_KORD_ENUM -> KordEnum(
+                name, kDoc, docUrl, valueName, mappedEntries, KordEnum.ValueType.INT, unknownConstructorWasPublic,
+            )
+            STRING_KORD_ENUM -> KordEnum(
+                name, kDoc, docUrl, valueName, mappedEntries, KordEnum.ValueType.STRING, unknownConstructorWasPublic,
+            )
             INT_FLAGS -> BitFlags(
                 name, kDoc, docUrl, valueName, mappedEntries, BitFlags.ValueType.INT, wasEnum, collectionWasDataClass,
                 hadFlagsProperty, flagsPropertyWasSet, builderHadFlagsFunction,

--- a/ksp-processors/src/main/kotlin/generation/kordenum/KordEnumGeneration.kt
+++ b/ksp-processors/src/main/kotlin/generation/kordenum/KordEnumGeneration.kt
@@ -33,14 +33,14 @@ internal fun KordEnum.generateFileSpec(originatingFile: KSFile) = fileSpecForGen
             primaryConstructor {
                 addModifiers(INTERNAL)
                 addParameter(valueName, valueCN)
-                addParameter("unused", type = NOTHING.copy(nullable = true)) {
+                if (unknownConstructorWasPublic) addParameter("unused", type = NOTHING.copy(nullable = true)) {
                     @OptIn(DelicateKotlinPoetApi::class)
                     addAnnotation(Suppress("UNUSED_PARAMETER"))
                 }
             }
             addSuperclassConstructorParameter(valueName)
             // TODO bump deprecation level and remove eventually (also share code with bit flags then)
-            addConstructor {
+            if (unknownConstructorWasPublic) addConstructor {
                 @OptIn(DelicateKotlinPoetApi::class)
                 addAnnotation(
                     Deprecated(
@@ -69,7 +69,7 @@ internal fun KordEnum.generateFileSpec(originatingFile: KSFile) = fileSpecForGen
                     for (entry in entriesDistinctByValue) {
                         addStatement("$valueFormat·->·${entry.nameWithSuppressedDeprecation}", entry.value)
                     }
-                    addStatement("else·->·Unknown($valueName,·null)")
+                    addStatement(if (unknownConstructorWasPublic) "else·->·Unknown($valueName,·null)" else "else·->·Unknown($valueName)")
                 }
             }
         }

--- a/rest/api/rest.api
+++ b/rest/api/rest.api
@@ -1255,6 +1255,28 @@ public final class dev/kord/rest/builder/guild/GuildModifyBuilder : dev/kord/res
 	public synthetic fun toRequest ()Ljava/lang/Object;
 }
 
+public final class dev/kord/rest/builder/guild/GuildOnboardingModifyBuilder : dev/kord/rest/builder/AuditRequestBuilder {
+	public fun <init> ()V
+	public final fun getDefaultChannelIds ()Ljava/util/List;
+	public final fun getEnabled ()Ljava/lang/Boolean;
+	public final fun getMode ()Ldev/kord/common/entity/OnboardingMode;
+	public final fun getPrompts ()Ljava/util/List;
+	public fun getReason ()Ljava/lang/String;
+	public final fun setDefaultChannelIds (Ljava/util/List;)V
+	public final fun setEnabled (Ljava/lang/Boolean;)V
+	public final fun setMode (Ldev/kord/common/entity/OnboardingMode;)V
+	public final fun setPrompts (Ljava/util/List;)V
+	public fun setReason (Ljava/lang/String;)V
+	public fun toRequest ()Ldev/kord/rest/json/request/GuildOnboardingModifyRequest;
+	public synthetic fun toRequest ()Ljava/lang/Object;
+}
+
+public final class dev/kord/rest/builder/guild/GuildOnboardingModifyBuilderKt {
+	public static final fun defaultChannelId (Ldev/kord/rest/builder/guild/GuildOnboardingModifyBuilder;Ldev/kord/common/entity/Snowflake;)V
+	public static final fun option (Ldev/kord/rest/builder/guild/OnboardingPromptBuilder;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public static final fun prompt (Ldev/kord/rest/builder/guild/GuildOnboardingModifyBuilder;Ldev/kord/common/entity/OnboardingPromptType;Ljava/lang/String;ZZZLkotlin/jvm/functions/Function1;)V
+}
+
 public final class dev/kord/rest/builder/guild/GuildWidgetModifyBuilder : dev/kord/rest/builder/AuditRequestBuilder {
 	public fun <init> ()V
 	public final fun getChannelId ()Ldev/kord/common/entity/Snowflake;
@@ -1264,6 +1286,37 @@ public final class dev/kord/rest/builder/guild/GuildWidgetModifyBuilder : dev/ko
 	public final fun setEnabled (Ljava/lang/Boolean;)V
 	public fun setReason (Ljava/lang/String;)V
 	public fun toRequest ()Ldev/kord/rest/json/request/GuildWidgetModifyRequest;
+	public synthetic fun toRequest ()Ljava/lang/Object;
+}
+
+public final class dev/kord/rest/builder/guild/OnboardingPromptBuilder : dev/kord/rest/builder/RequestBuilder {
+	public fun <init> (Ldev/kord/common/entity/OnboardingPromptType;Ljava/lang/String;ZZZ)V
+	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getInOnboarding ()Z
+	public final fun getOptions ()Ljava/util/List;
+	public final fun getRequired ()Z
+	public final fun getSingleSelect ()Z
+	public final fun getTitle ()Ljava/lang/String;
+	public final fun getType ()Ldev/kord/common/entity/OnboardingPromptType;
+	public final fun setId (Ldev/kord/common/entity/Snowflake;)V
+	public final fun setInOnboarding (Z)V
+	public final fun setRequired (Z)V
+	public final fun setSingleSelect (Z)V
+	public final fun setTitle (Ljava/lang/String;)V
+	public final fun setType (Ldev/kord/common/entity/OnboardingPromptType;)V
+	public fun toRequest ()Ldev/kord/rest/json/request/OnboardingPromptRequest;
+	public synthetic fun toRequest ()Ljava/lang/Object;
+}
+
+public final class dev/kord/rest/builder/guild/OnboardingPromptOptionBuilder : dev/kord/rest/builder/RequestBuilder {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun getChannelIds ()Ljava/util/List;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getRoleIds ()Ljava/util/List;
+	public final fun getTitle ()Ljava/lang/String;
+	public final fun setDescription (Ljava/lang/String;)V
+	public final fun setTitle (Ljava/lang/String;)V
+	public fun toRequest ()Ldev/kord/rest/json/request/OnboardingPromptOptionRequest;
 	public synthetic fun toRequest ()Ljava/lang/Object;
 }
 
@@ -2566,6 +2619,7 @@ public final class dev/kord/rest/json/JsonErrorCode : java/lang/Enum {
 	public static final field CannotDeleteRequiredCommunityChannel Ldev/kord/rest/json/JsonErrorCode;
 	public static final field CannotEditMessageByAnotherUser Ldev/kord/rest/json/JsonErrorCode;
 	public static final field CannotEditStickersWithinMessage Ldev/kord/rest/json/JsonErrorCode;
+	public static final field CannotEnableOnboarding Ldev/kord/rest/json/JsonErrorCode;
 	public static final field CannotExecuteOnDM Ldev/kord/rest/json/JsonErrorCode;
 	public static final field CannotExecuteOnSystemMessage Ldev/kord/rest/json/JsonErrorCode;
 	public static final field CannotMixSubscriptionAndNonSubscriptionRoles Ldev/kord/rest/json/JsonErrorCode;
@@ -2580,6 +2634,7 @@ public final class dev/kord/rest/json/JsonErrorCode : java/lang/Enum {
 	public static final field CannotSendMessagesToUser Ldev/kord/rest/json/JsonErrorCode;
 	public static final field CannotSendVoiceMessagesInThisChannel Ldev/kord/rest/json/JsonErrorCode;
 	public static final field CannotUpdateFinishedEvent Ldev/kord/rest/json/JsonErrorCode;
+	public static final field CannotUpdateOnboarding Ldev/kord/rest/json/JsonErrorCode;
 	public static final field ChannelVerificationTooHigh Ldev/kord/rest/json/JsonErrorCode;
 	public static final field ChannelWriteRateLimit Ldev/kord/rest/json/JsonErrorCode;
 	public static final field ChannelsTooLarge Ldev/kord/rest/json/JsonErrorCode;
@@ -4277,6 +4332,43 @@ public final class dev/kord/rest/json/request/GuildModifyRequest$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class dev/kord/rest/json/request/GuildOnboardingModifyRequest {
+	public static final field Companion Ldev/kord/rest/json/request/GuildOnboardingModifyRequest$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;)V
+	public synthetic fun <init> (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ldev/kord/common/entity/optional/Optional;
+	public final fun component2 ()Ldev/kord/common/entity/optional/Optional;
+	public final fun component3 ()Ldev/kord/common/entity/optional/OptionalBoolean;
+	public final fun component4 ()Ldev/kord/common/entity/optional/Optional;
+	public final fun copy (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/rest/json/request/GuildOnboardingModifyRequest;
+	public static synthetic fun copy$default (Ldev/kord/rest/json/request/GuildOnboardingModifyRequest;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/rest/json/request/GuildOnboardingModifyRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDefaultChannelIds ()Ldev/kord/common/entity/optional/Optional;
+	public final fun getEnabled ()Ldev/kord/common/entity/optional/OptionalBoolean;
+	public final fun getMode ()Ldev/kord/common/entity/optional/Optional;
+	public final fun getPrompts ()Ldev/kord/common/entity/optional/Optional;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final synthetic fun write$Self (Ldev/kord/rest/json/request/GuildOnboardingModifyRequest;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class dev/kord/rest/json/request/GuildOnboardingModifyRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Ldev/kord/rest/json/request/GuildOnboardingModifyRequest$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/kord/rest/json/request/GuildOnboardingModifyRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ldev/kord/rest/json/request/GuildOnboardingModifyRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/kord/rest/json/request/GuildOnboardingModifyRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class dev/kord/rest/json/request/GuildRoleCreateRequest {
 	public static final field Companion Ldev/kord/rest/json/request/GuildRoleCreateRequest$Companion;
 	public fun <init> ()V
@@ -5117,6 +5209,82 @@ public final class dev/kord/rest/json/request/MultipartWebhookEditMessageRequest
 	public final fun getRequest ()Ldev/kord/rest/json/request/WebhookEditMessageRequest;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/kord/rest/json/request/OnboardingPromptOptionRequest {
+	public static final field Companion Ldev/kord/rest/json/request/OnboardingPromptOptionRequest$Companion;
+	public synthetic fun <init> (ILjava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)Ldev/kord/rest/json/request/OnboardingPromptOptionRequest;
+	public static synthetic fun copy$default (Ldev/kord/rest/json/request/OnboardingPromptOptionRequest;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ldev/kord/rest/json/request/OnboardingPromptOptionRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChannelIds ()Ljava/util/List;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getRoleIds ()Ljava/util/List;
+	public final fun getTitle ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final synthetic fun write$Self (Ldev/kord/rest/json/request/OnboardingPromptOptionRequest;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class dev/kord/rest/json/request/OnboardingPromptOptionRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Ldev/kord/rest/json/request/OnboardingPromptOptionRequest$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/kord/rest/json/request/OnboardingPromptOptionRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ldev/kord/rest/json/request/OnboardingPromptOptionRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/kord/rest/json/request/OnboardingPromptOptionRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/kord/rest/json/request/OnboardingPromptRequest {
+	public static final field Companion Ldev/kord/rest/json/request/OnboardingPromptRequest$Companion;
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/OnboardingPromptType;Ljava/util/List;Ljava/lang/String;ZZZLkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/OnboardingPromptType;Ljava/util/List;Ljava/lang/String;ZZZ)V
+	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
+	public final fun component2 ()Ldev/kord/common/entity/OnboardingPromptType;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Z
+	public final fun component6 ()Z
+	public final fun component7 ()Z
+	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/OnboardingPromptType;Ljava/util/List;Ljava/lang/String;ZZZ)Ldev/kord/rest/json/request/OnboardingPromptRequest;
+	public static synthetic fun copy$default (Ldev/kord/rest/json/request/OnboardingPromptRequest;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/OnboardingPromptType;Ljava/util/List;Ljava/lang/String;ZZZILjava/lang/Object;)Ldev/kord/rest/json/request/OnboardingPromptRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getInOnboarding ()Z
+	public final fun getOptions ()Ljava/util/List;
+	public final fun getRequired ()Z
+	public final fun getSingleSelect ()Z
+	public final fun getTitle ()Ljava/lang/String;
+	public final fun getType ()Ldev/kord/common/entity/OnboardingPromptType;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final synthetic fun write$Self (Ldev/kord/rest/json/request/OnboardingPromptRequest;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class dev/kord/rest/json/request/OnboardingPromptRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Ldev/kord/rest/json/request/OnboardingPromptRequest$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/kord/rest/json/request/OnboardingPromptRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ldev/kord/rest/json/request/OnboardingPromptRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/kord/rest/json/request/OnboardingPromptRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class dev/kord/rest/json/request/ScheduledEventModifyRequest {
@@ -6760,6 +6928,10 @@ public final class dev/kord/rest/route/Route$GuildOnboardingGet : dev/kord/rest/
 	public static final field INSTANCE Ldev/kord/rest/route/Route$GuildOnboardingGet;
 }
 
+public final class dev/kord/rest/route/Route$GuildOnboardingModify : dev/kord/rest/route/Route {
+	public static final field INSTANCE Ldev/kord/rest/route/Route$GuildOnboardingModify;
+}
+
 public final class dev/kord/rest/route/Route$GuildPatch : dev/kord/rest/route/Route {
 	public static final field INSTANCE Ldev/kord/rest/route/Route$GuildPatch;
 }
@@ -7359,6 +7531,9 @@ public final class dev/kord/rest/service/GuildService : dev/kord/rest/service/Re
 	public final fun modifyGuildMFALevel (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/MFALevel;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun modifyGuildMFALevel$default (Ldev/kord/rest/service/GuildService;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/MFALevel;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun modifyGuildMember (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun modifyGuildOnboarding (Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/GuildOnboardingModifyRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun modifyGuildOnboarding (Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun modifyGuildOnboarding$default (Ldev/kord/rest/service/GuildService;Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/GuildOnboardingModifyRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun modifyGuildRole (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun modifyGuildRolePosition (Ldev/kord/common/entity/Snowflake;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun modifyGuildWelcomeScreen (Ldev/kord/common/entity/Snowflake;Ldev/kord/rest/json/request/GuildWelcomeScreenModifyRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/rest/src/commonMain/kotlin/builder/guild/GuildOnboardingModifyBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/guild/GuildOnboardingModifyBuilder.kt
@@ -1,0 +1,150 @@
+package dev.kord.rest.builder.guild
+
+import dev.kord.common.annotation.KordDsl
+import dev.kord.common.entity.OnboardingMode
+import dev.kord.common.entity.OnboardingPromptType
+import dev.kord.common.entity.Snowflake
+import dev.kord.common.entity.optional.Optional
+import dev.kord.common.entity.optional.OptionalBoolean
+import dev.kord.common.entity.optional.delegate.delegate
+import dev.kord.common.entity.optional.map
+import dev.kord.common.entity.optional.mapCopy
+import dev.kord.rest.builder.AuditRequestBuilder
+import dev.kord.rest.builder.RequestBuilder
+import dev.kord.rest.json.request.GuildOnboardingModifyRequest
+import dev.kord.rest.json.request.OnboardingPromptOptionRequest
+import dev.kord.rest.json.request.OnboardingPromptRequest
+import kotlin.contracts.InvocationKind.EXACTLY_ONCE
+import kotlin.contracts.contract
+
+@KordDsl
+public class GuildOnboardingModifyBuilder : AuditRequestBuilder<GuildOnboardingModifyRequest> {
+    override var reason: String? = null
+
+    private var _prompts: Optional<MutableList<OnboardingPromptBuilder>> = Optional.Missing()
+
+    /** The prompts shown during onboarding and in customize community. */
+    public var prompts: MutableList<OnboardingPromptBuilder>? by ::_prompts.delegate()
+
+    private var _defaultChannelIds: Optional<MutableList<Snowflake>> = Optional.Missing()
+
+    /** The IDs of the channels that members get opted into automatically. */
+    public var defaultChannelIds: MutableList<Snowflake>? by ::_defaultChannelIds.delegate()
+
+    private var _enabled: OptionalBoolean = OptionalBoolean.Missing
+
+    /** Whether onboarding is enabled in the guild. */
+    public var enabled: Boolean? by ::_enabled.delegate()
+
+    private var _mode: Optional<OnboardingMode> = Optional.Missing()
+
+    /** Current [mode][OnboardingMode] of onboarding. */
+    public var mode: OnboardingMode? by ::_mode.delegate()
+
+    override fun toRequest(): GuildOnboardingModifyRequest = GuildOnboardingModifyRequest(
+        prompts = _prompts.map { it.map(OnboardingPromptBuilder::toRequest) },
+        defaultChannelIds = _defaultChannelIds.mapCopy(),
+        enabled = _enabled,
+        mode = _mode,
+    )
+}
+
+/** Add a [channelId] to [defaultChannelIds][GuildOnboardingModifyBuilder.defaultChannelIds]. */
+public fun GuildOnboardingModifyBuilder.defaultChannelId(channelId: Snowflake) {
+    defaultChannelIds?.add(channelId) ?: run { defaultChannelIds = mutableListOf(channelId) }
+}
+
+/**
+ * Add a prompt to [prompts][GuildOnboardingModifyBuilder.prompts].
+ *
+ * @param type The [type][OnboardingPromptType] of the prompt.
+ * @param title The title of the prompt.
+ * @param singleSelect Indicates whether users are limited to selecting one option for the prompt.
+ * @param required Indicates whether the prompt is required before a user completes the onboarding flow.
+ * @param inOnboarding Indicates whether the prompt is present in the onboarding flow. If `false`, the prompt will only
+ * appear in the Channels & Roles tab.
+ */
+public inline fun GuildOnboardingModifyBuilder.prompt(
+    type: OnboardingPromptType,
+    title: String,
+    singleSelect: Boolean,
+    required: Boolean,
+    inOnboarding: Boolean,
+    builder: OnboardingPromptBuilder.() -> Unit,
+) {
+    contract { callsInPlace(builder, EXACTLY_ONCE) }
+    val prompt = OnboardingPromptBuilder(type, title, singleSelect, required, inOnboarding).apply(builder)
+    prompts?.add(prompt) ?: run { prompts = mutableListOf(prompt) }
+}
+
+
+@KordDsl
+public class OnboardingPromptBuilder(
+    /** The [type][OnboardingPromptType] of the prompt. */
+    public var type: OnboardingPromptType,
+    /** The title of the prompt. */
+    public var title: String,
+    /** Indicates whether users are limited to selecting one option for the prompt. */
+    public var singleSelect: Boolean,
+    /** Indicates whether the prompt is required before a user completes the onboarding flow. */
+    public var required: Boolean,
+    /**
+     * Indicates whether the prompt is present in the onboarding flow. If `false`, the prompt will only appear in the
+     * Channels & Roles tab.
+     */
+    public var inOnboarding: Boolean,
+) : RequestBuilder<OnboardingPromptRequest> {
+
+    /** The ID of the prompt. */
+    public var id: Snowflake? = null
+
+    /** The options available within the prompt. */
+    public val options: MutableList<OnboardingPromptOptionBuilder> = mutableListOf()
+
+    override fun toRequest(): OnboardingPromptRequest = OnboardingPromptRequest(
+        id = id ?: Snowflake.min, // it needs an ID, if we don't have one yet, pass 0
+        type = type,
+        options = options.map(OnboardingPromptOptionBuilder::toRequest),
+        title = title,
+        singleSelect = singleSelect,
+        required = required,
+        inOnboarding = inOnboarding,
+    )
+}
+
+/**
+ * Add an option to [options][OnboardingPromptBuilder.options].
+ *
+ * @param title The title of the option.
+ */
+public inline fun OnboardingPromptBuilder.option(
+    title: String,
+    builder: OnboardingPromptOptionBuilder.() -> Unit,
+) {
+    contract { callsInPlace(builder, EXACTLY_ONCE) }
+    options.add(OnboardingPromptOptionBuilder(title).apply(builder))
+}
+
+
+@KordDsl
+public class OnboardingPromptOptionBuilder(
+    /** The title of the option. */
+    public var title: String,
+) : RequestBuilder<OnboardingPromptOptionRequest> {
+
+    /** The IDs for the channels a member is added to when the option is selected. */
+    public val channelIds: MutableList<Snowflake> = mutableListOf()
+
+    /** The IDs for the roles assigned to a member when the option is selected. */
+    public val roleIds: MutableList<Snowflake> = mutableListOf()
+
+    /** The description of the option. */
+    public var description: String? = null
+
+    override fun toRequest(): OnboardingPromptOptionRequest = OnboardingPromptOptionRequest(
+        channelIds = channelIds.toList(),
+        roleIds = roleIds.toList(),
+        title = title,
+        description = description,
+    )
+}

--- a/rest/src/commonMain/kotlin/json/JsonErrorCode.kt
+++ b/rest/src/commonMain/kotlin/json/JsonErrorCode.kt
@@ -620,6 +620,12 @@ public enum class JsonErrorCode(public val code: Int) {
     /** Message blocked by harmful links filter. */
     MessageBlockedByHarmfulLinksFilter(240000),
 
+    /** Cannot enable onboarding, requirements are not met. */
+    CannotEnableOnboarding(350000),
+
+    /** Cannot update onboarding while below requirements. */
+    CannotUpdateOnboarding(350001),
+
     ;
 
     internal object Serializer : KSerializer<JsonErrorCode> {

--- a/rest/src/commonMain/kotlin/json/request/GuildOnboardingModifyRequest.kt
+++ b/rest/src/commonMain/kotlin/json/request/GuildOnboardingModifyRequest.kt
@@ -1,0 +1,39 @@
+package dev.kord.rest.json.request
+
+import dev.kord.common.entity.*
+import dev.kord.common.entity.optional.Optional
+import dev.kord.common.entity.optional.OptionalBoolean
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+public data class GuildOnboardingModifyRequest(
+    val prompts: Optional<List<OnboardingPromptRequest>> = Optional.Missing(),
+    @SerialName("default_channel_ids")
+    val defaultChannelIds: Optional<List<Snowflake>> = Optional.Missing(),
+    val enabled: OptionalBoolean = OptionalBoolean.Missing,
+    val mode: Optional<OnboardingMode> = Optional.Missing(),
+)
+
+@Serializable
+public data class OnboardingPromptRequest(
+    val id: Snowflake,
+    val type: OnboardingPromptType,
+    val options: List<OnboardingPromptOptionRequest>,
+    val title: String,
+    @SerialName("single_select")
+    val singleSelect: Boolean,
+    val required: Boolean,
+    @SerialName("in_onboarding")
+    val inOnboarding: Boolean,
+)
+
+@Serializable
+public data class OnboardingPromptOptionRequest(
+    @SerialName("channel_ids")
+    val channelIds: List<Snowflake>,
+    @SerialName("role_ids")
+    val roleIds: List<Snowflake>,
+    val title: String,
+    val description: String?,
+)

--- a/rest/src/commonMain/kotlin/route/Route.kt
+++ b/rest/src/commonMain/kotlin/route/Route.kt
@@ -592,7 +592,18 @@ public sealed class Route<T>(
         Route<DiscordGuildPreview>(HttpMethod.Get, "/guilds/$GuildId/preview", DiscordGuildPreview.serializer())
 
     public object GuildOnboardingGet :
-        Route<DiscordGuildOnboarding>(HttpMethod.Get, "/guilds/$GuildId/onboarding", DiscordGuildOnboarding.serializer())
+        Route<DiscordGuildOnboarding>(
+            HttpMethod.Get,
+            "/guilds/$GuildId/onboarding",
+            DiscordGuildOnboarding.serializer(),
+        )
+
+    public object GuildOnboardingModify :
+        Route<DiscordGuildOnboarding>(
+            HttpMethod.Put,
+            "/guilds/$GuildId/onboarding",
+            DiscordGuildOnboarding.serializer(),
+        )
 
     public object SelfVoiceStatePatch :
         Route<Unit>(HttpMethod.Patch, "/guilds/$GuildId/voice-states/@me", NoStrategy)

--- a/rest/src/commonMain/kotlin/service/GuildService.kt
+++ b/rest/src/commonMain/kotlin/service/GuildService.kt
@@ -54,6 +54,25 @@ public class GuildService(requestHandler: RequestHandler) : RestService(requestH
         keys[Route.GuildId] = guildId
     }
 
+    public suspend fun modifyGuildOnboarding(
+        guildId: Snowflake,
+        request: GuildOnboardingModifyRequest,
+        reason: String? = null,
+    ): DiscordGuildOnboarding = call(Route.GuildOnboardingModify) {
+        keys[Route.GuildId] = guildId
+        body(GuildOnboardingModifyRequest.serializer(), request)
+        auditLogReason(reason)
+    }
+
+    public suspend inline fun modifyGuildOnboarding(
+        guildId: Snowflake,
+        builder: GuildOnboardingModifyBuilder.() -> Unit,
+    ): DiscordGuildOnboarding {
+        contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
+        val request = GuildOnboardingModifyBuilder().apply(builder)
+        return modifyGuildOnboarding(guildId, request.toRequest(), request.reason)
+    }
+
     public suspend inline fun modifyGuild(guildId: Snowflake, builder: GuildModifyBuilder.() -> Unit): DiscordGuild {
         contract {
             callsInPlace(builder, InvocationKind.EXACTLY_ONCE)


### PR DESCRIPTION
The DSL looks like this:
```kotlin
val onboarding = guild.editOnboarding {
    enabled = true
    mode = OnboardingMode.Advanced
    defaultChannelId(channelId1)
    defaultChannelId(channelId2)
    defaultChannelId(channelId3)
    defaultChannelId(channelId4)
    defaultChannelId(channelId5)
    defaultChannelId(channelId6)
    defaultChannelId(channelId7)
    prompt(
        OnboardingPromptType.MultipleChoice,
        title = "prompt title",
        singleSelect = false,
        required = false,
        inOnboarding = true,
    ) {
        option(title = "option 1 title") {
            channelIds += someChannelId
            description = "option 1 description"
        }
        option(title = "option 2 title") {
            roleIds += someRoleId
        }
    }
}
println(onboarding)
```

See https://github.com/discord/discord-api-docs/pull/6101