### PR TITLE
Remove unnecessary `RedundantVisibilityModifier` suppression

### DIFF
--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/ActivityType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/ActivityType.kt
@@ -1,6 +1,6 @@
 // THIS FILE IS AUTO-GENERATED, DO NOT EDIT!
-@file:Suppress(names = arrayOf("RedundantVisibilityModifier", "IncorrectFormatting",
-                "ReplaceArrayOfWithLiteral", "SpellCheckingInspection", "GrazieInspection"))
+@file:Suppress(names = arrayOf("IncorrectFormatting", "ReplaceArrayOfWithLiteral",
+                "SpellCheckingInspection", "GrazieInspection"))
 
 package dev.kord.common.entity
 

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/AllowedMentionType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/AllowedMentionType.kt
@@ -1,6 +1,6 @@
 // THIS FILE IS AUTO-GENERATED, DO NOT EDIT!
-@file:Suppress(names = arrayOf("RedundantVisibilityModifier", "IncorrectFormatting",
-                "ReplaceArrayOfWithLiteral", "SpellCheckingInspection", "GrazieInspection"))
+@file:Suppress(names = arrayOf("IncorrectFormatting", "ReplaceArrayOfWithLiteral",
+                "SpellCheckingInspection", "GrazieInspection"))
 
 package dev.kord.common.entity
 

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/ApplicationCommandOptionType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/ApplicationCommandOptionType.kt
@@ -1,6 +1,6 @@
 // THIS FILE IS AUTO-GENERATED, DO NOT EDIT!
-@file:Suppress(names = arrayOf("RedundantVisibilityModifier", "IncorrectFormatting",
-                "ReplaceArrayOfWithLiteral", "SpellCheckingInspection", "GrazieInspection"))
+@file:Suppress(names = arrayOf("IncorrectFormatting", "ReplaceArrayOfWithLiteral",
+                "SpellCheckingInspection", "GrazieInspection"))
 
 package dev.kord.common.entity
 

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/ApplicationCommandPermissionType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/ApplicationCommandPermissionType.kt
@@ -1,6 +1,6 @@
 // THIS FILE IS AUTO-GENERATED, DO NOT EDIT!
-@file:Suppress(names = arrayOf("RedundantVisibilityModifier", "IncorrectFormatting",
-                "ReplaceArrayOfWithLiteral", "SpellCheckingInspection", "GrazieInspection"))
+@file:Suppress(names = arrayOf("IncorrectFormatting", "ReplaceArrayOfWithLiteral",
+                "SpellCheckingInspection", "GrazieInspection"))
 
 package dev.kord.common.entity
 

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/ApplicationCommandType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/ApplicationCommandType.kt
@@ -1,6 +1,6 @@
 // THIS FILE IS AUTO-GENERATED, DO NOT EDIT!
-@file:Suppress(names = arrayOf("RedundantVisibilityModifier", "IncorrectFormatting",
-                "ReplaceArrayOfWithLiteral", "SpellCheckingInspection", "GrazieInspection"))
+@file:Suppress(names = arrayOf("IncorrectFormatting", "ReplaceArrayOfWithLiteral",
+                "SpellCheckingInspection", "GrazieInspection"))
 
 package dev.kord.common.entity
 

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/ApplicationRoleConnectionMetadataType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/ApplicationRoleConnectionMetadataType.kt
@@ -1,6 +1,6 @@
 // THIS FILE IS AUTO-GENERATED, DO NOT EDIT!
-@file:Suppress(names = arrayOf("RedundantVisibilityModifier", "IncorrectFormatting",
-                "ReplaceArrayOfWithLiteral", "SpellCheckingInspection", "GrazieInspection"))
+@file:Suppress(names = arrayOf("IncorrectFormatting", "ReplaceArrayOfWithLiteral",
+                "SpellCheckingInspection", "GrazieInspection"))
 
 package dev.kord.common.entity
 

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/AuditLogEvent.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/AuditLogEvent.kt
@@ -1,6 +1,6 @@
 // THIS FILE IS AUTO-GENERATED, DO NOT EDIT!
