### PR TITLE
Create sourceLink URL with non-deprecated URI constructor

### DIFF
--- a/buildSrc/src/main/kotlin/Documentation.kt
+++ b/buildSrc/src/main/kotlin/Documentation.kt
@@ -1,6 +1,6 @@
 import org.gradle.kotlin.dsl.assign
 import org.jetbrains.dokka.gradle.AbstractDokkaLeafTask
-import java.net.URL
+import java.net.URI
 
 fun AbstractDokkaLeafTask.applyKordDokkaOptions() {
 
@@ -16,7 +16,7 @@ fun AbstractDokkaLeafTask.applyKordDokkaOptions() {
 
         sourceLink {
             localDirectory = project.projectDir
-            remoteUrl = URL("https://github.com/kordlib/kord/blob/${project.commitHash}/${project.name}")
+            remoteUrl = URI("https://github.com/kordlib/kord/blob/${project.commitHash}/${project.name}").toURL()
             remoteLineSuffix = "#L"
         }
 


### PR DESCRIPTION
Fixes failing Gradle import of the project since `-Werror` is set and the URL constructor is deprecated.