### PR TITLE
Use debug level for unknown gateway event name 

### DIFF
--- a/gateway/src/commonMain/kotlin/Event.kt
+++ b/gateway/src/commonMain/kotlin/Event.kt
@@ -491,7 +491,7 @@ public sealed class Event {
 
 
                 else -> {
-                    jsonLogger.warn { "unknown gateway event name $name" }
+                    jsonLogger.debug { "unknown gateway event name $name" }
                     // consume json elements that are unknown to us
                     val data = decoder.decodeSerializableElement(descriptor, index, JsonElement.serializer().nullable)
                     UnknownDispatchEvent(name, data, sequence)


### PR DESCRIPTION
Similar to the voice package, use debug logs on unknown event. 

Using `warn` isn't beneficial to the developer and may end up filling logs with something useless.