### PR TITLE
Remove type parameter from `Choice`

### DIFF
--- a/common/api/common.api
+++ b/common/api/common.api
@@ -1849,6 +1849,7 @@ public abstract class dev/kord/common/entity/Choice {
 }
 
 public final class dev/kord/common/entity/Choice$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 	public final fun serializer (Lkotlinx/serialization/KSerializer;)Lkotlinx/serialization/KSerializer;
 }
 
@@ -2915,11 +2916,11 @@ public final class dev/kord/common/entity/DiscordAutoComplete {
 	public final fun getChoices ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final synthetic fun write$Self (Ldev/kord/common/entity/DiscordAutoComplete;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;Lkotlinx/serialization/KSerializer;)V
+	public static final synthetic fun write$Self (Ldev/kord/common/entity/DiscordAutoComplete;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class dev/kord/common/entity/DiscordAutoComplete$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
-	public synthetic fun <init> (Lkotlinx/serialization/KSerializer;)V
+	public static final field INSTANCE Ldev/kord/common/entity/DiscordAutoComplete$$serializer;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/kord/common/entity/DiscordAutoComplete;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
@@ -2930,6 +2931,7 @@ public final class dev/kord/common/entity/DiscordAutoComplete$$serializer : kotl
 }
 
 public final class dev/kord/common/entity/DiscordAutoComplete$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 	public final fun serializer (Lkotlinx/serialization/KSerializer;)Lkotlinx/serialization/KSerializer;
 }
 

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -1784,6 +1784,7 @@ public final class dev/kord/core/behavior/interaction/AutoCompleteInteractionBeh
 }
 
 public final class dev/kord/core/behavior/interaction/AutoCompleteInteractionBehaviorKt {
+	public static final fun suggest (Ldev/kord/core/behavior/interaction/AutoCompleteInteractionBehavior;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun suggestInteger (Ldev/kord/core/behavior/interaction/AutoCompleteInteractionBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun suggestNumber (Ldev/kord/core/behavior/interaction/AutoCompleteInteractionBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun suggestString (Ldev/kord/core/behavior/interaction/AutoCompleteInteractionBehavior;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/core/src/commonMain/kotlin/behavior/interaction/AutoCompleteInteractionBehavior.kt
+++ b/core/src/commonMain/kotlin/behavior/interaction/AutoCompleteInteractionBehavior.kt
@@ -73,7 +73,7 @@ public suspend inline fun AutoCompleteInteractionBehavior.suggestString(builder:
  *
  * The provided choices are only suggestions and the user can provide any other input as well.
  */
-public suspend inline fun <reified T> AutoCompleteInteractionBehavior.suggest(choices: List<Choice<T>>) {
+public suspend fun AutoCompleteInteractionBehavior.suggest(choices: List<Choice>) {
     kord.rest.interaction.createAutoCompleteInteractionResponse(
         id,
         token,

--- a/core/src/commonMain/kotlin/cache/data/ApplicationCommandData.kt
+++ b/core/src/commonMain/kotlin/cache/data/ApplicationCommandData.kt
@@ -155,7 +155,7 @@ public data class ApplicationCommandOptionChoiceData(
     val value: String
 ) {
     public companion object {
-        public fun from(choice: Choice<*>): ApplicationCommandOptionChoiceData {
+        public fun from(choice: Choice): ApplicationCommandOptionChoiceData {
             return with(choice) {
                 ApplicationCommandOptionChoiceData(name, value.toString())
             }

--- a/rest/api/rest.api
+++ b/rest/api/rest.api
@@ -2891,11 +2891,11 @@ public final class dev/kord/rest/json/request/AutoCompleteResponseCreateRequest 
 	public final fun getType ()Ldev/kord/common/entity/InteractionResponseType;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public static final synthetic fun write$Self (Ldev/kord/rest/json/request/AutoCompleteResponseCreateRequest;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;Lkotlinx/serialization/KSerializer;)V
+	public static final synthetic fun write$Self (Ldev/kord/rest/json/request/AutoCompleteResponseCreateRequest;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class dev/kord/rest/json/request/AutoCompleteResponseCreateRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
-	public synthetic fun <init> (Lkotlinx/serialization/KSerializer;)V
+	public static final field INSTANCE Ldev/kord/rest/json/request/AutoCompleteResponseCreateRequest$$serializer;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/kord/rest/json/request/AutoCompleteResponseCreateRequest;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
@@ -2906,6 +2906,7 @@ public final class dev/kord/rest/json/request/AutoCompleteResponseCreateRequest$
 }
 
 public final class dev/kord/rest/json/request/AutoCompleteResponseCreateRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 	public final fun serializer (Lkotlinx/serialization/KSerializer;)Lkotlinx/serialization/KSerializer;
 }
 
@@ -7389,6 +7390,8 @@ public final class dev/kord/rest/service/GuildServiceKt {
 
 public final class dev/kord/rest/service/InteractionService : dev/kord/rest/service/RestService {
 	public fun <init> (Ldev/kord/rest/request/RequestHandler;)V
+	public final fun createAutoCompleteInteractionResponse (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/common/entity/DiscordAutoComplete;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun createBuilderAutoCompleteInteractionResponse (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/rest/builder/interaction/BaseChoiceBuilder;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun createFollowupMessage (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;Ldev/kord/rest/json/request/MultipartFollowupMessageCreateRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun createFollowupMessage (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun createFollowupMessage$default (Ldev/kord/rest/service/InteractionService;Ldev/kord/common/entity/Snowflake;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;

--- a/rest/src/commonMain/kotlin/builder/interaction/OptionsBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/interaction/OptionsBuilder.kt
@@ -59,12 +59,12 @@ public sealed class BaseChoiceBuilder<T>(
     description: String,
     type: ApplicationCommandOptionType
 ) : OptionsBuilder(name, description, type) {
-    // TODO We can change these types to Optional<MutableList<Choice<T>>> and MutableList<Choice<T>> once
-    //  https://youtrack.jetbrains.com/issue/KT-51045 is fixed.
-    //  The bug from that issue prevents you from setting BaseChoiceBuilder<*>.choices to `null`.
+    // TODO We can add another generic C : Choice and change these types to Optional<MutableList<C>> and MutableList<C>?
+    //  once https://youtrack.jetbrains.com/issue/KT-51045 is fixed.
+    //  The bug from that issue prevents you from setting BaseChoiceBuilder<*, *>.choices to `null`.
     @Suppress("PropertyName")
-    internal var _choices: Optional<MutableList<Choice<*>>> = Optional.Missing()
-    public var choices: MutableList<Choice<*>>? by ::_choices.delegate()
+    internal var _choices: Optional<MutableList<Choice>> = Optional.Missing()
+    public var choices: MutableList<Choice>? by ::_choices.delegate()
 
     public abstract fun choice(name: String, value: T, nameLocalizations: Optional<Map<Locale, String>?> = Optional.Missing())
 

--- a/rest/src/commonMain/kotlin/json/request/InteractionsRequests.kt
+++ b/rest/src/commonMain/kotlin/json/request/InteractionsRequests.kt
@@ -5,6 +5,7 @@ import dev.kord.common.entity.*
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
 import dev.kord.rest.NamedFile
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -70,10 +71,21 @@ public data class InteractionResponseCreateRequest(
 )
 
 @Serializable
-public data class AutoCompleteResponseCreateRequest<T>(
+public data class AutoCompleteResponseCreateRequest(
     val type: InteractionResponseType,
-    val data: DiscordAutoComplete<T>
-)
+    val data: DiscordAutoComplete,
+) {
+    public companion object {
+        @Suppress("UNUSED_PARAMETER")
+        @Deprecated(
+            "AutoCompleteResponseCreateRequest is no longer generic",
+            ReplaceWith("this.serializer()"),
+            DeprecationLevel.WARNING,
+        )
+        public fun <T0> serializer(typeSerial0: KSerializer<T0>): KSerializer<AutoCompleteResponseCreateRequest> =
+            serializer()
+    }
+}
 
 @Serializable
 public data class ModalResponseCreateRequest(


### PR DESCRIPTION
Because `Choice` was generic, something like the following could happen:

```kotlin
val choice: Choice<String> = Json.decodeFromString(
    Choice.serializer(String.serializer()),
    string = "{\"name\":\"name\",\"value\":1234}",
)
val value: String = choice.value // ClassCastException
```

Apart from this, the type parameter wasn't really useful since it was only used in one place.

Therefore, the type parameter was removed from `Choice` and its usages.