### PR TITLE
Support Spanish (Latin America)

### DIFF
--- a/common/api/common.api
+++ b/common/api/common.api
@@ -141,6 +141,7 @@ public final class dev/kord/common/Locale$Companion {
 	public final fun getPORTUGUESE_BRAZIL ()Ldev/kord/common/Locale;
 	public final fun getROMANIAN ()Ldev/kord/common/Locale;
 	public final fun getRUSSIAN ()Ldev/kord/common/Locale;
+	public final fun getSPANISH_LATIN_AMERICA ()Ldev/kord/common/Locale;
 	public final fun getSPANISH_SPAIN ()Ldev/kord/common/Locale;
 	public final fun getSWEDISH ()Ldev/kord/common/Locale;
 	public final fun getTHAI ()Ldev/kord/common/Locale;

--- a/common/src/commonMain/kotlin/Locale.kt
+++ b/common/src/commonMain/kotlin/Locale.kt
@@ -49,6 +49,11 @@ public data class Locale(val language: String, val country: String? = null) {
         public val SPANISH_SPAIN: Locale = Locale("es", "ES")
 
         /**
+         * Spanish (Latin America).
+         */
+        public val SPANISH_LATIN_AMERICA: Locale = Locale("es", "419")
+
+        /**
          * French.
          */
         public val FRENCH: Locale = Locale("fr")
@@ -184,6 +189,7 @@ public data class Locale(val language: String, val country: String? = null) {
             ENGLISH_GREAT_BRITAIN,
             ENGLISH_UNITED_STATES,
             SPANISH_SPAIN,
+            SPANISH_LATIN_AMERICA,
             FRENCH,
             CROATIAN,
             ITALIAN,
@@ -211,8 +217,8 @@ public data class Locale(val language: String, val country: String? = null) {
             KOREAN,
         )
 
-        // https://regex101.com/r/KCHTj8/1
-        private val languageTagFormat = "([a-z]{2})(?:-([A-Z]{2}))?".toRegex()
+        // https://regex101.com/r/8iMEWT/1
+        private val languageTagFormat = "([a-z]{2})(?:-([A-Z]{2}|\\d{3}))?".toRegex()
 
         /**
          * Decodes the [Locale] from a `languageCode-countryCode` or `languageCode` format.

--- a/common/src/commonTest/kotlin/LocaleTest.kt
+++ b/common/src/commonTest/kotlin/LocaleTest.kt
@@ -1,6 +1,5 @@
 package dev.kord.common
 
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlin.js.JsName
@@ -17,6 +16,7 @@ class LocaleTest {
             "en-GB" to ENGLISH_GREAT_BRITAIN,
             "en-US" to ENGLISH_UNITED_STATES,
             "es-ES" to SPANISH_SPAIN,
+            "es-419" to SPANISH_LATIN_AMERICA,
             "fr" to FRENCH,
             "hr" to CROATIAN,
             "it" to ITALIAN,


### PR DESCRIPTION
As reported by manusaurio on Discord.

![image](https://github.com/kordlib/kord/assets/204153/a0f56744-1f57-48f6-bffd-cc04be8d6a5b)
 
This isn't documented on Discord's end (of course, why make our lives easy), but this is a valid locale code.