### PR TITLE
Deprecate `DiscordBitSetSerializer` and `Locale.Serializer`

### DIFF
--- a/common/src/commonMain/kotlin/DiscordBitSet.kt
+++ b/common/src/commonMain/kotlin/DiscordBitSet.kt
@@ -4,7 +4,6 @@ import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
-import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlin.math.max
@@ -19,7 +18,7 @@ public fun EmptyBitSet(): DiscordBitSet = DiscordBitSet()
 internal expect fun formatIntegerFromLittleEndianLongArray(data: LongArray): String
 internal expect fun parseIntegerToBigEndianByteArray(value: String): ByteArray
 
-@Serializable(with = DiscordBitSetSerializer::class)
+@Serializable(with = DiscordBitSet.Serializer::class)
 public class DiscordBitSet(internal var data: LongArray) { // data is in little-endian order
 
     public val isEmpty: Boolean
@@ -113,6 +112,12 @@ public class DiscordBitSet(internal var data: LongArray) { // data is in little-
     }
 
     public fun copy(): DiscordBitSet = DiscordBitSet(data = data.copyOf())
+
+    internal object Serializer : KSerializer<DiscordBitSet> {
+        override val descriptor = PrimitiveSerialDescriptor("dev.kord.common.DiscordBitSet", PrimitiveKind.STRING)
+        override fun serialize(encoder: Encoder, value: DiscordBitSet) = encoder.encodeString(value.value)
+        override fun deserialize(decoder: Decoder) = DiscordBitSet(decoder.decodeString())
+    }
 }
 
 public fun DiscordBitSet(vararg widths: Long): DiscordBitSet {
@@ -144,15 +149,9 @@ public fun DiscordBitSet(value: String): DiscordBitSet {
 }
 
 
-public object DiscordBitSetSerializer : KSerializer<DiscordBitSet> {
-    override val descriptor: SerialDescriptor
-        get() = PrimitiveSerialDescriptor("DiscordBitSet", PrimitiveKind.STRING)
-
-    override fun deserialize(decoder: Decoder): DiscordBitSet {
-        return DiscordBitSet(decoder.decodeString())
-    }
-
-    override fun serialize(encoder: Encoder, value: DiscordBitSet) {
-        encoder.encodeString(value.value)
-    }
-}
+@Deprecated(
+    "Replaced by 'DiscordBitSet.serializer()'.",
+    ReplaceWith("DiscordBitSet.serializer()", imports = ["dev.kord.common.DiscordBitSet"]),
+    DeprecationLevel.WARNING,
+)
+public object DiscordBitSetSerializer : KSerializer<DiscordBitSet> by DiscordBitSet.Serializer

--- a/common/src/commonMain/kotlin/Locale.kt
+++ b/common/src/commonMain/kotlin/Locale.kt
@@ -4,7 +4,6 @@ import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
-import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
@@ -14,7 +13,7 @@ import kotlinx.serialization.encoding.Encoder
  * @property language A language code representing the language.
  * @property country A country code representing the country.
  */
-@Serializable(with = Locale.Serializer::class)
+@Serializable(with = Locale.NewSerializer::class)
 public data class Locale(val language: String, val country: String? = null) {
     public companion object {
 
@@ -231,13 +230,20 @@ public data class Locale(val language: String, val country: String? = null) {
         }
     }
 
-    public object Serializer : KSerializer<Locale> {
-        override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("Locale", PrimitiveKind.STRING)
+    @Deprecated(
+        "Replaced by 'Locale.serializer()'.",
+        ReplaceWith("Locale.serializer()", imports = ["dev.kord.common.Locale"]),
+        DeprecationLevel.WARNING,
+    )
+    public object Serializer : KSerializer<Locale> by NewSerializer
 
-        override fun serialize(encoder: Encoder, value: Locale) {
+    // TODO rename to 'Serializer' once deprecated public serializer is removed
+    internal object NewSerializer : KSerializer<Locale> {
+        override val descriptor = PrimitiveSerialDescriptor("dev.kord.common.Locale", PrimitiveKind.STRING)
+
+        override fun serialize(encoder: Encoder, value: Locale) =
             encoder.encodeString("${value.language}${value.country?.let { "-$it" } ?: ""}")
-        }
 
-        override fun deserialize(decoder: Decoder): Locale = fromString(decoder.decodeString())
+        override fun deserialize(decoder: Decoder) = fromString(decoder.decodeString())
     }
 }


### PR DESCRIPTION
The replacements are already there: `DiscordBitSet.serializer()` and `Locale.serializer()`.