### PR TITLE
Bring kord enum API closer to bit flags API

### DIFF
--- a/common/api/common.api
+++ b/common/api/common.api
@@ -307,6 +307,7 @@ public abstract class dev/kord/common/entity/ActivityType {
 }
 
 public final class dev/kord/common/entity/ActivityType$Companion {
+	public final fun from (I)Ldev/kord/common/entity/ActivityType;
 	public final fun getEntries ()Ljava/util/List;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -383,6 +384,7 @@ public abstract class dev/kord/common/entity/AllowedMentionType {
 }
 
 public final class dev/kord/common/entity/AllowedMentionType$Companion {
+	public final fun from (Ljava/lang/String;)Ldev/kord/common/entity/AllowedMentionType;
 	public final fun getEntries ()Ljava/util/List;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -519,6 +521,7 @@ public final class dev/kord/common/entity/ApplicationCommandOptionType$Channel :
 }
 
 public final class dev/kord/common/entity/ApplicationCommandOptionType$Companion {
+	public final fun from (I)Ldev/kord/common/entity/ApplicationCommandOptionType;
 	public final fun getEntries ()Ljava/util/List;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -573,6 +576,7 @@ public final class dev/kord/common/entity/ApplicationCommandPermissionType$Chann
 }
 
 public final class dev/kord/common/entity/ApplicationCommandPermissionType$Companion {
+	public final fun from (I)Ldev/kord/common/entity/ApplicationCommandPermissionType;
 	public final fun getEntries ()Ljava/util/List;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -603,6 +607,7 @@ public final class dev/kord/common/entity/ApplicationCommandType$ChatInput : dev
 }
 
 public final class dev/kord/common/entity/ApplicationCommandType$Companion {
+	public final fun from (I)Ldev/kord/common/entity/ApplicationCommandType;
 	public final fun getEntries ()Ljava/util/List;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -761,6 +766,7 @@ public final class dev/kord/common/entity/ApplicationRoleConnectionMetadataType$
 }
 
 public final class dev/kord/common/entity/ApplicationRoleConnectionMetadataType$Companion {
+	public final fun from (I)Ldev/kord/common/entity/ApplicationRoleConnectionMetadataType;
 	public final fun getEntries ()Ljava/util/List;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -1216,6 +1222,7 @@ public final class dev/kord/common/entity/AuditLogEvent$ChannelUpdate : dev/kord
 }
 
 public final class dev/kord/common/entity/AuditLogEvent$Companion {
+	public final fun from (I)Ldev/kord/common/entity/AuditLogEvent;
 	public final fun getEntries ()Ljava/util/List;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -1398,6 +1405,7 @@ public final class dev/kord/common/entity/AutoModerationActionType$BlockMessage 
 }
 
 public final class dev/kord/common/entity/AutoModerationActionType$Companion {
+	public final fun from (I)Ldev/kord/common/entity/AutoModerationActionType;
 	public final fun getEntries ()Ljava/util/List;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -1424,6 +1432,7 @@ public abstract class dev/kord/common/entity/AutoModerationRuleEventType {
 }
 
 public final class dev/kord/common/entity/AutoModerationRuleEventType$Companion {
+	public final fun from (I)Ldev/kord/common/entity/AutoModerationRuleEventType;
 	public final fun getEntries ()Ljava/util/List;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -1446,6 +1455,7 @@ public abstract class dev/kord/common/entity/AutoModerationRuleKeywordPresetType
 }
 
 public final class dev/kord/common/entity/AutoModerationRuleKeywordPresetType$Companion {
+	public final fun from (I)Ldev/kord/common/entity/AutoModerationRuleKeywordPresetType;
 	public final fun getEntries ()Ljava/util/List;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -1476,6 +1486,7 @@ public abstract class dev/kord/common/entity/AutoModerationRuleTriggerType {
 }
 
 public final class dev/kord/common/entity/AutoModerationRuleTriggerType$Companion {
+	public final fun from (I)Ldev/kord/common/entity/AutoModerationRuleTriggerType;
 	public final fun getEntries ()Ljava/util/List;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -1579,6 +1590,7 @@ public abstract class dev/kord/common/entity/ButtonStyle {
 }
 
 public final class dev/kord/common/entity/ButtonStyle$Companion {
+	public final fun from (I)Ldev/kord/common/entity/ButtonStyle;
 	public final fun getEntries ()Ljava/util/List;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -1700,6 +1712,7 @@ public abstract class dev/kord/common/entity/ChannelType {
 }
 
 public final class dev/kord/common/entity/ChannelType$Companion {
+	public final fun from (I)Ldev/kord/common/entity/ChannelType;
 	public final fun getEntries ()Ljava/util/List;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -2042,6 +2055,7 @@ public final class dev/kord/common/entity/ComponentType$ChannelSelect : dev/kord
 }
 
 public final class dev/kord/common/entity/ComponentType$Companion {
+	public final fun from (I)Ldev/kord/common/entity/ComponentType;
 	public final fun getEntries ()Ljava/util/List;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -2084,6 +2098,7 @@ public final class dev/kord/common/entity/DefaultMessageNotificationLevel$AllMes
 }
 
 public final class dev/kord/common/entity/DefaultMessageNotificationLevel$Companion {
+	public final fun from (I)Ldev/kord/common/entity/DefaultMessageNotificationLevel;
 	public final fun getEntries ()Ljava/util/List;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -3318,6 +3333,7 @@ public abstract class dev/kord/common/entity/DiscordConnectionVisibility {
 }
 
 public final class dev/kord/common/entity/DiscordConnectionVisibility$Companion {
+	public final fun from (I)Ldev/kord/common/entity/DiscordConnectionVisibility;
 	public final fun getEntries ()Ljava/util/List;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -6530,6 +6546,7 @@ public final class dev/kord/common/entity/EmbedType$Article : dev/kord/common/en
 }
 
 public final class dev/kord/common/entity/EmbedType$Companion {
+	public final fun from (Ljava/lang/String;)Ldev/kord/common/entity/EmbedType;
 	public final fun getEntries ()Ljava/util/List;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -6572,6 +6589,7 @@ public final class dev/kord/common/entity/ExplicitContentFilter$AllMembers : dev
 }
 
 public final class dev/kord/common/entity/ExplicitContentFilter$Companion {
+	public final fun from (I)Ldev/kord/common/entity/ExplicitContentFilter;
 	public final fun getEntries ()Ljava/util/List;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -6598,6 +6616,7 @@ public abstract class dev/kord/common/entity/ForumLayoutType {
 }
 
 public final class dev/kord/common/entity/ForumLayoutType$Companion {
+	public final fun from (I)Ldev/kord/common/entity/ForumLayoutType;
 	public final fun getEntries ()Ljava/util/List;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -6689,6 +6708,7 @@ public final class dev/kord/common/entity/GuildFeature$Community : dev/kord/comm
 }
 
 public final class dev/kord/common/entity/GuildFeature$Companion {
+	public final fun from (Ljava/lang/String;)Ldev/kord/common/entity/GuildFeature;
 	public final fun getEntries ()Ljava/util/List;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -6916,6 +6936,7 @@ public abstract class dev/kord/common/entity/GuildScheduledEventPrivacyLevel {
 }
 
 public final class dev/kord/common/entity/GuildScheduledEventPrivacyLevel$Companion {
+	public final fun from (I)Ldev/kord/common/entity/GuildScheduledEventPrivacyLevel;
 	public final fun getEntries ()Ljava/util/List;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -6946,6 +6967,7 @@ public final class dev/kord/common/entity/GuildScheduledEventStatus$Cancelled : 
 }
 
 public final class dev/kord/common/entity/GuildScheduledEventStatus$Companion {
+	public final fun from (I)Ldev/kord/common/entity/GuildScheduledEventStatus;
 	public final fun getEntries ()Ljava/util/List;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -7041,6 +7063,7 @@ public abstract class dev/kord/common/entity/IntegrationExpireBehavior {
 }
 
 public final class dev/kord/common/entity/IntegrationExpireBehavior$Companion {
+	public final fun from (I)Ldev/kord/common/entity/IntegrationExpireBehavior;
 	public final fun getEntries ()Ljava/util/List;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -7126,6 +7149,7 @@ public final class dev/kord/common/entity/InteractionResponseType$ChannelMessage
 }
 
 public final class dev/kord/common/entity/InteractionResponseType$Companion {
+	public final fun from (I)Ldev/kord/common/entity/InteractionResponseType;
 	public final fun getEntries ()Ljava/util/List;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -7172,6 +7196,7 @@ public final class dev/kord/common/entity/InteractionType$AutoComplete : dev/kor
 }
 
 public final class dev/kord/common/entity/InteractionType$Companion {
+	public final fun from (I)Ldev/kord/common/entity/InteractionType;
 	public final fun getEntries ()Ljava/util/List;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -7202,6 +7227,7 @@ public abstract class dev/kord/common/entity/InviteTargetType {
 }
 
 public final class dev/kord/common/entity/InviteTargetType$Companion {
+	public final fun from (I)Ldev/kord/common/entity/InviteTargetType;
 	public final fun getEntries ()Ljava/util/List;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -7228,6 +7254,7 @@ public abstract class dev/kord/common/entity/MFALevel {
 }
 
 public final class dev/kord/common/entity/MFALevel$Companion {
+	public final fun from (I)Ldev/kord/common/entity/MFALevel;
 	public final fun getEntries ()Ljava/util/List;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -7286,6 +7313,7 @@ public abstract class dev/kord/common/entity/MessageActivityType {
 }
 
 public final class dev/kord/common/entity/MessageActivityType$Companion {
+	public final fun from (I)Ldev/kord/common/entity/MessageActivityType;
 	public final fun getEntries ()Ljava/util/List;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -7569,6 +7597,7 @@ public final class dev/kord/common/entity/MessageStickerType$APNG : dev/kord/com
 }
 
 public final class dev/kord/common/entity/MessageStickerType$Companion {
+	public final fun from (I)Ldev/kord/common/entity/MessageStickerType;
 	public final fun getEntries ()Ljava/util/List;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -7627,6 +7656,7 @@ public final class dev/kord/common/entity/MessageType$ChatInputCommand : dev/kor
 }
 
 public final class dev/kord/common/entity/MessageType$Companion {
+	public final fun from (I)Ldev/kord/common/entity/MessageType;
 	public final fun getEntries ()Ljava/util/List;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -7754,6 +7784,7 @@ public final class dev/kord/common/entity/NsfwLevel$AgeRestricted : dev/kord/com
 }
 
 public final class dev/kord/common/entity/NsfwLevel$Companion {
+	public final fun from (I)Ldev/kord/common/entity/NsfwLevel;
 	public final fun getEntries ()Ljava/util/List;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -7784,6 +7815,7 @@ public abstract class dev/kord/common/entity/OnboardingPromptType {
 }
 
 public final class dev/kord/common/entity/OnboardingPromptType$Companion {
+	public final fun from (I)Ldev/kord/common/entity/OnboardingPromptType;
 	public final fun getEntries ()Ljava/util/List;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -7855,6 +7887,7 @@ public abstract class dev/kord/common/entity/OverwriteType {
 }
 
 public final class dev/kord/common/entity/OverwriteType$Companion {
+	public final fun from (I)Ldev/kord/common/entity/OverwriteType;
 	public final fun getEntries ()Ljava/util/List;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -8165,6 +8198,7 @@ public abstract class dev/kord/common/entity/PremiumTier {
 }
 
 public final class dev/kord/common/entity/PremiumTier$Companion {
+	public final fun from (I)Ldev/kord/common/entity/PremiumTier;
 	public final fun getEntries ()Ljava/util/List;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -8199,6 +8233,7 @@ public abstract class dev/kord/common/entity/PresenceStatus {
 }
 
 public final class dev/kord/common/entity/PresenceStatus$Companion {
+	public final fun from (Ljava/lang/String;)Ldev/kord/common/entity/PresenceStatus;
 	public final fun getEntries ()Ljava/util/List;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -8346,6 +8381,7 @@ public abstract class dev/kord/common/entity/ScheduledEntityType {
 }
 
 public final class dev/kord/common/entity/ScheduledEntityType$Companion {
+	public final fun from (I)Ldev/kord/common/entity/ScheduledEntityType;
 	public final fun getEntries ()Ljava/util/List;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -8412,6 +8448,7 @@ public abstract class dev/kord/common/entity/SortOrderType {
 }
 
 public final class dev/kord/common/entity/SortOrderType$Companion {
+	public final fun from (I)Ldev/kord/common/entity/SortOrderType;
 	public final fun getEntries ()Ljava/util/List;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -8438,6 +8475,7 @@ public abstract class dev/kord/common/entity/StageInstancePrivacyLevel {
 }
 
 public final class dev/kord/common/entity/StageInstancePrivacyLevel$Companion {
+	public final fun from (I)Ldev/kord/common/entity/StageInstancePrivacyLevel;
 	public final fun getEntries ()Ljava/util/List;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -8614,6 +8652,7 @@ public final class dev/kord/common/entity/TeamMembershipState$Accepted : dev/kor
 }
 
 public final class dev/kord/common/entity/TeamMembershipState$Companion {
+	public final fun from (I)Ldev/kord/common/entity/TeamMembershipState;
 	public final fun getEntries ()Ljava/util/List;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -8636,6 +8675,7 @@ public abstract class dev/kord/common/entity/TextInputStyle {
 }
 
 public final class dev/kord/common/entity/TextInputStyle$Companion {
+	public final fun from (I)Ldev/kord/common/entity/TextInputStyle;
 	public final fun getEntries ()Ljava/util/List;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -8836,6 +8876,7 @@ public abstract class dev/kord/common/entity/UserPremium {
 }
 
 public final class dev/kord/common/entity/UserPremium$Companion {
+	public final fun from (I)Ldev/kord/common/entity/UserPremium;
 	public final fun getEntries ()Ljava/util/List;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -8870,6 +8911,7 @@ public abstract class dev/kord/common/entity/VerificationLevel {
 }
 
 public final class dev/kord/common/entity/VerificationLevel$Companion {
+	public final fun from (I)Ldev/kord/common/entity/VerificationLevel;
 	public final fun getEntries ()Ljava/util/List;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -8912,6 +8954,7 @@ public final class dev/kord/common/entity/VideoQualityMode$Auto : dev/kord/commo
 }
 
 public final class dev/kord/common/entity/VideoQualityMode$Companion {
+	public final fun from (I)Ldev/kord/common/entity/VideoQualityMode;
 	public final fun getEntries ()Ljava/util/List;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -8942,6 +8985,7 @@ public final class dev/kord/common/entity/WebhookType$ChannelFollower : dev/kord
 }
 
 public final class dev/kord/common/entity/WebhookType$Companion {
+	public final fun from (I)Ldev/kord/common/entity/WebhookType;
 	public final fun getEntries ()Ljava/util/List;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/ActivityType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/ActivityType.kt
@@ -29,16 +29,26 @@ public sealed class ActivityType(
 
     final override fun hashCode(): Int = code.hashCode()
 
-    final override fun toString(): String = "ActivityType.${this::class.simpleName}(code=$code)"
+    final override fun toString(): String = if (this is Unknown) "ActivityType.Unknown(code=$code)"
+            else "ActivityType.${this::class.simpleName}"
 
     /**
      * An unknown [ActivityType].
      *
      * This is used as a fallback for [ActivityType]s that haven't been added to Kord yet.
      */
-    public class Unknown(
+    public class Unknown internal constructor(
         code: Int,
-    ) : ActivityType(code)
+        @Suppress(names = arrayOf("UNUSED_PARAMETER"))
+        unused: Nothing?,
+    ) : ActivityType(code) {
+        @Deprecated(
+            message = "Replaced by 'ActivityType.from()'.",
+            replaceWith = ReplaceWith(expression = "ActivityType.from(code)", imports =
+                        arrayOf("dev.kord.common.entity.ActivityType")),
+        )
+        public constructor(code: Int) : this(code, null)
+    }
 
     public object Game : ActivityType(0)
 
@@ -60,16 +70,7 @@ public sealed class ActivityType(
             encoder.encodeInt(value.code)
         }
 
-        override fun deserialize(decoder: Decoder): ActivityType =
-                when (val code = decoder.decodeInt()) {
-            0 -> Game
-            1 -> Streaming
-            2 -> Listening
-            3 -> Watching
-            4 -> Custom
-            5 -> Competing
-            else -> Unknown(code)
-        }
+        override fun deserialize(decoder: Decoder): ActivityType = from(decoder.decodeInt())
     }
 
     public companion object {
@@ -87,5 +88,19 @@ public sealed class ActivityType(
             )
         }
 
+
+        /**
+         * Returns an instance of [ActivityType] with [ActivityType.code] equal to the specified
+         * [code].
+         */
+        public fun from(code: Int): ActivityType = when (code) {
+            0 -> Game
+            1 -> Streaming
+            2 -> Listening
+            3 -> Watching
+            4 -> Custom
+            5 -> Competing
+            else -> Unknown(code, null)
+        }
     }
 }

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/AllowedMentionType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/AllowedMentionType.kt
@@ -30,16 +30,26 @@ public sealed class AllowedMentionType(
     final override fun hashCode(): Int = value.hashCode()
 
     final override fun toString(): String =
-            "AllowedMentionType.${this::class.simpleName}(value=$value)"
+            if (this is Unknown) "AllowedMentionType.Unknown(value=$value)"
+            else "AllowedMentionType.${this::class.simpleName}"
 
     /**
      * An unknown [AllowedMentionType].
      *
      * This is used as a fallback for [AllowedMentionType]s that haven't been added to Kord yet.
      */
-    public class Unknown(
+    public class Unknown internal constructor(
         `value`: String,
-    ) : AllowedMentionType(value)
+        @Suppress(names = arrayOf("UNUSED_PARAMETER"))
+        unused: Nothing?,
+    ) : AllowedMentionType(value) {
+        @Deprecated(
+            message = "Replaced by 'AllowedMentionType.from()'.",
+            replaceWith = ReplaceWith(expression = "AllowedMentionType.from(value)", imports =
+                        arrayOf("dev.kord.common.entity.AllowedMentionType")),
+        )
+        public constructor(`value`: String) : this(value, null)
+    }
 
     /**
      * Controls role mentions.
@@ -66,12 +76,7 @@ public sealed class AllowedMentionType(
         }
 
         override fun deserialize(decoder: Decoder): AllowedMentionType =
-                when (val value = decoder.decodeString()) {
-            "roles" -> RoleMentions
-            "users" -> UserMentions
-            "everyone" -> EveryoneMentions
-            else -> Unknown(value)
-        }
+                from(decoder.decodeString())
     }
 
     public companion object {
@@ -86,5 +91,16 @@ public sealed class AllowedMentionType(
             )
         }
 
+
+        /**
+         * Returns an instance of [AllowedMentionType] with [AllowedMentionType.value] equal to the
+         * specified [value].
+         */
+        public fun from(`value`: String): AllowedMentionType = when (value) {
+            "roles" -> RoleMentions
+            "users" -> UserMentions
+            "everyone" -> EveryoneMentions
+            else -> Unknown(value, null)
+        }
     }
 }

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/ApplicationCommandOptionType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/ApplicationCommandOptionType.kt
@@ -30,7 +30,8 @@ public sealed class ApplicationCommandOptionType(
     final override fun hashCode(): Int = type.hashCode()
 
     final override fun toString(): kotlin.String =
-            "ApplicationCommandOptionType.${this::class.simpleName}(type=$type)"
+            if (this is Unknown) "ApplicationCommandOptionType.Unknown(type=$type)"
+            else "ApplicationCommandOptionType.${this::class.simpleName}"
 
     /**
      * An unknown [ApplicationCommandOptionType].
@@ -38,9 +39,18 @@ public sealed class ApplicationCommandOptionType(
      * This is used as a fallback for [ApplicationCommandOptionType]s that haven't been added to
      * Kord yet.
      */
-    public class Unknown(
+    public class Unknown internal constructor(
         type: Int,
-    ) : ApplicationCommandOptionType(type)
+        @Suppress(names = arrayOf("UNUSED_PARAMETER"))
+        unused: Nothing?,
+    ) : ApplicationCommandOptionType(type) {
+        @Deprecated(
+            message = "Replaced by 'ApplicationCommandOptionType.from()'.",
+            replaceWith = ReplaceWith(expression = "ApplicationCommandOptionType.from(type)",
+                        imports = arrayOf("dev.kord.common.entity.ApplicationCommandOptionType")),
+        )
+        public constructor(type: Int) : this(type, null)
+    }
 
     public object SubCommand : ApplicationCommandOptionType(1)
 
@@ -86,20 +96,7 @@ public sealed class ApplicationCommandOptionType(
         }
 
         override fun deserialize(decoder: Decoder): ApplicationCommandOptionType =
-                when (val type = decoder.decodeInt()) {
-            1 -> SubCommand
-            2 -> SubCommandGroup
-            3 -> String
-            4 -> Integer
-            5 -> Boolean
-            6 -> User
-            7 -> Channel
-            8 -> Role
-            9 -> Mentionable
-            10 -> Number
-            11 -> Attachment
-            else -> Unknown(type)
-        }
+                from(decoder.decodeInt())
     }
 
     public companion object {
@@ -122,5 +119,24 @@ public sealed class ApplicationCommandOptionType(
             )
         }
 
+
+        /**
+         * Returns an instance of [ApplicationCommandOptionType] with
+         * [ApplicationCommandOptionType.type] equal to the specified [type].
+         */
+        public fun from(type: Int): ApplicationCommandOptionType = when (type) {
+            1 -> SubCommand
+            2 -> SubCommandGroup
+            3 -> String
+            4 -> Integer
+            5 -> Boolean
+            6 -> User
+            7 -> Channel
+            8 -> Role
+            9 -> Mentionable
+            10 -> Number
+            11 -> Attachment
+            else -> Unknown(type, null)
+        }
     }
 }

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/ApplicationCommandPermissionType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/ApplicationCommandPermissionType.kt
@@ -30,7 +30,8 @@ public sealed class ApplicationCommandPermissionType(
     final override fun hashCode(): Int = value.hashCode()
 
     final override fun toString(): String =
-            "ApplicationCommandPermissionType.${this::class.simpleName}(value=$value)"
+            if (this is Unknown) "ApplicationCommandPermissionType.Unknown(value=$value)"
+            else "ApplicationCommandPermissionType.${this::class.simpleName}"
 
     /**
      * An unknown [ApplicationCommandPermissionType].
@@ -38,9 +39,19 @@ public sealed class ApplicationCommandPermissionType(
      * This is used as a fallback for [ApplicationCommandPermissionType]s that haven't been added to
      * Kord yet.
      */
-    public class Unknown(
+    public class Unknown internal constructor(
         `value`: Int,
-    ) : ApplicationCommandPermissionType(value)
+        @Suppress(names = arrayOf("UNUSED_PARAMETER"))
+        unused: Nothing?,
+    ) : ApplicationCommandPermissionType(value) {
+        @Deprecated(
+            message = "Replaced by 'ApplicationCommandPermissionType.from()'.",
+            replaceWith = ReplaceWith(expression = "ApplicationCommandPermissionType.from(value)",
+                        imports =
+                        arrayOf("dev.kord.common.entity.ApplicationCommandPermissionType")),
+        )
+        public constructor(`value`: Int) : this(value, null)
+    }
 
     public object Role : ApplicationCommandPermissionType(1)
 
@@ -58,12 +69,7 @@ public sealed class ApplicationCommandPermissionType(
         }
 
         override fun deserialize(decoder: Decoder): ApplicationCommandPermissionType =
-                when (val value = decoder.decodeInt()) {
-            1 -> Role
-            2 -> User
-            3 -> Channel
-            else -> Unknown(value)
-        }
+                from(decoder.decodeInt())
     }
 
     public companion object {
@@ -78,5 +84,16 @@ public sealed class ApplicationCommandPermissionType(
             )
         }
 
+
+        /**
+         * Returns an instance of [ApplicationCommandPermissionType] with
+         * [ApplicationCommandPermissionType.value] equal to the specified [value].
+         */
+        public fun from(`value`: Int): ApplicationCommandPermissionType = when (value) {
+            1 -> Role
+            2 -> User
+            3 -> Channel
+            else -> Unknown(value, null)
+        }
     }
 }

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/ApplicationCommandType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/ApplicationCommandType.kt
@@ -30,16 +30,26 @@ public sealed class ApplicationCommandType(
     final override fun hashCode(): Int = value.hashCode()
 
     final override fun toString(): String =
-            "ApplicationCommandType.${this::class.simpleName}(value=$value)"
+            if (this is Unknown) "ApplicationCommandType.Unknown(value=$value)"
+            else "ApplicationCommandType.${this::class.simpleName}"
 
     /**
      * An unknown [ApplicationCommandType].
      *
      * This is used as a fallback for [ApplicationCommandType]s that haven't been added to Kord yet.
      */
-    public class Unknown(
+    public class Unknown internal constructor(
         `value`: Int,
-    ) : ApplicationCommandType(value)
+        @Suppress(names = arrayOf("UNUSED_PARAMETER"))
+        unused: Nothing?,
+    ) : ApplicationCommandType(value) {
+        @Deprecated(
+            message = "Replaced by 'ApplicationCommandType.from()'.",
+            replaceWith = ReplaceWith(expression = "ApplicationCommandType.from(value)", imports =
+                        arrayOf("dev.kord.common.entity.ApplicationCommandType")),
+        )
+        public constructor(`value`: Int) : this(value, null)
+    }
 
     /**
      * A text-based command that shows up when a user types `/`.
@@ -66,12 +76,7 @@ public sealed class ApplicationCommandType(
         }
 
         override fun deserialize(decoder: Decoder): ApplicationCommandType =
-                when (val value = decoder.decodeInt()) {
-            1 -> ChatInput
-            2 -> User
-            3 -> Message
-            else -> Unknown(value)
-        }
+                from(decoder.decodeInt())
     }
 
     public companion object {
@@ -86,5 +91,16 @@ public sealed class ApplicationCommandType(
             )
         }
 
+
+        /**
+         * Returns an instance of [ApplicationCommandType] with [ApplicationCommandType.value] equal
+         * to the specified [value].
+         */
+        public fun from(`value`: Int): ApplicationCommandType = when (value) {
+            1 -> ChatInput
+            2 -> User
+            3 -> Message
+            else -> Unknown(value, null)
+        }
     }
 }

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/ApplicationFlag.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/ApplicationFlag.kt
@@ -61,8 +61,9 @@ public sealed class ApplicationFlag(
 
     final override fun hashCode(): Int = shift.hashCode()
 
-    final override fun toString(): String = if (this is Unknown)
-            "ApplicationFlag.Unknown(shift=$shift)" else "ApplicationFlag.${this::class.simpleName}"
+    final override fun toString(): String =
+            if (this is Unknown) "ApplicationFlag.Unknown(shift=$shift)"
+            else "ApplicationFlag.${this::class.simpleName}"
 
     /**
      * @suppress

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/ApplicationRoleConnectionMetadataType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/ApplicationRoleConnectionMetadataType.kt
@@ -35,7 +35,8 @@ public sealed class ApplicationRoleConnectionMetadataType(
     final override fun hashCode(): Int = value.hashCode()
 
     final override fun toString(): String =
-            "ApplicationRoleConnectionMetadataType.${this::class.simpleName}(value=$value)"
+            if (this is Unknown) "ApplicationRoleConnectionMetadataType.Unknown(value=$value)"
+            else "ApplicationRoleConnectionMetadataType.${this::class.simpleName}"
 
     /**
      * An unknown [ApplicationRoleConnectionMetadataType].
@@ -43,9 +44,19 @@ public sealed class ApplicationRoleConnectionMetadataType(
      * This is used as a fallback for [ApplicationRoleConnectionMetadataType]s that haven't been
      * added to Kord yet.
      */
-    public class Unknown(
+    public class Unknown internal constructor(
         `value`: Int,
-    ) : ApplicationRoleConnectionMetadataType(value)
+        @Suppress(names = arrayOf("UNUSED_PARAMETER"))
+        unused: Nothing?,
+    ) : ApplicationRoleConnectionMetadataType(value) {
+        @Deprecated(
+            message = "Replaced by 'ApplicationRoleConnectionMetadataType.from()'.",
+            replaceWith = ReplaceWith(expression =
+                        "ApplicationRoleConnectionMetadataType.from(value)", imports =
+                        arrayOf("dev.kord.common.entity.ApplicationRoleConnectionMetadataType")),
+        )
+        public constructor(`value`: Int) : this(value, null)
+    }
 
     /**
      * The metadata value (`integer`) is less than or equal to the guild's configured value
@@ -101,17 +112,7 @@ public sealed class ApplicationRoleConnectionMetadataType(
         }
 
         override fun deserialize(decoder: Decoder): ApplicationRoleConnectionMetadataType =
-                when (val value = decoder.decodeInt()) {
-            1 -> IntegerLessThanOrEqual
-            2 -> IntegerGreaterThanOrEqual
-            3 -> IntegerEqual
-            4 -> IntegerNotEqual
-            5 -> DateTimeLessThanOrEqual
-            6 -> DateTimeGreaterThanOrEqual
-            7 -> BooleanEqual
-            8 -> BooleanNotEqual
-            else -> Unknown(value)
-        }
+                from(decoder.decodeInt())
     }
 
     public companion object {
@@ -132,5 +133,21 @@ public sealed class ApplicationRoleConnectionMetadataType(
             )
         }
 
+
+        /**
+         * Returns an instance of [ApplicationRoleConnectionMetadataType] with
+         * [ApplicationRoleConnectionMetadataType.value] equal to the specified [value].
+         */
+        public fun from(`value`: Int): ApplicationRoleConnectionMetadataType = when (value) {
+            1 -> IntegerLessThanOrEqual
+            2 -> IntegerGreaterThanOrEqual
+            3 -> IntegerEqual
+            4 -> IntegerNotEqual
+            5 -> DateTimeLessThanOrEqual
+            6 -> DateTimeGreaterThanOrEqual
+            7 -> BooleanEqual
+            8 -> BooleanNotEqual
+            else -> Unknown(value, null)
+        }
     }
 }

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/AuditLogEvent.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/AuditLogEvent.kt
@@ -29,16 +29,27 @@ public sealed class AuditLogEvent(
 
     final override fun hashCode(): Int = value.hashCode()
 
-    final override fun toString(): String = "AuditLogEvent.${this::class.simpleName}(value=$value)"
+    final override fun toString(): String =
+            if (this is Unknown) "AuditLogEvent.Unknown(value=$value)"
+            else "AuditLogEvent.${this::class.simpleName}"
 
     /**
      * An unknown [AuditLogEvent].
      *
      * This is used as a fallback for [AuditLogEvent]s that haven't been added to Kord yet.
      */
-    public class Unknown(
+    public class Unknown internal constructor(
         `value`: Int,
-    ) : AuditLogEvent(value)
+        @Suppress(names = arrayOf("UNUSED_PARAMETER"))
+        unused: Nothing?,
+    ) : AuditLogEvent(value) {
+        @Deprecated(
+            message = "Replaced by 'AuditLogEvent.from()'.",
+            replaceWith = ReplaceWith(expression = "AuditLogEvent.from(value)", imports =
+                        arrayOf("dev.kord.common.entity.AuditLogEvent")),
+        )
+        public constructor(`value`: Int) : this(value, null)
+    }
 
     /**
      * Server settings were updated.
@@ -318,64 +329,7 @@ public sealed class AuditLogEvent(
             encoder.encodeInt(value.value)
         }
 
-        override fun deserialize(decoder: Decoder): AuditLogEvent =
-                when (val value = decoder.decodeInt()) {
-            1 -> GuildUpdate
-            10 -> ChannelCreate
-            11 -> ChannelUpdate
-            12 -> ChannelDelete
-            13 -> ChannelOverwriteCreate
-            14 -> ChannelOverwriteUpdate
-            15 -> ChannelOverwriteDelete
-            20 -> MemberKick
-            21 -> MemberPrune
-            22 -> MemberBanAdd
-            23 -> MemberBanRemove
-            24 -> MemberUpdate
-            25 -> MemberRoleUpdate
-            26 -> MemberMove
-            27 -> MemberDisconnect
-            28 -> BotAdd
-            30 -> RoleCreate
-            31 -> RoleUpdate
-            32 -> RoleDelete
-            40 -> InviteCreate
-            41 -> InviteUpdate
-            42 -> InviteDelete
-            50 -> WebhookCreate
-            51 -> WebhookUpdate
-            52 -> WebhookDelete
-            60 -> EmojiCreate
-            61 -> EmojiUpdate
-            62 -> EmojiDelete
-            72 -> MessageDelete
-            73 -> MessageBulkDelete
-            74 -> MessagePin
-            75 -> MessageUnpin
-            80 -> IntegrationCreate
-            81 -> IntegrationUpdate
-            82 -> IntegrationDelete
-            83 -> StageInstanceCreate
-            84 -> StageInstanceUpdate
-            85 -> StageInstanceDelete
-            90 -> StickerCreate
-            91 -> StickerUpdate
-            92 -> StickerDelete
-            100 -> GuildScheduledEventCreate
-            101 -> GuildScheduledEventUpdate
-            102 -> GuildScheduledEventDelete
-            110 -> ThreadCreate
-            111 -> ThreadUpdate
-            112 -> ThreadDelete
-            121 -> ApplicationCommandPermissionUpdate
-            140 -> AutoModerationRuleCreate
-            141 -> AutoModerationRuleUpdate
-            142 -> AutoModerationRuleDelete
-            143 -> AutoModerationBlockMessage
-            144 -> AutoModerationFlagToChannel
-            145 -> AutoModerationUserCommunicationDisabled
-            else -> Unknown(value)
-        }
+        override fun deserialize(decoder: Decoder): AuditLogEvent = from(decoder.decodeInt())
     }
 
     public companion object {
@@ -441,5 +395,67 @@ public sealed class AuditLogEvent(
             )
         }
 
+
+        /**
+         * Returns an instance of [AuditLogEvent] with [AuditLogEvent.value] equal to the specified
+         * [value].
+         */
+        public fun from(`value`: Int): AuditLogEvent = when (value) {
+            1 -> GuildUpdate
+            10 -> ChannelCreate
+            11 -> ChannelUpdate
+            12 -> ChannelDelete
+            13 -> ChannelOverwriteCreate
+            14 -> ChannelOverwriteUpdate
+            15 -> ChannelOverwriteDelete
+            20 -> MemberKick
+            21 -> MemberPrune
+            22 -> MemberBanAdd
+            23 -> MemberBanRemove
+            24 -> MemberUpdate
+            25 -> MemberRoleUpdate
+            26 -> MemberMove
+            27 -> MemberDisconnect
+            28 -> BotAdd
+            30 -> RoleCreate
+            31 -> RoleUpdate
+            32 -> RoleDelete
+            40 -> InviteCreate
+            41 -> InviteUpdate
+            42 -> InviteDelete
+            50 -> WebhookCreate
+            51 -> WebhookUpdate
+            52 -> WebhookDelete
+            60 -> EmojiCreate
+            61 -> EmojiUpdate
+            62 -> EmojiDelete
+            72 -> MessageDelete
+            73 -> MessageBulkDelete
+            74 -> MessagePin
+            75 -> MessageUnpin
+            80 -> IntegrationCreate
+            81 -> IntegrationUpdate
+            82 -> IntegrationDelete
+            83 -> StageInstanceCreate
+            84 -> StageInstanceUpdate
+            85 -> StageInstanceDelete
+            90 -> StickerCreate
+            91 -> StickerUpdate
+            92 -> StickerDelete
+            100 -> GuildScheduledEventCreate
+            101 -> GuildScheduledEventUpdate
+            102 -> GuildScheduledEventDelete
+            110 -> ThreadCreate
+            111 -> ThreadUpdate
+            112 -> ThreadDelete
+            121 -> ApplicationCommandPermissionUpdate
+            140 -> AutoModerationRuleCreate
+            141 -> AutoModerationRuleUpdate
+            142 -> AutoModerationRuleDelete
+            143 -> AutoModerationBlockMessage
+            144 -> AutoModerationFlagToChannel
+            145 -> AutoModerationUserCommunicationDisabled
+            else -> Unknown(value, null)
+        }
     }
 }

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/AutoModerationActionType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/AutoModerationActionType.kt
@@ -32,7 +32,8 @@ public sealed class AutoModerationActionType(
     final override fun hashCode(): Int = value.hashCode()
 
     final override fun toString(): String =
-            "AutoModerationActionType.${this::class.simpleName}(value=$value)"
+            if (this is Unknown) "AutoModerationActionType.Unknown(value=$value)"
+            else "AutoModerationActionType.${this::class.simpleName}"
 
     /**
      * An unknown [AutoModerationActionType].
@@ -40,9 +41,18 @@ public sealed class AutoModerationActionType(
      * This is used as a fallback for [AutoModerationActionType]s that haven't been added to Kord
      * yet.
      */
-    public class Unknown(
+    public class Unknown internal constructor(
         `value`: Int,
-    ) : AutoModerationActionType(value)
+        @Suppress(names = arrayOf("UNUSED_PARAMETER"))
+        unused: Nothing?,
+    ) : AutoModerationActionType(value) {
+        @Deprecated(
+            message = "Replaced by 'AutoModerationActionType.from()'.",
+            replaceWith = ReplaceWith(expression = "AutoModerationActionType.from(value)", imports =
+                        arrayOf("dev.kord.common.entity.AutoModerationActionType")),
+        )
+        public constructor(`value`: Int) : this(value, null)
+    }
 
     /**
      * Blocks a member's message and prevents it from being posted.
@@ -77,12 +87,7 @@ public sealed class AutoModerationActionType(
         }
 
         override fun deserialize(decoder: Decoder): AutoModerationActionType =
-                when (val value = decoder.decodeInt()) {
-            1 -> BlockMessage
-            2 -> SendAlertMessage
-            3 -> Timeout
-            else -> Unknown(value)
-        }
+                from(decoder.decodeInt())
     }
 
     public companion object {
@@ -97,5 +102,16 @@ public sealed class AutoModerationActionType(
             )
         }
 
+
+        /**
+         * Returns an instance of [AutoModerationActionType] with [AutoModerationActionType.value]
+         * equal to the specified [value].
+         */
+        public fun from(`value`: Int): AutoModerationActionType = when (value) {
+            1 -> BlockMessage
+            2 -> SendAlertMessage
+            3 -> Timeout
+            else -> Unknown(value, null)
+        }
     }
 }

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/AutoModerationRuleEventType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/AutoModerationRuleEventType.kt
@@ -32,7 +32,8 @@ public sealed class AutoModerationRuleEventType(
     final override fun hashCode(): Int = value.hashCode()
 
     final override fun toString(): String =
-            "AutoModerationRuleEventType.${this::class.simpleName}(value=$value)"
+            if (this is Unknown) "AutoModerationRuleEventType.Unknown(value=$value)"
+            else "AutoModerationRuleEventType.${this::class.simpleName}"
 
     /**
      * An unknown [AutoModerationRuleEventType].
@@ -40,9 +41,18 @@ public sealed class AutoModerationRuleEventType(
      * This is used as a fallback for [AutoModerationRuleEventType]s that haven't been added to Kord
      * yet.
      */
-    public class Unknown(
+    public class Unknown internal constructor(
         `value`: Int,
-    ) : AutoModerationRuleEventType(value)
+        @Suppress(names = arrayOf("UNUSED_PARAMETER"))
+        unused: Nothing?,
+    ) : AutoModerationRuleEventType(value) {
+        @Deprecated(
+            message = "Replaced by 'AutoModerationRuleEventType.from()'.",
+            replaceWith = ReplaceWith(expression = "AutoModerationRuleEventType.from(value)",
+                        imports = arrayOf("dev.kord.common.entity.AutoModerationRuleEventType")),
+        )
+        public constructor(`value`: Int) : this(value, null)
+    }
 
     /**
      * When a member sends or edits a message in the guild.
@@ -59,10 +69,7 @@ public sealed class AutoModerationRuleEventType(
         }
 
         override fun deserialize(decoder: Decoder): AutoModerationRuleEventType =
-                when (val value = decoder.decodeInt()) {
-            1 -> MessageSend
-            else -> Unknown(value)
-        }
+                from(decoder.decodeInt())
     }
 
     public companion object {
@@ -75,5 +82,14 @@ public sealed class AutoModerationRuleEventType(
             )
         }
 
+
+        /**
+         * Returns an instance of [AutoModerationRuleEventType] with
+         * [AutoModerationRuleEventType.value] equal to the specified [value].
+         */
+        public fun from(`value`: Int): AutoModerationRuleEventType = when (value) {
+            1 -> MessageSend
+            else -> Unknown(value, null)
+        }
     }
 }

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/AutoModerationRuleKeywordPresetType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/AutoModerationRuleKeywordPresetType.kt
@@ -32,7 +32,8 @@ public sealed class AutoModerationRuleKeywordPresetType(
     final override fun hashCode(): Int = value.hashCode()
 
     final override fun toString(): String =
-            "AutoModerationRuleKeywordPresetType.${this::class.simpleName}(value=$value)"
+            if (this is Unknown) "AutoModerationRuleKeywordPresetType.Unknown(value=$value)"
+            else "AutoModerationRuleKeywordPresetType.${this::class.simpleName}"
 
     /**
      * An unknown [AutoModerationRuleKeywordPresetType].
@@ -40,9 +41,19 @@ public sealed class AutoModerationRuleKeywordPresetType(
      * This is used as a fallback for [AutoModerationRuleKeywordPresetType]s that haven't been added
      * to Kord yet.
      */
-    public class Unknown(
+    public class Unknown internal constructor(
         `value`: Int,
-    ) : AutoModerationRuleKeywordPresetType(value)
+        @Suppress(names = arrayOf("UNUSED_PARAMETER"))
+        unused: Nothing?,
+    ) : AutoModerationRuleKeywordPresetType(value) {
+        @Deprecated(
+            message = "Replaced by 'AutoModerationRuleKeywordPresetType.from()'.",
+            replaceWith = ReplaceWith(expression =
+                        "AutoModerationRuleKeywordPresetType.from(value)", imports =
+                        arrayOf("dev.kord.common.entity.AutoModerationRuleKeywordPresetType")),
+        )
+        public constructor(`value`: Int) : this(value, null)
+    }
 
     /**
      * Words that may be considered forms of swearing or cursing.
@@ -69,12 +80,7 @@ public sealed class AutoModerationRuleKeywordPresetType(
         }
 
         override fun deserialize(decoder: Decoder): AutoModerationRuleKeywordPresetType =
-                when (val value = decoder.decodeInt()) {
-            1 -> Profanity
-            2 -> SexualContent
-            3 -> Slurs
-            else -> Unknown(value)
-        }
+                from(decoder.decodeInt())
     }
 
     public companion object {
@@ -89,5 +95,16 @@ public sealed class AutoModerationRuleKeywordPresetType(
             )
         }
 
+
+        /**
+         * Returns an instance of [AutoModerationRuleKeywordPresetType] with
+         * [AutoModerationRuleKeywordPresetType.value] equal to the specified [value].
+         */
+        public fun from(`value`: Int): AutoModerationRuleKeywordPresetType = when (value) {
+            1 -> Profanity
+            2 -> SexualContent
+            3 -> Slurs
+            else -> Unknown(value, null)
+        }
     }
 }

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/AutoModerationRuleTriggerType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/AutoModerationRuleTriggerType.kt
@@ -32,7 +32,8 @@ public sealed class AutoModerationRuleTriggerType(
     final override fun hashCode(): Int = value.hashCode()
 
     final override fun toString(): String =
-            "AutoModerationRuleTriggerType.${this::class.simpleName}(value=$value)"
+            if (this is Unknown) "AutoModerationRuleTriggerType.Unknown(value=$value)"
+            else "AutoModerationRuleTriggerType.${this::class.simpleName}"
 
     /**
      * An unknown [AutoModerationRuleTriggerType].
@@ -40,9 +41,18 @@ public sealed class AutoModerationRuleTriggerType(
      * This is used as a fallback for [AutoModerationRuleTriggerType]s that haven't been added to
      * Kord yet.
      */
-    public class Unknown(
+    public class Unknown internal constructor(
         `value`: Int,
-    ) : AutoModerationRuleTriggerType(value)
+        @Suppress(names = arrayOf("UNUSED_PARAMETER"))
+        unused: Nothing?,
+    ) : AutoModerationRuleTriggerType(value) {
+        @Deprecated(
+            message = "Replaced by 'AutoModerationRuleTriggerType.from()'.",
+            replaceWith = ReplaceWith(expression = "AutoModerationRuleTriggerType.from(value)",
+                        imports = arrayOf("dev.kord.common.entity.AutoModerationRuleTriggerType")),
+        )
+        public constructor(`value`: Int) : this(value, null)
+    }
 
     /**
      * Check if content contains words from a user defined list of keywords.
@@ -74,13 +84,7 @@ public sealed class AutoModerationRuleTriggerType(
         }
 
         override fun deserialize(decoder: Decoder): AutoModerationRuleTriggerType =
-                when (val value = decoder.decodeInt()) {
-            1 -> Keyword
-            3 -> Spam
-            4 -> KeywordPreset
-            5 -> MentionSpam
-            else -> Unknown(value)
-        }
+                from(decoder.decodeInt())
     }
 
     public companion object {
@@ -96,5 +100,17 @@ public sealed class AutoModerationRuleTriggerType(
             )
         }
 
+
+        /**
+         * Returns an instance of [AutoModerationRuleTriggerType] with
+         * [AutoModerationRuleTriggerType.value] equal to the specified [value].
+         */
+        public fun from(`value`: Int): AutoModerationRuleTriggerType = when (value) {
+            1 -> Keyword
+            3 -> Spam
+            4 -> KeywordPreset
+            5 -> MentionSpam
+            else -> Unknown(value, null)
+        }
     }
 }

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/ButtonStyle.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/ButtonStyle.kt
@@ -31,16 +31,26 @@ public sealed class ButtonStyle(
 
     final override fun hashCode(): Int = value.hashCode()
 
-    final override fun toString(): String = "ButtonStyle.${this::class.simpleName}(value=$value)"
+    final override fun toString(): String = if (this is Unknown) "ButtonStyle.Unknown(value=$value)"
+            else "ButtonStyle.${this::class.simpleName}"
 
     /**
      * An unknown [ButtonStyle].
      *
      * This is used as a fallback for [ButtonStyle]s that haven't been added to Kord yet.
      */
-    public class Unknown(
+    public class Unknown internal constructor(
         `value`: Int,
-    ) : ButtonStyle(value)
+        @Suppress(names = arrayOf("UNUSED_PARAMETER"))
+        unused: Nothing?,
+    ) : ButtonStyle(value) {
+        @Deprecated(
+            message = "Replaced by 'ButtonStyle.from()'.",
+            replaceWith = ReplaceWith(expression = "ButtonStyle.from(value)", imports =
+                        arrayOf("dev.kord.common.entity.ButtonStyle")),
+        )
+        public constructor(`value`: Int) : this(value, null)
+    }
 
     /**
      * Blurple.
@@ -75,15 +85,7 @@ public sealed class ButtonStyle(
             encoder.encodeInt(value.value)
         }
 
-        override fun deserialize(decoder: Decoder): ButtonStyle =
-                when (val value = decoder.decodeInt()) {
-            1 -> Primary
-            2 -> Secondary
-            3 -> Success
-            4 -> Danger
-            5 -> Link
-            else -> Unknown(value)
-        }
+        override fun deserialize(decoder: Decoder): ButtonStyle = from(decoder.decodeInt())
     }
 
     public companion object {
@@ -100,5 +102,18 @@ public sealed class ButtonStyle(
             )
         }
 
+
+        /**
+         * Returns an instance of [ButtonStyle] with [ButtonStyle.value] equal to the specified
+         * [value].
+         */
+        public fun from(`value`: Int): ButtonStyle = when (value) {
+            1 -> Primary
+            2 -> Secondary
+            3 -> Success
+            4 -> Danger
+            5 -> Link
+            else -> Unknown(value, null)
+        }
     }
 }

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/ChannelType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/ChannelType.kt
@@ -29,16 +29,26 @@ public sealed class ChannelType(
 
     final override fun hashCode(): Int = value.hashCode()
 
-    final override fun toString(): String = "ChannelType.${this::class.simpleName}(value=$value)"
+    final override fun toString(): String = if (this is Unknown) "ChannelType.Unknown(value=$value)"
+            else "ChannelType.${this::class.simpleName}"
 
     /**
      * An unknown [ChannelType].
      *
      * This is used as a fallback for [ChannelType]s that haven't been added to Kord yet.
      */
-    public class Unknown(
+    public class Unknown internal constructor(
         `value`: Int,
-    ) : ChannelType(value)
+        @Suppress(names = arrayOf("UNUSED_PARAMETER"))
+        unused: Nothing?,
+    ) : ChannelType(value) {
+        @Deprecated(
+            message = "Replaced by 'ChannelType.from()'.",
+            replaceWith = ReplaceWith(expression = "ChannelType.from(value)", imports =
+                        arrayOf("dev.kord.common.entity.ChannelType")),
+        )
+        public constructor(`value`: Int) : this(value, null)
+    }
 
     /**
      * A text channel within a server.
@@ -115,22 +125,7 @@ public sealed class ChannelType(
             encoder.encodeInt(value.value)
         }
 
-        override fun deserialize(decoder: Decoder): ChannelType =
-                when (val value = decoder.decodeInt()) {
-            0 -> GuildText
-            1 -> DM
-            2 -> GuildVoice
-            3 -> GroupDM
-            4 -> GuildCategory
-            5 -> GuildNews
-            10 -> PublicNewsThread
-            11 -> PublicGuildThread
-            12 -> PrivateThread
-            13 -> GuildStageVoice
-            14 -> GuildDirectory
-            15 -> GuildForum
-            else -> Unknown(value)
-        }
+        override fun deserialize(decoder: Decoder): ChannelType = from(decoder.decodeInt())
     }
 
     public companion object {
@@ -154,5 +149,25 @@ public sealed class ChannelType(
             )
         }
 
+
+        /**
+         * Returns an instance of [ChannelType] with [ChannelType.value] equal to the specified
+         * [value].
+         */
+        public fun from(`value`: Int): ChannelType = when (value) {
+            0 -> GuildText
+            1 -> DM
+            2 -> GuildVoice
+            3 -> GroupDM
+            4 -> GuildCategory
+            5 -> GuildNews
+            10 -> PublicNewsThread
+            11 -> PublicGuildThread
+            12 -> PrivateThread
+            13 -> GuildStageVoice
+            14 -> GuildDirectory
+            15 -> GuildForum
+            else -> Unknown(value, null)
+        }
     }
 }

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/ComponentType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/ComponentType.kt
@@ -29,16 +29,27 @@ public sealed class ComponentType(
 
     final override fun hashCode(): Int = value.hashCode()
 
-    final override fun toString(): String = "ComponentType.${this::class.simpleName}(value=$value)"
+    final override fun toString(): String =
+            if (this is Unknown) "ComponentType.Unknown(value=$value)"
+            else "ComponentType.${this::class.simpleName}"
 
     /**
      * An unknown [ComponentType].
      *
      * This is used as a fallback for [ComponentType]s that haven't been added to Kord yet.
      */
-    public class Unknown(
+    public class Unknown internal constructor(
         `value`: Int,
-    ) : ComponentType(value)
+        @Suppress(names = arrayOf("UNUSED_PARAMETER"))
+        unused: Nothing?,
+    ) : ComponentType(value) {
+        @Deprecated(
+            message = "Replaced by 'ComponentType.from()'.",
+            replaceWith = ReplaceWith(expression = "ComponentType.from(value)", imports =
+                        arrayOf("dev.kord.common.entity.ComponentType")),
+        )
+        public constructor(`value`: Int) : this(value, null)
+    }
 
     /**
      * A container for other components.
@@ -88,18 +99,7 @@ public sealed class ComponentType(
             encoder.encodeInt(value.value)
         }
 
-        override fun deserialize(decoder: Decoder): ComponentType =
-                when (val value = decoder.decodeInt()) {
-            1 -> ActionRow
-            2 -> Button
-            3 -> StringSelect
-            4 -> TextInput
-            5 -> UserSelect
-            6 -> RoleSelect
-            7 -> MentionableSelect
-            8 -> ChannelSelect
-            else -> Unknown(value)
-        }
+        override fun deserialize(decoder: Decoder): ComponentType = from(decoder.decodeInt())
     }
 
     public companion object {
@@ -119,5 +119,21 @@ public sealed class ComponentType(
             )
         }
 
+
+        /**
+         * Returns an instance of [ComponentType] with [ComponentType.value] equal to the specified
+         * [value].
+         */
+        public fun from(`value`: Int): ComponentType = when (value) {
+            1 -> ActionRow
+            2 -> Button
+            3 -> StringSelect
+            4 -> TextInput
+            5 -> UserSelect
+            6 -> RoleSelect
+            7 -> MentionableSelect
+            8 -> ChannelSelect
+            else -> Unknown(value, null)
+        }
     }
 }

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/DefaultMessageNotificationLevel.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/DefaultMessageNotificationLevel.kt
@@ -30,7 +30,8 @@ public sealed class DefaultMessageNotificationLevel(
     final override fun hashCode(): Int = value.hashCode()
 
     final override fun toString(): String =
-            "DefaultMessageNotificationLevel.${this::class.simpleName}(value=$value)"
+            if (this is Unknown) "DefaultMessageNotificationLevel.Unknown(value=$value)"
+            else "DefaultMessageNotificationLevel.${this::class.simpleName}"
 
     /**
      * An unknown [DefaultMessageNotificationLevel].
@@ -38,9 +39,19 @@ public sealed class DefaultMessageNotificationLevel(
      * This is used as a fallback for [DefaultMessageNotificationLevel]s that haven't been added to
      * Kord yet.
      */
-    public class Unknown(
+    public class Unknown internal constructor(
         `value`: Int,
-    ) : DefaultMessageNotificationLevel(value)
+        @Suppress(names = arrayOf("UNUSED_PARAMETER"))
+        unused: Nothing?,
+    ) : DefaultMessageNotificationLevel(value) {
+        @Deprecated(
+            message = "Replaced by 'DefaultMessageNotificationLevel.from()'.",
+            replaceWith = ReplaceWith(expression = "DefaultMessageNotificationLevel.from(value)",
+                        imports =
+                        arrayOf("dev.kord.common.entity.DefaultMessageNotificationLevel")),
+        )
+        public constructor(`value`: Int) : this(value, null)
+    }
 
     /**
      * Members will receive notifications for all messages by default.
@@ -62,11 +73,7 @@ public sealed class DefaultMessageNotificationLevel(
         }
 
         override fun deserialize(decoder: Decoder): DefaultMessageNotificationLevel =
-                when (val value = decoder.decodeInt()) {
-            0 -> AllMessages
-            1 -> OnlyMentions
-            else -> Unknown(value)
-        }
+                from(decoder.decodeInt())
     }
 
     public companion object {
@@ -80,5 +87,15 @@ public sealed class DefaultMessageNotificationLevel(
             )
         }
 
+
+        /**
+         * Returns an instance of [DefaultMessageNotificationLevel] with
+         * [DefaultMessageNotificationLevel.value] equal to the specified [value].
+         */
+        public fun from(`value`: Int): DefaultMessageNotificationLevel = when (value) {
+            0 -> AllMessages
+            1 -> OnlyMentions
+            else -> Unknown(value, null)
+        }
     }
 }

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/DiscordConnectionVisibility.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/DiscordConnectionVisibility.kt
@@ -30,7 +30,8 @@ public sealed class DiscordConnectionVisibility(
     final override fun hashCode(): Int = value.hashCode()
 
     final override fun toString(): String =
-            "DiscordConnectionVisibility.${this::class.simpleName}(value=$value)"
+            if (this is Unknown) "DiscordConnectionVisibility.Unknown(value=$value)"
+            else "DiscordConnectionVisibility.${this::class.simpleName}"
 
     /**
      * An unknown [DiscordConnectionVisibility].
@@ -38,9 +39,18 @@ public sealed class DiscordConnectionVisibility(
      * This is used as a fallback for [DiscordConnectionVisibility]s that haven't been added to Kord
      * yet.
      */
-    public class Unknown(
+    public class Unknown internal constructor(
         `value`: Int,
-    ) : DiscordConnectionVisibility(value)
+        @Suppress(names = arrayOf("UNUSED_PARAMETER"))
+        unused: Nothing?,
+    ) : DiscordConnectionVisibility(value) {
+        @Deprecated(
+            message = "Replaced by 'DiscordConnectionVisibility.from()'.",
+            replaceWith = ReplaceWith(expression = "DiscordConnectionVisibility.from(value)",
+                        imports = arrayOf("dev.kord.common.entity.DiscordConnectionVisibility")),
+        )
+        public constructor(`value`: Int) : this(value, null)
+    }
 
     /**
      * Invisible to everyone except the user themselves.
@@ -62,11 +72,7 @@ public sealed class DiscordConnectionVisibility(
         }
 
         override fun deserialize(decoder: Decoder): DiscordConnectionVisibility =
-                when (val value = decoder.decodeInt()) {
-            0 -> None
-            1 -> Everyone
-            else -> Unknown(value)
-        }
+                from(decoder.decodeInt())
     }
 
     public companion object {
@@ -80,5 +86,15 @@ public sealed class DiscordConnectionVisibility(
             )
         }
 
+
+        /**
+         * Returns an instance of [DiscordConnectionVisibility] with
+         * [DiscordConnectionVisibility.value] equal to the specified [value].
+         */
+        public fun from(`value`: Int): DiscordConnectionVisibility = when (value) {
+            0 -> None
+            1 -> Everyone
+            else -> Unknown(value, null)
+        }
     }
 }

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/EmbedType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/EmbedType.kt
@@ -29,16 +29,26 @@ public sealed class EmbedType(
 
     final override fun hashCode(): Int = value.hashCode()
 
-    final override fun toString(): String = "EmbedType.${this::class.simpleName}(value=$value)"
+    final override fun toString(): String = if (this is Unknown) "EmbedType.Unknown(value=$value)"
+            else "EmbedType.${this::class.simpleName}"
 
     /**
      * An unknown [EmbedType].
      *
      * This is used as a fallback for [EmbedType]s that haven't been added to Kord yet.
      */
-    public class Unknown(
+    public class Unknown internal constructor(
         `value`: String,
-    ) : EmbedType(value)
+        @Suppress(names = arrayOf("UNUSED_PARAMETER"))
+        unused: Nothing?,
+    ) : EmbedType(value) {
+        @Deprecated(
+            message = "Replaced by 'EmbedType.from()'.",
+            replaceWith = ReplaceWith(expression = "EmbedType.from(value)", imports =
+                        arrayOf("dev.kord.common.entity.EmbedType")),
+        )
+        public constructor(`value`: String) : this(value, null)
+    }
 
     /**
      * Generic embed rendered from embed attributes.
@@ -78,16 +88,7 @@ public sealed class EmbedType(
             encoder.encodeString(value.value)
         }
 
-        override fun deserialize(decoder: Decoder): EmbedType =
-                when (val value = decoder.decodeString()) {
-            "rich" -> Rich
-            "image" -> Image
-            "video" -> Video
-            "gifv" -> Gifv
-            "article" -> Article
-            "link" -> Link
-            else -> Unknown(value)
-        }
+        override fun deserialize(decoder: Decoder): EmbedType = from(decoder.decodeString())
     }
 
     public companion object {
@@ -105,5 +106,18 @@ public sealed class EmbedType(
             )
         }
 
+
+        /**
+         * Returns an instance of [EmbedType] with [EmbedType.value] equal to the specified [value].
+         */
+        public fun from(`value`: String): EmbedType = when (value) {
+            "rich" -> Rich
+            "image" -> Image
+            "video" -> Video
+            "gifv" -> Gifv
+            "article" -> Article
+            "link" -> Link
+            else -> Unknown(value, null)
+        }
     }
 }

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/ExplicitContentFilter.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/ExplicitContentFilter.kt
@@ -30,16 +30,26 @@ public sealed class ExplicitContentFilter(
     final override fun hashCode(): Int = value.hashCode()
 
     final override fun toString(): String =
-            "ExplicitContentFilter.${this::class.simpleName}(value=$value)"
+            if (this is Unknown) "ExplicitContentFilter.Unknown(value=$value)"
+            else "ExplicitContentFilter.${this::class.simpleName}"
 
     /**
      * An unknown [ExplicitContentFilter].
      *
      * This is used as a fallback for [ExplicitContentFilter]s that haven't been added to Kord yet.
      */
-    public class Unknown(
+    public class Unknown internal constructor(
         `value`: Int,
-    ) : ExplicitContentFilter(value)
+        @Suppress(names = arrayOf("UNUSED_PARAMETER"))
+        unused: Nothing?,
+    ) : ExplicitContentFilter(value) {
+        @Deprecated(
+            message = "Replaced by 'ExplicitContentFilter.from()'.",
+            replaceWith = ReplaceWith(expression = "ExplicitContentFilter.from(value)", imports =
+                        arrayOf("dev.kord.common.entity.ExplicitContentFilter")),
+        )
+        public constructor(`value`: Int) : this(value, null)
+    }
 
     /**
      * Media content will not be scanned.
@@ -66,12 +76,7 @@ public sealed class ExplicitContentFilter(
         }
 
         override fun deserialize(decoder: Decoder): ExplicitContentFilter =
-                when (val value = decoder.decodeInt()) {
-            0 -> Disabled
-            1 -> MembersWithoutRoles
-            2 -> AllMembers
-            else -> Unknown(value)
-        }
+                from(decoder.decodeInt())
     }
 
     public companion object {
@@ -86,5 +91,16 @@ public sealed class ExplicitContentFilter(
             )
         }
 
+
+        /**
+         * Returns an instance of [ExplicitContentFilter] with [ExplicitContentFilter.value] equal
+         * to the specified [value].
+         */
+        public fun from(`value`: Int): ExplicitContentFilter = when (value) {
+            0 -> Disabled
+            1 -> MembersWithoutRoles
+            2 -> AllMembers
+            else -> Unknown(value, null)
+        }
     }
 }

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/ForumLayoutType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/ForumLayoutType.kt
@@ -30,16 +30,26 @@ public sealed class ForumLayoutType(
     final override fun hashCode(): Int = value.hashCode()
 
     final override fun toString(): String =
-            "ForumLayoutType.${this::class.simpleName}(value=$value)"
+            if (this is Unknown) "ForumLayoutType.Unknown(value=$value)"
+            else "ForumLayoutType.${this::class.simpleName}"
 
     /**
      * An unknown [ForumLayoutType].
      *
      * This is used as a fallback for [ForumLayoutType]s that haven't been added to Kord yet.
      */
-    public class Unknown(
+    public class Unknown internal constructor(
         `value`: Int,
-    ) : ForumLayoutType(value)
+        @Suppress(names = arrayOf("UNUSED_PARAMETER"))
+        unused: Nothing?,
+    ) : ForumLayoutType(value) {
+        @Deprecated(
+            message = "Replaced by 'ForumLayoutType.from()'.",
+            replaceWith = ReplaceWith(expression = "ForumLayoutType.from(value)", imports =
+                        arrayOf("dev.kord.common.entity.ForumLayoutType")),
+        )
+        public constructor(`value`: Int) : this(value, null)
+    }
 
     /**
      * No default has been set for forum channel.
@@ -65,13 +75,7 @@ public sealed class ForumLayoutType(
             encoder.encodeInt(value.value)
         }
 
-        override fun deserialize(decoder: Decoder): ForumLayoutType =
-                when (val value = decoder.decodeInt()) {
-            0 -> NotSet
-            1 -> ListView
-            2 -> GalleryView
-            else -> Unknown(value)
-        }
+        override fun deserialize(decoder: Decoder): ForumLayoutType = from(decoder.decodeInt())
     }
 
     public companion object {
@@ -86,5 +90,16 @@ public sealed class ForumLayoutType(
             )
         }
 
+
+        /**
+         * Returns an instance of [ForumLayoutType] with [ForumLayoutType.value] equal to the
+         * specified [value].
+         */
+        public fun from(`value`: Int): ForumLayoutType = when (value) {
+            0 -> NotSet
+            1 -> ListView
+            2 -> GalleryView
+            else -> Unknown(value, null)
+        }
     }
 }

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/GuildFeature.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/GuildFeature.kt
@@ -29,16 +29,27 @@ public sealed class GuildFeature(
 
     final override fun hashCode(): Int = value.hashCode()
 
-    final override fun toString(): String = "GuildFeature.${this::class.simpleName}(value=$value)"
+    final override fun toString(): String =
+            if (this is Unknown) "GuildFeature.Unknown(value=$value)"
+            else "GuildFeature.${this::class.simpleName}"
 
     /**
      * An unknown [GuildFeature].
      *
      * This is used as a fallback for [GuildFeature]s that haven't been added to Kord yet.
      */
-    public class Unknown(
+    public class Unknown internal constructor(
         `value`: String,
-    ) : GuildFeature(value)
+        @Suppress(names = arrayOf("UNUSED_PARAMETER"))
+        unused: Nothing?,
+    ) : GuildFeature(value) {
+        @Deprecated(
+            message = "Replaced by 'GuildFeature.from()'.",
+            replaceWith = ReplaceWith(expression = "GuildFeature.from(value)", imports =
+                        arrayOf("dev.kord.common.entity.GuildFeature")),
+        )
+        public constructor(`value`: String) : this(value, null)
+    }
 
     /**
      * Guild has access to set an animated guild banner image.
@@ -187,37 +198,7 @@ public sealed class GuildFeature(
             encoder.encodeString(value.value)
         }
 
-        override fun deserialize(decoder: Decoder): GuildFeature =
-                when (val value = decoder.decodeString()) {
-            "ANIMATED_BANNER" -> AnimatedBanner
-            "ANIMATED_ICON" -> AnimatedIcon
-            "APPLICATION_COMMAND_PERMISSIONS_V2" -> ApplicationCommandPermissionsV2
-            "AUTO_MODERATION" -> AutoModeration
-            "BANNER" -> Banner
-            "COMMUNITY" -> Community
-            "CREATOR_MONETIZABLE_PROVISIONAL" -> CreatorMonetizableProvisional
-            "CREATOR_STORE_PAGE" -> CreatorStorePage
-            "DEVELOPER_SUPPORT_SERVER" -> DeveloperSupportServer
-            "DISCOVERABLE" -> Discoverable
-            "FEATURABLE" -> Featurable
-            "INVITES_DISABLED" -> InvitesDisabled
-            "INVITE_SPLASH" -> InviteSplash
-            "MEMBER_VERIFICATION_GATE_ENABLED" -> MemberVerificationGateEnabled
-            "MORE_STICKERS" -> MoreStickers
-            "NEWS" -> News
-            "PARTNERED" -> Partnered
-            "PREVIEW_ENABLED" -> PreviewEnabled
-            "RAID_ALERTS_DISABLED" -> RaidAlertsDisabled
-            "ROLE_ICONS" -> RoleIcons
-            "ROLE_SUBSCRIPTIONS_AVAILABLE_FOR_PURCHASE" -> RoleSubscriptionsAvailableForPurchase
-            "ROLE_SUBSCRIPTIONS_ENABLED" -> RoleSubscriptionsEnabled
-            "TICKETED_EVENTS_ENABLED" -> TicketedEventsEnabled
-            "VANITY_URL" -> VanityUrl
-            "VERIFIED" -> Verified
-            "VIP_REGIONS" -> VIPRegions
-            "WELCOME_SCREEN_ENABLED" -> WelcomeScreenEnabled
-            else -> Unknown(value)
-        }
+        override fun deserialize(decoder: Decoder): GuildFeature = from(decoder.decodeString())
     }
 
     public companion object {
@@ -256,5 +237,40 @@ public sealed class GuildFeature(
             )
         }
 
+
+        /**
+         * Returns an instance of [GuildFeature] with [GuildFeature.value] equal to the specified
+         * [value].
+         */
+        public fun from(`value`: String): GuildFeature = when (value) {
+            "ANIMATED_BANNER" -> AnimatedBanner
+            "ANIMATED_ICON" -> AnimatedIcon
+            "APPLICATION_COMMAND_PERMISSIONS_V2" -> ApplicationCommandPermissionsV2
+            "AUTO_MODERATION" -> AutoModeration
+            "BANNER" -> Banner
+            "COMMUNITY" -> Community
+            "CREATOR_MONETIZABLE_PROVISIONAL" -> CreatorMonetizableProvisional
+            "CREATOR_STORE_PAGE" -> CreatorStorePage
+            "DEVELOPER_SUPPORT_SERVER" -> DeveloperSupportServer
+            "DISCOVERABLE" -> Discoverable
+            "FEATURABLE" -> Featurable
+            "INVITES_DISABLED" -> InvitesDisabled
+            "INVITE_SPLASH" -> InviteSplash
+            "MEMBER_VERIFICATION_GATE_ENABLED" -> MemberVerificationGateEnabled
+            "MORE_STICKERS" -> MoreStickers
+            "NEWS" -> News
+            "PARTNERED" -> Partnered
+            "PREVIEW_ENABLED" -> PreviewEnabled
+            "RAID_ALERTS_DISABLED" -> RaidAlertsDisabled
+            "ROLE_ICONS" -> RoleIcons
+            "ROLE_SUBSCRIPTIONS_AVAILABLE_FOR_PURCHASE" -> RoleSubscriptionsAvailableForPurchase
+            "ROLE_SUBSCRIPTIONS_ENABLED" -> RoleSubscriptionsEnabled
+            "TICKETED_EVENTS_ENABLED" -> TicketedEventsEnabled
+            "VANITY_URL" -> VanityUrl
+            "VERIFIED" -> Verified
+            "VIP_REGIONS" -> VIPRegions
+            "WELCOME_SCREEN_ENABLED" -> WelcomeScreenEnabled
+            else -> Unknown(value, null)
+        }
     }
 }

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/GuildScheduledEventPrivacyLevel.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/GuildScheduledEventPrivacyLevel.kt
@@ -30,7 +30,8 @@ public sealed class GuildScheduledEventPrivacyLevel(
     final override fun hashCode(): Int = value.hashCode()
 
     final override fun toString(): String =
-            "GuildScheduledEventPrivacyLevel.${this::class.simpleName}(value=$value)"
+            if (this is Unknown) "GuildScheduledEventPrivacyLevel.Unknown(value=$value)"
+            else "GuildScheduledEventPrivacyLevel.${this::class.simpleName}"
 
     /**
      * An unknown [GuildScheduledEventPrivacyLevel].
@@ -38,9 +39,19 @@ public sealed class GuildScheduledEventPrivacyLevel(
      * This is used as a fallback for [GuildScheduledEventPrivacyLevel]s that haven't been added to
      * Kord yet.
      */
-    public class Unknown(
+    public class Unknown internal constructor(
         `value`: Int,
-    ) : GuildScheduledEventPrivacyLevel(value)
+        @Suppress(names = arrayOf("UNUSED_PARAMETER"))
+        unused: Nothing?,
+    ) : GuildScheduledEventPrivacyLevel(value) {
+        @Deprecated(
+            message = "Replaced by 'GuildScheduledEventPrivacyLevel.from()'.",
+            replaceWith = ReplaceWith(expression = "GuildScheduledEventPrivacyLevel.from(value)",
+                        imports =
+                        arrayOf("dev.kord.common.entity.GuildScheduledEventPrivacyLevel")),
+        )
+        public constructor(`value`: Int) : this(value, null)
+    }
 
     /**
      * The scheduled event is only accessible to guild members.
@@ -57,10 +68,7 @@ public sealed class GuildScheduledEventPrivacyLevel(
         }
 
         override fun deserialize(decoder: Decoder): GuildScheduledEventPrivacyLevel =
-                when (val value = decoder.decodeInt()) {
-            2 -> GuildOnly
-            else -> Unknown(value)
-        }
+                from(decoder.decodeInt())
     }
 
     public companion object {
@@ -73,5 +81,14 @@ public sealed class GuildScheduledEventPrivacyLevel(
             )
         }
 
+
+        /**
+         * Returns an instance of [GuildScheduledEventPrivacyLevel] with
+         * [GuildScheduledEventPrivacyLevel.value] equal to the specified [value].
+         */
+        public fun from(`value`: Int): GuildScheduledEventPrivacyLevel = when (value) {
+            2 -> GuildOnly
+            else -> Unknown(value, null)
+        }
     }
 }

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/GuildScheduledEventStatus.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/GuildScheduledEventStatus.kt
@@ -30,7 +30,8 @@ public sealed class GuildScheduledEventStatus(
     final override fun hashCode(): Int = value.hashCode()
 
     final override fun toString(): String =
-            "GuildScheduledEventStatus.${this::class.simpleName}(value=$value)"
+            if (this is Unknown) "GuildScheduledEventStatus.Unknown(value=$value)"
+            else "GuildScheduledEventStatus.${this::class.simpleName}"
 
     /**
      * An unknown [GuildScheduledEventStatus].
@@ -38,9 +39,18 @@ public sealed class GuildScheduledEventStatus(
      * This is used as a fallback for [GuildScheduledEventStatus]s that haven't been added to Kord
      * yet.
      */
-    public class Unknown(
+    public class Unknown internal constructor(
         `value`: Int,
-    ) : GuildScheduledEventStatus(value)
+        @Suppress(names = arrayOf("UNUSED_PARAMETER"))
+        unused: Nothing?,
+    ) : GuildScheduledEventStatus(value) {
+        @Deprecated(
+            message = "Replaced by 'GuildScheduledEventStatus.from()'.",
+            replaceWith = ReplaceWith(expression = "GuildScheduledEventStatus.from(value)", imports
+                        = arrayOf("dev.kord.common.entity.GuildScheduledEventStatus")),
+        )
+        public constructor(`value`: Int) : this(value, null)
+    }
 
     public object Scheduled : GuildScheduledEventStatus(1)
 
@@ -60,13 +70,7 @@ public sealed class GuildScheduledEventStatus(
         }
 
         override fun deserialize(decoder: Decoder): GuildScheduledEventStatus =
-                when (val value = decoder.decodeInt()) {
-            1 -> Scheduled
-            2 -> Active
-            3 -> Completed
-            4 -> Cancelled
-            else -> Unknown(value)
-        }
+                from(decoder.decodeInt())
     }
 
     public companion object {
@@ -82,5 +86,17 @@ public sealed class GuildScheduledEventStatus(
             )
         }
 
