### PR TITLE
Implement Media Sink Wants in Voice

### DIFF
--- a/voice/src/main/kotlin/gateway/Command.kt
+++ b/voice/src/main/kotlin/gateway/Command.kt
@@ -31,6 +31,10 @@ public sealed class Command {
                     composite.encodeSerializableElement(descriptor, 0, OpCode.Serializer, OpCode.Heartbeat)
                     composite.encodeLongElement(descriptor, 1, value.nonce)
                 }
+                is MediaSinkWants -> {
+                    composite.encodeSerializableElement(descriptor, 0, OpCode.Serializer, OpCode.MediaSinkWants)
+                    composite.encodeSerializableElement(descriptor, 1, MediaSinkWants.serializer(), value)
+                }
                 is SendSpeaking -> {
                     composite.encodeSerializableElement(descriptor, 0, OpCode.Serializer, OpCode.Speaking)
                     composite.encodeSerializableElement(descriptor, 1, SendSpeaking.serializer(), value)
@@ -70,6 +74,12 @@ public data class SendSpeaking(
     val speaking: SpeakingFlags,
     val delay: Int,
     val ssrc: UInt
+) : Command()
+
+@KordVoice
+@Serializable
+public data class MediaSinkWants(
+    val any: Int
 ) : Command()
 
 @KordVoice

--- a/voice/src/main/kotlin/gateway/DefaultVoiceGateway.kt
+++ b/voice/src/main/kotlin/gateway/DefaultVoiceGateway.kt
@@ -37,6 +37,7 @@ public data class DefaultVoiceGatewayData(
     val sessionId: String,
     val client: HttpClient,
     val reconnectRetry: Retry,
+    val isDeaf: Boolean,
     val eventFlow: MutableSharedFlow<VoiceEvent>
 )
 
@@ -196,7 +197,7 @@ public class DefaultVoiceGateway(
                     val copy = command.copy(data = command.data.copy(address = "ip"))
                     "Voice Gateway >>> ${Json.encodeToString(Command.SerializationStrategy, copy)}"
                 }
-                is Heartbeat, is Resume, is SendSpeaking -> "Voice Gateway >>> $json"
+                else -> "Voice Gateway >>> $json"
             }
         }
         socket.send(Frame.Text(json))

--- a/voice/src/main/kotlin/gateway/DefaultVoiceGatewayBuilder.kt
+++ b/voice/src/main/kotlin/gateway/DefaultVoiceGatewayBuilder.kt
@@ -21,6 +21,7 @@ public class DefaultVoiceGatewayBuilder(
     public var client: HttpClient? = null
     public var reconnectRetry: Retry? = null
     public var eventFlow: MutableSharedFlow<VoiceEvent> = MutableSharedFlow(extraBufferCapacity = Int.MAX_VALUE)
+    public var isDeaf: Boolean = false
 
     public fun build(): DefaultVoiceGateway {
         val client = client ?: HttpClient(CIO) {
@@ -37,6 +38,7 @@ public class DefaultVoiceGatewayBuilder(
             sessionId,
             client,
             retry,
+            isDeaf,
             eventFlow
         )
 

--- a/voice/src/main/kotlin/gateway/OpCode.kt
+++ b/voice/src/main/kotlin/gateway/OpCode.kt
@@ -19,7 +19,8 @@ public enum class OpCode(public val code: Int) {
     Resume(7),
     Hello(8),
     Resumed(9),
-    ClientDisconnect(13);
+    ClientDisconnect(13),
+    MediaSinkWants(15);
 
     internal object Serializer : KSerializer<OpCode> {
         override val descriptor: SerialDescriptor

--- a/voice/src/main/kotlin/gateway/handler/HandshakeHandler.kt
+++ b/voice/src/main/kotlin/gateway/handler/HandshakeHandler.kt
@@ -23,6 +23,7 @@ internal class HandshakeHandler(
         on<Hello> {
             data.reconnectRetry.reset()
             send(identify)
+            send(MediaSinkWants(if (data.isDeaf) 0 else 100))
         }
     }
 }


### PR DESCRIPTION
Adds a new voice gateway command (op code `15`) that controls whether the voice server sends voice packets to the bot. 

Still a bit unsure on the API since Kord voice allows setting the deafen value when joining and the streams implementation to use.