### PR TITLE
Improve publishing

### DIFF
--- a/.github/workflows/deployment-ci.yml
+++ b/.github/workflows/deployment-ci.yml
@@ -40,10 +40,10 @@ jobs:
       !contains(github.event.head_commit.message, '[publish skip]') && github.event_name != 'pull_request' &&  github.ref != 'refs/heads/master'
     env:
       KORD_TEST_TOKEN: ${{ secrets.KORD_TEST_TOKEN }}
-      NEXUS_USER: ${{ secrets.NEXUS_USER }}
-      NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
-      SIGNING_KEY: ${{ secrets.signingKey }}
-      SIGNING_PASSWORD: ${{ secrets.signingPassword }}
+      ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.NEXUS_USER }}
+      ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.NEXUS_PASSWORD }}
+      ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.signingKey }}
+      ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.signingPassword }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/deployment-ci.yml
+++ b/.github/workflows/deployment-ci.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 11
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
         with:

--- a/.github/workflows/deployment-ci.yml
+++ b/.github/workflows/deployment-ci.yml
@@ -42,8 +42,8 @@ jobs:
       KORD_TEST_TOKEN: ${{ secrets.KORD_TEST_TOKEN }}
       ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.NEXUS_USER }}
       ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.NEXUS_PASSWORD }}
-      ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.signingKey }}
-      ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.signingPassword }}
+      SIGNING_KEY: ${{ secrets.signingKey }}
+      SIGNING_PASSWORD: ${{ secrets.signingPassword }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/deployment-ci.yml
+++ b/.github/workflows/deployment-ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 11
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
         with:

--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -1,6 +1,8 @@
+import com.vanniktech.maven.publish.JavaPlatform
+
 plugins {
     `java-platform`
-    `maven-publish`
+    id("com.vanniktech.maven.publish.base")
 }
 
 val me = project
@@ -26,10 +28,8 @@ dependencies {
     }
 }
 