+
+        /**
+         * Returns an instance of [GuildScheduledEventStatus] with [GuildScheduledEventStatus.value]
+         * equal to the specified [value].
+         */
+        public fun from(`value`: Int): GuildScheduledEventStatus = when (value) {
+            1 -> Scheduled
+            2 -> Active
+            3 -> Completed
+            4 -> Cancelled
+            else -> Unknown(value, null)
+        }
     }
 }

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/IntegrationExpireBehavior.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/IntegrationExpireBehavior.kt
@@ -30,7 +30,8 @@ public sealed class IntegrationExpireBehavior(
     final override fun hashCode(): Int = value.hashCode()
 
     final override fun toString(): String =
-            "IntegrationExpireBehavior.${this::class.simpleName}(value=$value)"
+            if (this is Unknown) "IntegrationExpireBehavior.Unknown(value=$value)"
+            else "IntegrationExpireBehavior.${this::class.simpleName}"
 
     /**
      * An unknown [IntegrationExpireBehavior].
@@ -38,9 +39,18 @@ public sealed class IntegrationExpireBehavior(
      * This is used as a fallback for [IntegrationExpireBehavior]s that haven't been added to Kord
      * yet.
      */
-    public class Unknown(
+    public class Unknown internal constructor(
         `value`: Int,
-    ) : IntegrationExpireBehavior(value)
+        @Suppress(names = arrayOf("UNUSED_PARAMETER"))
+        unused: Nothing?,
+    ) : IntegrationExpireBehavior(value) {
+        @Deprecated(
+            message = "Replaced by 'IntegrationExpireBehavior.from()'.",
+            replaceWith = ReplaceWith(expression = "IntegrationExpireBehavior.from(value)", imports
+                        = arrayOf("dev.kord.common.entity.IntegrationExpireBehavior")),
+        )
+        public constructor(`value`: Int) : this(value, null)
+    }
 
     public object RemoveRole : IntegrationExpireBehavior(0)
 
@@ -56,11 +66,7 @@ public sealed class IntegrationExpireBehavior(
         }
 
         override fun deserialize(decoder: Decoder): IntegrationExpireBehavior =
-                when (val value = decoder.decodeInt()) {
-            0 -> RemoveRole
-            1 -> Kick
-            else -> Unknown(value)
-        }
+                from(decoder.decodeInt())
     }
 
     public companion object {
@@ -74,5 +80,15 @@ public sealed class IntegrationExpireBehavior(
             )
         }
 
