### PR TITLE
Add `WebhookMessageCreateBuilder.appliedTags`

### DIFF
--- a/rest/api/rest.api
+++ b/rest/api/rest.api
@@ -929,6 +929,10 @@ public final class dev/kord/rest/builder/channel/thread/StartForumThreadBuilder 
 	public synthetic fun toRequest ()Ljava/lang/Object;
 }
 
+public final class dev/kord/rest/builder/channel/thread/StartForumThreadBuilderKt {
+	public static final fun applyTag (Ldev/kord/rest/builder/channel/thread/StartForumThreadBuilder;Ldev/kord/common/entity/Snowflake;)V
+}
+
 public final class dev/kord/rest/builder/channel/thread/StartThreadBuilder : dev/kord/rest/builder/AuditRequestBuilder {
 	public fun <init> (Ljava/lang/String;Ldev/kord/common/entity/ChannelType;)V
 	public final fun getAutoArchiveDuration ()Ldev/kord/common/entity/ArchiveDuration;
@@ -982,6 +986,10 @@ public final class dev/kord/rest/builder/channel/thread/ThreadModifyBuilder : de
 	public fun setReason (Ljava/lang/String;)V
 	public fun toRequest ()Ldev/kord/rest/json/request/ChannelModifyPatchRequest;
 	public synthetic fun toRequest ()Ljava/lang/Object;
+}
+
+public final class dev/kord/rest/builder/channel/thread/ThreadModifyBuilderKt {
+	public static final fun applyTag (Ldev/kord/rest/builder/channel/thread/ThreadModifyBuilder;Ldev/kord/common/entity/Snowflake;)V
 }
 
 public final class dev/kord/rest/builder/component/ActionRowBuilder : dev/kord/rest/builder/component/MessageComponentBuilder {
@@ -2255,14 +2263,20 @@ public final class dev/kord/rest/builder/message/create/UserMessageCreateBuilder
 
 public final class dev/kord/rest/builder/message/create/WebhookMessageCreateBuilder : dev/kord/rest/builder/message/create/AbstractMessageCreateBuilder, dev/kord/rest/builder/RequestBuilder {
 	public fun <init> ()V
+	public final fun getAppliedTags ()Ljava/util/List;
 	public final fun getAvatarUrl ()Ljava/lang/String;
 	public final fun getThreadName ()Ljava/lang/String;
 	public final fun getUsername ()Ljava/lang/String;
+	public final fun setAppliedTags (Ljava/util/List;)V
 	public final fun setAvatarUrl (Ljava/lang/String;)V
 	public final fun setThreadName (Ljava/lang/String;)V
 	public final fun setUsername (Ljava/lang/String;)V
 	public fun toRequest ()Ldev/kord/rest/json/request/MultiPartWebhookExecuteRequest;
 	public synthetic fun toRequest ()Ljava/lang/Object;
+}
+
+public final class dev/kord/rest/builder/message/create/WebhookMessageCreateBuilderKt {
+	public static final fun applyTag (Ldev/kord/rest/builder/message/create/WebhookMessageCreateBuilder;Ldev/kord/common/entity/Snowflake;)V
 }
 
 public abstract class dev/kord/rest/builder/message/modify/AbstractMessageModifyBuilder : dev/kord/rest/builder/message/modify/MessageModifyBuilder {
@@ -5410,10 +5424,11 @@ public final class dev/kord/rest/json/request/WebhookEditMessageRequest$Companio
 public final class dev/kord/rest/json/request/WebhookExecuteRequest {
 	public static final field Companion Ldev/kord/rest/json/request/WebhookExecuteRequest$Companion;
 	public fun <init> ()V
-	public fun <init> (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)V
-	public synthetic fun <init> (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)V
+	public synthetic fun <init> (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component10 ()Ldev/kord/common/entity/optional/Optional;
+	public final fun component11 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component2 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component3 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component4 ()Ldev/kord/common/entity/optional/OptionalBoolean;
@@ -5422,10 +5437,11 @@ public final class dev/kord/rest/json/request/WebhookExecuteRequest {
 	public final fun component7 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component8 ()Ldev/kord/common/entity/optional/Optional;
 	public final fun component9 ()Ldev/kord/common/entity/optional/Optional;
-	public final fun copy (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/rest/json/request/WebhookExecuteRequest;
-	public static synthetic fun copy$default (Ldev/kord/rest/json/request/WebhookExecuteRequest;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/rest/json/request/WebhookExecuteRequest;
+	public final fun copy (Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;)Ldev/kord/rest/json/request/WebhookExecuteRequest;
+	public static synthetic fun copy$default (Ldev/kord/rest/json/request/WebhookExecuteRequest;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/OptionalBoolean;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;Ldev/kord/common/entity/optional/Optional;ILjava/lang/Object;)Ldev/kord/rest/json/request/WebhookExecuteRequest;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAllowedMentions ()Ldev/kord/common/entity/optional/Optional;
+	public final fun getAppliedTags ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getAttachments ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getAvatar ()Ldev/kord/common/entity/optional/Optional;
 	public final fun getComponents ()Ldev/kord/common/entity/optional/Optional;

--- a/rest/src/commonMain/kotlin/builder/channel/thread/StartForumThreadBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/channel/thread/StartForumThreadBuilder.kt
@@ -52,3 +52,8 @@ public class StartForumThreadBuilder(public var name: String) : AuditRequestBuil
         )
     }
 }
+
+/** Add a [tagId] to [appliedTags][StartForumThreadBuilder.appliedTags]. */
+public fun StartForumThreadBuilder.applyTag(tagId: Snowflake) {
+    appliedTags?.add(tagId) ?: run { appliedTags = mutableListOf(tagId) }
+}

--- a/rest/src/commonMain/kotlin/builder/channel/thread/ThreadModifyBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/channel/thread/ThreadModifyBuilder.kt
@@ -53,3 +53,8 @@ public class ThreadModifyBuilder : AuditRequestBuilder<ChannelModifyPatchRequest
 
     override var reason: String? = null
 }
+
+/** Add a [tagId] to [appliedTags][ThreadModifyBuilder.appliedTags]. */
+public fun ThreadModifyBuilder.applyTag(tagId: Snowflake) {
+    appliedTags?.add(tagId) ?: run { appliedTags = mutableListOf(tagId) }
+}

--- a/rest/src/commonMain/kotlin/builder/message/MessageBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/message/MessageBuilder.kt
@@ -74,7 +74,7 @@ public inline fun MessageBuilder.embed(builder: EmbedBuilder.() -> Unit) {
  * Configures the mentions in the message that are allowed to trigger a ping.
  *
  * Not calling this function will result in the default behavior (ping for all mentions), calling this function but not
- * configuring it before the request is build will result in all mentions being ignored.
+ * configuring it before the request is built will result in all mentions being ignored.
  */
 public inline fun MessageBuilder.allowedMentions(builder: AllowedMentionsBuilder.() -> Unit = {}) {
     contract { callsInPlace(builder, EXACTLY_ONCE) }

--- a/rest/src/commonMain/kotlin/builder/message/create/WebhookMessageCreateBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/message/create/WebhookMessageCreateBuilder.kt
@@ -3,9 +3,11 @@ package dev.kord.rest.builder.message.create
 import dev.kord.common.annotation.KordDsl
 import dev.kord.common.entity.ChannelType.GuildForum
 import dev.kord.common.entity.ChannelType.GuildMedia
+import dev.kord.common.entity.Snowflake
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.delegate.delegate
 import dev.kord.common.entity.optional.map
+import dev.kord.common.entity.optional.mapCopy
 import dev.kord.common.entity.optional.mapList
 import dev.kord.rest.builder.RequestBuilder
 import dev.kord.rest.builder.message.buildMessageFlags
@@ -36,6 +38,14 @@ public class WebhookMessageCreateBuilder :
     /** Name of the thread to create (requires the webhook channel to be a [GuildForum] or [GuildMedia] channel). */
     public var threadName: String? by ::_threadName.delegate()
 
+    private var _appliedTags: Optional<MutableList<Snowflake>> = Optional.Missing()
+
+    /**
+     * List of tag ids to apply to the thread (requires the webhook channel to be a [GuildForum] or [GuildMedia]
+     * channel).
+     */
+    public var appliedTags: MutableList<Snowflake>? by ::_appliedTags.delegate()
+
     override fun toRequest(): MultiPartWebhookExecuteRequest = MultiPartWebhookExecuteRequest(
         request = WebhookExecuteRequest(
             content = _content,
@@ -48,7 +58,13 @@ public class WebhookMessageCreateBuilder :
             attachments = _attachments.mapList { it.toRequest() },
             flags = buildMessageFlags(flags, suppressEmbeds, suppressNotifications),
             threadName = _threadName,
+            appliedTags = _appliedTags.mapCopy(),
         ),
         files = files.toList(),
     )
+}
+
+/** Add a [tagId] to [appliedTags][WebhookMessageCreateBuilder.appliedTags]. */
+public fun WebhookMessageCreateBuilder.applyTag(tagId: Snowflake) {
+    appliedTags?.add(tagId) ?: run { appliedTags = mutableListOf(tagId) }
 }

--- a/rest/src/commonMain/kotlin/json/request/WebhookRequests.kt
+++ b/rest/src/commonMain/kotlin/json/request/WebhookRequests.kt
@@ -3,6 +3,7 @@ package dev.kord.rest.json.request
 import dev.kord.common.entity.AllowedMentions
 import dev.kord.common.entity.DiscordComponent
 import dev.kord.common.entity.MessageFlags
+import dev.kord.common.entity.Snowflake
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
 import dev.kord.common.entity.optional.OptionalSnowflake
@@ -36,6 +37,8 @@ public data class WebhookExecuteRequest(
     val flags: Optional<MessageFlags> = Optional.Missing(),
     @SerialName("thread_name")
     val threadName: Optional<String> = Optional.Missing(),
+    @SerialName("applied_tags")
+    val appliedTags: Optional<List<Snowflake>> = Optional.Missing(),
 )
 
 public data class MultiPartWebhookExecuteRequest(


### PR DESCRIPTION
See https://github.com/discord/discord-api-docs/pull/6560

`applyTag` convenience functions for `StartForumThreadBuilder` and `ThreadModifyBuilder` were also added.