-@file:Suppress(names = arrayOf("RedundantVisibilityModifier", "IncorrectFormatting",
-                "ReplaceArrayOfWithLiteral", "SpellCheckingInspection", "GrazieInspection"))
+@file:Suppress(names = arrayOf("IncorrectFormatting", "ReplaceArrayOfWithLiteral",
+                "SpellCheckingInspection", "GrazieInspection"))
 
 package dev.kord.common.entity
 

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/AutoModerationActionType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/AutoModerationActionType.kt
@@ -1,6 +1,6 @@
 // THIS FILE IS AUTO-GENERATED, DO NOT EDIT!
-@file:Suppress(names = arrayOf("RedundantVisibilityModifier", "IncorrectFormatting",
-                "ReplaceArrayOfWithLiteral", "SpellCheckingInspection", "GrazieInspection"))
+@file:Suppress(names = arrayOf("IncorrectFormatting", "ReplaceArrayOfWithLiteral",
+                "SpellCheckingInspection", "GrazieInspection"))
 
 package dev.kord.common.entity
 

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/AutoModerationRuleEventType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/AutoModerationRuleEventType.kt
@@ -1,6 +1,6 @@
 // THIS FILE IS AUTO-GENERATED, DO NOT EDIT!
-@file:Suppress(names = arrayOf("RedundantVisibilityModifier", "IncorrectFormatting",
-                "ReplaceArrayOfWithLiteral", "SpellCheckingInspection", "GrazieInspection"))
+@file:Suppress(names = arrayOf("IncorrectFormatting", "ReplaceArrayOfWithLiteral",
+                "SpellCheckingInspection", "GrazieInspection"))
 
 package dev.kord.common.entity
 

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/AutoModerationRuleKeywordPresetType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/AutoModerationRuleKeywordPresetType.kt
@@ -1,6 +1,6 @@
 // THIS FILE IS AUTO-GENERATED, DO NOT EDIT!
-@file:Suppress(names = arrayOf("RedundantVisibilityModifier", "IncorrectFormatting",
-                "ReplaceArrayOfWithLiteral", "SpellCheckingInspection", "GrazieInspection"))
+@file:Suppress(names = arrayOf("IncorrectFormatting", "ReplaceArrayOfWithLiteral",
+                "SpellCheckingInspection", "GrazieInspection"))
 
 package dev.kord.common.entity
 

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/AutoModerationRuleTriggerType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/AutoModerationRuleTriggerType.kt
@@ -1,6 +1,6 @@
 // THIS FILE IS AUTO-GENERATED, DO NOT EDIT!
-@file:Suppress(names = arrayOf("RedundantVisibilityModifier", "IncorrectFormatting",
-                "ReplaceArrayOfWithLiteral", "SpellCheckingInspection", "GrazieInspection"))
+@file:Suppress(names = arrayOf("IncorrectFormatting", "ReplaceArrayOfWithLiteral",
+                "SpellCheckingInspection", "GrazieInspection"))
 
 package dev.kord.common.entity
 

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/ButtonStyle.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/ButtonStyle.kt
@@ -1,6 +1,6 @@
 // THIS FILE IS AUTO-GENERATED, DO NOT EDIT!
-@file:Suppress(names = arrayOf("RedundantVisibilityModifier", "IncorrectFormatting",
-                "ReplaceArrayOfWithLiteral", "SpellCheckingInspection", "GrazieInspection"))
+@file:Suppress(names = arrayOf("IncorrectFormatting", "ReplaceArrayOfWithLiteral",
+                "SpellCheckingInspection", "GrazieInspection"))
 
 package dev.kord.common.entity
 

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/ChannelType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/ChannelType.kt
@@ -1,6 +1,6 @@
 // THIS FILE IS AUTO-GENERATED, DO NOT EDIT!
-@file:Suppress(names = arrayOf("RedundantVisibilityModifier", "IncorrectFormatting",
-                "ReplaceArrayOfWithLiteral", "SpellCheckingInspection", "GrazieInspection"))
+@file:Suppress(names = arrayOf("IncorrectFormatting", "ReplaceArrayOfWithLiteral",
+                "SpellCheckingInspection", "GrazieInspection"))
 
 package dev.kord.common.entity
 

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/ComponentType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/ComponentType.kt
@@ -1,6 +1,6 @@
 // THIS FILE IS AUTO-GENERATED, DO NOT EDIT!