+
+        /**
+         * Returns an instance of [IntegrationExpireBehavior] with [IntegrationExpireBehavior.value]
+         * equal to the specified [value].
+         */
+        public fun from(`value`: Int): IntegrationExpireBehavior = when (value) {
+            0 -> RemoveRole
+            1 -> Kick
+            else -> Unknown(value, null)
+        }
     }
 }

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/InteractionResponseType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/InteractionResponseType.kt
@@ -30,7 +30,8 @@ public sealed class InteractionResponseType(
     final override fun hashCode(): Int = type.hashCode()
 
     final override fun toString(): String =
-            "InteractionResponseType.${this::class.simpleName}(type=$type)"
+            if (this is Unknown) "InteractionResponseType.Unknown(type=$type)"
+            else "InteractionResponseType.${this::class.simpleName}"
 
     /**
      * An unknown [InteractionResponseType].
@@ -38,9 +39,18 @@ public sealed class InteractionResponseType(
      * This is used as a fallback for [InteractionResponseType]s that haven't been added to Kord
      * yet.
      */
-    public class Unknown(
+    public class Unknown internal constructor(
         type: Int,
-    ) : InteractionResponseType(type)
+        @Suppress(names = arrayOf("UNUSED_PARAMETER"))
+        unused: Nothing?,
+    ) : InteractionResponseType(type) {
+        @Deprecated(
+            message = "Replaced by 'InteractionResponseType.from()'.",
+            replaceWith = ReplaceWith(expression = "InteractionResponseType.from(type)", imports =
+                        arrayOf("dev.kord.common.entity.InteractionResponseType")),
+        )
+        public constructor(type: Int) : this(type, null)
+    }
 
     /**
      * ACK a [Ping][dev.kord.common.entity.InteractionType.Ping].
@@ -88,16 +98,7 @@ public sealed class InteractionResponseType(
         }
 
         override fun deserialize(decoder: Decoder): InteractionResponseType =
-                when (val type = decoder.decodeInt()) {
-            1 -> Pong
-            4 -> ChannelMessageWithSource
-            5 -> DeferredChannelMessageWithSource
-            6 -> DeferredUpdateMessage
-            7 -> UpdateMessage
-            8 -> ApplicationCommandAutoCompleteResult
-            9 -> Modal
-            else -> Unknown(type)
-        }
+                from(decoder.decodeInt())
     }
 
     public companion object {
@@ -116,5 +117,20 @@ public sealed class InteractionResponseType(
             )
         }
 
+
+        /**
+         * Returns an instance of [InteractionResponseType] with [InteractionResponseType.type]
+         * equal to the specified [type].
+         */
+        public fun from(type: Int): InteractionResponseType = when (type) {
+            1 -> Pong
+            4 -> ChannelMessageWithSource
+            5 -> DeferredChannelMessageWithSource
+            6 -> DeferredUpdateMessage
+            7 -> UpdateMessage
+            8 -> ApplicationCommandAutoCompleteResult
+            9 -> Modal
+            else -> Unknown(type, null)
+        }
     }
 }

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/InteractionType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/InteractionType.kt
@@ -29,16 +29,27 @@ public sealed class InteractionType(
 
     final override fun hashCode(): Int = type.hashCode()
 
-    final override fun toString(): String = "InteractionType.${this::class.simpleName}(type=$type)"
+    final override fun toString(): String =
+            if (this is Unknown) "InteractionType.Unknown(type=$type)"
+            else "InteractionType.${this::class.simpleName}"
 
     /**
      * An unknown [InteractionType].
      *
      * This is used as a fallback for [InteractionType]s that haven't been added to Kord yet.
      */
-    public class Unknown(
+    public class Unknown internal constructor(
         type: Int,
-    ) : InteractionType(type)
+        @Suppress(names = arrayOf("UNUSED_PARAMETER"))
+        unused: Nothing?,
+    ) : InteractionType(type) {
+        @Deprecated(
+            message = "Replaced by 'InteractionType.from()'.",
+            replaceWith = ReplaceWith(expression = "InteractionType.from(type)", imports =
+                        arrayOf("dev.kord.common.entity.InteractionType")),
+        )
+        public constructor(type: Int) : this(type, null)
+    }
 
     public object Ping : InteractionType(1)
 
@@ -59,15 +70,7 @@ public sealed class InteractionType(
             encoder.encodeInt(value.type)
         }
 
-        override fun deserialize(decoder: Decoder): InteractionType =
-                when (val type = decoder.decodeInt()) {
-            1 -> Ping
-            2 -> ApplicationCommand
-            3 -> Component
-            4 -> AutoComplete
-            5 -> ModalSubmit
-            else -> Unknown(type)
-        }
+        override fun deserialize(decoder: Decoder): InteractionType = from(decoder.decodeInt())
     }
 
     public companion object {
@@ -84,5 +87,18 @@ public sealed class InteractionType(
             )
         }
 
