### PR TITLE
Simplify CI

### DIFF
--- a/.github/workflows/deployment-ci.yml
+++ b/.github/workflows/deployment-ci.yml
@@ -44,7 +44,6 @@ jobs:
       NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
       SIGNING_KEY: ${{ secrets.signingKey }}
       SIGNING_PASSWORD: ${{ secrets.signingPassword }}
-      GITHUB_TAG_NAME: ${{ github.event.release.tag_name }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/deployment-ci.yml
+++ b/.github/workflows/deployment-ci.yml
@@ -28,8 +28,6 @@ jobs:
         with:
           distribution: temurin
           java-version: 8
-      - name: Set SHORT_SHA environment variable to short commit hash
-        run: echo "SHORT_SHA=$(git rev-parse --short ${{ github.sha }})" >> $GITHUB_ENV
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
         with:
@@ -47,7 +45,6 @@ jobs:
       ORG_GRADLE_PROJECT_signingKey: ${{ secrets.signingKey }}
       ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.signingPassword }}
       GITHUB_TAG_NAME: ${{ github.event.release.tag_name }}
-      GITHUB_BRANCH_NAME: ${{ github.ref }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -57,8 +54,6 @@ jobs:
         with:
           distribution: temurin
           java-version: 8
-      - name: Set SHORT_SHA environment variable to short commit hash
-        run: echo "SHORT_SHA=$(git rev-parse --short ${{ github.sha }})" >> $GITHUB_ENV
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
         with:

--- a/.github/workflows/deployment-ci.yml
+++ b/.github/workflows/deployment-ci.yml
@@ -42,8 +42,8 @@ jobs:
       KORD_TEST_TOKEN: ${{ secrets.KORD_TEST_TOKEN }}
       NEXUS_USER: ${{ secrets.NEXUS_USER }}
       NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
-      ORG_GRADLE_PROJECT_signingKey: ${{ secrets.signingKey }}
-      ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.signingPassword }}
+      SIGNING_KEY: ${{ secrets.signingKey }}
+      SIGNING_PASSWORD: ${{ secrets.signingPassword }}
       GITHUB_TAG_NAME: ${{ github.event.release.tag_name }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -15,8 +15,6 @@ jobs:
     concurrency: # Allow one concurrent deployment
       group: pages
       cancel-in-progress: true
-    env:
-      GITHUB_TAG_NAME: ${{ github.event.release.tag_name }}
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -17,7 +17,6 @@ jobs:
       cancel-in-progress: true
     env:
       GITHUB_TAG_NAME: ${{ github.event.release.tag_name }}
-      GITHUB_BRANCH_NAME: ${{ github.ref }}
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,4 +7,4 @@ repositories {
 }
 
 group = Library.group
-version = Library.version
+version = libraryVersion

--- a/buildSrc/src/main/kotlin/Documentation.kt
+++ b/buildSrc/src/main/kotlin/Documentation.kt
@@ -16,7 +16,7 @@ fun AbstractDokkaLeafTask.applyKordDokkaOptions() {
 
         sourceLink {
             localDirectory = project.projectDir
-            remoteUrl = URL("https://github.com/kordlib/kord/blob/${Library.commitHashOrDefault("0.9.x")}/${project.name}")
+            remoteUrl = URL("https://github.com/kordlib/kord/blob/${project.commitHash}/${project.name}")
             remoteLineSuffix = "#L"
         }
 

--- a/buildSrc/src/main/kotlin/Git.kt
+++ b/buildSrc/src/main/kotlin/Git.kt
@@ -1,0 +1,12 @@
+import org.gradle.api.Project
+
+internal fun Project.git(vararg command: String): String {
+    val process = ProcessBuilder("git", *command)
+        .redirectErrorStream(true)
+        .directory(rootDir)
+        .start()
+    val output = process.inputStream.reader().use { it.readText() }.trim()
+    val exitStatus = process.waitFor()
+    check(exitStatus == 0) { "git exited with status $exitStatus, output:\n$output" }
+    return output
+}

--- a/buildSrc/src/main/kotlin/Git.kt
+++ b/buildSrc/src/main/kotlin/Git.kt
@@ -1,12 +1,13 @@
 import org.gradle.api.Project
+import java.io.ByteArrayOutputStream
 
 internal fun Project.git(vararg command: String): String {
-    val process = ProcessBuilder("git", *command)
-        .redirectErrorStream(true)
-        .directory(rootDir)
-        .start()
-    val output = process.inputStream.reader().use { it.readText() }.trim()
-    val exitStatus = process.waitFor()
-    check(exitStatus == 0) { "git exited with status $exitStatus, output:\n$output" }
-    return output
+    val output = ByteArrayOutputStream()
+    exec {
+        commandLine("git", *command)
+        standardOutput = output
+        errorOutput = output
+        workingDir = rootDir
+    }.rethrowFailure().assertNormalExitValue()
+    return output.toString().trim()
 }

--- a/buildSrc/src/main/kotlin/Projects.kt
+++ b/buildSrc/src/main/kotlin/Projects.kt
@@ -7,16 +7,18 @@ object Library {
     const val projectUrl = "https://github.com/kordlib/kord"
 }
 
-val Project.libraryVersion: String
-    get() {
-        val tag = System.getenv("GITHUB_TAG_NAME").takeUnless { it.isNullOrBlank() }
-        return tag ?: "${git("branch", "--show-current").replace('/', '-')}-SNAPSHOT"
-    }
+private val Project.tag
+    get() = git("tag", "--no-column", "--points-at", "HEAD")
+        .takeIf { it.isNotBlank() }
+        ?.lines()
+        ?.single()
+
+val Project.libraryVersion get() = tag ?: "${git("branch", "--show-current").replace('/', '-')}-SNAPSHOT"
 
 val Project.commitHash get() = git("rev-parse", "--verify", "HEAD")
 val Project.shortCommitHash get() = git("rev-parse", "--short", "HEAD")
 
-val Project.isRelease get() = !libraryVersion.endsWith("-SNAPSHOT")
+val Project.isRelease get() = tag != null
 
 object Repo {
     const val releasesUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"

--- a/buildSrc/src/main/kotlin/Projects.kt
+++ b/buildSrc/src/main/kotlin/Projects.kt
@@ -13,7 +13,7 @@ val Project.libraryVersion: String
         return tag ?: "${git("branch", "--show-current").replace('/', '-')}-SNAPSHOT"
     }
 
-val Project.commitHash get() = git("rev-parse", "HEAD")
+val Project.commitHash get() = git("rev-parse", "--verify", "HEAD")
 val Project.shortCommitHash get() = git("rev-parse", "--short", "HEAD")
 
 val Project.isRelease get() = !libraryVersion.endsWith("-SNAPSHOT")

--- a/buildSrc/src/main/kotlin/Projects.kt
+++ b/buildSrc/src/main/kotlin/Projects.kt
@@ -1,3 +1,5 @@
+import org.gradle.api.Project
+
 /**
  * whether the process has been invoked by JitPack
  */
@@ -6,35 +8,24 @@ val isJitPack get() = "true" == System.getenv("JITPACK")
 object Library {
     const val name = "kord"
     const val group = "dev.kord"
-    val version: String
-        get() = if (isJitPack) System.getenv("RELEASE_TAG")
-        else {
-            val tag = System.getenv("GITHUB_TAG_NAME")
-            val branch = System.getenv("GITHUB_BRANCH_NAME")
-            when {
-                !tag.isNullOrBlank() -> tag
-                !branch.isNullOrBlank() && branch.startsWith("refs/heads/") ->
-                    branch.substringAfter("refs/heads/").replace("/", "-") + "-SNAPSHOT"
-                else -> "undefined"
-            }
-
-        }
-
-    val commitHash get() = System.getenv("GITHUB_SHA") ?: "unknown"
-    fun commitHashOrDefault(default: String) = System.getenv("GITHUB_SHA") ?: default
-
-    // this environment variable isn't available out of the box, we set it ourselves
-    val shortCommitHash get() = System.getenv("SHORT_SHA") ?: "unknown"
-
     const val description = "Idiomatic Kotlin Wrapper for The Discord API"
     const val projectUrl = "https://github.com/kordlib/kord"
-
-    val isSnapshot: Boolean get() = version.endsWith("-SNAPSHOT")
-
-    val isRelease: Boolean get() = !isSnapshot && !isUndefined
-
-    val isUndefined get() = version == "undefined"
 }
+
+
+val Project.libraryVersion: String
+    get() = if (isJitPack) {
+        System.getenv("RELEASE_TAG")
+    } else {
+        val tag = System.getenv("GITHUB_TAG_NAME").takeUnless { it.isNullOrBlank() }
+        tag ?: "${git("branch", "--show-current").replace('/', '-')}-SNAPSHOT"
+    }
+
+val Project.commitHash get() = git("rev-parse", "HEAD")
+val Project.shortCommitHash get() = git("rev-parse", "--short", "HEAD")
+
+val Project.isSnapshot get() = libraryVersion.endsWith("-SNAPSHOT")
+val Project.isRelease get() = !isSnapshot
 
 object Repo {
     const val releasesUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"

--- a/buildSrc/src/main/kotlin/Projects.kt
+++ b/buildSrc/src/main/kotlin/Projects.kt
@@ -1,10 +1,5 @@
 import org.gradle.api.Project
 
-/**
- * whether the process has been invoked by JitPack
- */
-val isJitPack get() = "true" == System.getenv("JITPACK")
-
 object Library {
     const val name = "kord"
     const val group = "dev.kord"
@@ -12,20 +7,16 @@ object Library {
     const val projectUrl = "https://github.com/kordlib/kord"
 }
 
-
 val Project.libraryVersion: String
-    get() = if (isJitPack) {
-        System.getenv("RELEASE_TAG")
-    } else {
+    get() {
         val tag = System.getenv("GITHUB_TAG_NAME").takeUnless { it.isNullOrBlank() }
-        tag ?: "${git("branch", "--show-current").replace('/', '-')}-SNAPSHOT"
+        return tag ?: "${git("branch", "--show-current").replace('/', '-')}-SNAPSHOT"
     }
 
 val Project.commitHash get() = git("rev-parse", "HEAD")
 val Project.shortCommitHash get() = git("rev-parse", "--short", "HEAD")
 
-val Project.isSnapshot get() = libraryVersion.endsWith("-SNAPSHOT")
-val Project.isRelease get() = !isSnapshot
+val Project.isRelease get() = !libraryVersion.endsWith("-SNAPSHOT")
 
 object Repo {
     const val releasesUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"

--- a/buildSrc/src/main/kotlin/kord-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/kord-module.gradle.kts
@@ -51,10 +51,6 @@ tasks {
     withType<AbstractDokkaLeafTask>().configureEach {
         applyKordDokkaOptions()
     }
-
-    withType<PublishToMavenRepository>().configureEach {
-        doFirst { require(!Library.isUndefined) { "No release/snapshot version found." } }
-    }
 }
 
 publishing {

--- a/buildSrc/src/main/kotlin/kord-publishing.gradle.kts
+++ b/buildSrc/src/main/kotlin/kord-publishing.gradle.kts
@@ -19,7 +19,7 @@ publishing {
 
             groupId = Library.group
             artifactId = "kord-$artifactId"
-            version = Library.version
+            version = libraryVersion
 
             pom {
                 name = Library.name
@@ -61,7 +61,7 @@ publishing {
     if (!isJitPack) {
         repositories {
             maven {
-                url = uri(if (Library.isSnapshot) Repo.snapshotsUrl else Repo.releasesUrl)
+                url = uri(if (isSnapshot) Repo.snapshotsUrl else Repo.releasesUrl)
 
                 credentials {
                     username = System.getenv("NEXUS_USER")
@@ -72,7 +72,7 @@ publishing {
     }
 }
 
-if (!isJitPack && Library.isRelease) {
+if (!isJitPack && isRelease) {
     signing {
         val signingKey = findProperty("signingKey")?.toString()
         val signingPassword = findProperty("signingPassword")?.toString()

--- a/buildSrc/src/main/kotlin/kord-publishing.gradle.kts
+++ b/buildSrc/src/main/kotlin/kord-publishing.gradle.kts
@@ -1,3 +1,4 @@
+import java.lang.System.getenv
 import java.util.Base64
 
 plugins {
@@ -63,8 +64,8 @@ publishing {
             url = uri(if (isRelease) Repo.releasesUrl else Repo.snapshotsUrl)
 
             credentials {
-                username = System.getenv("NEXUS_USER")
-                password = System.getenv("NEXUS_PASSWORD")
+                username = getenv("NEXUS_USER")
+                password = getenv("NEXUS_PASSWORD")
             }
         }
     }
@@ -72,11 +73,9 @@ publishing {
 
 if (isRelease) {
     signing {
-        val signingKey = findProperty("signingKey")?.toString()
-        val signingPassword = findProperty("signingPassword")?.toString()
-        if (signingKey != null && signingPassword != null) {
-            useInMemoryPgpKeys(String(Base64.getDecoder().decode(signingKey)), signingPassword)
-        }
+        val secretKey = String(Base64.getDecoder().decode(getenv("SIGNING_KEY")))
+        val password = getenv("SIGNING_PASSWORD")
+        useInMemoryPgpKeys(secretKey, password)
         sign(publishing.publications)
     }
 }

--- a/buildSrc/src/main/kotlin/kord-publishing.gradle.kts
+++ b/buildSrc/src/main/kotlin/kord-publishing.gradle.kts
@@ -58,21 +58,19 @@ publishing {
         }
     }
 
-    if (!isJitPack) {
-        repositories {
-            maven {
-                url = uri(if (isSnapshot) Repo.snapshotsUrl else Repo.releasesUrl)
+    repositories {
+        maven {
+            url = uri(if (isRelease) Repo.releasesUrl else Repo.snapshotsUrl)
 
-                credentials {
-                    username = System.getenv("NEXUS_USER")
-                    password = System.getenv("NEXUS_PASSWORD")
-                }
+            credentials {
+                username = System.getenv("NEXUS_USER")
+                password = System.getenv("NEXUS_PASSWORD")
             }
         }
     }
 }
 
-if (!isJitPack && isRelease) {
+if (isRelease) {
     signing {
         val signingKey = findProperty("signingKey")?.toString()
         val signingPassword = findProperty("signingPassword")?.toString()

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -60,7 +60,7 @@ buildConfig {
         internalVisibility = true
     }
 
-    buildConfigField("String", "BUILD_CONFIG_GENERATED_LIBRARY_VERSION", "\"${Library.version}\"")
-    buildConfigField("String", "BUILD_CONFIG_GENERATED_COMMIT_HASH", "\"${Library.commitHash}\"")
-    buildConfigField("String", "BUILD_CONFIG_GENERATED_SHORT_COMMIT_HASH", "\"${Library.shortCommitHash}\"")
+    buildConfigField("String", "BUILD_CONFIG_GENERATED_LIBRARY_VERSION", "\"$libraryVersion\"")
+    buildConfigField("String", "BUILD_CONFIG_GENERATED_COMMIT_HASH", "\"$commitHash\"")
+    buildConfigField("String", "BUILD_CONFIG_GENERATED_SHORT_COMMIT_HASH", "\"$shortCommitHash\"")
 }


### PR DESCRIPTION
* call Git CLI from Gradle instead of depending on CI specifics
* use normal environment variables for signing
* remove JitPack support, we publish snapshots for all branches anyway