-@file:Suppress(names = arrayOf("RedundantVisibilityModifier", "IncorrectFormatting",
-                "ReplaceArrayOfWithLiteral", "SpellCheckingInspection", "GrazieInspection"))
+@file:Suppress(names = arrayOf("IncorrectFormatting", "ReplaceArrayOfWithLiteral",
+                "SpellCheckingInspection", "GrazieInspection"))
 
 package dev.kord.common.entity
 

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/DefaultMessageNotificationLevel.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/DefaultMessageNotificationLevel.kt
@@ -1,6 +1,6 @@
 // THIS FILE IS AUTO-GENERATED, DO NOT EDIT!
-@file:Suppress(names = arrayOf("RedundantVisibilityModifier", "IncorrectFormatting",
-                "ReplaceArrayOfWithLiteral", "SpellCheckingInspection", "GrazieInspection"))
+@file:Suppress(names = arrayOf("IncorrectFormatting", "ReplaceArrayOfWithLiteral",
+                "SpellCheckingInspection", "GrazieInspection"))
 
 package dev.kord.common.entity
 

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/DiscordConnectionVisibility.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/DiscordConnectionVisibility.kt
@@ -1,6 +1,6 @@
 // THIS FILE IS AUTO-GENERATED, DO NOT EDIT!
-@file:Suppress(names = arrayOf("RedundantVisibilityModifier", "IncorrectFormatting",
-                "ReplaceArrayOfWithLiteral", "SpellCheckingInspection", "GrazieInspection"))
+@file:Suppress(names = arrayOf("IncorrectFormatting", "ReplaceArrayOfWithLiteral",
+                "SpellCheckingInspection", "GrazieInspection"))
 
 package dev.kord.common.entity
 

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/EmbedType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/EmbedType.kt
@@ -1,6 +1,6 @@
 // THIS FILE IS AUTO-GENERATED, DO NOT EDIT!
-@file:Suppress(names = arrayOf("RedundantVisibilityModifier", "IncorrectFormatting",
-                "ReplaceArrayOfWithLiteral", "SpellCheckingInspection", "GrazieInspection"))
+@file:Suppress(names = arrayOf("IncorrectFormatting", "ReplaceArrayOfWithLiteral",
+                "SpellCheckingInspection", "GrazieInspection"))
 
 package dev.kord.common.entity
 

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/ExplicitContentFilter.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/ExplicitContentFilter.kt
@@ -1,6 +1,6 @@
 // THIS FILE IS AUTO-GENERATED, DO NOT EDIT!
-@file:Suppress(names = arrayOf("RedundantVisibilityModifier", "IncorrectFormatting",
-                "ReplaceArrayOfWithLiteral", "SpellCheckingInspection", "GrazieInspection"))
+@file:Suppress(names = arrayOf("IncorrectFormatting", "ReplaceArrayOfWithLiteral",
+                "SpellCheckingInspection", "GrazieInspection"))
 
 package dev.kord.common.entity
 

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/ForumLayoutType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/ForumLayoutType.kt
@@ -1,6 +1,6 @@
 // THIS FILE IS AUTO-GENERATED, DO NOT EDIT!
-@file:Suppress(names = arrayOf("RedundantVisibilityModifier", "IncorrectFormatting",
-                "ReplaceArrayOfWithLiteral", "SpellCheckingInspection", "GrazieInspection"))
+@file:Suppress(names = arrayOf("IncorrectFormatting", "ReplaceArrayOfWithLiteral",
+                "SpellCheckingInspection", "GrazieInspection"))
 
 package dev.kord.common.entity
 

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/GuildFeature.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/GuildFeature.kt
@@ -1,6 +1,6 @@
 // THIS FILE IS AUTO-GENERATED, DO NOT EDIT!
