### PR TITLE
Remove deprecation from `User.discriminator` and `User.tag`

### DIFF
--- a/common/src/commonMain/kotlin/entity/DiscordUser.kt
+++ b/common/src/commonMain/kotlin/entity/DiscordUser.kt
@@ -52,7 +52,6 @@ import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonNames
-import kotlin.DeprecationLevel.WARNING
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -80,11 +79,6 @@ import kotlin.contracts.contract
 public data class DiscordUser(
     val id: Snowflake,
     val username: String,
-    @Deprecated(
-        "Discord's username system is changing and discriminators are being removed, see " +
-            "https://discord.com/developers/docs/change-log#unique-usernames-on-discord for details.",
-        level = WARNING,
-    )
     val discriminator: Optional<String> = Optional.Missing(),
     @SerialName("global_name")
     val globalName: Optional<String?> = Optional.Missing(),
@@ -130,11 +124,6 @@ public data class DiscordUser(
 public data class DiscordOptionallyMemberUser(
     val id: Snowflake,
     val username: String,
-    @Deprecated(
-        "Discord's username system is changing and discriminators are being removed, see " +
-            "https://discord.com/developers/docs/change-log#unique-usernames-on-discord for details.",
-        level = WARNING,
-    )
     val discriminator: Optional<String> = Optional.Missing(),
     @SerialName("global_name")
     val globalName: Optional<String?> = Optional.Missing(),

--- a/common/src/commonTest/kotlin/json/ChannelTest.kt
+++ b/common/src/commonTest/kotlin/json/ChannelTest.kt
@@ -25,7 +25,6 @@ class ChannelTest {
             recipients.value!!.size shouldBe 1
             with(recipients.value!!.first()) {
                 username shouldBe "test"
-                @Suppress("DEPRECATION")
                 discriminator shouldBe "9999"
                 globalName shouldBe null
                 id.toString() shouldBe "82198898841029460"
@@ -64,7 +63,6 @@ class ChannelTest {
             recipients.value!!.size shouldBe 2
             with(recipients.value!!.first()) {
                 username shouldBe "test"
-                @Suppress("DEPRECATION")
                 discriminator shouldBe "9999"
                 globalName shouldBe null
                 id.toString() shouldBe "82198898841029460"
@@ -72,7 +70,6 @@ class ChannelTest {
             }
             with(recipients.value!![1]) {
                 username shouldBe "test2"
-                @Suppress("DEPRECATION")
                 discriminator shouldBe "9999"
                 globalName shouldBe "amazing name"
                 id.toString() shouldBe "82198810841029460"

--- a/common/src/commonTest/kotlin/json/EmojiTest.kt
+++ b/common/src/commonTest/kotlin/json/EmojiTest.kt
@@ -45,7 +45,6 @@ class EmojiTest {
             roles shouldBe listOf("41771983429993000", "41771983429993111").map { Snowflake(it) }
             with(user.value!!) {
                 username shouldBe "Luigi"
-                @Suppress("DEPRECATION")
                 discriminator shouldBe "0002"
                 globalName shouldBe null
                 id shouldBe "96008815106887111"

--- a/common/src/commonTest/kotlin/json/MessageTest.kt
+++ b/common/src/commonTest/kotlin/json/MessageTest.kt
@@ -37,7 +37,6 @@ class MessageTest {
             editedTimestamp shouldBe null
             with(author) {
                 username shouldBe "Mason"
-                @Suppress("DEPRECATION")
                 discriminator shouldBe "9999"
                 globalName shouldBe null
                 id shouldBe "53908099506183680"
@@ -77,7 +76,6 @@ class MessageTest {
             editedTimestamp shouldBe null
             with(author) {
                 username shouldBe "Mason"
-                @Suppress("DEPRECATION")
                 discriminator shouldBe "9999"
                 globalName shouldBe "Mason!"
                 id.toString() shouldBe "53908099506183680"

--- a/common/src/commonTest/kotlin/json/UserTest.kt
+++ b/common/src/commonTest/kotlin/json/UserTest.kt
@@ -21,7 +21,6 @@ class UserTest {
         with(user) {
             id.toString() shouldBe "80351110224678912"
             username shouldBe "Nelly"
-            @Suppress("DEPRECATION")
             discriminator shouldBe "1337"
             globalName shouldBe "Nelly"
             avatar shouldBe "8342729096ea3675442027381ff50dfe"

--- a/core/src/commonMain/kotlin/cache/data/UserData.kt
+++ b/core/src/commonMain/kotlin/cache/data/UserData.kt
@@ -9,7 +9,6 @@ import dev.kord.common.entity.UserFlags
 import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
 import kotlinx.serialization.Serializable
-import kotlin.DeprecationLevel.WARNING
 
 private val WebhookData.nullableUserId get() = userId.value
 
@@ -17,11 +16,6 @@ private val WebhookData.nullableUserId get() = userId.value
 public data class UserData(
     val id: Snowflake,
     val username: String,
-    @Deprecated(
-        "Discord's username system is changing and discriminators are being removed, see " +
-            "https://discord.com/developers/docs/change-log#unique-usernames-on-discord for details.",
-        level = WARNING,
-    )
     val discriminator: Optional<String> = Optional.Missing(),
     val globalName: Optional<String?> = Optional.Missing(),
     val avatar: String? = null,
@@ -41,11 +35,11 @@ public data class UserData(
         }
 
         public fun from(entity: DiscordUser): UserData = with(entity) {
-            UserData(id, username, @Suppress("DEPRECATION") discriminator, globalName, avatar, bot, publicFlags, banner, accentColor, avatarDecoration)
+            UserData(id, username, discriminator, globalName, avatar, bot, publicFlags, banner, accentColor, avatarDecoration)
         }
 
         public fun from(entity: DiscordOptionallyMemberUser): UserData = with(entity) {
-            UserData(id, username, @Suppress("DEPRECATION") discriminator, globalName, avatar, bot, publicFlags)
+            UserData(id, username, discriminator, globalName, avatar, bot, publicFlags)
         }
 
     }

--- a/core/src/commonMain/kotlin/entity/Asset.kt
+++ b/core/src/commonMain/kotlin/entity/Asset.kt
@@ -51,15 +51,8 @@ public class Asset private constructor(
         public fun userBanner(userId: Snowflake, hash: String, kord: Kord): Asset =
             Asset(hash.isAnimated, DiscordCdn.userBanner(userId, hash), kord)
 
-        @Suppress("DEPRECATION")
-        @Deprecated(
-            "Discord's username system is changing and discriminators are being removed, see " +
-                "https://discord.com/developers/docs/change-log#unique-usernames-on-discord for details.",
-            ReplaceWith("Asset.defaultUserAvatar(userId, kord)", imports = ["dev.kord.core.entity.Asset"]),
-            DeprecationLevel.WARNING,
-        )
         public fun defaultUserAvatar(discriminator: Int, kord: Kord): Asset =
-            Asset(isAnimated = false, DiscordCdn.defaultAvatar(discriminator), kord, recommendedFormat = PNG)
+            Asset(isAnimated = false, DiscordCdn.defaultUserAvatar(discriminator), kord, recommendedFormat = PNG)
 
         public fun defaultUserAvatar(userId: Snowflake, kord: Kord): Asset =
             Asset(isAnimated = false, DiscordCdn.defaultUserAvatar(userId), kord, recommendedFormat = PNG)

--- a/core/src/commonMain/kotlin/entity/User.kt
+++ b/core/src/commonMain/kotlin/entity/User.kt
@@ -8,7 +8,6 @@ import dev.kord.core.behavior.UserBehavior
 import dev.kord.core.cache.data.UserData
 import dev.kord.core.supplier.EntitySupplier
 import dev.kord.core.supplier.EntitySupplyStrategy
-import kotlin.DeprecationLevel.WARNING
 
 /**
  * The user's effective name, prioritizing [globalName][User.globalName] over [username][User.username].
@@ -46,7 +45,7 @@ public open class User(
     public val defaultAvatar: Asset
         get() =
             if (migratedToNewUsernameSystem) Asset.defaultUserAvatar(userId = id, kord)
-            else @Suppress("DEPRECATION") Asset.defaultUserAvatar(discriminator.toInt(), kord)
+            else Asset.defaultUserAvatar(discriminator.toInt(), kord)
 
     public val avatarDecorationHash: String? get() = data.avatarDecoration.value
 
@@ -67,16 +66,9 @@ public open class User(
     // "0" when data.discriminator is missing: if the field is missing, all users were migrated,
     // see https://discord.com/developers/docs/change-log#identifying-migrated-users:
     // "After migration of all users is complete, the `discriminator` field may be removed."
-    @Suppress("DEPRECATION", "DeprecatedCallableAddReplaceWith")
-    @Deprecated(
-        "Discord's username system is changing and discriminators are being removed, see " +
-            "https://discord.com/developers/docs/change-log#unique-usernames-on-discord for details.",
-        level = WARNING,
-    )
     public val discriminator: String get() = data.discriminator.value ?: "0"
 
     // see https://discord.com/developers/docs/change-log#identifying-migrated-users
-    @Suppress("DEPRECATION")
     private val migratedToNewUsernameSystem get() = discriminator == "0"
 
     /** The user's display name, if it is set. For bots, this is the application name. */
@@ -97,14 +89,10 @@ public open class User(
 
     /**
      * The complete user tag.
+     *
+     * If this user [has been migrated to the new username system][discriminator], this is the same as [username],
+     * otherwise a [String] of the form `"username#discriminator"` is returned.
      */
-    @Suppress("DEPRECATION")
-    @Deprecated(
-        "Discord's username system is changing and discriminators are being removed, see " +
-            "https://discord.com/developers/docs/change-log#unique-usernames-on-discord for details.",
-        ReplaceWith("this.username"),
-        level = WARNING,
-    )
     public val tag: String get() = if (migratedToNewUsernameSystem) username else "$username#$discriminator"
 
     /**

--- a/gateway/src/commonTest/kotlin/json/SerializationTest.kt
+++ b/gateway/src/commonTest/kotlin/json/SerializationTest.kt
@@ -56,7 +56,6 @@ class SerializationTest {
                 with(user) {
                     id.toString() shouldBe "80351110224678912"
                     username shouldBe "Nelly"
-                    @Suppress("DEPRECATION")
                     discriminator shouldBe Optional("1337")
                     globalName shouldBe Optional(null)
                     avatar shouldBe "8342729096ea3675442027381ff50dfe"

--- a/rest/api/rest.api
+++ b/rest/api/rest.api
@@ -6297,6 +6297,7 @@ public final class dev/kord/rest/route/DiscordCdn {
 	public final fun applicationCover (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;)Ldev/kord/rest/route/CdnUrl;
 	public final fun applicationIcon (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;)Ldev/kord/rest/route/CdnUrl;
 	public final fun defaultAvatar (I)Ldev/kord/rest/route/CdnUrl;
+	public final fun defaultUserAvatar (I)Ldev/kord/rest/route/CdnUrl;
 	public final fun defaultUserAvatar (Ldev/kord/common/entity/Snowflake;)Ldev/kord/rest/route/CdnUrl;
 	public final fun emoji (Ldev/kord/common/entity/Snowflake;)Ldev/kord/rest/route/CdnUrl;
 	public final fun guildBanner (Ldev/kord/common/entity/Snowflake;Ljava/lang/String;)Ldev/kord/rest/route/CdnUrl;

--- a/rest/src/commonMain/kotlin/route/DiscordCdn.kt
+++ b/rest/src/commonMain/kotlin/route/DiscordCdn.kt
@@ -21,12 +21,13 @@ public object DiscordCdn {
     public fun userBanner(userId: Snowflake, hash: String): CdnUrl = CdnUrl("$BASE_URL/banners/$userId/$hash")
 
     @Deprecated(
-        "Discord's username system is changing and discriminators are being removed, see " +
-            "https://discord.com/developers/docs/change-log#unique-usernames-on-discord for details.",
-        ReplaceWith("DiscordCdn.defaultUserAvatar(userId)", imports = ["dev.kord.rest.route.DiscordCdn"]),
+        "Renamed to 'defaultUserAvatar' to align name with documentation and overload taking Snowflake.",
+        ReplaceWith("DiscordCdn.defaultUserAvatar(discriminator)", imports = ["dev.kord.rest.route.DiscordCdn"]),
         DeprecationLevel.WARNING,
     )
-    public fun defaultAvatar(discriminator: Int): CdnUrl = CdnUrl("$BASE_URL/embed/avatars/${discriminator % 5}")
+    public fun defaultAvatar(discriminator: Int): CdnUrl = defaultUserAvatar(discriminator)
+
+    public fun defaultUserAvatar(discriminator: Int): CdnUrl = CdnUrl("$BASE_URL/embed/avatars/${discriminator % 5}")
 
     public fun defaultUserAvatar(userId: Snowflake): CdnUrl =
         CdnUrl("$BASE_URL/embed/avatars/${(userId.value shr 22) % 6u}")


### PR DESCRIPTION
Bot users still have discriminators, and it [doesn't seem like this will be changed any time soon](https://discord.com/developers/docs/change-log#unique-usernames-on-discord).