### PR TITLE
Update dependencies

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+
 plugins {
     `kord-multiplatform-module`
     `kord-publishing`
@@ -36,5 +38,15 @@ kotlin {
 tasks {
     dokkaHtmlMultiModule {
         enabled = false
+    }
+    compileTestKotlinJvm {
+        compilerOptions {
+            // needed to inline MockK functions
+            jvmTarget = JVM_11
+        }
+    }
+    jvmTest {
+        // needed to run the output of compileTestKotlinJvm targeting jvm 11
+        javaLauncher = project.javaToolchains.launcherFor { languageVersion = JavaLanguageVersion.of(11) }
     }
 }

--- a/core/src/commonMain/kotlin/builder/kord/KordBuilder.kt
+++ b/core/src/commonMain/kotlin/builder/kord/KordBuilder.kt
@@ -34,11 +34,9 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.serialization.json.Json
-import mu.KotlinLogging
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
-private val logger = KotlinLogging.logger { }
 private val gatewayInfoJson = Json { ignoreUnknownKeys = true }
 
 public expect class KordBuilder(token: String) : BaseKordBuilder
@@ -219,15 +217,6 @@ public abstract class BaseKordBuilder internal constructor(public val token: Str
         val recommendedShards = gatewayInfo.shards
         val shardsInfo = shardsBuilder(recommendedShards)
         val shards = shardsInfo.indices.toList()
-
-        if (client.engine.config.threadsCount < shards.size + 1) {
-            logger.warn {
-                """
-                kord's http client is currently using ${client.engine.config.threadsCount} threads, 
-                which is less than the advised thread count of ${shards.size + 1} (number of shards + 1)
-                """.trimIndent()
-            }
-        }
 
         val resources = ClientResources(
             token = token,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 
 # api dependencies
 kotlin = "1.9.10" # https://github.com/JetBrains/kotlin
-ktor = "2.3.4" # https://github.com/ktorio/ktor
+ktor = "2.3.5" # https://github.com/ktorio/ktor
 kotlinx-coroutines = "1.7.3" # https://github.com/Kotlin/kotlinx.coroutines
 kotlinx-serialization = "1.6.0" # https://github.com/Kotlin/kotlinx.serialization
 kotlinx-datetime = "0.4.1" # https://github.com/Kotlin/kotlinx-datetime
@@ -12,7 +12,7 @@ kord-cache = "0.4.0" # https://github.com/kordlib/cache
 # implementation dependencies
 kotlin-node = "18.16.12-pre.619" # https://github.com/JetBrains/kotlin-wrappers
 bignum = "0.3.8" # https://github.com/ionspin/kotlin-multiplatform-bignum
-stately = "2.0.2" # https://github.com/touchlab/Stately
+stately = "2.0.5" # https://github.com/touchlab/Stately
 fastZlib = "2.0.1" # https://github.com/timotejroiko/fast-zlib
 
 # code generation
@@ -21,11 +21,11 @@ kotlinpoet = "1.14.2" # https://github.com/square/kotlinpoet
 
 # tests
 junit5 = "5.10.0" # https://github.com/junit-team/junit5
-mockk = "1.13.7" # https://github.com/mockk/mockk
+mockk = "1.13.8" # https://github.com/mockk/mockk
 slf4j = "2.0.9" # https://www.slf4j.org
 
 # plugins
-dokka = "1.9.0" # https://github.com/Kotlin/dokka
+dokka = "1.9.10" # https://github.com/Kotlin/dokka
 kotlinx-atomicfu = "0.22.0" # https://github.com/Kotlin/kotlinx-atomicfu
 binary-compatibility-validator = "0.13.2" # https://github.com/Kotlin/binary-compatibility-validator
 buildconfig = "4.1.2" # https://github.com/gmazzo/gradle-buildconfig-plugin

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=591855b517fc635b9e04de1d05d5e76ada3f89f5fc76f87978d1b245b4f69225
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionSha256Sum=3e1af3ae886920c3ac87f7a91f816c0c7c436f276a6eefdb3da152100fef72ae
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradlew
+++ b/gradlew
@@ -145,7 +145,7 @@ if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
     case $MAX_FD in #(
       max*)
         # In POSIX sh, ulimit -H is undefined. That's why the result is checked to see if it worked.
-        # shellcheck disable=SC3045
+        # shellcheck disable=SC2039,SC3045
         MAX_FD=$( ulimit -H -n ) ||
             warn "Could not query maximum file descriptor limit"
     esac
@@ -153,7 +153,7 @@ if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
       '' | soft) :;; #(
       *)
         # In POSIX sh, ulimit -n is undefined. That's why the result is checked to see if it worked.
-        # shellcheck disable=SC3045
+        # shellcheck disable=SC2039,SC3045
         ulimit -n "$MAX_FD" ||
             warn "Could not set maximum file descriptor limit to $MAX_FD"
     esac
@@ -202,11 +202,11 @@ fi
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
 DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
 
-# Collect all arguments for the java command;
-#   * $DEFAULT_JVM_OPTS, $JAVA_OPTS, and $GRADLE_OPTS can contain fragments of
-#     shell script including quotes and variable substitutions, so put them in
-#     double quotes to make sure that they get re-expanded; and
-#   * put everything else in single quotes, so that it's not re-expanded.
+# Collect all arguments for the java command:
+#   * DEFAULT_JVM_OPTS, JAVA_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,
+#     and any embedded shellness will be escaped.
+#   * For example: A user cannot expect ${Hostname} to be expanded, as it is an environment variable and will be
+#     treated as '${Hostname}' itself on the command line.
 
 set -- \
         "-Dorg.gradle.appname=$APP_BASE_NAME" \


### PR DESCRIPTION
* [Gradle](https://github.com/gradle/gradle) 8.3 -> 8.4
* [Ktor](https://github.com/ktorio/ktor) 2.3.4 -> 2.3.5
* [Stately](https://github.com/touchlab/Stately) 2.0.2 -> 2.0.5
* [MockK](https://github.com/mockk/mockk) 1.13.7 -> 1.13.8
* [Dokka](https://github.com/Kotlin/dokka) 1.9.0 -> 1.9.10

Ktor's `HttpClient` now uses `Dispatchers.IO` by default and `HttpClientEngineConfig.threadsCount` [was deprecated](https://github.com/ktorio/ktor/pull/3748), so the warning in `BaseKordBuilder.buildBase()` is no longer needed.