### PR TITLE
Fix some cache links

### DIFF
--- a/core/src/commonMain/kotlin/cache/data/ApplicationCommandData.kt
+++ b/core/src/commonMain/kotlin/cache/data/ApplicationCommandData.kt
@@ -27,9 +27,11 @@ public data class ApplicationCommandData(
     val version: Snowflake
 ) {
     public companion object {
-        public val description: DataDescription<ApplicationCommandData, Snowflake> = description(ApplicationCommandData::id) {
-            link(ApplicationCommandData::guildId to GuildData::id)
-        }
+        public val description: DataDescription<ApplicationCommandData, Snowflake> =
+            description(ApplicationCommandData::id) {
+                link(ApplicationCommandData::id to GuildApplicationCommandPermissionsData::id)
+            }
+
         public fun from(command: DiscordApplicationCommand): ApplicationCommandData {
             return with(command) {
                 ApplicationCommandData(

--- a/core/src/commonMain/kotlin/cache/data/ChannelData.kt
+++ b/core/src/commonMain/kotlin/cache/data/ChannelData.kt
@@ -49,7 +49,12 @@ public data class ChannelData(
 
 
     public companion object {
-        public val description: DataDescription<ChannelData, Snowflake> = description(ChannelData::id)
+        public val description: DataDescription<ChannelData, Snowflake> = description(ChannelData::id) {
+            link(ChannelData::id to MessageData::channelId)
+            link(ChannelData::id to ThreadMemberData::id)
+            link(ChannelData::id to WebhookData::channelId)
+            link(ChannelData::id to VoiceStateData::channelId)
+        }
 
         public fun from(entity: DiscordChannel): ChannelData = with(entity) {
             ChannelData(

--- a/core/src/commonMain/kotlin/cache/data/GuildApplicationCommandPermissionsData.kt
+++ b/core/src/commonMain/kotlin/cache/data/GuildApplicationCommandPermissionsData.kt
@@ -14,10 +14,7 @@ public data class GuildApplicationCommandPermissionsData(
 
     public companion object {
         public val description: DataDescription<GuildApplicationCommandPermissionsData, Snowflake> =
-            description(GuildApplicationCommandPermissionsData::id) {
-                link(GuildApplicationCommandPermissionsData::guildId to GuildData::id)
-                link(GuildApplicationCommandPermissionsData::id to ApplicationCommandData::id)
-            }
+            description(GuildApplicationCommandPermissionsData::id)
 
         public fun from(permissions: DiscordGuildApplicationCommandPermissions): GuildApplicationCommandPermissionsData =
             with(permissions) {

--- a/core/src/commonMain/kotlin/cache/data/GuildData.kt
+++ b/core/src/commonMain/kotlin/cache/data/GuildData.kt
@@ -8,9 +8,11 @@ import dev.kord.common.serialization.DurationInSeconds
 import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
 
+private val ApplicationCommandData.nullableGuildId get() = guildId.value
 private val MessageData.nullableGuildId get() = guildId.value
 private val ChannelData.nullableGuildId get() = guildId.value
 private val WebhookData.nullableGuildId get() = guildId.value
+private val StickerData.nullableGuildId get() = guildId.value
 
 @Serializable
 public data class GuildData(
@@ -71,7 +73,8 @@ public data class GuildData(
     public companion object {
 
         public val description: DataDescription<GuildData, Snowflake> = description(GuildData::id) {
-
+            link(GuildData::id to ApplicationCommandData::nullableGuildId)
+            link(GuildData::id to GuildApplicationCommandPermissionsData::guildId)
             link(GuildData::id to RoleData::guildId)
             link(GuildData::id to ChannelData::nullableGuildId)
             link(GuildData::id to MemberData::guildId)
@@ -79,6 +82,7 @@ public data class GuildData(
             link(GuildData::id to WebhookData::nullableGuildId)
             link(GuildData::id to VoiceStateData::guildId)
             link(GuildData::id to PresenceData::guildId)
+            link(GuildData::id to StickerData::nullableGuildId)
             link(GuildData::id to AutoModerationRuleData::guildId)
         }
 

--- a/core/src/commonMain/kotlin/cache/data/GuildData.kt
+++ b/core/src/commonMain/kotlin/cache/data/GuildData.kt
@@ -83,6 +83,7 @@ public data class GuildData(
             link(GuildData::id to VoiceStateData::guildId)
             link(GuildData::id to PresenceData::guildId)
             link(GuildData::id to StickerData::nullableGuildId)
+            link(GuildData::id to EmojiData::guildId)
             link(GuildData::id to AutoModerationRuleData::guildId)
         }
 

--- a/core/src/commonMain/kotlin/cache/data/StickerData.kt
+++ b/core/src/commonMain/kotlin/cache/data/StickerData.kt
@@ -24,11 +24,7 @@ public data class StickerData(
 ) {
     public companion object {
 
-        public val description: DataDescription<StickerData, Snowflake> = description(StickerData::id) {
-            link(StickerData::guildId to GuildData::id)
-            link(StickerData::packId to StickerPackData::id)
-        }
-
+        public val description: DataDescription<StickerData, Snowflake> = description(StickerData::id)
 
         public fun from(entity: DiscordMessageSticker): StickerData = with(entity) {
             StickerData(id, packId, name, description, tags, formatType, available, guildId, user.map { it.toData() }, sortValue)
@@ -49,6 +45,7 @@ public data class StickerItemData(
     }
 }
 
+private val StickerData.nullablePackId get() = packId.value
 
 public data class StickerPackData(
     val id: Snowflake,
@@ -58,10 +55,12 @@ public data class StickerPackData(
     val coverStickerId: OptionalSnowflake = OptionalSnowflake.Missing,
     val description: String,
     val bannerAssetId: Snowflake
-    ) {
+) {
     public companion object {
 
-        public val description: DataDescription<StickerPackData, Snowflake> = description(StickerPackData::id)
+        public val description: DataDescription<StickerPackData, Snowflake> = description(StickerPackData::id) {
+            link(StickerPackData::id to StickerData::nullablePackId)
+        }
 
         public fun from(entity: DiscordStickerPack): StickerPackData = with(entity) {
             StickerPackData(id, stickers.map { StickerData.from(it) }, name, skuId, coverStickerId, description, bannerAssetId)

--- a/core/src/commonMain/kotlin/cache/data/UserData.kt
+++ b/core/src/commonMain/kotlin/cache/data/UserData.kt
@@ -10,6 +10,7 @@ import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
 import kotlinx.serialization.Serializable
 
+private val ThreadMemberData.nullableUserId get() = userId.value
 
 @Serializable
 public data class UserData(
@@ -28,6 +29,7 @@ public data class UserData(
 
         public val description: DataDescription<UserData, Snowflake> = description(UserData::id) {
             link(UserData::id to MemberData::userId)
+            link(UserData::id to ThreadMemberData::nullableUserId)
             link(UserData::id to VoiceStateData::userId)
             link(UserData::id to PresenceData::userId)
         }

--- a/core/src/commonMain/kotlin/cache/data/UserData.kt
+++ b/core/src/commonMain/kotlin/cache/data/UserData.kt
@@ -10,7 +10,6 @@ import dev.kord.common.entity.optional.Optional
 import dev.kord.common.entity.optional.OptionalBoolean
 import kotlinx.serialization.Serializable
 
-private val WebhookData.nullableUserId get() = userId.value
 
 @Serializable
 public data class UserData(
@@ -29,7 +28,6 @@ public data class UserData(
 
         public val description: DataDescription<UserData, Snowflake> = description(UserData::id) {
             link(UserData::id to MemberData::userId)
-            link(UserData::id to WebhookData::nullableUserId)
             link(UserData::id to VoiceStateData::userId)
             link(UserData::id to PresenceData::userId)
         }


### PR DESCRIPTION
Links are supposed to go from the primary data to the data that should be removed on deletion of the primary data (e.g. guild -> member, members should be removed when a guild is deleted).

The link from `UserData` to `WebhookData` was removed, the webhook shouldn't be deleted if the user that created it is deleted.

More links were added:

 * from `ChannelData` to `MessageData`, `ThreadMemberData`, `WebhookData` and `VoiceStateData`
 * from `GuildData` to `EmojiData`
 * from `UserData` to `ThreadMemberData`

See https://github.com/kordlib/cache/blob/024dedd2b866d4098df5d3f885636c7eb6a22a8f/README.md#cascading