+
+        /**
+         * Returns an instance of [InteractionType] with [InteractionType.type] equal to the
+         * specified [type].
+         */
+        public fun from(type: Int): InteractionType = when (type) {
+            1 -> Ping
+            2 -> ApplicationCommand
+            3 -> Component
+            4 -> AutoComplete
+            5 -> ModalSubmit
+            else -> Unknown(type, null)
+        }
     }
 }

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/InviteTargetType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/InviteTargetType.kt
@@ -30,16 +30,26 @@ public sealed class InviteTargetType(
     final override fun hashCode(): Int = value.hashCode()
 
     final override fun toString(): String =
-            "InviteTargetType.${this::class.simpleName}(value=$value)"
+            if (this is Unknown) "InviteTargetType.Unknown(value=$value)"
+            else "InviteTargetType.${this::class.simpleName}"
 
     /**
      * An unknown [InviteTargetType].
      *
      * This is used as a fallback for [InviteTargetType]s that haven't been added to Kord yet.
      */
-    public class Unknown(
+    public class Unknown internal constructor(
         `value`: Int,
-    ) : InviteTargetType(value)
+        @Suppress(names = arrayOf("UNUSED_PARAMETER"))
+        unused: Nothing?,
+    ) : InviteTargetType(value) {
+        @Deprecated(
+            message = "Replaced by 'InviteTargetType.from()'.",
+            replaceWith = ReplaceWith(expression = "InviteTargetType.from(value)", imports =
+                        arrayOf("dev.kord.common.entity.InviteTargetType")),
+        )
+        public constructor(`value`: Int) : this(value, null)
+    }
 
     public object Stream : InviteTargetType(1)
 
@@ -54,12 +64,7 @@ public sealed class InviteTargetType(
             encoder.encodeInt(value.value)
         }
 
-        override fun deserialize(decoder: Decoder): InviteTargetType =
-                when (val value = decoder.decodeInt()) {
-            1 -> Stream
-            2 -> EmbeddedApplication
-            else -> Unknown(value)
-        }
+        override fun deserialize(decoder: Decoder): InviteTargetType = from(decoder.decodeInt())
     }
 
     public companion object {
@@ -73,5 +78,15 @@ public sealed class InviteTargetType(
             )
         }
 
