### PR TITLE
Change `parentId` and `lockPermissionsToParent` to Optionals

### DIFF
--- a/rest/api/rest.api
+++ b/rest/api/rest.api
@@ -3059,19 +3059,19 @@ public final class dev/kord/rest/json/request/ChannelPermissionEditRequest$Compa
 
 public final class dev/kord/rest/json/request/ChannelPositionSwapRequest {
 	public static final field Companion Ldev/kord/rest/json/request/ChannelPositionSwapRequest$Companion;
-	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalInt;Ljava/lang/Boolean;Ldev/kord/common/entity/Snowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalInt;Ljava/lang/Boolean;Ldev/kord/common/entity/Snowflake;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalInt;Ljava/lang/Boolean;Ldev/kord/common/entity/Snowflake;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (ILdev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;)V
+	public synthetic fun <init> (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ldev/kord/common/entity/Snowflake;
 	public final fun component2 ()Ldev/kord/common/entity/optional/OptionalInt;
-	public final fun component3 ()Ljava/lang/Boolean;
-	public final fun component4 ()Ldev/kord/common/entity/Snowflake;
-	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalInt;Ljava/lang/Boolean;Ldev/kord/common/entity/Snowflake;)Ldev/kord/rest/json/request/ChannelPositionSwapRequest;
-	public static synthetic fun copy$default (Ldev/kord/rest/json/request/ChannelPositionSwapRequest;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalInt;Ljava/lang/Boolean;Ldev/kord/common/entity/Snowflake;ILjava/lang/Object;)Ldev/kord/rest/json/request/ChannelPositionSwapRequest;
+	public final fun component3 ()Ldev/kord/common/entity/optional/OptionalBoolean;
+	public final fun component4 ()Ldev/kord/common/entity/optional/OptionalSnowflake;
+	public final fun copy (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;)Ldev/kord/rest/json/request/ChannelPositionSwapRequest;
+	public static synthetic fun copy$default (Ldev/kord/rest/json/request/ChannelPositionSwapRequest;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/OptionalSnowflake;ILjava/lang/Object;)Ldev/kord/rest/json/request/ChannelPositionSwapRequest;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getId ()Ldev/kord/common/entity/Snowflake;
-	public final fun getLockPermissions ()Ljava/lang/Boolean;
-	public final fun getParentId ()Ldev/kord/common/entity/Snowflake;
+	public final fun getLockPermissions ()Ldev/kord/common/entity/optional/OptionalBoolean;
+	public final fun getParentId ()Ldev/kord/common/entity/optional/OptionalSnowflake;
 	public final fun getPosition ()Ldev/kord/common/entity/optional/OptionalInt;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;

--- a/rest/src/commonMain/kotlin/builder/channel/GuildChannelPositionModifyBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/channel/GuildChannelPositionModifyBuilder.kt
@@ -3,7 +3,9 @@ package dev.kord.rest.builder.channel
 import dev.kord.common.annotation.KordDsl
 import dev.kord.common.annotation.KordExperimental
 import dev.kord.common.entity.Snowflake
+import dev.kord.common.entity.optional.OptionalBoolean
 import dev.kord.common.entity.optional.OptionalInt
+import dev.kord.common.entity.optional.OptionalSnowflake
 import dev.kord.common.entity.optional.delegate.delegate
 import dev.kord.rest.builder.RequestBuilder
 import dev.kord.rest.json.request.ChannelPositionSwapRequest
@@ -39,6 +41,8 @@ public class GuildChannelSwapBuilder(public var channelId: Snowflake) {
 
 
     private var _position: OptionalInt? = OptionalInt.Missing
+    private var _parentId: OptionalSnowflake? = OptionalSnowflake.Missing
+    private var _lockPermissionsToParent: OptionalBoolean? = OptionalBoolean.Missing
 
     /**
      * The new position of this channel
@@ -53,7 +57,7 @@ public class GuildChannelSwapBuilder(public var channelId: Snowflake) {
      * This field is not officially supported by the Discord API, and might change/be removed in the future.
      */
     @KordExperimental
-    public var parentId: Snowflake? = null
+    public var parentId: Snowflake? by ::_parentId.delegate()
 
     /**
      * Locks the permissions of this channel to the new category it is moved to.
@@ -62,10 +66,10 @@ public class GuildChannelSwapBuilder(public var channelId: Snowflake) {
      * This field is not officially supported by the Discord API, and might change/be removed in the future.
      */
     @KordExperimental
-    public var lockPermissionsToParent: Boolean? = null
+    public var lockPermissionsToParent: Boolean? by ::_lockPermissionsToParent.delegate()
 
     public fun toRequest(): ChannelPositionSwapRequest = ChannelPositionSwapRequest(
-        channelId, _position, lockPermissionsToParent, parentId
+        channelId, _position, _lockPermissionsToParent, _parentId
     )
 
 }

--- a/rest/src/commonMain/kotlin/json/request/GuildRequests.kt
+++ b/rest/src/commonMain/kotlin/json/request/GuildRequests.kt
@@ -77,10 +77,10 @@ public data class ChannelPositionSwapRequest(
     val position: OptionalInt? = OptionalInt.Missing,
     @KordExperimental
     @SerialName("lock_permissions")
-    val lockPermissions: Boolean?,
+    val lockPermissions: OptionalBoolean? = OptionalBoolean.Missing,
     @KordExperimental
     @SerialName("parent_id")
-    val parentId: Snowflake?
+    val parentId: OptionalSnowflake? = OptionalSnowflake.Missing,
 )
 
 @Serializable(with = GuildChannelPositionModifyRequest.Serializer::class)


### PR DESCRIPTION
The documentation was incorrect regarding these fields' optionality, and as such it was impossible to swap multiple channels in one request. By changing these fields to Optionals (like `position` already was), this issue is fixed.

Closes #827