-@file:Suppress(names = arrayOf("RedundantVisibilityModifier", "IncorrectFormatting",
-                "ReplaceArrayOfWithLiteral", "SpellCheckingInspection", "GrazieInspection"))
+@file:Suppress(names = arrayOf("IncorrectFormatting", "ReplaceArrayOfWithLiteral",
+                "SpellCheckingInspection", "GrazieInspection"))
 
 package dev.kord.common.entity
 

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/GuildScheduledEventPrivacyLevel.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/GuildScheduledEventPrivacyLevel.kt
@@ -1,6 +1,6 @@
 // THIS FILE IS AUTO-GENERATED, DO NOT EDIT!
-@file:Suppress(names = arrayOf("RedundantVisibilityModifier", "IncorrectFormatting",
-                "ReplaceArrayOfWithLiteral", "SpellCheckingInspection", "GrazieInspection"))
+@file:Suppress(names = arrayOf("IncorrectFormatting", "ReplaceArrayOfWithLiteral",
+                "SpellCheckingInspection", "GrazieInspection"))
 
 package dev.kord.common.entity
 

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/GuildScheduledEventStatus.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/GuildScheduledEventStatus.kt
@@ -1,6 +1,6 @@
 // THIS FILE IS AUTO-GENERATED, DO NOT EDIT!
-@file:Suppress(names = arrayOf("RedundantVisibilityModifier", "IncorrectFormatting",
-                "ReplaceArrayOfWithLiteral", "SpellCheckingInspection", "GrazieInspection"))
+@file:Suppress(names = arrayOf("IncorrectFormatting", "ReplaceArrayOfWithLiteral",
+                "SpellCheckingInspection", "GrazieInspection"))
 
 package dev.kord.common.entity
 

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/IntegrationExpireBehavior.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/IntegrationExpireBehavior.kt
@@ -1,6 +1,6 @@
 // THIS FILE IS AUTO-GENERATED, DO NOT EDIT!
-@file:Suppress(names = arrayOf("RedundantVisibilityModifier", "IncorrectFormatting",
-                "ReplaceArrayOfWithLiteral", "SpellCheckingInspection", "GrazieInspection"))
+@file:Suppress(names = arrayOf("IncorrectFormatting", "ReplaceArrayOfWithLiteral",
+                "SpellCheckingInspection", "GrazieInspection"))
 
 package dev.kord.common.entity
 

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/InteractionResponseType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/InteractionResponseType.kt
@@ -1,6 +1,6 @@
 // THIS FILE IS AUTO-GENERATED, DO NOT EDIT!
-@file:Suppress(names = arrayOf("RedundantVisibilityModifier", "IncorrectFormatting",
-                "ReplaceArrayOfWithLiteral", "SpellCheckingInspection", "GrazieInspection"))
+@file:Suppress(names = arrayOf("IncorrectFormatting", "ReplaceArrayOfWithLiteral",
+                "SpellCheckingInspection", "GrazieInspection"))
 
 package dev.kord.common.entity
 

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/InteractionType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/InteractionType.kt
@@ -1,6 +1,6 @@
 // THIS FILE IS AUTO-GENERATED, DO NOT EDIT!
-@file:Suppress(names = arrayOf("RedundantVisibilityModifier", "IncorrectFormatting",
-                "ReplaceArrayOfWithLiteral", "SpellCheckingInspection", "GrazieInspection"))
+@file:Suppress(names = arrayOf("IncorrectFormatting", "ReplaceArrayOfWithLiteral",
+                "SpellCheckingInspection", "GrazieInspection"))
 
 package dev.kord.common.entity
 

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/InviteTargetType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/InviteTargetType.kt
@@ -1,6 +1,6 @@
 // THIS FILE IS AUTO-GENERATED, DO NOT EDIT!
-@file:Suppress(names = arrayOf("RedundantVisibilityModifier", "IncorrectFormatting",
-                "ReplaceArrayOfWithLiteral", "SpellCheckingInspection", "GrazieInspection"))
+@file:Suppress(names = arrayOf("IncorrectFormatting", "ReplaceArrayOfWithLiteral",
+                "SpellCheckingInspection", "GrazieInspection"))
 
 package dev.kord.common.entity
 

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/MFALevel.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/MFALevel.kt
@@ -1,6 +1,6 @@
 // THIS FILE IS AUTO-GENERATED, DO NOT EDIT!