+
+        /**
+         * Returns an instance of [InviteTargetType] with [InviteTargetType.value] equal to the
+         * specified [value].
+         */
+        public fun from(`value`: Int): InviteTargetType = when (value) {
+            1 -> Stream
+            2 -> EmbeddedApplication
+            else -> Unknown(value, null)
+        }
     }
 }

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/MFALevel.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/MFALevel.kt
@@ -29,16 +29,26 @@ public sealed class MFALevel(
 
     final override fun hashCode(): Int = value.hashCode()
 
-    final override fun toString(): String = "MFALevel.${this::class.simpleName}(value=$value)"
+    final override fun toString(): String = if (this is Unknown) "MFALevel.Unknown(value=$value)"
+            else "MFALevel.${this::class.simpleName}"
 
     /**
      * An unknown [MFALevel].
      *
      * This is used as a fallback for [MFALevel]s that haven't been added to Kord yet.
      */
-    public class Unknown(
+    public class Unknown internal constructor(
         `value`: Int,
-    ) : MFALevel(value)
+        @Suppress(names = arrayOf("UNUSED_PARAMETER"))
+        unused: Nothing?,
+    ) : MFALevel(value) {
+        @Deprecated(
+            message = "Replaced by 'MFALevel.from()'.",
+            replaceWith = ReplaceWith(expression = "MFALevel.from(value)", imports =
+                        arrayOf("dev.kord.common.entity.MFALevel")),
+        )
+        public constructor(`value`: Int) : this(value, null)
+    }
 
     /**
      * Guild has no MFA/2FA requirement for moderation actions.
@@ -58,12 +68,7 @@ public sealed class MFALevel(
             encoder.encodeInt(value.value)
         }
 
-        override fun deserialize(decoder: Decoder): MFALevel =
-                when (val value = decoder.decodeInt()) {
-            0 -> None
-            1 -> Elevated
-            else -> Unknown(value)
-        }
+        override fun deserialize(decoder: Decoder): MFALevel = from(decoder.decodeInt())
     }
 
     public companion object {
@@ -77,5 +82,14 @@ public sealed class MFALevel(
             )
         }
 
+
+        /**
+         * Returns an instance of [MFALevel] with [MFALevel.value] equal to the specified [value].
+         */
+        public fun from(`value`: Int): MFALevel = when (value) {
+            0 -> None
+            1 -> Elevated
+            else -> Unknown(value, null)
+        }
     }
 }

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/MessageActivityType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/MessageActivityType.kt
@@ -30,16 +30,26 @@ public sealed class MessageActivityType(
     final override fun hashCode(): Int = value.hashCode()
 
     final override fun toString(): String =
-            "MessageActivityType.${this::class.simpleName}(value=$value)"
+            if (this is Unknown) "MessageActivityType.Unknown(value=$value)"
+            else "MessageActivityType.${this::class.simpleName}"
 
     /**
      * An unknown [MessageActivityType].
      *
      * This is used as a fallback for [MessageActivityType]s that haven't been added to Kord yet.
      */
-    public class Unknown(
+    public class Unknown internal constructor(
         `value`: Int,
-    ) : MessageActivityType(value)
+        @Suppress(names = arrayOf("UNUSED_PARAMETER"))
+        unused: Nothing?,
+    ) : MessageActivityType(value) {
+        @Deprecated(
+            message = "Replaced by 'MessageActivityType.from()'.",
+            replaceWith = ReplaceWith(expression = "MessageActivityType.from(value)", imports =
+                        arrayOf("dev.kord.common.entity.MessageActivityType")),
+        )
+        public constructor(`value`: Int) : this(value, null)
+    }
 
     public object Join : MessageActivityType(1)
 
@@ -58,14 +68,7 @@ public sealed class MessageActivityType(
             encoder.encodeInt(value.value)
         }
 
-        override fun deserialize(decoder: Decoder): MessageActivityType =
-                when (val value = decoder.decodeInt()) {
-            1 -> Join
-            2 -> Spectate
-            3 -> Listen
-            5 -> JoinRequest
-            else -> Unknown(value)
-        }
+        override fun deserialize(decoder: Decoder): MessageActivityType = from(decoder.decodeInt())
     }
 
     public companion object {
@@ -81,5 +84,17 @@ public sealed class MessageActivityType(
             )
         }
 
