### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/deployment-ci.yml
+++ b/.github/workflows/deployment-ci.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 11
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
         with:
@@ -52,7 +52,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 11
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
         with:

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 11
       - name: Build docs with Gradle
         uses: gradle/gradle-build-action@v2
         with:

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,3 +10,4 @@ kotlin.code.style=official
 # https://github.com/Kotlin/kotlinx-atomicfu#atomicfu-compiler-plugin
 kotlinx.atomicfu.enableJvmIrTransformation=true
 kotlinx.atomicfu.enableJsIrTransformation=true
+kotlinx.atomicfu.enableNativeIrTransformations=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,9 +2,9 @@
 
 # api dependencies
 kotlin = "1.9.20" # https://github.com/JetBrains/kotlin
-ktor = "2.3.5" # https://github.com/ktorio/ktor
+ktor = "2.3.6" # https://github.com/ktorio/ktor
 kotlinx-coroutines = "1.7.3" # https://github.com/Kotlin/kotlinx.coroutines
-kotlinx-serialization = "1.6.0" # https://github.com/Kotlin/kotlinx.serialization
+kotlinx-serialization = "1.6.1" # https://github.com/Kotlin/kotlinx.serialization
 kotlinx-datetime = "0.4.1" # https://github.com/Kotlin/kotlinx-datetime
 kotlin-logging = "3.0.5" # https://github.com/oshai/kotlin-logging
 kord-cache = "0.4.0" # https://github.com/kordlib/cache
@@ -16,19 +16,19 @@ stately = "2.0.5" # https://github.com/touchlab/Stately
 fastZlib = "2.0.1" # https://github.com/timotejroiko/fast-zlib
 
 # code generation
-ksp = "1.9.20-1.0.13" # https://github.com/google/ksp
-kotlinpoet = "1.14.2" # https://github.com/square/kotlinpoet
+ksp = "1.9.20-1.0.14" # https://github.com/google/ksp
+kotlinpoet = "1.15.1" # https://github.com/square/kotlinpoet
 
 # tests
-junit5 = "5.10.0" # https://github.com/junit-team/junit5
+junit5 = "5.10.1" # https://github.com/junit-team/junit5
 mockk = "1.13.8" # https://github.com/mockk/mockk
 slf4j = "2.0.9" # https://www.slf4j.org
 
 # plugins
 dokka = "1.9.10" # https://github.com/Kotlin/dokka
-kotlinx-atomicfu = "0.22.0" # https://github.com/Kotlin/kotlinx-atomicfu
+kotlinx-atomicfu = "0.23.0" # https://github.com/Kotlin/kotlinx-atomicfu
 binary-compatibility-validator = "0.13.2" # https://github.com/Kotlin/binary-compatibility-validator
-buildconfig = "4.1.2" # https://github.com/gmazzo/gradle-buildconfig-plugin
+buildconfig = "4.2.0" # https://github.com/gmazzo/gradle-buildconfig-plugin
 
 
 [libraries]

--- a/ksp-processors/src/main/kotlin/KotlinPoetDsl.kt
+++ b/ksp-processors/src/main/kotlin/KotlinPoetDsl.kt
@@ -43,30 +43,31 @@ internal inline fun <reified A : Annotation> Annotatable.Builder<*>.addAnnotatio
     addAnnotation(AnnotationSpec.builder(A::class).apply(builder).build())
 
 
-// extensions for `FileSpec.Builder`
+// extensions for `TypeSpecHolder.Builder`
 
-internal inline fun FileSpec.Builder.addClass(className: ClassName, builder: TypeSpecBuilder) =
+internal inline fun <T : TypeSpecHolder.Builder<T>> T.addClass(name: String, builder: TypeSpecBuilder) =
+    addType(TypeSpec.classBuilder(name).apply(builder).build())
+
+internal inline fun <T : TypeSpecHolder.Builder<T>> T.addClass(className: ClassName, builder: TypeSpecBuilder) =
     addType(TypeSpec.classBuilder(className).apply(builder).build())
+
+internal inline fun <T : TypeSpecHolder.Builder<T>> T.addObject(name: String, builder: TypeSpecBuilder) =
+    addType(TypeSpec.objectBuilder(name).apply(builder).build())
+
+
+// extensions for `FileSpec.Builder`
 
 internal inline fun FileSpec.Builder.addFunction(name: String, builder: FunSpecBuilder) =
     addFunction(FunSpec.builder(name).apply(builder).build())
 
 
 // extensions for `TypeSpec.Builder`
-internal inline fun TypeSpec.Builder.addClass(name: String, builder: TypeSpecBuilder) =
-    addType(TypeSpec.classBuilder(name).apply(builder).build())
-
-internal inline fun TypeSpec.Builder.addClass(className: ClassName, builder: TypeSpecBuilder) =
-    addType(TypeSpec.classBuilder(className).apply(builder).build())
 
 internal inline fun TypeSpec.Builder.addCompanionObject(name: String? = null, builder: TypeSpecBuilder) =
     addType(TypeSpec.companionObjectBuilder(name).apply(builder).build())
 
 internal inline fun TypeSpec.Builder.addFunction(name: String, builder: FunSpecBuilder) =
     addFunction(FunSpec.builder(name).apply(builder).build())
-
-internal inline fun TypeSpec.Builder.addObject(name: String, builder: TypeSpecBuilder) =
-    addType(TypeSpec.objectBuilder(name).apply(builder).build())
 
 internal inline fun <reified T> TypeSpec.Builder.addProperty(
     name: String,


### PR DESCRIPTION
* [Ktor](https://github.com/ktorio/ktor) 2.3.5 -> 2.3.6
* [kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization) 1.6.0 -> 1.6.1
* [KSP](https://github.com/google/ksp) 1.9.20-1.0.13 -> 1.9.20-1.0.14
* [KotlinPoet](https://github.com/square/kotlinpoet) 1.14.2 -> 1.15.1
* [JUnit 5](https://github.com/junit-team/junit5) 5.10.0 -> 5.10.1
* [AtomicFU](https://github.com/Kotlin/kotlinx-atomicfu) 0.22.0 -> 0.23.0
* [gradle-buildconfig-plugin](https://github.com/gmazzo/gradle-buildconfig-plugin) 4.1.2 -> 4.2.0

The Gradle builds now have to be run with JDK 11+ because of https://github.com/gmazzo/gradle-buildconfig-plugin/pull/89.