### PR TITLE
Add MessageBuilder.Limits object

### DIFF
--- a/rest/api/rest.api
+++ b/rest/api/rest.api
@@ -2143,6 +2143,12 @@ public final class dev/kord/rest/builder/message/MessageBuilder$DefaultImpls {
 	public static fun addFile (Ldev/kord/rest/builder/message/MessageBuilder;Ljava/lang/String;Lio/ktor/client/request/forms/ChannelProvider;)Ldev/kord/rest/NamedFile;
 }
 
+public final class dev/kord/rest/builder/message/MessageBuilder$Limits {
+	public static final field INSTANCE Ldev/kord/rest/builder/message/MessageBuilder$Limits;
+	public static final field content I
+	public static final field embedCount I
+}
+
 public final class dev/kord/rest/builder/message/MessageBuilderJvmKt {
 	public static final fun addFile (Ldev/kord/rest/builder/message/MessageBuilder;Ljava/nio/file/Path;)Ldev/kord/rest/NamedFile;
 	public static final fun addFile (Ldev/kord/rest/builder/message/MessageBuilder;Ljava/nio/file/Path;Lkotlin/jvm/functions/Function1;)Ldev/kord/rest/NamedFile;

--- a/rest/api/rest.klib.api
+++ b/rest/api/rest.klib.api
@@ -385,6 +385,13 @@ abstract interface dev.kord.rest.builder.message/MessageBuilder { // dev.kord.re
         abstract fun <set-suppressEmbeds>(kotlin/Boolean?) // dev.kord.rest.builder.message/MessageBuilder.suppressEmbeds.<set-suppressEmbeds>|<set-suppressEmbeds>(kotlin.Boolean?){}[0]
 
     open fun addFile(kotlin/String, io.ktor.client.request.forms/ChannelProvider): dev.kord.rest/NamedFile // dev.kord.rest.builder.message/MessageBuilder.addFile|addFile(kotlin.String;io.ktor.client.request.forms.ChannelProvider){}[0]
+
+    final object Limits { // dev.kord.rest.builder.message/MessageBuilder.Limits|null[0]
+        final const val content // dev.kord.rest.builder.message/MessageBuilder.Limits.content|{}content[0]
+            final fun <get-content>(): kotlin/Int // dev.kord.rest.builder.message/MessageBuilder.Limits.content.<get-content>|<get-content>(){}[0]
+        final const val embedCount // dev.kord.rest.builder.message/MessageBuilder.Limits.embedCount|{}embedCount[0]
+            final fun <get-embedCount>(): kotlin/Int // dev.kord.rest.builder.message/MessageBuilder.Limits.embedCount.<get-embedCount>|<get-embedCount>(){}[0]
+    }
 }
 
 abstract interface dev.kord.rest.builder/AuditBuilder { // dev.kord.rest.builder/AuditBuilder|null[0]

--- a/rest/src/commonMain/kotlin/builder/message/MessageBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/message/MessageBuilder.kt
@@ -16,10 +16,10 @@ import kotlin.contracts.contract
 @KordDsl
 public interface MessageBuilder {
 
-    /** The message contents (up to 2000 characters). */
+    /** The message contents. Limited to the length of [Limits.content]. */
     public var content: String?
 
-    /** Up to 10 embeds (up to 6000 characters). */
+    /** The embeds in the message. Limited to [Limits.embedCount] embeds. */
     public var embeds: MutableList<EmbedBuilder>?
 
     /**
@@ -56,6 +56,18 @@ public interface MessageBuilder {
         val file = NamedFile(name, contentProvider)
         files.add(file)
         return file
+    }
+
+    public object Limits {
+        /**
+         * The maximum length of the [MessageBuilder.content] field.
+         */
+        public const val content: Int = 2000
+
+        /**
+         * The maximum amount of [MessageBuilder.embeds] in a [MessageBuilder].
+         */
+        public const val embedCount: Int = 10
     }
 }
 


### PR DESCRIPTION
Similar to `EmbedBuilder.Limits`,  added one for `MessageBuilder`, altough this one is an interface, so I'm not sure if there are any side effects to this?

Also, I'm missing one for files/attachments, but then when I saw that they are two separate fields, I wasn't sure how to do it.