+
+        /**
+         * Returns an instance of [MessageActivityType] with [MessageActivityType.value] equal to
+         * the specified [value].
+         */
+        public fun from(`value`: Int): MessageActivityType = when (value) {
+            1 -> Join
+            2 -> Spectate
+            3 -> Listen
+            5 -> JoinRequest
+            else -> Unknown(value, null)
+        }
     }
 }

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/MessageStickerType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/MessageStickerType.kt
@@ -30,16 +30,26 @@ public sealed class MessageStickerType(
     final override fun hashCode(): Int = value.hashCode()
 
     final override fun toString(): String =
-            "MessageStickerType.${this::class.simpleName}(value=$value)"
+            if (this is Unknown) "MessageStickerType.Unknown(value=$value)"
+            else "MessageStickerType.${this::class.simpleName}"
 
     /**
      * An unknown [MessageStickerType].
      *
      * This is used as a fallback for [MessageStickerType]s that haven't been added to Kord yet.
      */
-    public class Unknown(
+    public class Unknown internal constructor(
         `value`: Int,
-    ) : MessageStickerType(value)
+        @Suppress(names = arrayOf("UNUSED_PARAMETER"))
+        unused: Nothing?,
+    ) : MessageStickerType(value) {
+        @Deprecated(
+            message = "Replaced by 'MessageStickerType.from()'.",
+            replaceWith = ReplaceWith(expression = "MessageStickerType.from(value)", imports =
+                        arrayOf("dev.kord.common.entity.MessageStickerType")),
+        )
+        public constructor(`value`: Int) : this(value, null)
+    }
 
     public object PNG : MessageStickerType(1)
 
@@ -58,14 +68,7 @@ public sealed class MessageStickerType(
             encoder.encodeInt(value.value)
         }
 
-        override fun deserialize(decoder: Decoder): MessageStickerType =
-                when (val value = decoder.decodeInt()) {
-            1 -> PNG
-            2 -> APNG
-            3 -> LOTTIE
-            4 -> GIF
-            else -> Unknown(value)
-        }
+        override fun deserialize(decoder: Decoder): MessageStickerType = from(decoder.decodeInt())
     }
 
     public companion object {
@@ -81,5 +84,17 @@ public sealed class MessageStickerType(
             )
         }
 
+
+        /**
+         * Returns an instance of [MessageStickerType] with [MessageStickerType.value] equal to the
+         * specified [value].
+         */
+        public fun from(`value`: Int): MessageStickerType = when (value) {
+            1 -> PNG
+            2 -> APNG
+            3 -> LOTTIE
+            4 -> GIF
+            else -> Unknown(value, null)
+        }
     }
 }

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/MessageType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/MessageType.kt
@@ -29,16 +29,26 @@ public sealed class MessageType(
 
     final override fun hashCode(): Int = code.hashCode()
 
-    final override fun toString(): String = "MessageType.${this::class.simpleName}(code=$code)"
+    final override fun toString(): String = if (this is Unknown) "MessageType.Unknown(code=$code)"
+            else "MessageType.${this::class.simpleName}"
 
     /**
      * An unknown [MessageType].
      *
      * This is used as a fallback for [MessageType]s that haven't been added to Kord yet.
      */
-    public class Unknown(
+    public class Unknown internal constructor(
         code: Int,
-    ) : MessageType(code)
+        @Suppress(names = arrayOf("UNUSED_PARAMETER"))
+        unused: Nothing?,
+    ) : MessageType(code) {
+        @Deprecated(
+            message = "Replaced by 'MessageType.from()'.",
+            replaceWith = ReplaceWith(expression = "MessageType.from(code)", imports =
+                        arrayOf("dev.kord.common.entity.MessageType")),
+        )
+        public constructor(code: Int) : this(code, null)
+    }
 
     public object Default : MessageType(0)
 
@@ -110,41 +120,7 @@ public sealed class MessageType(
             encoder.encodeInt(value.code)
         }
 
-        override fun deserialize(decoder: Decoder): MessageType =
-                when (val code = decoder.decodeInt()) {
-            0 -> Default
-            1 -> RecipientAdd
-            2 -> RecipientRemove
-            3 -> Call
-            4 -> ChannelNameChange
-            5 -> ChannelIconChange
-            6 -> ChannelPinnedMessage
-            7 -> UserJoin
-            8 -> GuildBoost
-            9 -> GuildBoostTier1
-            10 -> GuildBoostTier2
-            11 -> GuildBoostTier3
-            12 -> ChannelFollowAdd
-            14 -> GuildDiscoveryDisqualified
-            15 -> GuildDiscoveryRequalified
-            16 -> GuildDiscoveryGracePeriodInitialWarning
-            17 -> GuildDiscoveryGracePeriodFinalWarning
-            18 -> ThreadCreated
-            19 -> Reply
-            20 -> ChatInputCommand
-            21 -> ThreadStarterMessage
-            22 -> GuildInviteReminder
-            23 -> ContextMenuCommand
-            24 -> AutoModerationAction
-            25 -> RoleSubscriptionPurchase
-            26 -> InteractionPremiumUpsell
-            27 -> StageStart
-            28 -> StageEnd
-            29 -> StageSpeaker
-            31 -> StageTopic
-            32 -> GuildApplicationPremiumSubscription
-            else -> Unknown(code)
-        }
+        override fun deserialize(decoder: Decoder): MessageType = from(decoder.decodeInt())
     }
 
     public companion object {
@@ -187,5 +163,44 @@ public sealed class MessageType(
             )
         }
 
+
+        /**
+         * Returns an instance of [MessageType] with [MessageType.code] equal to the specified
+         * [code].
+         */
+        public fun from(code: Int): MessageType = when (code) {
+            0 -> Default
+            1 -> RecipientAdd
+            2 -> RecipientRemove
+            3 -> Call
+            4 -> ChannelNameChange
+            5 -> ChannelIconChange
+            6 -> ChannelPinnedMessage
+            7 -> UserJoin
+            8 -> GuildBoost
+            9 -> GuildBoostTier1
+            10 -> GuildBoostTier2
+            11 -> GuildBoostTier3
+            12 -> ChannelFollowAdd
+            14 -> GuildDiscoveryDisqualified
+            15 -> GuildDiscoveryRequalified
+            16 -> GuildDiscoveryGracePeriodInitialWarning
+            17 -> GuildDiscoveryGracePeriodFinalWarning
+            18 -> ThreadCreated
+            19 -> Reply
+            20 -> ChatInputCommand
+            21 -> ThreadStarterMessage
+            22 -> GuildInviteReminder
+            23 -> ContextMenuCommand
+            24 -> AutoModerationAction
+            25 -> RoleSubscriptionPurchase
+            26 -> InteractionPremiumUpsell
+            27 -> StageStart
+            28 -> StageEnd
+            29 -> StageSpeaker
+            31 -> StageTopic
+            32 -> GuildApplicationPremiumSubscription
+            else -> Unknown(code, null)
+        }
     }
 }

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/NsfwLevel.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/NsfwLevel.kt
@@ -29,16 +29,26 @@ public sealed class NsfwLevel(
 
     final override fun hashCode(): Int = value.hashCode()
 
-    final override fun toString(): String = "NsfwLevel.${this::class.simpleName}(value=$value)"
+    final override fun toString(): String = if (this is Unknown) "NsfwLevel.Unknown(value=$value)"
+            else "NsfwLevel.${this::class.simpleName}"
 
     /**
      * An unknown [NsfwLevel].
      *
      * This is used as a fallback for [NsfwLevel]s that haven't been added to Kord yet.
      */
-    public class Unknown(
+    public class Unknown internal constructor(
         `value`: Int,
-    ) : NsfwLevel(value)
+        @Suppress(names = arrayOf("UNUSED_PARAMETER"))
+        unused: Nothing?,
+    ) : NsfwLevel(value) {
+        @Deprecated(
+            message = "Replaced by 'NsfwLevel.from()'.",
+            replaceWith = ReplaceWith(expression = "NsfwLevel.from(value)", imports =
+                        arrayOf("dev.kord.common.entity.NsfwLevel")),
+        )
+        public constructor(`value`: Int) : this(value, null)
+    }
 
     public object Default : NsfwLevel(0)
 
@@ -56,14 +66,7 @@ public sealed class NsfwLevel(
             encoder.encodeInt(value.value)
         }
 
-        override fun deserialize(decoder: Decoder): NsfwLevel =
-                when (val value = decoder.decodeInt()) {
-            0 -> Default
-            1 -> Explicit
-            2 -> Safe
-            3 -> AgeRestricted
-            else -> Unknown(value)
-        }
+        override fun deserialize(decoder: Decoder): NsfwLevel = from(decoder.decodeInt())
     }
 
     public companion object {
@@ -79,5 +82,16 @@ public sealed class NsfwLevel(
             )
         }
 
+
+        /**
+         * Returns an instance of [NsfwLevel] with [NsfwLevel.value] equal to the specified [value].
+         */
+        public fun from(`value`: Int): NsfwLevel = when (value) {
+            0 -> Default
+            1 -> Explicit
+            2 -> Safe
+            3 -> AgeRestricted
+            else -> Unknown(value, null)
+        }
     }
 }

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/OnboardingPromptType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/OnboardingPromptType.kt
@@ -30,16 +30,26 @@ public sealed class OnboardingPromptType(
     final override fun hashCode(): Int = value.hashCode()
 
     final override fun toString(): String =
-            "OnboardingPromptType.${this::class.simpleName}(value=$value)"
+            if (this is Unknown) "OnboardingPromptType.Unknown(value=$value)"
+            else "OnboardingPromptType.${this::class.simpleName}"
 
     /**
      * An unknown [OnboardingPromptType].
      *
      * This is used as a fallback for [OnboardingPromptType]s that haven't been added to Kord yet.
      */
-    public class Unknown(
+    public class Unknown internal constructor(
         `value`: Int,
-    ) : OnboardingPromptType(value)
+        @Suppress(names = arrayOf("UNUSED_PARAMETER"))
+        unused: Nothing?,
+    ) : OnboardingPromptType(value) {
+        @Deprecated(
+            message = "Replaced by 'OnboardingPromptType.from()'.",
+            replaceWith = ReplaceWith(expression = "OnboardingPromptType.from(value)", imports =
+                        arrayOf("dev.kord.common.entity.OnboardingPromptType")),
+        )
+        public constructor(`value`: Int) : this(value, null)
+    }
 
     public object MultipleChoice : OnboardingPromptType(0)
 
@@ -54,12 +64,7 @@ public sealed class OnboardingPromptType(
             encoder.encodeInt(value.value)
         }
 
-        override fun deserialize(decoder: Decoder): OnboardingPromptType =
-                when (val value = decoder.decodeInt()) {
-            0 -> MultipleChoice
-            1 -> Dropdown
-            else -> Unknown(value)
-        }
+        override fun deserialize(decoder: Decoder): OnboardingPromptType = from(decoder.decodeInt())
     }
 
     public companion object {
@@ -73,5 +78,15 @@ public sealed class OnboardingPromptType(
             )
         }
 
+
+        /**
+         * Returns an instance of [OnboardingPromptType] with [OnboardingPromptType.value] equal to
+         * the specified [value].
+         */
+        public fun from(`value`: Int): OnboardingPromptType = when (value) {
+            0 -> MultipleChoice
+            1 -> Dropdown
+            else -> Unknown(value, null)
+        }
     }
 }

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/OverwriteType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/OverwriteType.kt
@@ -29,16 +29,27 @@ public sealed class OverwriteType(
 
     final override fun hashCode(): Int = value.hashCode()
 
-    final override fun toString(): String = "OverwriteType.${this::class.simpleName}(value=$value)"
+    final override fun toString(): String =
+            if (this is Unknown) "OverwriteType.Unknown(value=$value)"
+            else "OverwriteType.${this::class.simpleName}"
 
     /**
      * An unknown [OverwriteType].
      *
      * This is used as a fallback for [OverwriteType]s that haven't been added to Kord yet.
      */
-    public class Unknown(
+    public class Unknown internal constructor(
         `value`: Int,
-    ) : OverwriteType(value)
+        @Suppress(names = arrayOf("UNUSED_PARAMETER"))
+        unused: Nothing?,
+    ) : OverwriteType(value) {
+        @Deprecated(
+            message = "Replaced by 'OverwriteType.from()'.",
+            replaceWith = ReplaceWith(expression = "OverwriteType.from(value)", imports =
+                        arrayOf("dev.kord.common.entity.OverwriteType")),
+        )
+        public constructor(`value`: Int) : this(value, null)
+    }
 
     public object Role : OverwriteType(0)
 
@@ -52,12 +63,7 @@ public sealed class OverwriteType(
             encoder.encodeInt(value.value)
         }
 
-        override fun deserialize(decoder: Decoder): OverwriteType =
-                when (val value = decoder.decodeInt()) {
-            0 -> Role
-            1 -> Member
-            else -> Unknown(value)
-        }
+        override fun deserialize(decoder: Decoder): OverwriteType = from(decoder.decodeInt())
     }
 
     public companion object {
@@ -71,5 +77,15 @@ public sealed class OverwriteType(
             )
         }
 
