### PR TITLE
Fix getMemberOrNull and getGuildMembers caching user data instead of member data

### DIFF
--- a/core/src/commonMain/kotlin/supplier/StoreEntitySupplier.kt
+++ b/core/src/commonMain/kotlin/supplier/StoreEntitySupplier.kt
@@ -61,7 +61,7 @@ public class StoreEntitySupplier(
     }
 
     override suspend fun getMemberOrNull(guildId: Snowflake, userId: Snowflake): Member? {
-        return storeAndReturn(supplier.getMemberOrNull(guildId, userId)) { it.data }
+        return storeAndReturn(supplier.getMemberOrNull(guildId, userId)) { it.memberData }
     }
 
     override suspend fun getMessageOrNull(channelId: Snowflake, messageId: Snowflake): Message? {
@@ -105,7 +105,7 @@ public class StoreEntitySupplier(
     }
 
     override fun getGuildMembers(guildId: Snowflake, limit: Int?): Flow<Member> {
-        return storeOnEach(supplier.getGuildMembers(guildId, limit)) { it.data }
+        return storeOnEach(supplier.getGuildMembers(guildId, limit)) { it.memberData }
     }
 
     override fun getGuildVoiceRegions(guildId: Snowflake): Flow<Region> {

--- a/core/src/commonMain/kotlin/supplier/StoreEntitySupplier.kt
+++ b/core/src/commonMain/kotlin/supplier/StoreEntitySupplier.kt
@@ -60,9 +60,11 @@ public class StoreEntitySupplier(
 
     }
 
-    override suspend fun getMemberOrNull(guildId: Snowflake, userId: Snowflake): Member? {
-        return storeAndReturn(supplier.getMemberOrNull(guildId, userId)) { it.memberData }
-    }
+    override suspend fun getMemberOrNull(guildId: Snowflake, userId: Snowflake): Member? =
+        supplier.getMemberOrNull(guildId, userId)?.also { member ->
+            cache.put(member.data)
+            cache.put(member.memberData)
+        }
 
     override suspend fun getMessageOrNull(channelId: Snowflake, messageId: Snowflake): Message? {
         return storeAndReturn(supplier.getMessageOrNull(channelId, messageId)) { it.data }
@@ -104,9 +106,11 @@ public class StoreEntitySupplier(
         return storeOnEach(supplier.getGuildBans(guildId, limit)) { it.data }
     }
 
-    override fun getGuildMembers(guildId: Snowflake, limit: Int?): Flow<Member> {
-        return storeOnEach(supplier.getGuildMembers(guildId, limit)) { it.memberData }
-    }
+    override fun getGuildMembers(guildId: Snowflake, limit: Int?): Flow<Member> =
+        supplier.getGuildMembers(guildId, limit).onEach { member ->
+            cache.put(member.data)
+            cache.put(member.memberData)
+        }
 
     override fun getGuildVoiceRegions(guildId: Snowflake): Flow<Region> {
         return storeOnEach(supplier.getGuildVoiceRegions(guildId)) { it.data }


### PR DESCRIPTION
[As reported in Discord](https://canary.discord.com/channels/556525343595298817/1271484633610981493), these calls are storing the results to the user cache, so subsequent calls would not find them from cache.

When using `cacheWithCachingRestFallback`, this results in REST calls being made every single time to get members, unless they got cached from a gateway event.