### PR TITLE
Align `ArchiveDuration` with generated kord enums

### DIFF
--- a/common/api/common.api
+++ b/common/api/common.api
@@ -802,6 +802,7 @@ public abstract class dev/kord/common/entity/ArchiveDuration {
 }
 
 public final class dev/kord/common/entity/ArchiveDuration$Companion {
+	public final fun from-LRDsOJo (J)Ldev/kord/common/entity/ArchiveDuration;
 	public final fun getEntries ()Ljava/util/List;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }


### PR DESCRIPTION
The changes are the same as in #861, I simply forgot `ArchiveDuration` there.