-@file:Suppress(names = arrayOf("RedundantVisibilityModifier", "IncorrectFormatting",
-                "ReplaceArrayOfWithLiteral", "SpellCheckingInspection", "GrazieInspection"))
+@file:Suppress(names = arrayOf("IncorrectFormatting", "ReplaceArrayOfWithLiteral",
+                "SpellCheckingInspection", "GrazieInspection"))
 
 package dev.kord.common.entity
 

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/MessageActivityType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/MessageActivityType.kt
@@ -1,6 +1,6 @@
 // THIS FILE IS AUTO-GENERATED, DO NOT EDIT!
-@file:Suppress(names = arrayOf("RedundantVisibilityModifier", "IncorrectFormatting",
-                "ReplaceArrayOfWithLiteral", "SpellCheckingInspection", "GrazieInspection"))
+@file:Suppress(names = arrayOf("IncorrectFormatting", "ReplaceArrayOfWithLiteral",
+                "SpellCheckingInspection", "GrazieInspection"))
 
 package dev.kord.common.entity
 

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/MessageStickerType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/MessageStickerType.kt
@@ -1,6 +1,6 @@
 // THIS FILE IS AUTO-GENERATED, DO NOT EDIT!
-@file:Suppress(names = arrayOf("RedundantVisibilityModifier", "IncorrectFormatting",
-                "ReplaceArrayOfWithLiteral", "SpellCheckingInspection", "GrazieInspection"))
+@file:Suppress(names = arrayOf("IncorrectFormatting", "ReplaceArrayOfWithLiteral",
+                "SpellCheckingInspection", "GrazieInspection"))
 
 package dev.kord.common.entity
 

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/MessageType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/MessageType.kt
@@ -1,6 +1,6 @@
 // THIS FILE IS AUTO-GENERATED, DO NOT EDIT!
-@file:Suppress(names = arrayOf("RedundantVisibilityModifier", "IncorrectFormatting",
-                "ReplaceArrayOfWithLiteral", "SpellCheckingInspection", "GrazieInspection"))
+@file:Suppress(names = arrayOf("IncorrectFormatting", "ReplaceArrayOfWithLiteral",
+                "SpellCheckingInspection", "GrazieInspection"))
 
 package dev.kord.common.entity
 

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/NsfwLevel.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/NsfwLevel.kt
@@ -1,6 +1,6 @@
 // THIS FILE IS AUTO-GENERATED, DO NOT EDIT!
-@file:Suppress(names = arrayOf("RedundantVisibilityModifier", "IncorrectFormatting",
-                "ReplaceArrayOfWithLiteral", "SpellCheckingInspection", "GrazieInspection"))
+@file:Suppress(names = arrayOf("IncorrectFormatting", "ReplaceArrayOfWithLiteral",
+                "SpellCheckingInspection", "GrazieInspection"))
 
 package dev.kord.common.entity
 

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/OnboardingPromptType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/OnboardingPromptType.kt
@@ -1,6 +1,6 @@
 // THIS FILE IS AUTO-GENERATED, DO NOT EDIT!
-@file:Suppress(names = arrayOf("RedundantVisibilityModifier", "IncorrectFormatting",
-                "ReplaceArrayOfWithLiteral", "SpellCheckingInspection", "GrazieInspection"))
+@file:Suppress(names = arrayOf("IncorrectFormatting", "ReplaceArrayOfWithLiteral",
+                "SpellCheckingInspection", "GrazieInspection"))
 
 package dev.kord.common.entity
 

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/OverwriteType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/OverwriteType.kt
@@ -1,6 +1,6 @@
 // THIS FILE IS AUTO-GENERATED, DO NOT EDIT!
-@file:Suppress(names = arrayOf("RedundantVisibilityModifier", "IncorrectFormatting",
-                "ReplaceArrayOfWithLiteral", "SpellCheckingInspection", "GrazieInspection"))
+@file:Suppress(names = arrayOf("IncorrectFormatting", "ReplaceArrayOfWithLiteral",
+                "SpellCheckingInspection", "GrazieInspection"))
 
 package dev.kord.common.entity
 

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/PremiumTier.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/PremiumTier.kt
@@ -1,6 +1,6 @@
 // THIS FILE IS AUTO-GENERATED, DO NOT EDIT!
