### PR TITLE
Support other `SerialFormat`s in `LongOrStringSerializer`

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -37,6 +37,12 @@ kotlin {
                 implementation(projects.kspAnnotations)
             }
         }
+        jvmTest {
+            dependencies {
+                implementation(libs.bson)
+                implementation(libs.kbson)
+            }
+        }
     }
 }
 

--- a/common/src/jvmTest/kotlin/serialization/LongOrStringSerializerBsonTest.kt
+++ b/common/src/jvmTest/kotlin/serialization/LongOrStringSerializerBsonTest.kt
@@ -1,0 +1,38 @@
+package dev.kord.common.serialization
+
+import com.github.jershell.kbson.KBson
+import dev.kord.common.entity.Permission.*
+import dev.kord.common.entity.Permissions
+import kotlinx.serialization.Serializable
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class LongOrStringSerializerBsonTest {
+
+    @Serializable
+    private data class SomeObject(
+        @Serializable(with = LongOrStringSerializer::class) val someLong: String,
+        @Serializable(with = LongOrStringSerializer::class) val someString: String,
+        val somePermissions: Permissions,
+    )
+
+    private val someObject = SomeObject(
+        someLong = Random.nextLong().toString(),
+        someString = "some totally random string",
+        somePermissions = Permissions(DeafenMembers, ManageThreads, SendTTSMessages, ModerateMembers),
+    )
+
+    @Test
+    fun `test Bson serialization and deserialization with LongOrStringSerializer`() {
+        val kBson = KBson.default
+        assertEquals(
+            expected = someObject,
+            actual = kBson.load(SomeObject.serializer(), kBson.stringify(SomeObject.serializer(), someObject)),
+        )
+        assertEquals(
+            expected = someObject,
+            actual = kBson.load(SomeObject.serializer(), kBson.dump(SomeObject.serializer(), someObject)),
+        )
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,8 @@ kotlinpoet = "1.16.0" # https://github.com/square/kotlinpoet
 # tests
 junit5 = "5.10.2" # https://github.com/junit-team/junit5
 mockk = "1.13.10" # https://github.com/mockk/mockk
+bson = "5.0.1" # https://github.com/mongodb/mongo-java-driver
+kbson = "0.5.0" # https://github.com/jershell/kbson
 
 # plugins
 dokka = "1.9.20" # https://github.com/Kotlin/dokka
@@ -78,6 +80,8 @@ kotlin-test-junit5 = { module = "org.jetbrains.kotlin:kotlin-test-junit5", versi
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit5" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
+bson = { module = "org.mongodb:bson", version.ref = "bson" }
+kbson = { module = "com.github.jershell:kbson", version.ref = "kbson" }
 
 # actually plugins, not libraries, but used is 'buildSrc/build.gradle.kts' as implementation dependencies:
 # https://docs.gradle.org/current/userguide/custom_plugins.html#applying_external_plugins_in_precompiled_script_plugins


### PR DESCRIPTION
Non-`Json` formats are supported by falling back to a `String`.