### PR TITLE
Fix deserialization of `DiscordApplication`

### DIFF
--- a/common/src/commonMain/kotlin/entity/DiscordApplication.kt
+++ b/common/src/commonMain/kotlin/entity/DiscordApplication.kt
@@ -86,7 +86,7 @@ public sealed interface BaseDiscordApplication {
     public val tags: Optional<List<String>>
     public val installParams: Optional<InstallParams>
     public val customInstallUrl: Optional<String>
-    public val roleConnectionsVerificationUrl: Optional<String>
+    public val roleConnectionsVerificationUrl: Optional<String?>
 }
 
 /**
@@ -127,7 +127,7 @@ public data class DiscordApplication(
     @SerialName("custom_install_url")
     override val customInstallUrl: Optional<String> = Optional.Missing(),
     @SerialName("role_connections_verification_url")
-    override val roleConnectionsVerificationUrl: Optional<String> = Optional.Missing(),
+    override val roleConnectionsVerificationUrl: Optional<String?> = Optional.Missing(),
 ) : BaseDiscordApplication
 
 /**
@@ -164,7 +164,7 @@ public data class DiscordPartialApplication(
     @SerialName("custom_install_url")
     override val customInstallUrl: Optional<String> = Optional.Missing(),
     @SerialName("role_connections_verification_url")
-    override val roleConnectionsVerificationUrl: Optional<String> = Optional.Missing(),
+    override val roleConnectionsVerificationUrl: Optional<String?> = Optional.Missing(),
 ) : BaseDiscordApplication
 
 @Deprecated("Binary compatibility. Keep for some releases.", level = DeprecationLevel.HIDDEN)

--- a/core/src/commonMain/kotlin/cache/data/ApplicationData.kt
+++ b/core/src/commonMain/kotlin/cache/data/ApplicationData.kt
@@ -24,7 +24,7 @@ public sealed interface BaseApplicationData {
     public val tags: Optional<List<String>>
     public val installParams: Optional<InstallParams>
     public val customInstallUrl: Optional<String>
-    public val roleConnectionsVerificationUrl: Optional<String>
+    public val roleConnectionsVerificationUrl: Optional<String?>
 }
 
 @Serializable
@@ -49,7 +49,7 @@ public data class ApplicationData(
     override val tags: Optional<List<String>> = Optional.Missing(),
     override val installParams: Optional<InstallParams> = Optional.Missing(),
     override val customInstallUrl: Optional<String> = Optional.Missing(),
-    override val roleConnectionsVerificationUrl: Optional<String> = Optional.Missing(),
+    override val roleConnectionsVerificationUrl: Optional<String?> = Optional.Missing(),
 ) : BaseApplicationData {
     public companion object {
 
@@ -101,7 +101,7 @@ public data class PartialApplicationData(
     override val tags: Optional<List<String>> = Optional.Missing(),
     override val installParams: Optional<InstallParams> = Optional.Missing(),
     override val customInstallUrl: Optional<String> = Optional.Missing(),
-    override val roleConnectionsVerificationUrl: Optional<String> = Optional.Missing(),
+    override val roleConnectionsVerificationUrl: Optional<String?> = Optional.Missing(),
 ) : BaseApplicationData {
     public companion object {
 


### PR DESCRIPTION
Discord started sending `null` values for `role_connections_verification_url`, although it is only documented as optional.

Fixes #870