### PR TITLE
Fix `DiscordAuditLogEntry.userId` nullability

### DIFF
--- a/common/src/commonMain/kotlin/entity/AuditLog.kt
+++ b/common/src/commonMain/kotlin/entity/AuditLog.kt
@@ -108,7 +108,7 @@ public data class DiscordAuditLogEntry(
     val targetId: Snowflake?,
     val changes: Optional<List<AuditLogChange<in @Contextual Any?>>> = Optional.Missing(),
     @SerialName("user_id")
-    val userId: Snowflake,
+    val userId: Snowflake?,
     val id: Snowflake,
     @SerialName("action_type")
     val actionType: AuditLogEvent,

--- a/core/src/commonMain/kotlin/entity/AuditLog.kt
+++ b/core/src/commonMain/kotlin/entity/AuditLog.kt
@@ -53,7 +53,7 @@ public class AuditLogEntry(public val data: DiscordAuditLogEntry, override val k
 
     public val changes: List<AuditLogChange<*>> get() = data.changes.orEmpty()
 
-    public val userId: Snowflake get() = data.userId
+    public val userId: Snowflake? get() = data.userId
 
     public val id: Snowflake get() = data.id
 


### PR DESCRIPTION
It can be `null` as documented [here](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-entry-structure).

See https://discord.com/channels/556525343595298817/1162448602115866716