+
+        /**
+         * Returns an instance of [OverwriteType] with [OverwriteType.value] equal to the specified
+         * [value].
+         */
+        public fun from(`value`: Int): OverwriteType = when (value) {
+            0 -> Role
+            1 -> Member
+            else -> Unknown(value, null)
+        }
     }
 }

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/PremiumTier.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/PremiumTier.kt
@@ -29,16 +29,26 @@ public sealed class PremiumTier(
 
     final override fun hashCode(): Int = value.hashCode()
 
-    final override fun toString(): String = "PremiumTier.${this::class.simpleName}(value=$value)"
+    final override fun toString(): String = if (this is Unknown) "PremiumTier.Unknown(value=$value)"
+            else "PremiumTier.${this::class.simpleName}"
 
     /**
      * An unknown [PremiumTier].
      *
      * This is used as a fallback for [PremiumTier]s that haven't been added to Kord yet.
      */
-    public class Unknown(
+    public class Unknown internal constructor(
         `value`: Int,
-    ) : PremiumTier(value)
+        @Suppress(names = arrayOf("UNUSED_PARAMETER"))
+        unused: Nothing?,
+    ) : PremiumTier(value) {
+        @Deprecated(
+            message = "Replaced by 'PremiumTier.from()'.",
+            replaceWith = ReplaceWith(expression = "PremiumTier.from(value)", imports =
+                        arrayOf("dev.kord.common.entity.PremiumTier")),
+        )
+        public constructor(`value`: Int) : this(value, null)
+    }
 
     /**
      * Guild has not unlocked any Server Boost perks.
@@ -68,14 +78,7 @@ public sealed class PremiumTier(
             encoder.encodeInt(value.value)
         }
 
-        override fun deserialize(decoder: Decoder): PremiumTier =
-                when (val value = decoder.decodeInt()) {
-            0 -> None
-            1 -> One
-            2 -> Two
-            3 -> Three
-            else -> Unknown(value)
-        }
+        override fun deserialize(decoder: Decoder): PremiumTier = from(decoder.decodeInt())
     }
 
     public companion object {
@@ -91,5 +94,17 @@ public sealed class PremiumTier(
             )
         }
 
+
+        /**
+         * Returns an instance of [PremiumTier] with [PremiumTier.value] equal to the specified
+         * [value].
+         */
+        public fun from(`value`: Int): PremiumTier = when (value) {
+            0 -> None
+            1 -> One
+            2 -> Two
+            3 -> Three
+            else -> Unknown(value, null)
+        }
     }
 }

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/PresenceStatus.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/PresenceStatus.kt
@@ -29,16 +29,27 @@ public sealed class PresenceStatus(
 
     final override fun hashCode(): Int = value.hashCode()
 
-    final override fun toString(): String = "PresenceStatus.${this::class.simpleName}(value=$value)"
+    final override fun toString(): String =
+            if (this is Unknown) "PresenceStatus.Unknown(value=$value)"
+            else "PresenceStatus.${this::class.simpleName}"
 
     /**
      * An unknown [PresenceStatus].
      *
      * This is used as a fallback for [PresenceStatus]s that haven't been added to Kord yet.
      */
-    public class Unknown(
+    public class Unknown internal constructor(
         `value`: String,
-    ) : PresenceStatus(value)
+        @Suppress(names = arrayOf("UNUSED_PARAMETER"))
+        unused: Nothing?,
+    ) : PresenceStatus(value) {
+        @Deprecated(
+            message = "Replaced by 'PresenceStatus.from()'.",
+            replaceWith = ReplaceWith(expression = "PresenceStatus.from(value)", imports =
+                        arrayOf("dev.kord.common.entity.PresenceStatus")),
+        )
+        public constructor(`value`: String) : this(value, null)
+    }
 
     /**
      * Online.
@@ -74,15 +85,7 @@ public sealed class PresenceStatus(
             encoder.encodeString(value.value)
         }
 
-        override fun deserialize(decoder: Decoder): PresenceStatus =
-                when (val value = decoder.decodeString()) {
-            "online" -> Online
-            "dnd" -> DoNotDisturb
-            "idle" -> Idle
-            "invisible" -> Invisible
-            "offline" -> Offline
-            else -> Unknown(value)
-        }
+        override fun deserialize(decoder: Decoder): PresenceStatus = from(decoder.decodeString())
     }
 
     public companion object {
@@ -99,5 +102,18 @@ public sealed class PresenceStatus(
             )
         }
 
+
+        /**
+         * Returns an instance of [PresenceStatus] with [PresenceStatus.value] equal to the
+         * specified [value].
+         */
+        public fun from(`value`: String): PresenceStatus = when (value) {
+            "online" -> Online
+            "dnd" -> DoNotDisturb
+            "idle" -> Idle
+            "invisible" -> Invisible
+            "offline" -> Offline
+            else -> Unknown(value, null)
+        }
     }
 }

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/ScheduledEntityType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/ScheduledEntityType.kt
@@ -30,16 +30,26 @@ public sealed class ScheduledEntityType(
     final override fun hashCode(): Int = value.hashCode()
 
     final override fun toString(): String =
-            "ScheduledEntityType.${this::class.simpleName}(value=$value)"
+            if (this is Unknown) "ScheduledEntityType.Unknown(value=$value)"
+            else "ScheduledEntityType.${this::class.simpleName}"
 
     /**
      * An unknown [ScheduledEntityType].
      *
      * This is used as a fallback for [ScheduledEntityType]s that haven't been added to Kord yet.
      */
-    public class Unknown(
+    public class Unknown internal constructor(
         `value`: Int,
-    ) : ScheduledEntityType(value)
+        @Suppress(names = arrayOf("UNUSED_PARAMETER"))
+        unused: Nothing?,
+    ) : ScheduledEntityType(value) {
+        @Deprecated(
+            message = "Replaced by 'ScheduledEntityType.from()'.",
+            replaceWith = ReplaceWith(expression = "ScheduledEntityType.from(value)", imports =
+                        arrayOf("dev.kord.common.entity.ScheduledEntityType")),
+        )
+        public constructor(`value`: Int) : this(value, null)
+    }
 
     public object StageInstance : ScheduledEntityType(1)
 
@@ -56,13 +66,7 @@ public sealed class ScheduledEntityType(
             encoder.encodeInt(value.value)
         }
 
-        override fun deserialize(decoder: Decoder): ScheduledEntityType =
-                when (val value = decoder.decodeInt()) {
-            1 -> StageInstance
-            2 -> Voice
-            3 -> External
-            else -> Unknown(value)
-        }
+        override fun deserialize(decoder: Decoder): ScheduledEntityType = from(decoder.decodeInt())
     }
 
     public companion object {
@@ -77,5 +81,16 @@ public sealed class ScheduledEntityType(
             )
         }
 
+
+        /**
+         * Returns an instance of [ScheduledEntityType] with [ScheduledEntityType.value] equal to
+         * the specified [value].
+         */
+        public fun from(`value`: Int): ScheduledEntityType = when (value) {
+            1 -> StageInstance
+            2 -> Voice
+            3 -> External
+            else -> Unknown(value, null)
+        }
     }
 }

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/SortOrderType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/SortOrderType.kt
@@ -29,16 +29,27 @@ public sealed class SortOrderType(
 
     final override fun hashCode(): Int = value.hashCode()
 
-    final override fun toString(): String = "SortOrderType.${this::class.simpleName}(value=$value)"
+    final override fun toString(): String =
+            if (this is Unknown) "SortOrderType.Unknown(value=$value)"
+            else "SortOrderType.${this::class.simpleName}"
 
     /**
      * An unknown [SortOrderType].
      *
      * This is used as a fallback for [SortOrderType]s that haven't been added to Kord yet.
      */
-    public class Unknown(
+    public class Unknown internal constructor(
         `value`: Int,
-    ) : SortOrderType(value)
+        @Suppress(names = arrayOf("UNUSED_PARAMETER"))
+        unused: Nothing?,
+    ) : SortOrderType(value) {
+        @Deprecated(
+            message = "Replaced by 'SortOrderType.from()'.",
+            replaceWith = ReplaceWith(expression = "SortOrderType.from(value)", imports =
+                        arrayOf("dev.kord.common.entity.SortOrderType")),
+        )
+        public constructor(`value`: Int) : this(value, null)
+    }
 
     /**
      * Sort forum posts by activity.
@@ -58,12 +69,7 @@ public sealed class SortOrderType(
             encoder.encodeInt(value.value)
         }
 
-        override fun deserialize(decoder: Decoder): SortOrderType =
-                when (val value = decoder.decodeInt()) {
-            0 -> LatestActivity
-            1 -> CreationDate
-            else -> Unknown(value)
-        }
+        override fun deserialize(decoder: Decoder): SortOrderType = from(decoder.decodeInt())
     }
 
     public companion object {
@@ -77,5 +83,15 @@ public sealed class SortOrderType(
             )
         }
 
+
+        /**
+         * Returns an instance of [SortOrderType] with [SortOrderType.value] equal to the specified
+         * [value].
+         */
+        public fun from(`value`: Int): SortOrderType = when (value) {
+            0 -> LatestActivity
+            1 -> CreationDate
+            else -> Unknown(value, null)
+        }
     }
 }

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/StageInstancePrivacyLevel.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/StageInstancePrivacyLevel.kt
@@ -30,7 +30,8 @@ public sealed class StageInstancePrivacyLevel(
     final override fun hashCode(): Int = value.hashCode()
 
     final override fun toString(): String =
-            "StageInstancePrivacyLevel.${this::class.simpleName}(value=$value)"
+            if (this is Unknown) "StageInstancePrivacyLevel.Unknown(value=$value)"
+            else "StageInstancePrivacyLevel.${this::class.simpleName}"
 
     /**
      * An unknown [StageInstancePrivacyLevel].
@@ -38,9 +39,18 @@ public sealed class StageInstancePrivacyLevel(
      * This is used as a fallback for [StageInstancePrivacyLevel]s that haven't been added to Kord
      * yet.
      */
-    public class Unknown(
+    public class Unknown internal constructor(
         `value`: Int,
-    ) : StageInstancePrivacyLevel(value)
+        @Suppress(names = arrayOf("UNUSED_PARAMETER"))
+        unused: Nothing?,
+    ) : StageInstancePrivacyLevel(value) {
+        @Deprecated(
+            message = "Replaced by 'StageInstancePrivacyLevel.from()'.",
+            replaceWith = ReplaceWith(expression = "StageInstancePrivacyLevel.from(value)", imports
+                        = arrayOf("dev.kord.common.entity.StageInstancePrivacyLevel")),
+        )
+        public constructor(`value`: Int) : this(value, null)
+    }
 
     /**
      * The Stage instance is visible publicly.
@@ -63,11 +73,7 @@ public sealed class StageInstancePrivacyLevel(
         }
 
         override fun deserialize(decoder: Decoder): StageInstancePrivacyLevel =
-                when (val value = decoder.decodeInt()) {
-            1 -> @Suppress("DEPRECATION") Public
-            2 -> GuildOnly
-            else -> Unknown(value)
-        }
+                from(decoder.decodeInt())
     }
 
     public companion object {
@@ -81,5 +87,15 @@ public sealed class StageInstancePrivacyLevel(
             )
         }
 
+
+        /**
+         * Returns an instance of [StageInstancePrivacyLevel] with [StageInstancePrivacyLevel.value]
+         * equal to the specified [value].
+         */
+        public fun from(`value`: Int): StageInstancePrivacyLevel = when (value) {
+            1 -> @Suppress("DEPRECATION") Public
+            2 -> GuildOnly
+            else -> Unknown(value, null)
+        }
     }
 }

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/TeamMembershipState.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/TeamMembershipState.kt
@@ -30,16 +30,26 @@ public sealed class TeamMembershipState(
     final override fun hashCode(): Int = value.hashCode()
 
     final override fun toString(): String =
-            "TeamMembershipState.${this::class.simpleName}(value=$value)"
+            if (this is Unknown) "TeamMembershipState.Unknown(value=$value)"
+            else "TeamMembershipState.${this::class.simpleName}"
 
     /**
      * An unknown [TeamMembershipState].
      *
      * This is used as a fallback for [TeamMembershipState]s that haven't been added to Kord yet.
      */
-    public class Unknown(
+    public class Unknown internal constructor(
         `value`: Int,
-    ) : TeamMembershipState(value)
+        @Suppress(names = arrayOf("UNUSED_PARAMETER"))
+        unused: Nothing?,
+    ) : TeamMembershipState(value) {
+        @Deprecated(
+            message = "Replaced by 'TeamMembershipState.from()'.",
+            replaceWith = ReplaceWith(expression = "TeamMembershipState.from(value)", imports =
+                        arrayOf("dev.kord.common.entity.TeamMembershipState")),
+        )
+        public constructor(`value`: Int) : this(value, null)
+    }
 
     public object Invited : TeamMembershipState(1)
 
@@ -54,12 +64,7 @@ public sealed class TeamMembershipState(
             encoder.encodeInt(value.value)
         }
 
-        override fun deserialize(decoder: Decoder): TeamMembershipState =
-                when (val value = decoder.decodeInt()) {
-            1 -> Invited
-            2 -> Accepted
-            else -> Unknown(value)
-        }
+        override fun deserialize(decoder: Decoder): TeamMembershipState = from(decoder.decodeInt())
     }
 
     public companion object {
@@ -73,5 +78,15 @@ public sealed class TeamMembershipState(
             )
         }
 
+
+        /**
+         * Returns an instance of [TeamMembershipState] with [TeamMembershipState.value] equal to
+         * the specified [value].
+         */
+        public fun from(`value`: Int): TeamMembershipState = when (value) {
+            1 -> Invited
+            2 -> Accepted
+            else -> Unknown(value, null)
+        }
     }
 }

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/TextInputStyle.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/TextInputStyle.kt
@@ -31,16 +31,27 @@ public sealed class TextInputStyle(
 
     final override fun hashCode(): Int = value.hashCode()
 
-    final override fun toString(): String = "TextInputStyle.${this::class.simpleName}(value=$value)"
+    final override fun toString(): String =
+            if (this is Unknown) "TextInputStyle.Unknown(value=$value)"
+            else "TextInputStyle.${this::class.simpleName}"
 
     /**
      * An unknown [TextInputStyle].
      *
      * This is used as a fallback for [TextInputStyle]s that haven't been added to Kord yet.
      */
-    public class Unknown(
+    public class Unknown internal constructor(
         `value`: Int,
-    ) : TextInputStyle(value)
+        @Suppress(names = arrayOf("UNUSED_PARAMETER"))
+        unused: Nothing?,
+    ) : TextInputStyle(value) {
+        @Deprecated(
+            message = "Replaced by 'TextInputStyle.from()'.",
+            replaceWith = ReplaceWith(expression = "TextInputStyle.from(value)", imports =
+                        arrayOf("dev.kord.common.entity.TextInputStyle")),
+        )
+        public constructor(`value`: Int) : this(value, null)
+    }
 
     /**
      * A single-line input.
@@ -61,12 +72,7 @@ public sealed class TextInputStyle(
             encoder.encodeInt(value.value)
         }
 
-        override fun deserialize(decoder: Decoder): TextInputStyle =
-                when (val value = decoder.decodeInt()) {
-            1 -> Short
-            2 -> Paragraph
-            else -> Unknown(value)
-        }
+        override fun deserialize(decoder: Decoder): TextInputStyle = from(decoder.decodeInt())
     }
 
     public companion object {
@@ -80,5 +86,15 @@ public sealed class TextInputStyle(
             )
         }
 
+
+        /**
+         * Returns an instance of [TextInputStyle] with [TextInputStyle.value] equal to the
+         * specified [value].
+         */
+        public fun from(`value`: Int): TextInputStyle = when (value) {
+            1 -> Short
+            2 -> Paragraph
+            else -> Unknown(value, null)
+        }
     }
 }

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/UserPremium.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/UserPremium.kt
@@ -31,16 +31,26 @@ public sealed class UserPremium(
 
     final override fun hashCode(): Int = value.hashCode()
 
-    final override fun toString(): String = "UserPremium.${this::class.simpleName}(value=$value)"
+    final override fun toString(): String = if (this is Unknown) "UserPremium.Unknown(value=$value)"
+            else "UserPremium.${this::class.simpleName}"
 
     /**
      * An unknown [UserPremium].
      *
      * This is used as a fallback for [UserPremium]s that haven't been added to Kord yet.
      */
-    public class Unknown(
+    public class Unknown internal constructor(
         `value`: Int,
-    ) : UserPremium(value)
+        @Suppress(names = arrayOf("UNUSED_PARAMETER"))
+        unused: Nothing?,
+    ) : UserPremium(value) {
+        @Deprecated(
+            message = "Replaced by 'UserPremium.from()'.",
+            replaceWith = ReplaceWith(expression = "UserPremium.from(value)", imports =
+                        arrayOf("dev.kord.common.entity.UserPremium")),
+        )
+        public constructor(`value`: Int) : this(value, null)
+    }
 
     public object None : UserPremium(0)
 
@@ -58,14 +68,7 @@ public sealed class UserPremium(
             encoder.encodeInt(value.value)
         }
 
-        override fun deserialize(decoder: Decoder): UserPremium =
-                when (val value = decoder.decodeInt()) {
-            0 -> None
-            1 -> NitroClassic
-            2 -> Nitro
-            3 -> NitroBasic
-            else -> Unknown(value)
-        }
+        override fun deserialize(decoder: Decoder): UserPremium = from(decoder.decodeInt())
     }
 
     public companion object {
@@ -81,5 +84,17 @@ public sealed class UserPremium(
             )
         }
 
