### PR TITLE
Disable timeouts for Kotlin/JS tests

### DIFF
--- a/buildSrc/src/main/kotlin/kord-multiplatform-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/kord-multiplatform-module.gradle.kts
@@ -27,7 +27,15 @@ kotlin {
 
     jvm()
     js {
-        nodejs()
+        nodejs {
+            testTask {
+                useMocha {
+                    // disable timeouts, some tests are too slow for default 2-second timeout:
+                    // https://mochajs.org/#-timeout-ms-t-ms
+                    timeout = "0"
+                }
+            }
+        }
         useCommonJs()
     }
     jvmToolchain(Jvm.target)

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -4,16 +4,6 @@ plugins {
 }
 
 kotlin {
-    js {
-        nodejs {
-            testTask {
-                useMocha {
-                    timeout = "10000" // KordEventDropTest is too slow for default 2 seconds timeout
-                }
-            }
-        }
-    }
-
     sourceSets {
         commonMain {
             dependencies {


### PR DESCRIPTION
Some tests added in #923 seem to time out on Kotlin/JS. To avoid problems like this in the future, this PR disables test timeouts on Kotlin/JS completely.