-@file:Suppress(names = arrayOf("RedundantVisibilityModifier", "IncorrectFormatting",
-                "ReplaceArrayOfWithLiteral", "SpellCheckingInspection", "GrazieInspection"))
+@file:Suppress(names = arrayOf("IncorrectFormatting", "ReplaceArrayOfWithLiteral",
+                "SpellCheckingInspection", "GrazieInspection"))
 
 package dev.kord.common.entity
 

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/PresenceStatus.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/PresenceStatus.kt
@@ -1,6 +1,6 @@
 // THIS FILE IS AUTO-GENERATED, DO NOT EDIT!
-@file:Suppress(names = arrayOf("RedundantVisibilityModifier", "IncorrectFormatting",
-                "ReplaceArrayOfWithLiteral", "SpellCheckingInspection", "GrazieInspection"))
+@file:Suppress(names = arrayOf("IncorrectFormatting", "ReplaceArrayOfWithLiteral",
+                "SpellCheckingInspection", "GrazieInspection"))
 
 package dev.kord.common.entity
 

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/ScheduledEntityType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/ScheduledEntityType.kt
@@ -1,6 +1,6 @@
 // THIS FILE IS AUTO-GENERATED, DO NOT EDIT!
-@file:Suppress(names = arrayOf("RedundantVisibilityModifier", "IncorrectFormatting",
-                "ReplaceArrayOfWithLiteral", "SpellCheckingInspection", "GrazieInspection"))
+@file:Suppress(names = arrayOf("IncorrectFormatting", "ReplaceArrayOfWithLiteral",
+                "SpellCheckingInspection", "GrazieInspection"))
 
 package dev.kord.common.entity
 

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/SortOrderType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/SortOrderType.kt
@@ -1,6 +1,6 @@
 // THIS FILE IS AUTO-GENERATED, DO NOT EDIT!
-@file:Suppress(names = arrayOf("RedundantVisibilityModifier", "IncorrectFormatting",
-                "ReplaceArrayOfWithLiteral", "SpellCheckingInspection", "GrazieInspection"))
+@file:Suppress(names = arrayOf("IncorrectFormatting", "ReplaceArrayOfWithLiteral",
+                "SpellCheckingInspection", "GrazieInspection"))
 
 package dev.kord.common.entity
 

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/StageInstancePrivacyLevel.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/StageInstancePrivacyLevel.kt
@@ -1,6 +1,6 @@
 // THIS FILE IS AUTO-GENERATED, DO NOT EDIT!
-@file:Suppress(names = arrayOf("RedundantVisibilityModifier", "IncorrectFormatting",
-                "ReplaceArrayOfWithLiteral", "SpellCheckingInspection", "GrazieInspection"))
+@file:Suppress(names = arrayOf("IncorrectFormatting", "ReplaceArrayOfWithLiteral",
+                "SpellCheckingInspection", "GrazieInspection"))
 
 package dev.kord.common.entity
 

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/TeamMembershipState.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/TeamMembershipState.kt
@@ -1,6 +1,6 @@
 // THIS FILE IS AUTO-GENERATED, DO NOT EDIT!
-@file:Suppress(names = arrayOf("RedundantVisibilityModifier", "IncorrectFormatting",
-                "ReplaceArrayOfWithLiteral", "SpellCheckingInspection", "GrazieInspection"))
+@file:Suppress(names = arrayOf("IncorrectFormatting", "ReplaceArrayOfWithLiteral",
+                "SpellCheckingInspection", "GrazieInspection"))
 
 package dev.kord.common.entity
 

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/TextInputStyle.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/TextInputStyle.kt
@@ -1,6 +1,6 @@
 // THIS FILE IS AUTO-GENERATED, DO NOT EDIT!
-@file:Suppress(names = arrayOf("RedundantVisibilityModifier", "IncorrectFormatting",
-                "ReplaceArrayOfWithLiteral", "SpellCheckingInspection", "GrazieInspection"))
+@file:Suppress(names = arrayOf("IncorrectFormatting", "ReplaceArrayOfWithLiteral",
+                "SpellCheckingInspection", "GrazieInspection"))
 
 package dev.kord.common.entity
 

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/UserPremium.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/UserPremium.kt
@@ -1,6 +1,6 @@
 // THIS FILE IS AUTO-GENERATED, DO NOT EDIT!