+
+        /**
+         * Returns an instance of [UserPremium] with [UserPremium.value] equal to the specified
+         * [value].
+         */
+        public fun from(`value`: Int): UserPremium = when (value) {
+            0 -> None
+            1 -> NitroClassic
+            2 -> Nitro
+            3 -> NitroBasic
+            else -> Unknown(value, null)
+        }
     }
 }

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/VerificationLevel.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/VerificationLevel.kt
@@ -30,16 +30,26 @@ public sealed class VerificationLevel(
     final override fun hashCode(): Int = value.hashCode()
 
     final override fun toString(): String =
-            "VerificationLevel.${this::class.simpleName}(value=$value)"
+            if (this is Unknown) "VerificationLevel.Unknown(value=$value)"
+            else "VerificationLevel.${this::class.simpleName}"
 
     /**
      * An unknown [VerificationLevel].
      *
      * This is used as a fallback for [VerificationLevel]s that haven't been added to Kord yet.
      */
-    public class Unknown(
+    public class Unknown internal constructor(
         `value`: Int,
-    ) : VerificationLevel(value)
+        @Suppress(names = arrayOf("UNUSED_PARAMETER"))
+        unused: Nothing?,
+    ) : VerificationLevel(value) {
+        @Deprecated(
+            message = "Replaced by 'VerificationLevel.from()'.",
+            replaceWith = ReplaceWith(expression = "VerificationLevel.from(value)", imports =
+                        arrayOf("dev.kord.common.entity.VerificationLevel")),
+        )
+        public constructor(`value`: Int) : this(value, null)
+    }
 
     /**
      * Unrestricted.
@@ -75,15 +85,7 @@ public sealed class VerificationLevel(
             encoder.encodeInt(value.value)
         }
 
-        override fun deserialize(decoder: Decoder): VerificationLevel =
-                when (val value = decoder.decodeInt()) {
-            0 -> None
-            1 -> Low
-            2 -> Medium
-            3 -> High
-            4 -> VeryHigh
-            else -> Unknown(value)
-        }
+        override fun deserialize(decoder: Decoder): VerificationLevel = from(decoder.decodeInt())
     }
 
     public companion object {
@@ -100,5 +102,18 @@ public sealed class VerificationLevel(
             )
         }
 
+
+        /**
+         * Returns an instance of [VerificationLevel] with [VerificationLevel.value] equal to the
+         * specified [value].
+         */
+        public fun from(`value`: Int): VerificationLevel = when (value) {
+            0 -> None
+            1 -> Low
+            2 -> Medium
+            3 -> High
+            4 -> VeryHigh
+            else -> Unknown(value, null)
+        }
     }
 }

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/VideoQualityMode.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/VideoQualityMode.kt
@@ -30,16 +30,26 @@ public sealed class VideoQualityMode(
     final override fun hashCode(): Int = value.hashCode()
 
     final override fun toString(): String =
-            "VideoQualityMode.${this::class.simpleName}(value=$value)"
+            if (this is Unknown) "VideoQualityMode.Unknown(value=$value)"
+            else "VideoQualityMode.${this::class.simpleName}"
 
     /**
      * An unknown [VideoQualityMode].
      *
      * This is used as a fallback for [VideoQualityMode]s that haven't been added to Kord yet.
      */
-    public class Unknown(
+    public class Unknown internal constructor(
         `value`: Int,
-    ) : VideoQualityMode(value)
+        @Suppress(names = arrayOf("UNUSED_PARAMETER"))
+        unused: Nothing?,
+    ) : VideoQualityMode(value) {
+        @Deprecated(
+            message = "Replaced by 'VideoQualityMode.from()'.",
+            replaceWith = ReplaceWith(expression = "VideoQualityMode.from(value)", imports =
+                        arrayOf("dev.kord.common.entity.VideoQualityMode")),
+        )
+        public constructor(`value`: Int) : this(value, null)
+    }
 
     /**
      * Discord chooses the quality for optimal performance.
@@ -60,12 +70,7 @@ public sealed class VideoQualityMode(
             encoder.encodeInt(value.value)
         }
 
-        override fun deserialize(decoder: Decoder): VideoQualityMode =
-                when (val value = decoder.decodeInt()) {
-            1 -> Auto
-            2 -> Full
-            else -> Unknown(value)
-        }
+        override fun deserialize(decoder: Decoder): VideoQualityMode = from(decoder.decodeInt())
     }
 
     public companion object {
@@ -79,5 +84,15 @@ public sealed class VideoQualityMode(
             )
         }
 
+
+        /**
+         * Returns an instance of [VideoQualityMode] with [VideoQualityMode.value] equal to the
+         * specified [value].
+         */
+        public fun from(`value`: Int): VideoQualityMode = when (value) {
+            1 -> Auto
+            2 -> Full
+            else -> Unknown(value, null)
+        }
     }
 }

--- a/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/WebhookType.kt
+++ b/common/build/generated/ksp/metadata/commonMain/kotlin/dev/kord/common/entity/WebhookType.kt
@@ -29,16 +29,26 @@ public sealed class WebhookType(
 
     final override fun hashCode(): Int = value.hashCode()
 
-    final override fun toString(): String = "WebhookType.${this::class.simpleName}(value=$value)"
+    final override fun toString(): String = if (this is Unknown) "WebhookType.Unknown(value=$value)"
+            else "WebhookType.${this::class.simpleName}"
 
     /**
      * An unknown [WebhookType].
      *
      * This is used as a fallback for [WebhookType]s that haven't been added to Kord yet.
      */
-    public class Unknown(
+    public class Unknown internal constructor(
         `value`: Int,
-    ) : WebhookType(value)
+        @Suppress(names = arrayOf("UNUSED_PARAMETER"))
+        unused: Nothing?,
+    ) : WebhookType(value) {
+        @Deprecated(
+            message = "Replaced by 'WebhookType.from()'.",
+            replaceWith = ReplaceWith(expression = "WebhookType.from(value)", imports =
+                        arrayOf("dev.kord.common.entity.WebhookType")),
+        )
+        public constructor(`value`: Int) : this(value, null)
+    }
 
     /**
      * Incoming Webhooks can post messages to channels with a generated token.
@@ -64,13 +74,7 @@ public sealed class WebhookType(
             encoder.encodeInt(value.value)
         }
 
-        override fun deserialize(decoder: Decoder): WebhookType =
-                when (val value = decoder.decodeInt()) {
-            1 -> Incoming
-            2 -> ChannelFollower
-            3 -> Application
-            else -> Unknown(value)
-        }
+        override fun deserialize(decoder: Decoder): WebhookType = from(decoder.decodeInt())
     }
 
     public companion object {
@@ -85,5 +89,16 @@ public sealed class WebhookType(
             )
         }
 
+
+        /**
+         * Returns an instance of [WebhookType] with [WebhookType.value] equal to the specified
+         * [value].
+         */
+        public fun from(`value`: Int): WebhookType = when (value) {
+            1 -> Incoming
+            2 -> ChannelFollower
+            3 -> Application
+            else -> Unknown(value, null)
+        }
     }
 }

--- a/ksp-processors/src/main/kotlin/KotlinPoetDsl.kt
+++ b/ksp-processors/src/main/kotlin/KotlinPoetDsl.kt
@@ -87,6 +87,9 @@ internal inline fun TypeSpec.Builder.primaryConstructor(builder: FunSpecBuilder)
 internal inline fun TypeSpec.Builder.addInitializerBlock(builder: CodeBlockBuilder) =
     addInitializerBlock(CodeBlock.builder().apply(builder).build())
 
+internal inline fun TypeSpec.Builder.addConstructor(builder: FunSpecBuilder) =
+    addFunction(FunSpec.constructorBuilder().apply(builder).build())
+
 
 // extensions for `FunSpec.Builder`
 

--- a/ksp-processors/src/main/kotlin/generation/bitflags/BitFlagsGeneration.kt
+++ b/ksp-processors/src/main/kotlin/generation/bitflags/BitFlagsGeneration.kt
@@ -52,14 +52,7 @@ internal fun BitFlags.generateFileSpec(originatingFile: KSFile) = fileSpecForGen
         addPlus(parameterName = "flag", parameterType = entityCN)
         addPlus(parameterName = "flags", parameterType = collectionCN)
         addEqualsAndHashCodeBasedOnClassAndSingleProperty(entityCN, property = "shift", isFinal = true)
-        addFunction("toString") {
-            addModifiers(FINAL, OVERRIDE)
-            returns<String>()
-            addStatement(
-                "return if·(this·is·Unknown) \"$entityName.Unknown(shift=\$shift)\" else " +
-                    "\"$entityName.\${this::class.simpleName}\""
-            )
-        }
+        addEntityToString(property = "shift")
         if (wasEnum) {
             addDeprecatedEntityEnumArtifacts()
         }

--- a/ksp-processors/src/main/kotlin/generation/kordenum/KordEnumGeneration.kt
+++ b/ksp-processors/src/main/kotlin/generation/kordenum/KordEnumGeneration.kt
@@ -1,7 +1,9 @@
 package dev.kord.ksp.generation.kordenum
 
 import com.google.devtools.ksp.symbol.KSFile
+import com.squareup.kotlinpoet.DelicateKotlinPoetApi
 import com.squareup.kotlinpoet.KModifier.*
+import com.squareup.kotlinpoet.NOTHING
 import com.squareup.kotlinpoet.ksp.addOriginatingKSFile
 import dev.kord.ksp.*
 import dev.kord.ksp.generation.GenerationEntity.KordEnum
@@ -25,22 +27,51 @@ internal fun KordEnum.generateFileSpec(originatingFile: KSFile) = fileSpecForGen
             initializer(valueName)
         }
         addEqualsAndHashCodeBasedOnClassAndSingleProperty(entityCN, property = valueName, isFinal = true)
-        addFunction("toString") {
-            addModifiers(FINAL, OVERRIDE)
-            returns<String>()
-            addStatement("return \"$entityName.\${this::class.simpleName}($valueName=$$valueName)\"")
-        }
+        addEntityToString(property = valueName)
         addClass("Unknown") {
             addSharedUnknownClassContent()
             primaryConstructor {
+                addModifiers(INTERNAL)
                 addParameter(valueName, valueCN)
+                addParameter("unused", type = NOTHING.copy(nullable = true)) {
+                    @OptIn(DelicateKotlinPoetApi::class)
+                    addAnnotation(Suppress("UNUSED_PARAMETER"))
+                }
             }
             addSuperclassConstructorParameter(valueName)
+            // TODO bump deprecation level and remove eventually (also share code with bit flags then)
+            addConstructor {
+                @OptIn(DelicateKotlinPoetApi::class)
+                addAnnotation(
+                    Deprecated(
+                        "Replaced by '$entityName.from()'.",
+                        ReplaceWith("$entityName.from($valueName)", entityCN.canonicalName),
+                        DeprecationLevel.WARNING,
+                    )
+                )
+                addModifiers(PUBLIC)
+                addParameter(valueName, valueCN)
+                callThisConstructor(valueName, "null")
+            }
         }
         addEntityEntries()
         addSerializer()
         addCompanionObject {
             addSharedCompanionObjectContent()
+            addFunction("from") {
+                addKdoc(
+                    "Returns an instance of [%1T] with [%1T.$valueName] equal to the specified [$valueName].",
+                    entityCN,
+                )
+                addParameter(valueName, valueCN)
+                returns(entityCN)
+                withControlFlow("return when·($valueName)") {
+                    for (entry in entriesDistinctByValue) {
+                        addStatement("$valueFormat·->·${entry.nameWithSuppressedDeprecation}", entry.value)
+                    }
+                    addStatement("else·->·Unknown($valueName,·null)")
+                }
+            }
         }
     }
 }

--- a/ksp-processors/src/main/kotlin/generation/kordenum/Serializer.kt
+++ b/ksp-processors/src/main/kotlin/generation/kordenum/Serializer.kt
@@ -11,8 +11,6 @@ import dev.kord.ksp.generation.GenerationEntity.KordEnum.ValueType.INT
 import dev.kord.ksp.generation.GenerationEntity.KordEnum.ValueType.STRING
 import dev.kord.ksp.generation.shared.GenerationContext
 import dev.kord.ksp.generation.shared.addSharedSerializerContent
-import dev.kord.ksp.generation.shared.nameWithSuppressedDeprecation
-import dev.kord.ksp.withControlFlow
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
@@ -35,11 +33,6 @@ internal fun TypeSpec.Builder.addSerializer() = addObject("Serializer") {
         addModifiers(OVERRIDE)
         returns(entityCN)
         addParameter<Decoder>("decoder")
-        withControlFlow("return when·(val·$valueName·=·decoder.decode$encodingPostfix())") {
-            for (entry in entriesDistinctByValue) {
-                addStatement("$valueFormat·->·${entry.nameWithSuppressedDeprecation}", entry.value)
-            }
-            addStatement("else·->·Unknown($valueName)")
-        }
+        addStatement("return from(decoder.decode$encodingPostfix())")
     }
 }

--- a/ksp-processors/src/main/kotlin/generation/shared/EqualsHashCodeToString.kt
+++ b/ksp-processors/src/main/kotlin/generation/shared/EqualsHashCodeToString.kt
@@ -6,6 +6,7 @@ import com.squareup.kotlinpoet.KModifier.OVERRIDE
 import com.squareup.kotlinpoet.TypeSpec
 import dev.kord.ksp.addFunction
 import dev.kord.ksp.addParameter
+import dev.kord.ksp.generation.GenerationEntity
 import dev.kord.ksp.returns
 
 internal fun TypeSpec.Builder.addEqualsAndHashCodeBasedOnClassAndSingleProperty(
@@ -25,4 +26,14 @@ internal fun TypeSpec.Builder.addEqualsAndHashCodeBasedOnClassAndSingleProperty(
         returns<Int>()
         addStatement("return $property.hashCode()")
     }
+}
+
+context(GenerationEntity)
+internal fun TypeSpec.Builder.addEntityToString(property: String) = addFunction("toString") {
+    addModifiers(FINAL, OVERRIDE)
+    returns<String>()
+    addStatement(
+        "return if·(this·is·Unknown)·\"$entityName.Unknown($property=$$property)\" " +
+            "else·\"$entityName.\${this::class.simpleName}\""
+    )
 }

--- a/voice/api/voice.api
+++ b/voice/api/voice.api
@@ -205,6 +205,7 @@ public abstract class dev/kord/voice/EncryptionMode {
 }
 
 public final class dev/kord/voice/EncryptionMode$Companion {
+	public final fun from (Ljava/lang/String;)Ldev/kord/voice/EncryptionMode;
 	public final fun getEntries ()Ljava/util/List;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }

--- a/voice/build/generated/ksp/main/kotlin/dev/kord/voice/EncryptionMode.kt
+++ b/voice/build/generated/ksp/main/kotlin/dev/kord/voice/EncryptionMode.kt
@@ -29,16 +29,27 @@ public sealed class EncryptionMode(
 
     final override fun hashCode(): Int = value.hashCode()
 
-    final override fun toString(): String = "EncryptionMode.${this::class.simpleName}(value=$value)"
+    final override fun toString(): String =
+            if (this is Unknown) "EncryptionMode.Unknown(value=$value)"
+            else "EncryptionMode.${this::class.simpleName}"
 
     /**
      * An unknown [EncryptionMode].
      *
      * This is used as a fallback for [EncryptionMode]s that haven't been added to Kord yet.
      */
-    public class Unknown(
+    public class Unknown internal constructor(
         `value`: String,
-    ) : EncryptionMode(value)
+        @Suppress(names = arrayOf("UNUSED_PARAMETER"))
+        unused: Nothing?,
+    ) : EncryptionMode(value) {
+        @Deprecated(
+            message = "Replaced by 'EncryptionMode.from()'.",
+            replaceWith = ReplaceWith(expression = "EncryptionMode.from(value)", imports =
+                        arrayOf("dev.kord.voice.EncryptionMode")),
+        )
+        public constructor(`value`: String) : this(value, null)
+    }
 
     public object XSalsa20Poly1305 : EncryptionMode("xsalsa20_poly1305")
 
@@ -54,13 +65,7 @@ public sealed class EncryptionMode(
             encoder.encodeString(value.value)
         }
 
-        override fun deserialize(decoder: Decoder): EncryptionMode =
-                when (val value = decoder.decodeString()) {
-            "xsalsa20_poly1305" -> XSalsa20Poly1305
-            "xsalsa20_poly1305_suffix" -> XSalsa20Poly1305Suffix
-            "xsalsa20_poly1305_lite" -> XSalsa20Poly1305Lite
-            else -> Unknown(value)
-        }
+        override fun deserialize(decoder: Decoder): EncryptionMode = from(decoder.decodeString())
     }
 
     public companion object {
@@ -75,5 +80,16 @@ public sealed class EncryptionMode(
             )
         }
 
+
+        /**
+         * Returns an instance of [EncryptionMode] with [EncryptionMode.value] equal to the
+         * specified [value].
+         */
+        public fun from(`value`: String): EncryptionMode = when (value) {
+            "xsalsa20_poly1305" -> XSalsa20Poly1305
+            "xsalsa20_poly1305_suffix" -> XSalsa20Poly1305Suffix
+            "xsalsa20_poly1305_lite" -> XSalsa20Poly1305Lite
+            else -> Unknown(value, null)
+        }
     }
 }


### PR DESCRIPTION
This was done by only printing the raw value for `Unknown` entries in `toString()` and replacing the public `Unknown` constructor with a `from()` function in the companion object.