### PR TITLE
Add mention raid protection to Auto Moderation

### DIFF
--- a/common/api/common.api
+++ b/common/api/common.api
@@ -2690,19 +2690,21 @@ public final class dev/kord/common/entity/DiscordAutoModerationRule$Companion {
 public final class dev/kord/common/entity/DiscordAutoModerationRuleTriggerMetadata {
 	public static final field Companion Ldev/kord/common/entity/DiscordAutoModerationRuleTriggerMetadata$Companion;
 	public fun <init> ()V
-	public synthetic fun <init> (ILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (ILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;)V
+	public synthetic fun <init> (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component2 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component3 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component4 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component5 ()Ldev/kord/common/entity/optional/OptionalInt;
-	public final fun copy (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;)Ldev/kord/common/entity/DiscordAutoModerationRuleTriggerMetadata;
-	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordAutoModerationRuleTriggerMetadata;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordAutoModerationRuleTriggerMetadata;
+	public final fun component6 ()Ldev/kord/common/entity/optional/OptionalBoolean;
+	public final fun copy (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;)Ldev/kord/common/entity/DiscordAutoModerationRuleTriggerMetadata;
+	public static synthetic fun copy$default (Ldev/kord/common/entity/DiscordAutoModerationRuleTriggerMetadata;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;ILjava/lang/Object;)Ldev/kord/common/entity/DiscordAutoModerationRuleTriggerMetadata;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAllowList ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getKeywordFilter ()Ldev/kord/common/entity/optional/Optional;
+	public final fun getMentionRaidProtectionEnabled ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun getMentionTotalLimit ()Ldev/kord/common/entity/optional/OptionalInt;
 	public final fun getPresets ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getRegexPatterns ()Ldev/kord/common/entity/optional/Optional;

--- a/common/src/commonMain/kotlin/entity/AutoModeration.kt
+++ b/common/src/commonMain/kotlin/entity/AutoModeration.kt
@@ -58,6 +58,7 @@
 package dev.kord.common.entity
 
 import dev.kord.common.entity.optional.Optional
+import dev.kord.common.entity.optional.OptionalBoolean
 import dev.kord.common.entity.optional.OptionalInt
 import dev.kord.common.entity.optional.OptionalSnowflake
 import dev.kord.common.serialization.DurationInSeconds
@@ -100,6 +101,8 @@ public data class DiscordAutoModerationRuleTriggerMetadata(
     val allowList: Optional<List<String>> = Optional.Missing(),
     @SerialName("mention_total_limit")
     val mentionTotalLimit: OptionalInt = OptionalInt.Missing,
+    @SerialName("mention_raid_protection_enabled")
+    val mentionRaidProtectionEnabled: OptionalBoolean = OptionalBoolean.Missing,
 )
 
 @Serializable

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -393,7 +393,9 @@ public final class dev/kord/core/behavior/GuildBehaviorKt {
 	public static final fun createKeywordPresetAutoModerationRule (Ldev/kord/core/behavior/GuildBehavior;Ljava/lang/String;Ldev/kord/common/entity/AutoModerationRuleEventType;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun createKeywordPresetAutoModerationRule$default (Ldev/kord/core/behavior/GuildBehavior;Ljava/lang/String;Ldev/kord/common/entity/AutoModerationRuleEventType;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun createMentionSpamAutoModerationRule (Ldev/kord/core/behavior/GuildBehavior;Ljava/lang/String;Ldev/kord/common/entity/AutoModerationRuleEventType;ILkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun createMentionSpamAutoModerationRule (Ldev/kord/core/behavior/GuildBehavior;Ljava/lang/String;Ldev/kord/common/entity/AutoModerationRuleEventType;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun createMentionSpamAutoModerationRule$default (Ldev/kord/core/behavior/GuildBehavior;Ljava/lang/String;Ldev/kord/common/entity/AutoModerationRuleEventType;ILkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun createMentionSpamAutoModerationRule$default (Ldev/kord/core/behavior/GuildBehavior;Ljava/lang/String;Ldev/kord/common/entity/AutoModerationRuleEventType;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun createMessageCommand (Ldev/kord/core/behavior/GuildBehavior;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun createMessageCommand$default (Ldev/kord/core/behavior/GuildBehavior;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun createNewsChannel (Ldev/kord/core/behavior/GuildBehavior;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -2825,19 +2827,21 @@ public final class dev/kord/core/cache/data/AutoModerationRuleData$Companion {
 public final class dev/kord/core/cache/data/AutoModerationRuleTriggerMetadataData {
 	public static final field Companion Ldev/kord/core/cache/data/AutoModerationRuleTriggerMetadataData$Companion;
 	public fun <init> ()V
-	public synthetic fun <init> (ILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (ILdev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;)V
+	public synthetic fun <init> (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component2 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component3 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component4 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component5 ()Ldev/kord/common/entity/optional/OptionalInt;
-	public final fun copy (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;)Ldev/kord/core/cache/data/AutoModerationRuleTriggerMetadataData;
-	public static synthetic fun copy$default (Ldev/kord/core/cache/data/AutoModerationRuleTriggerMetadataData;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;ILjava/lang/Object;)Ldev/kord/core/cache/data/AutoModerationRuleTriggerMetadataData;
+	public final fun component6 ()Ldev/kord/common/entity/optional/OptionalBoolean;
+	public final fun copy (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;)Ldev/kord/core/cache/data/AutoModerationRuleTriggerMetadataData;
+	public static synthetic fun copy$default (Ldev/kord/core/cache/data/AutoModerationRuleTriggerMetadataData;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalInt;Ldev/kord/common/entity/optional/OptionalBoolean;ILjava/lang/Object;)Ldev/kord/core/cache/data/AutoModerationRuleTriggerMetadataData;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAllowList ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getKeywordFilter ()Ldev/kord/common/entity/optional/Optional;
+	public final fun getMentionRaidProtectionEnabled ()Ldev/kord/common/entity/optional/OptionalBoolean;
 	public final fun getMentionTotalLimit ()Ldev/kord/common/entity/optional/OptionalInt;
 	public final fun getPresets ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getRegexPatterns ()Ldev/kord/common/entity/optional/Optional;
@@ -7750,6 +7754,7 @@ public final class dev/kord/core/entity/automoderation/MentionSpamAutoModeration
 	public final fun getMentionLimit ()I
 	public fun getTriggerType ()Ldev/kord/common/entity/AutoModerationRuleTriggerType$MentionSpam;
 	public synthetic fun getTriggerType ()Ldev/kord/common/entity/AutoModerationRuleTriggerType;
+	public final fun isMentionRaidProtectionEnabled ()Z
 	public fun toString ()Ljava/lang/String;
 	public synthetic fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/automoderation/AutoModerationRuleBehavior;
 	public synthetic fun withStrategy (Ldev/kord/core/supplier/EntitySupplyStrategy;)Ldev/kord/core/behavior/automoderation/MentionSpamAutoModerationRuleBehavior;

--- a/core/src/commonMain/kotlin/behavior/GuildBehavior.kt
+++ b/core/src/commonMain/kotlin/behavior/GuildBehavior.kt
@@ -1068,10 +1068,27 @@ public suspend inline fun GuildBehavior.createKeywordPresetAutoModerationRule(
  *
  * @param name the rule name.
  * @param eventType the rule [event type][AutoModerationRuleEventType].
- * @param mentionLimit total number of unique role and user mentions allowed per message (maximum of 50).
  *
  * @throws RestRequestException if something went wrong during the request.
  */
+public suspend inline fun GuildBehavior.createMentionSpamAutoModerationRule(
+    name: String,
+    eventType: AutoModerationRuleEventType = MessageSend,
+    builder: MentionSpamAutoModerationRuleCreateBuilder.() -> Unit,
+): MentionSpamAutoModerationRule {
+    contract { callsInPlace(builder, EXACTLY_ONCE) }
+    val rule = kord.rest.autoModeration.createMentionSpamAutoModerationRule(guildId = id, name, eventType, builder)
+    return MentionSpamAutoModerationRule(AutoModerationRuleData.from(rule), kord, supplier)
+}
+
+@Deprecated(
+    "The 'mentionLimit' parameter is optional, only 'mentionLimit' OR 'mentionRaidProtectionEnabled' is required.",
+    ReplaceWith(
+        "this.createMentionSpamAutoModerationRule(name, eventType) { this@createMentionSpamAutoModerationRule" +
+            ".mentionLimit = mentionLimit\nbuilder() }"
+    ),
+    DeprecationLevel.WARNING,
+)
 public suspend inline fun GuildBehavior.createMentionSpamAutoModerationRule(
     name: String,
     eventType: AutoModerationRuleEventType = MessageSend,
@@ -1079,7 +1096,8 @@ public suspend inline fun GuildBehavior.createMentionSpamAutoModerationRule(
     builder: MentionSpamAutoModerationRuleCreateBuilder.() -> Unit,
 ): MentionSpamAutoModerationRule {
     contract { callsInPlace(builder, EXACTLY_ONCE) }
-    val rule = kord.rest.autoModeration
-        .createMentionSpamAutoModerationRule(guildId = id, name, eventType, mentionLimit, builder)
-    return MentionSpamAutoModerationRule(AutoModerationRuleData.from(rule), kord, supplier)
+    return createMentionSpamAutoModerationRule(name, eventType) {
+        this.mentionLimit = mentionLimit
+        builder()
+    }
 }

--- a/core/src/commonMain/kotlin/cache/data/AutoModeration.kt
+++ b/core/src/commonMain/kotlin/cache/data/AutoModeration.kt
@@ -3,10 +3,7 @@ package dev.kord.core.cache.data
 import dev.kord.cache.api.data.DataDescription
 import dev.kord.cache.api.data.description
 import dev.kord.common.entity.*
-import dev.kord.common.entity.optional.Optional
-import dev.kord.common.entity.optional.OptionalInt
-import dev.kord.common.entity.optional.OptionalSnowflake
-import dev.kord.common.entity.optional.map
+import dev.kord.common.entity.optional.*
 import dev.kord.common.serialization.DurationInSeconds
 import kotlinx.serialization.Serializable
 
@@ -53,6 +50,7 @@ public data class AutoModerationRuleTriggerMetadataData(
     val presets: Optional<List<AutoModerationRuleKeywordPresetType>> = Optional.Missing(),
     val allowList: Optional<List<String>> = Optional.Missing(),
     val mentionTotalLimit: OptionalInt = OptionalInt.Missing,
+    val mentionRaidProtectionEnabled: OptionalBoolean = OptionalBoolean.Missing,
 ) {
     public companion object {
         public fun from(metadata: DiscordAutoModerationRuleTriggerMetadata): AutoModerationRuleTriggerMetadataData =
@@ -63,6 +61,7 @@ public data class AutoModerationRuleTriggerMetadataData(
                     presets = presets,
                     allowList = allowList,
                     mentionTotalLimit = mentionTotalLimit,
+                    mentionRaidProtectionEnabled = mentionRaidProtectionEnabled,
                 )
             }
     }

--- a/core/src/commonMain/kotlin/entity/automoderation/AutoModerationRule.kt
+++ b/core/src/commonMain/kotlin/entity/automoderation/AutoModerationRule.kt
@@ -200,6 +200,10 @@ public class MentionSpamAutoModerationRule(data: AutoModerationRuleData, kord: K
     /** Total number of unique role and user mentions allowed per message. */
     public val mentionLimit: Int get() = data.triggerMetadata.mentionTotalLimit.value!!
 
+    /** Whether to automatically detect mention raids. */
+    public val isMentionRaidProtectionEnabled: Boolean
+        get() = data.triggerMetadata.mentionRaidProtectionEnabled.orElse(false)
+
     override suspend fun asAutoModerationRuleOrNull(): MentionSpamAutoModerationRule = this
     override suspend fun asAutoModerationRule(): MentionSpamAutoModerationRule = this
 

--- a/rest/api/rest.api
+++ b/rest/api/rest.api
@@ -276,7 +276,10 @@ public final class dev/kord/rest/builder/automoderation/KeywordPresetAutoModerat
 public abstract interface class dev/kord/rest/builder/automoderation/MentionSpamAutoModerationRuleBuilder : dev/kord/rest/builder/automoderation/TimeoutAutoModerationRuleBuilder {
 	public abstract fun assignMentionLimit (I)V
 	public abstract fun getMentionLimit ()Ljava/lang/Integer;
+	public abstract fun getMentionRaidProtectionEnabled ()Ljava/lang/Boolean;
 	public abstract fun getTriggerType ()Ldev/kord/common/entity/AutoModerationRuleTriggerType$MentionSpam;
+	public abstract fun setMentionLimit (Ljava/lang/Integer;)V
+	public abstract fun setMentionRaidProtectionEnabled (Ljava/lang/Boolean;)V
 }
 
 public final class dev/kord/rest/builder/automoderation/MentionSpamAutoModerationRuleBuilder$DefaultImpls {
@@ -284,22 +287,28 @@ public final class dev/kord/rest/builder/automoderation/MentionSpamAutoModeratio
 }
 
 public final class dev/kord/rest/builder/automoderation/MentionSpamAutoModerationRuleCreateBuilder : dev/kord/rest/builder/automoderation/AutoModerationRuleCreateBuilder, dev/kord/rest/builder/automoderation/MentionSpamAutoModerationRuleBuilder {
+	public fun <init> (Ljava/lang/String;Ldev/kord/common/entity/AutoModerationRuleEventType;)V
 	public fun <init> (Ljava/lang/String;Ldev/kord/common/entity/AutoModerationRuleEventType;I)V
 	public fun assignMentionLimit (I)V
 	public synthetic fun buildTriggerMetadata ()Ldev/kord/common/entity/optional/Optional;
 	public fun getMentionLimit ()Ljava/lang/Integer;
+	public fun getMentionRaidProtectionEnabled ()Ljava/lang/Boolean;
 	public fun getTriggerType ()Ldev/kord/common/entity/AutoModerationRuleTriggerType$MentionSpam;
 	public synthetic fun getTriggerType ()Ldev/kord/common/entity/AutoModerationRuleTriggerType;
 	public fun setMentionLimit (I)V
+	public fun setMentionLimit (Ljava/lang/Integer;)V
+	public fun setMentionRaidProtectionEnabled (Ljava/lang/Boolean;)V
 }
 
 public final class dev/kord/rest/builder/automoderation/MentionSpamAutoModerationRuleModifyBuilder : dev/kord/rest/builder/automoderation/AutoModerationRuleModifyBuilder, dev/kord/rest/builder/automoderation/MentionSpamAutoModerationRuleBuilder {
 	public fun <init> ()V
 	public fun assignMentionLimit (I)V
 	public fun getMentionLimit ()Ljava/lang/Integer;
+	public fun getMentionRaidProtectionEnabled ()Ljava/lang/Boolean;
 	public fun getTriggerType ()Ldev/kord/common/entity/AutoModerationRuleTriggerType$MentionSpam;
 	public synthetic fun getTriggerType ()Ldev/kord/common/entity/AutoModerationRuleTriggerType;
 	public fun setMentionLimit (Ljava/lang/Integer;)V
+	public fun setMentionRaidProtectionEnabled (Ljava/lang/Boolean;)V
 }
 
 public final class dev/kord/rest/builder/automoderation/SendAlertMessageAutoModerationActionBuilder : dev/kord/rest/builder/automoderation/AutoModerationActionBuilder {
@@ -7009,6 +7018,7 @@ public final class dev/kord/rest/service/AutoModerationService : dev/kord/rest/s
 	public final fun createKeywordAutoModerationRule (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/AutoModerationRuleEventType;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun createKeywordPresetAutoModerationRule (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/AutoModerationRuleEventType;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun createMentionSpamAutoModerationRule (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/AutoModerationRuleEventType;ILkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun createMentionSpamAutoModerationRule (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/AutoModerationRuleEventType;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun createSpamAutoModerationRule (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/AutoModerationRuleEventType;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun deleteAutoModerationRule (Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun deleteAutoModerationRule$default (Ldev/kord/rest/service/AutoModerationService;Ldev/kord/common/entity/Snowflake;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;

--- a/rest/src/commonMain/kotlin/builder/automoderation/AutoModerationRuleBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/automoderation/AutoModerationRuleBuilder.kt
@@ -314,11 +314,19 @@ public sealed interface MentionSpamAutoModerationRuleBuilder : TimeoutAutoModera
     override val triggerType: MentionSpam get() = MentionSpam
 
     /** Total number of unique role and user mentions allowed per message (maximum of 50). */
-    public val mentionLimit: Int?
+    public var mentionLimit: Int?
 
     /**
      * Use this to set [mentionLimit][MentionSpamAutoModerationRuleBuilder.mentionLimit] for
      * [MentionSpamAutoModerationRuleBuilder].
      */
+    @Deprecated(
+        "This can be replaced with 'mentionLimit', it is now a 'var'.",
+        ReplaceWith("this.run { this@run.mentionLimit = mentionLimit }"),
+        DeprecationLevel.WARNING,
+    )
     public fun assignMentionLimit(mentionLimit: Int)
+
+    /** Whether to automatically detect mention raids. */
+    public var mentionRaidProtectionEnabled: Boolean?
 }

--- a/rest/src/commonMain/kotlin/builder/automoderation/AutoModerationRuleCreateBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/automoderation/AutoModerationRuleCreateBuilder.kt
@@ -119,14 +119,54 @@ public class KeywordPresetAutoModerationRuleCreateBuilder(
 public class MentionSpamAutoModerationRuleCreateBuilder(
     name: String,
     eventType: AutoModerationRuleEventType,
-    override var mentionLimit: Int,
 ) : AutoModerationRuleCreateBuilder(name, eventType), MentionSpamAutoModerationRuleBuilder {
+    @Deprecated(
+        "The 'mentionLimit' parameter is optional, only 'mentionLimit' OR 'mentionRaidProtectionEnabled' is required.",
+        ReplaceWith(
+            "MentionSpamAutoModerationRuleCreateBuilder(name, eventType).apply { this@apply.mentionLimit = mentionLimit }",
+            imports = ["dev.kord.rest.builder.automoderation.MentionSpamAutoModerationRuleCreateBuilder"],
+        ),
+        DeprecationLevel.WARNING,
+    )
+    public constructor(name: String, eventType: AutoModerationRuleEventType, mentionLimit: Int) : this(
+        name,
+        eventType,
+    ) {
+        this.mentionLimit = mentionLimit
+    }
 
     /** @suppress Use `this.mentionLimit = mentionLimit` instead. */
+    @Deprecated(
+        "This can be replaced with 'mentionLimit', it is now a 'var'.",
+        ReplaceWith("this.run { this@run.mentionLimit = mentionLimit }"),
+        DeprecationLevel.WARNING,
+    )
     override fun assignMentionLimit(mentionLimit: Int) {
         this.mentionLimit = mentionLimit
     }
 
+    /** @suppress This declaration only exists to preserve binary compatibility. */
+    @Suppress("NON_FINAL_MEMBER_IN_FINAL_CLASS")
+    @Deprecated(
+        "This can be replaced with 'mentionLimit', it is now a 'var'.",
+        ReplaceWith("this.run { this@run.mentionLimit = mentionLimit }"),
+        DeprecationLevel.WARNING,
+    )
+    public open fun setMentionLimit(mentionLimit: Int) {
+        this.mentionLimit = mentionLimit
+    }
+
+    private var _mentionLimit: OptionalInt = OptionalInt.Missing
+    override var mentionLimit: Int? by ::_mentionLimit.delegate()
+
+    private var _mentionRaidProtectionEnabled: OptionalBoolean = OptionalBoolean.Missing
+    override var mentionRaidProtectionEnabled: Boolean? by ::_mentionRaidProtectionEnabled.delegate()
+
+    // one of mentionTotalLimit or mentionRaidProtectionEnabled is required, don't bother to send missing trigger
+    // metadata if both are missing
     override fun buildTriggerMetadata(): Optional.Value<DiscordAutoModerationRuleTriggerMetadata> =
-        DiscordAutoModerationRuleTriggerMetadata(mentionTotalLimit = mentionLimit.optionalInt()).optional()
+        DiscordAutoModerationRuleTriggerMetadata(
+            mentionTotalLimit = _mentionLimit,
+            mentionRaidProtectionEnabled = _mentionRaidProtectionEnabled,
+        ).optional()
 }

--- a/rest/src/commonMain/kotlin/builder/automoderation/AutoModerationRuleModifyBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/automoderation/AutoModerationRuleModifyBuilder.kt
@@ -148,15 +148,30 @@ public class MentionSpamAutoModerationRuleModifyBuilder :
     override var mentionLimit: Int? by ::_mentionLimit.delegate()
 
     /** @suppress Use `this.mentionLimit = mentionLimit` instead. */
+    @Deprecated(
+        "This can be replaced with 'mentionLimit', it is now a 'var'.",
+        ReplaceWith("this.run { this@run.mentionLimit = mentionLimit }"),
+        DeprecationLevel.WARNING,
+    )
     override fun assignMentionLimit(mentionLimit: Int) {
         this.mentionLimit = mentionLimit
     }
 
-    override fun buildTriggerMetadata(): Optional<DiscordAutoModerationRuleTriggerMetadata> =
-        when (val limit = _mentionLimit) {
-            OptionalInt.Missing -> Optional.Missing()
-            is OptionalInt.Value -> DiscordAutoModerationRuleTriggerMetadata(mentionTotalLimit = limit).optional()
+    private var _mentionRaidProtectionEnabled: OptionalBoolean = OptionalBoolean.Missing
+    override var mentionRaidProtectionEnabled: Boolean? by ::_mentionRaidProtectionEnabled.delegate()
+
+    override fun buildTriggerMetadata(): Optional<DiscordAutoModerationRuleTriggerMetadata> {
+        val mentionLimit = _mentionLimit
+        val mentionRaidProtectionEnabled = _mentionRaidProtectionEnabled
+        return if (mentionLimit is OptionalInt.Value || mentionRaidProtectionEnabled is OptionalBoolean.Value) {
+            DiscordAutoModerationRuleTriggerMetadata(
+                mentionTotalLimit = mentionLimit,
+                mentionRaidProtectionEnabled = mentionRaidProtectionEnabled,
+            ).optional()
+        } else {
+            Optional.Missing()
         }
+    }
 }
 
 private inline fun <T : Any> ifAnyPresent(vararg optionals: Optional<*>, block: () -> T): Optional<T> {

--- a/rest/src/commonMain/kotlin/service/AutoModerationService.kt
+++ b/rest/src/commonMain/kotlin/service/AutoModerationService.kt
@@ -72,12 +72,33 @@ public class AutoModerationService(requestHandler: RequestHandler) : RestService
         guildId: Snowflake,
         name: String,
         eventType: AutoModerationRuleEventType,
+        builder: MentionSpamAutoModerationRuleCreateBuilder.() -> Unit,
+    ): DiscordAutoModerationRule {
+        contract { callsInPlace(builder, EXACTLY_ONCE) }
+        val request = MentionSpamAutoModerationRuleCreateBuilder(name, eventType).apply(builder)
+        return createAutoModerationRule(guildId, request.toRequest(), request.reason)
+    }
+
+    @Deprecated(
+        "The 'mentionLimit' parameter is optional, only 'mentionLimit' OR 'mentionRaidProtectionEnabled' is required.",
+        ReplaceWith(
+            "this.createMentionSpamAutoModerationRule(guildId, name, eventType) { " +
+                "this@createMentionSpamAutoModerationRule.mentionLimit = mentionLimit\nbuilder() }"
+        ),
+        DeprecationLevel.WARNING,
+    )
+    public suspend inline fun createMentionSpamAutoModerationRule(
+        guildId: Snowflake,
+        name: String,
+        eventType: AutoModerationRuleEventType,
         mentionLimit: Int,
         builder: MentionSpamAutoModerationRuleCreateBuilder.() -> Unit,
     ): DiscordAutoModerationRule {
         contract { callsInPlace(builder, EXACTLY_ONCE) }
-        val request = MentionSpamAutoModerationRuleCreateBuilder(name, eventType, mentionLimit).apply(builder)
-        return createAutoModerationRule(guildId, request.toRequest(), request.reason)
+        return createMentionSpamAutoModerationRule(guildId, name, eventType) {
+            this.mentionLimit = mentionLimit
+            builder()
+        }
     }
 
     public suspend fun modifyAutoModerationRule(


### PR DESCRIPTION
The DSL looks like this:
```kotlin
val rule = guild.createMentionSpamAutoModerationRule("name") {
    mentionRaidProtectionEnabled = true
    blockMessage()
    enabled = true
}
println(rule.isMentionRaidProtectionEnabled)
```

see https://github.com/discord/discord-api-docs/pull/5778 and https://github.com/discord/discord-api-docs/pull/6133