-publishing {
-    publications.register<MavenPublication>(Library.name) {
-        from(components["javaPlatform"])
-    }
+mavenPublishing {
+    configure(JavaPlatform())
 }
 
 apply(plugin = "kord-publishing")

--- a/buildSrc/src/main/kotlin/kord-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/kord-module.gradle.kts
@@ -1,3 +1,5 @@
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.KotlinJvm
 import org.jetbrains.dokka.gradle.AbstractDokkaLeafTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -8,7 +10,7 @@ plugins {
     `kotlinx-atomicfu`
     org.jetbrains.kotlinx.`binary-compatibility-validator`
     com.google.devtools.ksp
-    `maven-publish`
+    id("com.vanniktech.maven.publish.base")
 }
 
 repositories {
@@ -51,9 +53,6 @@ tasks {
     }
 }
 
-publishing {
-    publications.register<MavenPublication>(Library.name) {
-        from(components["java"])
-        artifact(tasks.kotlinSourcesJar)
-    }
+mavenPublishing {
+    configure(KotlinJvm(javadocJar = JavadocJar.Dokka("dokkaHtml")))
 }

--- a/buildSrc/src/main/kotlin/kord-multiplatform-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/kord-multiplatform-module.gradle.kts
@@ -1,3 +1,5 @@
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.KotlinMultiplatform
 import org.jetbrains.dokka.gradle.AbstractDokkaLeafTask
 import org.jetbrains.kotlin.gradle.targets.js.testing.KotlinJsTest
 
@@ -8,6 +10,7 @@ plugins {
     `kotlinx-atomicfu`
     org.jetbrains.kotlinx.`binary-compatibility-validator`
     com.google.devtools.ksp
+    id("com.vanniktech.maven.publish.base")
 }
 
 repositories {
@@ -91,4 +94,8 @@ tasks {
         applyKordDokkaOptions()
         dependsOn("kspCommonMainKotlinMetadata")
     }
+}
+
+mavenPublishing {
+    configure(KotlinMultiplatform(javadocJar = JavadocJar.Dokka("dokkaHtml")))
 }

--- a/buildSrc/src/main/kotlin/kord-publishing.gradle.kts
+++ b/buildSrc/src/main/kotlin/kord-publishing.gradle.kts
@@ -1,79 +1,50 @@
-import java.lang.System.getenv
-import java.util.Base64
-
 plugins {
-    `maven-publish`
-    signing
+    // For some reason, Gradle does not generate an accessor for this
+    id("com.vanniktech.maven.publish.base")
 }
 
-fun MavenPublication.registerDokkaJar() =
-    tasks.register<Jar>("${name}DokkaJar") {
-        archiveClassifier = "javadoc"
-        destinationDirectory = destinationDirectory.get().dir(name)
-        from(tasks.named("dokkaHtml"))
-    }
+group = Library.group
+version = libraryVersion
 
-publishing {
-    publications {
-        withType<MavenPublication>().configureEach {
-            if (project.name != "bom") artifact(registerDokkaJar())
+mavenPublishing {
+    coordinates(Library.group, "kord-${project.name}", libraryVersion)
+    // This sets up OSSRH snapshots + maven central
+    publishToMavenCentral(automaticRelease = true)
+    signAllPublications()
 
-            groupId = Library.group
-            artifactId = "kord-$artifactId"
-            version = libraryVersion
+    pom {
+        name = Library.name
+        description = Library.description
+        url = Library.projectUrl
 
-            pom {
-                name = Library.name
-                description = Library.description
-                url = Library.projectUrl
+        organization {
+            name = "Kord"
+            url = "https://github.com/kordlib"
+        }
 
-                organization {
-                    name = "Kord"
-                    url = "https://github.com/kordlib"
-                }
-
-                developers {
-                    developer {
-                        name = "The Kord Team"
-                    }
-                }
-
-                issueManagement {
-                    system = "GitHub"
-                    url = "https://github.com/kordlib/kord/issues"
-                }
-
-                licenses {
-                    license {
-                        name = "MIT"
-                        url = "https://opensource.org/licenses/MIT"
-                    }
-                }
-
-                scm {
-                    connection = "scm:git:ssh://github.com/kordlib/kord.git"
-                    developerConnection = "scm:git:ssh://git@github.com:kordlib/kord.git"
-                    url = Library.projectUrl
-                }
+        developers {
+            developer {
+                name = "The Kord Team"
             }
         }
-    }
 
-    repositories {
-        maven {
-            url = uri(if (isRelease) Repo.releasesUrl else Repo.snapshotsUrl)
+        issueManagement {
+            system = "GitHub"
+            url = "https://github.com/kordlib/kord/issues"
+        }
 
-            credentials {
-                username = getenv("NEXUS_USER")
-                password = getenv("NEXUS_PASSWORD")
+        licenses {
+            license {
+                name = "MIT"
+                url = "https://opensource.org/licenses/MIT"
+                distribution = "https://github.com/kordlib/kord/blob/LICENSE"
             }
         }
-    }
-}
 
-signing {
-    val secretKey = getenv("SIGNING_KEY")?.let { String(Base64.getDecoder().decode(it)) }
-    val password = getenv("SIGNING_PASSWORD")
-    useInMemoryPgpKeys(secretKey, password)
-    sign(publishing.publications)
+        scm {
+            connection = "scm:git:ssh://github.com/kordlib/kord.git"
+            developerConnection = "scm:git:ssh://git@github.com:kordlib/kord.git"
+            url = Library.projectUrl
+        }
+    }
 }

--- a/buildSrc/src/main/kotlin/kord-publishing.gradle.kts
+++ b/buildSrc/src/main/kotlin/kord-publishing.gradle.kts
@@ -1,10 +1,20 @@
+import java.util.Base64
+
 plugins {
     // For some reason, Gradle does not generate an accessor for this
     id("com.vanniktech.maven.publish.base")
+    signing
 }
 
 group = Library.group
 version = libraryVersion
+
+signing {
+    val secretKey = System.getenv("SIGNING_KEY")?.let { String(Base64.getDecoder().decode(it)) }
+    val password = System.getenv("SIGNING_PASSWORD")
+    useInMemoryPgpKeys(secretKey, password)
+    sign(publishing.publications)
+}
 
 mavenPublishing {
     coordinates(Library.group, "kord-${project.name}", libraryVersion)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,7 @@ dokka = "1.8.20" # https://github.com/Kotlin/dokka
 kotlinx-atomicfu = "0.21.0" # https://github.com/Kotlin/kotlinx-atomicfu
 binary-compatibility-validator = "0.13.2" # https://github.com/Kotlin/binary-compatibility-validator
 buildconfig = "4.1.2" # https://github.com/gmazzo/gradle-buildconfig-plugin
+maven-publish-plugin = "0.25.3"
 
 
 [libraries]
@@ -84,7 +85,7 @@ dokka-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref
 atomicfu-plugin = { module = "org.jetbrains.kotlinx:atomicfu-gradle-plugin", version.ref = "kotlinx-atomicfu" }
 binary-compatibility-validator-plugin = { module = "org.jetbrains.kotlinx:binary-compatibility-validator", version.ref = "binary-compatibility-validator" }
 ksp-plugin = { module = "com.google.devtools.ksp:symbol-processing-gradle-plugin", version.ref = "ksp" }
-
+maven-publish-plugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "maven-publish-plugin" }
 
 [bundles]
 
@@ -101,6 +102,7 @@ pluginsForBuildSrc = [
     "atomicfu-plugin",
     "binary-compatibility-validator-plugin",
     "ksp-plugin",
+    "maven-publish-plugin"
 ]
 
 


### PR DESCRIPTION
This PR aims to prepare publishing for K/N and other advantages:
- We can now automatically publish to maven central even in a KMP setup where artifacts come from different CI runs
- We have the same ci configuration for all modules (since the plugin supports all sources)
- We no longer have to register artifacts on our own
