### PR TITLE
Fix `DiscordBitSet` deserialization from JSON number

### DIFF
--- a/common/src/commonTest/kotlin/BitSetTests.kt
+++ b/common/src/commonTest/kotlin/BitSetTests.kt
@@ -1,5 +1,9 @@
 package dev.kord.common
 
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.encodeToJsonElement
 import kotlin.js.JsName
 import kotlin.random.Random
 import kotlin.random.nextLong
@@ -124,6 +128,38 @@ class BitSetTests {
             data[size - 1] = Random.nextLong(Long.MIN_VALUE..-1)
             val bits = DiscordBitSet(data)
             assertTrue(bits.value.all { it in '0'..'9' })
+        }
+    }
+
+    @Test
+    fun negative_values_cant_be_parsed() {
+        assertFailsWith<NumberFormatException> { DiscordBitSet("-1") }
+        assertFailsWith<NumberFormatException> { DiscordBitSet("-99999999999999999999999999999999") }
+    }
+
+    private val numberStrings = listOf("0", "1", "1024", "6543654", "59946645771238946")
+
+    // https://github.com/kordlib/kord/issues/911
+    @Test
+    fun deserialization_works_with_json_strings_and_numbers() {
+        numberStrings.forEach { number ->
+            val string = "\"$number\""
+            val expected = DiscordBitSet(number)
+            assertEquals(expected, Json.decodeFromString(string))
+            assertEquals(expected, Json.decodeFromString(number))
+        }
+    }
+
+    @Test
+    fun serialization_works_and_produces_json_strings() {
+        numberStrings.forEach { number ->
+            val bitSet = DiscordBitSet(number)
+            val string = Json.encodeToString(bitSet)
+            val json = Json.encodeToJsonElement(bitSet)
+            assertEquals("\"$number\"", string)
+            assertIs<JsonPrimitive>(json)
+            assertTrue(json.isString)
+            assertEquals(number, json.content)
         }
     }
 }

--- a/common/src/jvmMain/kotlin/DiscordBitSetJvm.kt
+++ b/common/src/jvmMain/kotlin/DiscordBitSetJvm.kt
@@ -10,4 +10,6 @@ internal actual fun formatIntegerFromLittleEndianLongArray(data: LongArray): Str
     return BigInteger(/* signum = */ 1, /* magnitude = */ buffer.array()).toString()
 }
 
-internal actual fun parseIntegerToBigEndianByteArray(value: String): ByteArray = BigInteger(value).toByteArray()
+internal actual fun parseNonNegativeIntegerToBigEndianByteArray(value: String): ByteArray = BigInteger(value)
+    .also { if (it.signum() < 0) throw NumberFormatException("Invalid DiscordBitSet format: '$value'") }
+    .toByteArray()

--- a/common/src/nonJvmMain/kotlin/DiscordBitSet.kt
+++ b/common/src/nonJvmMain/kotlin/DiscordBitSet.kt
@@ -11,5 +11,7 @@ internal actual fun formatIntegerFromLittleEndianLongArray(data: LongArray) =
         BigInteger.fromByteArray(readBytes(), Sign.POSITIVE).toString()
     }
 
-internal actual fun parseIntegerToBigEndianByteArray(value: String): ByteArray =
-    BigInteger.parseString(value).toByteArray()
+internal actual fun parseNonNegativeIntegerToBigEndianByteArray(value: String): ByteArray = BigInteger
+    .parseString(value)
+    .also { if (it.isNegative) throw NumberFormatException("Invalid DiscordBitSet format: '$value'") }
+    .toByteArray()


### PR DESCRIPTION
Also throw `NumberFormatException` from `DiscordBitSet` factory function for large negative numbers while I'm here.

Fixes #911