-@file:Suppress(names = arrayOf("RedundantVisibilityModifier", "IncorrectFormatting",
-                "ReplaceArrayOfWithLiteral", "SpellCheckingInspection", "GrazieInspection"))
+@file:Suppress(names = arrayOf("IncorrectFormatting", "ReplaceArrayOfWithLiteral",
+                "SpellCheckingInspection", "GrazieInspection"))
 
 package dev.kord.common.entity
 

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/VerificationLevel.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/VerificationLevel.kt
@@ -1,6 +1,6 @@
 // THIS FILE IS AUTO-GENERATED, DO NOT EDIT!
-@file:Suppress(names = arrayOf("RedundantVisibilityModifier", "IncorrectFormatting",
-                "ReplaceArrayOfWithLiteral", "SpellCheckingInspection", "GrazieInspection"))
+@file:Suppress(names = arrayOf("IncorrectFormatting", "ReplaceArrayOfWithLiteral",
+                "SpellCheckingInspection", "GrazieInspection"))
 
 package dev.kord.common.entity
 

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/VideoQualityMode.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/VideoQualityMode.kt
@@ -1,6 +1,6 @@
 // THIS FILE IS AUTO-GENERATED, DO NOT EDIT!
-@file:Suppress(names = arrayOf("RedundantVisibilityModifier", "IncorrectFormatting",
-                "ReplaceArrayOfWithLiteral", "SpellCheckingInspection", "GrazieInspection"))
+@file:Suppress(names = arrayOf("IncorrectFormatting", "ReplaceArrayOfWithLiteral",
+                "SpellCheckingInspection", "GrazieInspection"))
 
 package dev.kord.common.entity
 

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/WebhookType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/WebhookType.kt
@@ -1,6 +1,6 @@
 // THIS FILE IS AUTO-GENERATED, DO NOT EDIT!
-@file:Suppress(names = arrayOf("RedundantVisibilityModifier", "IncorrectFormatting",
-                "ReplaceArrayOfWithLiteral", "SpellCheckingInspection", "GrazieInspection"))
+@file:Suppress(names = arrayOf("IncorrectFormatting", "ReplaceArrayOfWithLiteral",
+                "SpellCheckingInspection", "GrazieInspection"))
 
 package dev.kord.common.entity
 

--- a/ksp-processors/src/main/kotlin/kordenum/KordEnumGeneration.kt
+++ b/ksp-processors/src/main/kotlin/kordenum/KordEnumGeneration.kt
@@ -70,7 +70,6 @@ internal fun KordEnum.generateFileSpec(originatingFile: KSFile): FileSpec {
         @OptIn(DelicateKotlinPoetApi::class) // `AnnotationSpec.get` is ok for `Suppress`
         addAnnotation(
             Suppress(
-                "RedundantVisibilityModifier",
                 "IncorrectFormatting",
                 "ReplaceArrayOfWithLiteral",
                 "SpellCheckingInspection",

--- a/voice/build/generated/ksp/main/kotlin/dev/kord/voice/EncryptionMode.kt
+++ b/voice/build/generated/ksp/main/kotlin/dev/kord/voice/EncryptionMode.kt
@@ -1,6 +1,6 @@
 // THIS FILE IS AUTO-GENERATED, DO NOT EDIT!
-@file:Suppress(names = arrayOf("RedundantVisibilityModifier", "IncorrectFormatting",
-                "ReplaceArrayOfWithLiteral", "SpellCheckingInspection", "GrazieInspection"))
+@file:Suppress(names = arrayOf("IncorrectFormatting", "ReplaceArrayOfWithLiteral",
+                "SpellCheckingInspection", "GrazieInspection"))
 
 package dev.kord.voice
 


### PR DESCRIPTION
It's no longer needed since KotlinPoet [1.14.0](https://github.com/square/kotlinpoet/releases/tag/1.14.0) (updated from 1.13.2 to 1.14.2 in #842).