### PR TITLE
Fix test related Gradle deprecation warnings

### DIFF
--- a/buildSrc/src/main/kotlin/kord-internal-multiplatform-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/kord-internal-multiplatform-module.gradle.kts
@@ -20,3 +20,9 @@ kotlin {
         }
     }
 }
+
+tasks {
+    withType<Test>().configureEach {
+        useJUnitPlatform()
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,7 @@ nextPlannedVersion=0.14.0
 #dokka will run out of memory with the default meta space
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=1024m
 org.gradle.parallel=true
+org.gradle.warning.mode=all
 org.gradle.kotlin.dsl.allWarningsAsErrors=true
 kotlin.code.style=official
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,8 @@ ksp = "1.9.22-1.0.17" # https://github.com/google/ksp
 kotlinpoet = "1.16.0" # https://github.com/square/kotlinpoet
 
 # tests
-junit5 = "5.10.2" # https://github.com/junit-team/junit5
+junit-jupiter = "5.10.2" # https://github.com/junit-team/junit5
+junit-platform = "1.10.2"
 mockk = "1.13.10" # https://github.com/mockk/mockk
 
 # plugins
@@ -75,7 +76,9 @@ kotlin-test-annotations-common = { module = "org.jetbrains.kotlin:kotlin-test-an
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test-common", version.ref = "kotlin" }
 kotlin-test-js = { module = "org.jetbrains.kotlin:kotlin-test-js", version.ref = "kotlin" }
 kotlin-test-junit5 = { module = "org.jetbrains.kotlin:kotlin-test-junit5", version.ref = "kotlin" }
-junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit5" }
+junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit-jupiter" }
+junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit-jupiter" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version = "junit-platform" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
 
@@ -95,7 +98,8 @@ ktor-client-serialization = ["ktor-client-content-negotiation", "ktor-serializat
 
 test-common = ["kotlin-test-annotations-common", "kotlin-test", "kotlinx-coroutines-test"]
 test-js = ["kotlin-test-js", "kotlin-node"]
-test-jvm = ["kotlin-test-junit5", "junit-jupiter-engine", "slf4j-simple"]
+test-jvm = ["kotlin-test-junit5", "junit-jupiter-api"]
+test-jvm-runtime = ["junit-jupiter-engine", "junit-platform-launcher", "slf4j-simple"]
 
 pluginsForBuildSrc = [
     "kotlin-jvm-plugin",

--- a/test-kit/build.gradle.kts
+++ b/test-kit/build.gradle.kts
@@ -18,6 +18,7 @@ kotlin {
         jvmMain {
             dependencies {
                 api(libs.bundles.test.jvm)
+                runtimeOnly(libs.bundles.test.jvm.runtime)
             }
         }
     }


### PR DESCRIPTION
The following deprecation warnings have been fixed:

```
> Task :common:jvmTest
The automatic loading of test framework implementation dependencies has been deprecated. This is scheduled to be removed in Gradle 9.0. Declare the desired test framework directly on the test suite or explicitly declare the test framework implementation dependencies on the test's runtime classpath. Consult the upgrading guide for further information: https://docs.gradle.org/8.6/userguide/upgrading_version_8.html#test_framework_implementation_dependencies
```
-> fixed by adding an explicit `runtimeOnly` dependency on `org.junit.platform:junit-platform-launcher`

```
> Task :core:live-tests:jvmTest
No test executed. This behavior has been deprecated. This will fail with an error in Gradle 9.0. There are test sources present but no test was executed. Please check your test configuration. Consult the upgrading guide for further information:
https://docs.gradle.org/8.6/userguide/upgrading_version_8.html#test_task_fail_on_no_test_executed
```
-> fixed by configuring `Test` tasks with `useJUnitPlatform()` in `kord-internal-multiplatform-module` (used by `:core:live-tests`)

`org.gradle.warning.mode` was set to `all` to verify that these deprecation warnings are indeed fixed on CI.