### PR TITLE
fix: Implementation for Equals & Hashcode in Builder

### DIFF
--- a/rest/src/commonMain/kotlin/builder/application/ApplicationRoleConnectionMetadata.kt
+++ b/rest/src/commonMain/kotlin/builder/application/ApplicationRoleConnectionMetadata.kt
@@ -39,6 +39,20 @@ public class ApplicationRoleConnectionMetadataRecordsBuilder :
     }
 
     override fun toRequest(): List<DiscordApplicationRoleConnectionMetadata> = records.map { it.toRequest() }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as ApplicationRoleConnectionMetadataRecordsBuilder
+
+        return records == other.records
+    }
+
+    override fun hashCode(): Int {
+        return records.hashCode()
+    }
+
 }
 
 @KordDsl

--- a/rest/src/commonMain/kotlin/builder/auditlog/AuditLogGetRequestBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/auditlog/AuditLogGetRequestBuilder.kt
@@ -40,4 +40,29 @@ public class AuditLogGetRequestBuilder : RequestBuilder<AuditLogGetRequest> {
     public var limit: Int? = null
 
     override fun toRequest(): AuditLogGetRequest = AuditLogGetRequest(userId, action, before, after, limit)
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as AuditLogGetRequestBuilder
+
+        if (userId != other.userId) return false
+        if (action != other.action) return false
+        if (before != other.before) return false
+        if (after != other.after) return false
+        if (limit != other.limit) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = userId?.hashCode() ?: 0
+        result = 31 * result + (action?.hashCode() ?: 0)
+        result = 31 * result + (before?.hashCode() ?: 0)
+        result = 31 * result + (after?.hashCode() ?: 0)
+        result = 31 * result + (limit ?: 0)
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/automoderation/AutoModerationActionBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/automoderation/AutoModerationActionBuilder.kt
@@ -29,6 +29,20 @@ public sealed class AutoModerationActionBuilder : RequestBuilder<DiscordAutoMode
         type = type,
         metadata = buildMetadata(),
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as AutoModerationActionBuilder
+
+        return type == other.type
+    }
+
+    override fun hashCode(): Int {
+        return type.hashCode()
+    }
+
 }
 
 /** An [AutoModerationActionBuilder] for building actions with type [BlockMessage]. */
@@ -53,6 +67,23 @@ public class BlockMessageAutoModerationActionBuilder : AutoModerationActionBuild
             Optional.Missing()
         }
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        if (!super.equals(other)) return false
+
+        other as BlockMessageAutoModerationActionBuilder
+
+        return customMessage == other.customMessage
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + (customMessage?.hashCode() ?: 0)
+        return result
+    }
+
 }
 
 /** An [AutoModerationActionBuilder] for building actions with type [SendAlertMessage]. */
@@ -66,6 +97,23 @@ public class SendAlertMessageAutoModerationActionBuilder(
 
     override fun buildMetadata(): Optional.Value<DiscordAutoModerationActionMetadata> =
         DiscordAutoModerationActionMetadata(channelId = channelId.optionalSnowflake()).optional()
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        if (!super.equals(other)) return false
+
+        other as SendAlertMessageAutoModerationActionBuilder
+
+        return channelId == other.channelId
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + channelId.hashCode()
+        return result
+    }
+
 }
 
 /** An [AutoModerationActionBuilder] for building actions with type [Timeout]. */
@@ -79,4 +127,21 @@ public class TimeoutAutoModerationActionBuilder(
 
     override fun buildMetadata(): Optional.Value<DiscordAutoModerationActionMetadata> =
         DiscordAutoModerationActionMetadata(durationSeconds = duration.optional()).optional()
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        if (!super.equals(other)) return false
+
+        other as TimeoutAutoModerationActionBuilder
+
+        return duration == other.duration
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + duration.hashCode()
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/automoderation/AutoModerationRuleCreateBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/automoderation/AutoModerationRuleCreateBuilder.kt
@@ -56,6 +56,35 @@ public sealed class AutoModerationRuleCreateBuilder(
         exemptRoles = _exemptRoles.mapCopy(),
         exemptChannels = _exemptChannels.mapCopy(),
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as AutoModerationRuleCreateBuilder
+
+        if (name != other.name) return false
+        if (eventType != other.eventType) return false
+        if (reason != other.reason) return false
+        if (actions != other.actions) return false
+        if (enabled != other.enabled) return false
+        if (exemptRoles != other.exemptRoles) return false
+        if (exemptChannels != other.exemptChannels) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = name.hashCode()
+        result = 31 * result + eventType.hashCode()
+        result = 31 * result + (reason?.hashCode() ?: 0)
+        result = 31 * result + actions.hashCode()
+        result = 31 * result + (enabled?.hashCode() ?: 0)
+        result = 31 * result + (exemptRoles?.hashCode() ?: 0)
+        result = 31 * result + (exemptChannels?.hashCode() ?: 0)
+        return result
+    }
+
 }
 
 /** A [KeywordAutoModerationRuleBuilder] for building [AutoModerationRuleCreateRequest]s. */
@@ -81,6 +110,29 @@ public class KeywordAutoModerationRuleCreateBuilder(
             regexPatterns = _regexPatterns.mapCopy(),
             allowList = _allowedKeywords.mapCopy(),
         ).optional()
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        if (!super.equals(other)) return false
+
+        other as KeywordAutoModerationRuleCreateBuilder
+
+        if (keywords != other.keywords) return false
+        if (regexPatterns != other.regexPatterns) return false
+        if (allowedKeywords != other.allowedKeywords) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + (keywords?.hashCode() ?: 0)
+        result = 31 * result + (regexPatterns?.hashCode() ?: 0)
+        result = 31 * result + (allowedKeywords?.hashCode() ?: 0)
+        return result
+    }
+
 }
 
 /** A [SpamAutoModerationRuleBuilder] for building [AutoModerationRuleCreateRequest]s. */
@@ -112,6 +164,27 @@ public class KeywordPresetAutoModerationRuleCreateBuilder(
             presets = presets.toList().optional(),
             allowList = _allowedKeywords.mapCopy(),
         ).optional()
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        if (!super.equals(other)) return false
+
+        other as KeywordPresetAutoModerationRuleCreateBuilder
+
+        if (presets != other.presets) return false
+        if (allowedKeywords != other.allowedKeywords) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + presets.hashCode()
+        result = 31 * result + (allowedKeywords?.hashCode() ?: 0)
+        return result
+    }
+
 }
 
 /** A [MentionSpamAutoModerationRuleBuilder] for building [AutoModerationRuleCreateRequest]s. */
@@ -134,4 +207,25 @@ public class MentionSpamAutoModerationRuleCreateBuilder(
             mentionTotalLimit = _mentionLimit,
             mentionRaidProtectionEnabled = _mentionRaidProtectionEnabled,
         ).optional()
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        if (!super.equals(other)) return false
+
+        other as MentionSpamAutoModerationRuleCreateBuilder
+
+        if (mentionLimit != other.mentionLimit) return false
+        if (mentionRaidProtectionEnabled != other.mentionRaidProtectionEnabled) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + (mentionLimit ?: 0)
+        result = 31 * result + (mentionRaidProtectionEnabled?.hashCode() ?: 0)
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/automoderation/AutoModerationRuleModifyBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/automoderation/AutoModerationRuleModifyBuilder.kt
@@ -60,6 +60,35 @@ public sealed class AutoModerationRuleModifyBuilder :
         exemptRoles = _exemptRoles.mapCopy(),
         exemptChannels = _exemptChannels.mapCopy(),
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as AutoModerationRuleModifyBuilder
+
+        if (reason != other.reason) return false
+        if (name != other.name) return false
+        if (eventType != other.eventType) return false
+        if (actions != other.actions) return false
+        if (enabled != other.enabled) return false
+        if (exemptRoles != other.exemptRoles) return false
+        if (exemptChannels != other.exemptChannels) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = reason?.hashCode() ?: 0
+        result = 31 * result + (name?.hashCode() ?: 0)
+        result = 31 * result + (eventType?.hashCode() ?: 0)
+        result = 31 * result + (actions?.hashCode() ?: 0)
+        result = 31 * result + (enabled?.hashCode() ?: 0)
+        result = 31 * result + (exemptRoles?.hashCode() ?: 0)
+        result = 31 * result + (exemptChannels?.hashCode() ?: 0)
+        return result
+    }
+
 }
 
 /** An [AutoModerationRuleModifyBuilder] with an always `null` [triggerType]. */
@@ -71,6 +100,23 @@ public class UntypedAutoModerationRuleModifyBuilder : AutoModerationRuleModifyBu
      * [trigger type][AutoModerationRuleTriggerType] based on the type system.
      */
     override val triggerType: Nothing? get() = null
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        if (!super.equals(other)) return false
+
+        other as UntypedAutoModerationRuleModifyBuilder
+
+        return triggerType == other.triggerType
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + (triggerType?.hashCode() ?: 0)
+        return result
+    }
+
 }
 
 /** A [KeywordAutoModerationRuleBuilder] for building [AutoModerationRuleModifyRequest]s. */
@@ -100,6 +146,29 @@ public class KeywordAutoModerationRuleModifyBuilder :
             )
         }
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        if (!super.equals(other)) return false
+
+        other as KeywordAutoModerationRuleModifyBuilder
+
+        if (keywords != other.keywords) return false
+        if (regexPatterns != other.regexPatterns) return false
+        if (allowedKeywords != other.allowedKeywords) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + (keywords?.hashCode() ?: 0)
+        result = 31 * result + (regexPatterns?.hashCode() ?: 0)
+        result = 31 * result + (allowedKeywords?.hashCode() ?: 0)
+        return result
+    }
+
 }
 
 /** A [SpamAutoModerationRuleBuilder] for building [AutoModerationRuleModifyRequest]s. */
@@ -136,6 +205,27 @@ public class KeywordPresetAutoModerationRuleModifyBuilder :
             )
         }
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        if (!super.equals(other)) return false
+
+        other as KeywordPresetAutoModerationRuleModifyBuilder
+
+        if (presets != other.presets) return false
+        if (allowedKeywords != other.allowedKeywords) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + (presets?.hashCode() ?: 0)
+        result = 31 * result + (allowedKeywords?.hashCode() ?: 0)
+        return result
+    }
+
 }
 
 /** A [MentionSpamAutoModerationRuleBuilder] for building [AutoModerationRuleModifyRequest]s. */
@@ -162,6 +252,27 @@ public class MentionSpamAutoModerationRuleModifyBuilder :
             Optional.Missing()
         }
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        if (!super.equals(other)) return false
+
+        other as MentionSpamAutoModerationRuleModifyBuilder
+
+        if (mentionLimit != other.mentionLimit) return false
+        if (mentionRaidProtectionEnabled != other.mentionRaidProtectionEnabled) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + (mentionLimit ?: 0)
+        result = 31 * result + (mentionRaidProtectionEnabled?.hashCode() ?: 0)
+        return result
+    }
+
 }
 
 private inline fun <T : Any> ifAnyPresent(vararg optionals: Optional<*>, block: () -> T): Optional<T> {

--- a/rest/src/commonMain/kotlin/builder/ban/BanCreateBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/ban/BanCreateBuilder.kt
@@ -20,4 +20,23 @@ public class BanCreateBuilder : AuditRequestBuilder<GuildBanCreateRequest> {
     override fun toRequest(): GuildBanCreateRequest = GuildBanCreateRequest(
         deleteMessageSeconds = _deleteMessageDuration,
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as BanCreateBuilder
+
+        if (reason != other.reason) return false
+        if (deleteMessageDuration != other.deleteMessageDuration) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = reason?.hashCode() ?: 0
+        result = 31 * result + (deleteMessageDuration?.hashCode() ?: 0)
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/channel/CategoryCreateBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/channel/CategoryCreateBuilder.kt
@@ -31,4 +31,29 @@ public class CategoryCreateBuilder(
         permissionOverwrite = Optional.missingOnEmpty(permissionOverwrites),
         type = ChannelType.GuildCategory
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as CategoryCreateBuilder
+
+        if (name != other.name) return false
+        if (reason != other.reason) return false
+        if (position != other.position) return false
+        if (nsfw != other.nsfw) return false
+        if (permissionOverwrites != other.permissionOverwrites) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = name.hashCode()
+        result = 31 * result + (reason?.hashCode() ?: 0)
+        result = 31 * result + (position ?: 0)
+        result = 31 * result + (nsfw?.hashCode() ?: 0)
+        result = 31 * result + permissionOverwrites.hashCode()
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/channel/CategoryModifyBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/channel/CategoryModifyBuilder.kt
@@ -39,4 +39,27 @@ public class CategoryModifyBuilder : PermissionOverwritesModifyBuilder, AuditReq
         position = _position,
         permissionOverwrites = _permissionOverwrites
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as CategoryModifyBuilder
+
+        if (reason != other.reason) return false
+        if (name != other.name) return false
+        if (position != other.position) return false
+        if (permissionOverwrites != other.permissionOverwrites) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = reason?.hashCode() ?: 0
+        result = 31 * result + (name?.hashCode() ?: 0)
+        result = 31 * result + (position ?: 0)
+        result = 31 * result + (permissionOverwrites?.hashCode() ?: 0)
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/channel/ChannelPermissionModifyBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/channel/ChannelPermissionModifyBuilder.kt
@@ -24,4 +24,26 @@ public class ChannelPermissionModifyBuilder(private var type: OverwriteType) :
 
     override fun toRequest(): ChannelPermissionEditRequest = ChannelPermissionEditRequest(allowed, denied, type)
 
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as ChannelPermissionModifyBuilder
+
+        if (type != other.type) return false
+        if (reason != other.reason) return false
+        if (allowed != other.allowed) return false
+        if (denied != other.denied) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = type.hashCode()
+        result = 31 * result + (reason?.hashCode() ?: 0)
+        result = 31 * result + allowed.hashCode()
+        result = 31 * result + denied.hashCode()
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/channel/EditGuildChannelBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/channel/EditGuildChannelBuilder.kt
@@ -59,6 +59,41 @@ public class TextChannelModifyBuilder : PermissionOverwritesModifyBuilder,
         defaultAutoArchiveDuration = _defaultAutoArchiveDuration,
         defaultThreadRateLimitPerUser = _defaultThreadRateLimitPerUser,
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as TextChannelModifyBuilder
+
+        if (reason != other.reason) return false
+        if (name != other.name) return false
+        if (position != other.position) return false
+        if (topic != other.topic) return false
+        if (nsfw != other.nsfw) return false
+        if (parentId != other.parentId) return false
+        if (rateLimitPerUser != other.rateLimitPerUser) return false
+        if (permissionOverwrites != other.permissionOverwrites) return false
+        if (defaultAutoArchiveDuration != other.defaultAutoArchiveDuration) return false
+        if (defaultThreadRateLimitPerUser != other.defaultThreadRateLimitPerUser) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = reason?.hashCode() ?: 0
+        result = 31 * result + (name?.hashCode() ?: 0)
+        result = 31 * result + (position ?: 0)
+        result = 31 * result + (topic?.hashCode() ?: 0)
+        result = 31 * result + (nsfw?.hashCode() ?: 0)
+        result = 31 * result + (parentId?.hashCode() ?: 0)
+        result = 31 * result + (rateLimitPerUser?.hashCode() ?: 0)
+        result = 31 * result + (permissionOverwrites?.hashCode() ?: 0)
+        result = 31 * result + (defaultAutoArchiveDuration?.hashCode() ?: 0)
+        result = 31 * result + (defaultThreadRateLimitPerUser?.hashCode() ?: 0)
+        return result
+    }
+
 }
 
 @KordDsl
@@ -148,6 +183,54 @@ public class ForumChannelModifyBuilder : PermissionOverwritesModifyBuilder,
         flags = _flags
     )
 
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as ForumChannelModifyBuilder
+
+        if (reason != other.reason) return false
+        if (name != other.name) return false
+        if (position != other.position) return false
+        if (topic != other.topic) return false
+        if (nsfw != other.nsfw) return false
+        if (parentId != other.parentId) return false
+        if (rateLimitPerUser != other.rateLimitPerUser) return false
+        if (permissionOverwrites != other.permissionOverwrites) return false
+        if (defaultAutoArchiveDuration != other.defaultAutoArchiveDuration) return false
+        if (flags != other.flags) return false
+        if (defaultReactionEmoji != other.defaultReactionEmoji) return false
+        if (defaultReactionEmojiId != other.defaultReactionEmojiId) return false
+        if (defaultReactionEmojiName != other.defaultReactionEmojiName) return false
+        if (availableTags != other.availableTags) return false
+        if (defaultThreadRateLimitPerUser != other.defaultThreadRateLimitPerUser) return false
+        if (defaultSortOrder != other.defaultSortOrder) return false
+        if (defaultForumLayout != other.defaultForumLayout) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = reason?.hashCode() ?: 0
+        result = 31 * result + (name?.hashCode() ?: 0)
+        result = 31 * result + (position ?: 0)
+        result = 31 * result + (topic?.hashCode() ?: 0)
+        result = 31 * result + (nsfw?.hashCode() ?: 0)
+        result = 31 * result + (parentId?.hashCode() ?: 0)
+        result = 31 * result + (rateLimitPerUser?.hashCode() ?: 0)
+        result = 31 * result + (permissionOverwrites?.hashCode() ?: 0)
+        result = 31 * result + (defaultAutoArchiveDuration?.hashCode() ?: 0)
+        result = 31 * result + (flags?.hashCode() ?: 0)
+        result = 31 * result + (defaultReactionEmoji?.hashCode() ?: 0)
+        result = 31 * result + (defaultReactionEmojiId?.hashCode() ?: 0)
+        result = 31 * result + (defaultReactionEmojiName?.hashCode() ?: 0)
+        result = 31 * result + (availableTags?.hashCode() ?: 0)
+        result = 31 * result + (defaultThreadRateLimitPerUser?.hashCode() ?: 0)
+        result = 31 * result + (defaultSortOrder?.hashCode() ?: 0)
+        result = 31 * result + (defaultForumLayout?.hashCode() ?: 0)
+        return result
+    }
+
 }
 
 @KordDsl
@@ -229,6 +312,53 @@ public class MediaChannelModifyBuilder : PermissionOverwritesModifyBuilder,
         defaultSortOrder = _defaultSortOrder,
         flags = _flags
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as MediaChannelModifyBuilder
+
+        if (reason != other.reason) return false
+        if (name != other.name) return false
+        if (position != other.position) return false
+        if (topic != other.topic) return false
+        if (nsfw != other.nsfw) return false
+        if (parentId != other.parentId) return false
+        if (rateLimitPerUser != other.rateLimitPerUser) return false
+        if (permissionOverwrites != other.permissionOverwrites) return false
+        if (defaultAutoArchiveDuration != other.defaultAutoArchiveDuration) return false
+        if (flags != other.flags) return false
+        if (defaultReactionEmoji != other.defaultReactionEmoji) return false
+        if (defaultReactionEmojiId != other.defaultReactionEmojiId) return false
+        if (defaultReactionEmojiName != other.defaultReactionEmojiName) return false
+        if (availableTags != other.availableTags) return false
+        if (defaultThreadRateLimitPerUser != other.defaultThreadRateLimitPerUser) return false
+        if (defaultSortOrder != other.defaultSortOrder) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = reason?.hashCode() ?: 0
+        result = 31 * result + (name?.hashCode() ?: 0)
+        result = 31 * result + (position ?: 0)
+        result = 31 * result + (topic?.hashCode() ?: 0)
+        result = 31 * result + (nsfw?.hashCode() ?: 0)
+        result = 31 * result + (parentId?.hashCode() ?: 0)
+        result = 31 * result + (rateLimitPerUser?.hashCode() ?: 0)
+        result = 31 * result + (permissionOverwrites?.hashCode() ?: 0)
+        result = 31 * result + (defaultAutoArchiveDuration?.hashCode() ?: 0)
+        result = 31 * result + (flags?.hashCode() ?: 0)
+        result = 31 * result + (defaultReactionEmoji?.hashCode() ?: 0)
+        result = 31 * result + (defaultReactionEmojiId?.hashCode() ?: 0)
+        result = 31 * result + (defaultReactionEmojiName?.hashCode() ?: 0)
+        result = 31 * result + (availableTags?.hashCode() ?: 0)
+        result = 31 * result + (defaultThreadRateLimitPerUser?.hashCode() ?: 0)
+        result = 31 * result + (defaultSortOrder?.hashCode() ?: 0)
+        return result
+    }
+
 }
 
 @KordDsl
@@ -281,8 +411,43 @@ public class VoiceChannelModifyBuilder : PermissionOverwritesModifyBuilder,
         videoQualityMode = _videoQualityMode,
     )
 
-}
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
 
+        other as VoiceChannelModifyBuilder
+
+        if (reason != other.reason) return false
+        if (name != other.name) return false
+        if (rtcRegion != other.rtcRegion) return false
+        if (position != other.position) return false
+        if (topic != other.topic) return false
+        if (nsfw != other.nsfw) return false
+        if (parentId != other.parentId) return false
+        if (permissionOverwrites != other.permissionOverwrites) return false
+        if (bitrate != other.bitrate) return false
+        if (userLimit != other.userLimit) return false
+        if (videoQualityMode != other.videoQualityMode) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = reason?.hashCode() ?: 0
+        result = 31 * result + (name?.hashCode() ?: 0)
+        result = 31 * result + (rtcRegion?.hashCode() ?: 0)
+        result = 31 * result + (position ?: 0)
+        result = 31 * result + (topic?.hashCode() ?: 0)
+        result = 31 * result + (nsfw?.hashCode() ?: 0)
+        result = 31 * result + (parentId?.hashCode() ?: 0)
+        result = 31 * result + (permissionOverwrites?.hashCode() ?: 0)
+        result = 31 * result + (bitrate ?: 0)
+        result = 31 * result + (userLimit ?: 0)
+        result = 31 * result + (videoQualityMode?.hashCode() ?: 0)
+        return result
+    }
+
+}
 
 @KordDsl
 public class StageVoiceChannelModifyBuilder : PermissionOverwritesModifyBuilder,
@@ -319,6 +484,36 @@ public class StageVoiceChannelModifyBuilder : PermissionOverwritesModifyBuilder,
         permissionOverwrites = _permissionOverwrites,
         rtcRegion = _rtcRegion,
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as StageVoiceChannelModifyBuilder
+
+        if (reason != other.reason) return false
+        if (name != other.name) return false
+        if (rtcRegion != other.rtcRegion) return false
+        if (position != other.position) return false
+        if (topic != other.topic) return false
+        if (parentId != other.parentId) return false
+        if (permissionOverwrites != other.permissionOverwrites) return false
+        if (bitrate != other.bitrate) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = reason?.hashCode() ?: 0
+        result = 31 * result + (name?.hashCode() ?: 0)
+        result = 31 * result + (rtcRegion?.hashCode() ?: 0)
+        result = 31 * result + (position ?: 0)
+        result = 31 * result + (topic?.hashCode() ?: 0)
+        result = 31 * result + (parentId?.hashCode() ?: 0)
+        result = 31 * result + (permissionOverwrites?.hashCode() ?: 0)
+        result = 31 * result + (bitrate ?: 0)
+        return result
+    }
 
 }
 
@@ -366,4 +561,37 @@ public class NewsChannelModifyBuilder : PermissionOverwritesModifyBuilder,
         permissionOverwrites = _permissionOverwrites,
         defaultAutoArchiveDuration = _defaultAutoArchiveDuration,
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as NewsChannelModifyBuilder
+
+        if (reason != other.reason) return false
+        if (name != other.name) return false
+        if (position != other.position) return false
+        if (topic != other.topic) return false
+        if (nsfw != other.nsfw) return false
+        if (parentId != other.parentId) return false
+        if (rateLimitPerUser != other.rateLimitPerUser) return false
+        if (permissionOverwrites != other.permissionOverwrites) return false
+        if (defaultAutoArchiveDuration != other.defaultAutoArchiveDuration) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = reason?.hashCode() ?: 0
+        result = 31 * result + (name?.hashCode() ?: 0)
+        result = 31 * result + (position ?: 0)
+        result = 31 * result + (topic?.hashCode() ?: 0)
+        result = 31 * result + (nsfw?.hashCode() ?: 0)
+        result = 31 * result + (parentId?.hashCode() ?: 0)
+        result = 31 * result + (rateLimitPerUser?.hashCode() ?: 0)
+        result = 31 * result + (permissionOverwrites?.hashCode() ?: 0)
+        result = 31 * result + (defaultAutoArchiveDuration?.hashCode() ?: 0)
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/channel/ForumChannelCreateBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/channel/ForumChannelCreateBuilder.kt
@@ -96,6 +96,55 @@ public class ForumChannelCreateBuilder(public var name: String) :
         flags = _flags,
         defaultForumLayout = _defaultForumLayout,
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as ForumChannelCreateBuilder
+
+        if (name != other.name) return false
+        if (reason != other.reason) return false
+        if (topic != other.topic) return false
+        if (rateLimitPerUser != other.rateLimitPerUser) return false
+        if (position != other.position) return false
+        if (parentId != other.parentId) return false
+        if (nsfw != other.nsfw) return false
+        if (defaultAutoArchiveDuration != other.defaultAutoArchiveDuration) return false
+        if (permissionOverwrites != other.permissionOverwrites) return false
+        if (defaultReactionEmoji != other.defaultReactionEmoji) return false
+        if (defaultReactionEmojiId != other.defaultReactionEmojiId) return false
+        if (defaultReactionEmojiName != other.defaultReactionEmojiName) return false
+        if (availableTags != other.availableTags) return false
+        if (defaultThreadRateLimitPerUser != other.defaultThreadRateLimitPerUser) return false
+        if (defaultSortOrder != other.defaultSortOrder) return false
+        if (defaultForumLayout != other.defaultForumLayout) return false
+        if (flags != other.flags) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = name.hashCode()
+        result = 31 * result + (reason?.hashCode() ?: 0)
+        result = 31 * result + (topic?.hashCode() ?: 0)
+        result = 31 * result + (rateLimitPerUser?.hashCode() ?: 0)
+        result = 31 * result + (position ?: 0)
+        result = 31 * result + (parentId?.hashCode() ?: 0)
+        result = 31 * result + (nsfw?.hashCode() ?: 0)
+        result = 31 * result + (defaultAutoArchiveDuration?.hashCode() ?: 0)
+        result = 31 * result + permissionOverwrites.hashCode()
+        result = 31 * result + (defaultReactionEmoji?.hashCode() ?: 0)
+        result = 31 * result + (defaultReactionEmojiId?.hashCode() ?: 0)
+        result = 31 * result + (defaultReactionEmojiName?.hashCode() ?: 0)
+        result = 31 * result + (availableTags?.hashCode() ?: 0)
+        result = 31 * result + (defaultThreadRateLimitPerUser?.hashCode() ?: 0)
+        result = 31 * result + (defaultSortOrder?.hashCode() ?: 0)
+        result = 31 * result + (defaultForumLayout?.hashCode() ?: 0)
+        result = 31 * result + (flags?.hashCode() ?: 0)
+        return result
+    }
+
 }
 
 @KordDsl
@@ -117,4 +166,27 @@ public class ForumTagBuilder(public var name: String) : RequestBuilder<ForumTagR
             emojiName = _reactionEmojiName
         )
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as ForumTagBuilder
+
+        if (name != other.name) return false
+        if (moderated != other.moderated) return false
+        if (reactionEmojiId != other.reactionEmojiId) return false
+        if (reactionEmojiName != other.reactionEmojiName) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = name.hashCode()
+        result = 31 * result + (moderated?.hashCode() ?: 0)
+        result = 31 * result + (reactionEmojiId?.hashCode() ?: 0)
+        result = 31 * result + (reactionEmojiName?.hashCode() ?: 0)
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/channel/GuildChannelPositionModifyBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/channel/GuildChannelPositionModifyBuilder.kt
@@ -37,6 +37,20 @@ public class GuildChannelPositionModifyBuilder : RequestBuilder<GuildChannelPosi
 
     override fun toRequest(): GuildChannelPositionModifyRequest =
         GuildChannelPositionModifyRequest(swaps.map { it.toRequest() })
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as GuildChannelPositionModifyBuilder
+
+        return swaps == other.swaps
+    }
+
+    override fun hashCode(): Int {
+        return swaps.hashCode()
+    }
+
 }
 
 @KordDsl
@@ -74,5 +88,27 @@ public class GuildChannelSwapBuilder(public var channelId: Snowflake) {
     public fun toRequest(): ChannelPositionSwapRequest = ChannelPositionSwapRequest(
         channelId, _position, _lockPermissionsToParent, _parentId
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as GuildChannelSwapBuilder
+
+        if (channelId != other.channelId) return false
+        if (position != other.position) return false
+        if (parentId != other.parentId) return false
+        if (lockPermissionsToParent != other.lockPermissionsToParent) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = channelId.hashCode()
+        result = 31 * result + (position ?: 0)
+        result = 31 * result + (parentId?.hashCode() ?: 0)
+        result = 31 * result + (lockPermissionsToParent?.hashCode() ?: 0)
+        return result
+    }
 
 }

--- a/rest/src/commonMain/kotlin/builder/channel/InviteCreateBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/channel/InviteCreateBuilder.kt
@@ -89,6 +89,37 @@ public class InviteCreateBuilder : AuditRequestBuilder<InviteCreateRequest> {
             targetApplicationId = _targetApplicationId,
         )
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as InviteCreateBuilder
+
+        if (reason != other.reason) return false
+        if (maxAge != other.maxAge) return false
+        if (maxUses != other.maxUses) return false
+        if (temporary != other.temporary) return false
+        if (unique != other.unique) return false
+        if (targetType != other.targetType) return false
+        if (targetUserId != other.targetUserId) return false
+        if (targetApplicationId != other.targetApplicationId) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = reason?.hashCode() ?: 0
+        result = 31 * result + (maxAge?.hashCode() ?: 0)
+        result = 31 * result + (maxUses ?: 0)
+        result = 31 * result + (temporary?.hashCode() ?: 0)
+        result = 31 * result + (unique?.hashCode() ?: 0)
+        result = 31 * result + (targetType?.hashCode() ?: 0)
+        result = 31 * result + (targetUserId?.hashCode() ?: 0)
+        result = 31 * result + (targetApplicationId?.hashCode() ?: 0)
+        return result
+    }
+
 }
 
 private inline val OptionalSnowflake.isMissing get() = this == OptionalSnowflake.Missing

--- a/rest/src/commonMain/kotlin/builder/channel/MediaChannelCreateBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/channel/MediaChannelCreateBuilder.kt
@@ -91,4 +91,51 @@ public class MediaChannelCreateBuilder(public var name: String) :
         defaultSortOrder = _defaultSortOrder,
         flags = _flags,
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as MediaChannelCreateBuilder
+
+        if (name != other.name) return false
+        if (reason != other.reason) return false
+        if (topic != other.topic) return false
+        if (rateLimitPerUser != other.rateLimitPerUser) return false
+        if (position != other.position) return false
+        if (parentId != other.parentId) return false
+        if (nsfw != other.nsfw) return false
+        if (defaultAutoArchiveDuration != other.defaultAutoArchiveDuration) return false
+        if (permissionOverwrites != other.permissionOverwrites) return false
+        if (defaultReactionEmoji != other.defaultReactionEmoji) return false
+        if (defaultReactionEmojiId != other.defaultReactionEmojiId) return false
+        if (defaultReactionEmojiName != other.defaultReactionEmojiName) return false
+        if (availableTags != other.availableTags) return false
+        if (defaultThreadRateLimitPerUser != other.defaultThreadRateLimitPerUser) return false
+        if (defaultSortOrder != other.defaultSortOrder) return false
+        if (flags != other.flags) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = name.hashCode()
+        result = 31 * result + (reason?.hashCode() ?: 0)
+        result = 31 * result + (topic?.hashCode() ?: 0)
+        result = 31 * result + (rateLimitPerUser?.hashCode() ?: 0)
+        result = 31 * result + (position ?: 0)
+        result = 31 * result + (parentId?.hashCode() ?: 0)
+        result = 31 * result + (nsfw?.hashCode() ?: 0)
+        result = 31 * result + (defaultAutoArchiveDuration?.hashCode() ?: 0)
+        result = 31 * result + permissionOverwrites.hashCode()
+        result = 31 * result + (defaultReactionEmoji?.hashCode() ?: 0)
+        result = 31 * result + (defaultReactionEmojiId?.hashCode() ?: 0)
+        result = 31 * result + (defaultReactionEmojiName?.hashCode() ?: 0)
+        result = 31 * result + (availableTags?.hashCode() ?: 0)
+        result = 31 * result + (defaultThreadRateLimitPerUser?.hashCode() ?: 0)
+        result = 31 * result + (defaultSortOrder?.hashCode() ?: 0)
+        result = 31 * result + (flags?.hashCode() ?: 0)
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/channel/NewsChannelCreateBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/channel/NewsChannelCreateBuilder.kt
@@ -51,4 +51,35 @@ public class NewsChannelCreateBuilder(public var name: String) :
         type = ChannelType.GuildNews,
         defaultAutoArchiveDuration = _defaultAutoArchiveDuration,
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as NewsChannelCreateBuilder
+
+        if (name != other.name) return false
+        if (reason != other.reason) return false
+        if (topic != other.topic) return false
+        if (nsfw != other.nsfw) return false
+        if (parentId != other.parentId) return false
+        if (position != other.position) return false
+        if (defaultAutoArchiveDuration != other.defaultAutoArchiveDuration) return false
+        if (permissionOverwrites != other.permissionOverwrites) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = name.hashCode()
+        result = 31 * result + (reason?.hashCode() ?: 0)
+        result = 31 * result + (topic?.hashCode() ?: 0)
+        result = 31 * result + (nsfw?.hashCode() ?: 0)
+        result = 31 * result + (parentId?.hashCode() ?: 0)
+        result = 31 * result + (position ?: 0)
+        result = 31 * result + (defaultAutoArchiveDuration?.hashCode() ?: 0)
+        result = 31 * result + permissionOverwrites.hashCode()
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/channel/PermissionOverwriteBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/channel/PermissionOverwriteBuilder.kt
@@ -12,4 +12,27 @@ public class PermissionOverwriteBuilder(private val type: OverwriteType, private
     public var denied: Permissions = Permissions()
 
     public fun toOverwrite(): Overwrite = Overwrite(id = id, allow = allowed, deny = denied, type = type)
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as PermissionOverwriteBuilder
+
+        if (type != other.type) return false
+        if (id != other.id) return false
+        if (allowed != other.allowed) return false
+        if (denied != other.denied) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = type.hashCode()
+        result = 31 * result + id.hashCode()
+        result = 31 * result + allowed.hashCode()
+        result = 31 * result + denied.hashCode()
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/channel/StageChannelCreateBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/channel/StageChannelCreateBuilder.kt
@@ -50,4 +50,37 @@ public class StageChannelCreateBuilder(public var name: String) :
         parentId = _parentId,
         nsfw = _nsfw
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as StageChannelCreateBuilder
+
+        if (name != other.name) return false
+        if (reason != other.reason) return false
+        if (bitrate != other.bitrate) return false
+        if (userLimit != other.userLimit) return false
+        if (rateLimitPerUser != other.rateLimitPerUser) return false
+        if (position != other.position) return false
+        if (permissionOverwrites != other.permissionOverwrites) return false
+        if (parentId != other.parentId) return false
+        if (nsfw != other.nsfw) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = name.hashCode()
+        result = 31 * result + (reason?.hashCode() ?: 0)
+        result = 31 * result + (bitrate ?: 0)
+        result = 31 * result + (userLimit ?: 0)
+        result = 31 * result + (rateLimitPerUser?.hashCode() ?: 0)
+        result = 31 * result + (position ?: 0)
+        result = 31 * result + permissionOverwrites.hashCode()
+        result = 31 * result + (parentId?.hashCode() ?: 0)
+        result = 31 * result + (nsfw?.hashCode() ?: 0)
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/channel/TextChannelCreateBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/channel/TextChannelCreateBuilder.kt
@@ -60,4 +60,39 @@ public class TextChannelCreateBuilder(public var name: String) :
         defaultAutoArchiveDuration = _defaultAutoArchiveDuration,
         defaultThreadRateLimitPerUser = _defaultThreadRateLimitPerUser
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as TextChannelCreateBuilder
+
+        if (name != other.name) return false
+        if (reason != other.reason) return false
+        if (topic != other.topic) return false
+        if (rateLimitPerUser != other.rateLimitPerUser) return false
+        if (position != other.position) return false
+        if (parentId != other.parentId) return false
+        if (nsfw != other.nsfw) return false
+        if (defaultAutoArchiveDuration != other.defaultAutoArchiveDuration) return false
+        if (permissionOverwrites != other.permissionOverwrites) return false
+        if (defaultThreadRateLimitPerUser != other.defaultThreadRateLimitPerUser) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = name.hashCode()
+        result = 31 * result + (reason?.hashCode() ?: 0)
+        result = 31 * result + (topic?.hashCode() ?: 0)
+        result = 31 * result + (rateLimitPerUser?.hashCode() ?: 0)
+        result = 31 * result + (position ?: 0)
+        result = 31 * result + (parentId?.hashCode() ?: 0)
+        result = 31 * result + (nsfw?.hashCode() ?: 0)
+        result = 31 * result + (defaultAutoArchiveDuration?.hashCode() ?: 0)
+        result = 31 * result + permissionOverwrites.hashCode()
+        result = 31 * result + (defaultThreadRateLimitPerUser?.hashCode() ?: 0)
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/channel/VoiceChannelCreateBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/channel/VoiceChannelCreateBuilder.kt
@@ -45,4 +45,35 @@ public class VoiceChannelCreateBuilder(public var name: String) :
         permissionOverwrite = Optional.missingOnEmpty(permissionOverwrites),
         type = ChannelType.GuildVoice
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as VoiceChannelCreateBuilder
+
+        if (name != other.name) return false
+        if (reason != other.reason) return false
+        if (bitrate != other.bitrate) return false
+        if (userLimit != other.userLimit) return false
+        if (parentId != other.parentId) return false
+        if (nsfw != other.nsfw) return false
+        if (position != other.position) return false
+        if (permissionOverwrites != other.permissionOverwrites) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = name.hashCode()
+        result = 31 * result + (reason?.hashCode() ?: 0)
+        result = 31 * result + (bitrate ?: 0)
+        result = 31 * result + (userLimit ?: 0)
+        result = 31 * result + (parentId?.hashCode() ?: 0)
+        result = 31 * result + (nsfw?.hashCode() ?: 0)
+        result = 31 * result + (position ?: 0)
+        result = 31 * result + permissionOverwrites.hashCode()
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/channel/thread/StartForumThreadBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/channel/thread/StartForumThreadBuilder.kt
@@ -51,6 +51,33 @@ public class StartForumThreadBuilder(public var name: String) : AuditRequestBuil
             files = messageRequest.files,
         )
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as StartForumThreadBuilder
+
+        if (name != other.name) return false
+        if (reason != other.reason) return false
+        if (autoArchiveDuration != other.autoArchiveDuration) return false
+        if (rateLimitPerUser != other.rateLimitPerUser) return false
+        if (appliedTags != other.appliedTags) return false
+        if (message != other.message) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = name.hashCode()
+        result = 31 * result + (reason?.hashCode() ?: 0)
+        result = 31 * result + (autoArchiveDuration?.hashCode() ?: 0)
+        result = 31 * result + (rateLimitPerUser?.hashCode() ?: 0)
+        result = 31 * result + (appliedTags?.hashCode() ?: 0)
+        result = 31 * result + message.hashCode()
+        return result
+    }
+
 }
 
 /** Add a [tagId] to [appliedTags][StartForumThreadBuilder.appliedTags]. */

--- a/rest/src/commonMain/kotlin/builder/channel/thread/StartThreadBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/channel/thread/StartThreadBuilder.kt
@@ -37,4 +37,31 @@ public class StartThreadBuilder(
             rateLimitPerUser = _rateLimitPerUser
         )
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as StartThreadBuilder
+
+        if (name != other.name) return false
+        if (type != other.type) return false
+        if (reason != other.reason) return false
+        if (autoArchiveDuration != other.autoArchiveDuration) return false
+        if (rateLimitPerUser != other.rateLimitPerUser) return false
+        if (invitable != other.invitable) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = name.hashCode()
+        result = 31 * result + type.hashCode()
+        result = 31 * result + (reason?.hashCode() ?: 0)
+        result = 31 * result + (autoArchiveDuration?.hashCode() ?: 0)
+        result = 31 * result + (rateLimitPerUser?.hashCode() ?: 0)
+        result = 31 * result + (invitable?.hashCode() ?: 0)
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/channel/thread/StartThreadWithMessageBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/channel/thread/StartThreadWithMessageBuilder.kt
@@ -26,4 +26,27 @@ public class StartThreadWithMessageBuilder(public var name: String) : AuditReque
             rateLimitPerUser = _rateLimitPerUser
         )
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as StartThreadWithMessageBuilder
+
+        if (name != other.name) return false
+        if (reason != other.reason) return false
+        if (autoArchiveDuration != other.autoArchiveDuration) return false
+        if (rateLimitPerUser != other.rateLimitPerUser) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = name.hashCode()
+        result = 31 * result + (reason?.hashCode() ?: 0)
+        result = 31 * result + (autoArchiveDuration?.hashCode() ?: 0)
+        result = 31 * result + (rateLimitPerUser?.hashCode() ?: 0)
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/channel/thread/ThreadModifyBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/channel/thread/ThreadModifyBuilder.kt
@@ -38,6 +38,8 @@ public class ThreadModifyBuilder : AuditRequestBuilder<ChannelModifyPatchRequest
     private var _appliedTags: Optional<MutableList<Snowflake>> = Optional.Missing()
     public var appliedTags: MutableList<Snowflake>? by ::_appliedTags.delegate()
 
+    override var reason: String? = null
+
     override fun toRequest(): ChannelModifyPatchRequest {
         return ChannelModifyPatchRequest(
             name = _name,
@@ -51,7 +53,38 @@ public class ThreadModifyBuilder : AuditRequestBuilder<ChannelModifyPatchRequest
         )
     }
 
-    override var reason: String? = null
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as ThreadModifyBuilder
+
+        if (name != other.name) return false
+        if (archived != other.archived) return false
+        if (locked != other.locked) return false
+        if (rateLimitPerUser != other.rateLimitPerUser) return false
+        if (autoArchiveDuration != other.autoArchiveDuration) return false
+        if (invitable != other.invitable) return false
+        if (flags != other.flags) return false
+        if (appliedTags != other.appliedTags) return false
+        if (reason != other.reason) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = name?.hashCode() ?: 0
+        result = 31 * result + (archived?.hashCode() ?: 0)
+        result = 31 * result + (locked?.hashCode() ?: 0)
+        result = 31 * result + (rateLimitPerUser?.hashCode() ?: 0)
+        result = 31 * result + (autoArchiveDuration?.hashCode() ?: 0)
+        result = 31 * result + (invitable?.hashCode() ?: 0)
+        result = 31 * result + (flags?.hashCode() ?: 0)
+        result = 31 * result + (appliedTags?.hashCode() ?: 0)
+        result = 31 * result + (reason?.hashCode() ?: 0)
+        return result
+    }
+
 }
 
 /** Add a [tagId] to [appliedTags][ThreadModifyBuilder.appliedTags]. */

--- a/rest/src/commonMain/kotlin/builder/component/ActionRowBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/component/ActionRowBuilder.kt
@@ -122,4 +122,18 @@ public class ActionRowBuilder : MessageComponentBuilder {
             ComponentType.ActionRow,
             components = Optional.missingOnEmpty(components.map(ActionRowComponentBuilder::build))
         )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as ActionRowBuilder
+
+        return components == other.components
+    }
+
+    override fun hashCode(): Int {
+        return components.hashCode()
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/component/ButtonBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/component/ButtonBuilder.kt
@@ -33,6 +33,26 @@ public sealed class ButtonBuilder : ActionRowComponentBuilder() {
 
     abstract override fun build(): DiscordChatComponent
 
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        if (!super.equals(other)) return false
+
+        other as ButtonBuilder
+
+        if (label != other.label) return false
+        if (emoji != other.emoji) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + (label?.hashCode() ?: 0)
+        result = 31 * result + (emoji?.hashCode() ?: 0)
+        return result
+    }
+
     /**
      * A builder for a button that can create Interactions when clicked.
      *
@@ -53,6 +73,27 @@ public sealed class ButtonBuilder : ActionRowComponentBuilder() {
             Optional.Missing(),
             _disabled,
         )
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other == null || this::class != other::class) return false
+            if (!super.equals(other)) return false
+
+            other as InteractionButtonBuilder
+
+            if (style != other.style) return false
+            if (customId != other.customId) return false
+
+            return true
+        }
+
+        override fun hashCode(): Int {
+            var result = super.hashCode()
+            result = 31 * result + style.hashCode()
+            result = 31 * result + customId.hashCode()
+            return result
+        }
+
     }
 
     /**
@@ -73,5 +114,22 @@ public sealed class ButtonBuilder : ActionRowComponentBuilder() {
             Optional.Value(url),
             _disabled,
         )
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other == null || this::class != other::class) return false
+            if (!super.equals(other)) return false
+
+            other as LinkButtonBuilder
+
+            return url == other.url
+        }
+
+        override fun hashCode(): Int {
+            var result = super.hashCode()
+            result = 31 * result + url.hashCode()
+            return result
+        }
+
     }
 }

--- a/rest/src/commonMain/kotlin/builder/component/ComponentBuilders.kt
+++ b/rest/src/commonMain/kotlin/builder/component/ComponentBuilders.kt
@@ -20,6 +20,20 @@ public sealed class ActionRowComponentBuilder : ComponentBuilder {
 
     /** Whether the component is disabled. Defaults to `false`. */
     public var disabled: Boolean? by ::_disabled.delegate()
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as ActionRowComponentBuilder
+
+        return disabled == other.disabled
+    }
+
+    override fun hashCode(): Int {
+        return disabled?.hashCode() ?: 0
+    }
+
 }
 
 @KordDsl

--- a/rest/src/commonMain/kotlin/builder/component/SelectMenuBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/component/SelectMenuBuilder.kt
@@ -51,6 +51,31 @@ public sealed class SelectMenuBuilder(public var customId: String) : ActionRowCo
         maxValues = OptionalInt.Value(allowedValues.endInclusive),
         disabled = _disabled,
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        if (!super.equals(other)) return false
+
+        other as SelectMenuBuilder
+
+        if (customId != other.customId) return false
+        if (allowedValues != other.allowedValues) return false
+        if (placeholder != other.placeholder) return false
+        if (type != other.type) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + customId.hashCode()
+        result = 31 * result + allowedValues.hashCode()
+        result = 31 * result + (placeholder?.hashCode() ?: 0)
+        result = 31 * result + type.hashCode()
+        return result
+    }
+
 }
 
 @KordDsl
@@ -61,6 +86,27 @@ public class StringSelectBuilder(customId: String) : SelectMenuBuilder(customId)
     public var options: MutableList<SelectOptionBuilder> = mutableListOf()
 
     override fun buildOptions(): Optional<List<DiscordSelectOption>> = Optional(options.map { it.build() })
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        if (!super.equals(other)) return false
+
+        other as StringSelectBuilder
+
+        if (type != other.type) return false
+        if (options != other.options) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + type.hashCode()
+        result = 31 * result + options.hashCode()
+        return result
+    }
+
 }
 
 /**
@@ -92,6 +138,27 @@ public class UserSelectBuilder(customId: String) : SelectMenuBuilder(customId) {
 
     override fun buildDefaultValues(): Optional<List<DiscordSelectDefaultValue>> =
         Optional.missingOnEmpty(defaultUsers.map { id -> DiscordSelectDefaultValue(id, type = User) })
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        if (!super.equals(other)) return false
+
+        other as UserSelectBuilder
+
+        if (type != other.type) return false
+        if (defaultUsers != other.defaultUsers) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + type.hashCode()
+        result = 31 * result + defaultUsers.hashCode()
+        return result
+    }
+
 }
 
 @KordDsl
@@ -107,6 +174,27 @@ public class RoleSelectBuilder(customId: String) : SelectMenuBuilder(customId) {
 
     override fun buildDefaultValues(): Optional<List<DiscordSelectDefaultValue>> =
         Optional.missingOnEmpty(defaultRoles.map { id -> DiscordSelectDefaultValue(id, type = Role) })
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        if (!super.equals(other)) return false
+
+        other as RoleSelectBuilder
+
+        if (type != other.type) return false
+        if (defaultRoles != other.defaultRoles) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + type.hashCode()
+        result = 31 * result + defaultRoles.hashCode()
+        return result
+    }
+
 }
 
 @KordDsl
@@ -131,6 +219,29 @@ public class MentionableSelectBuilder(customId: String) : SelectMenuBuilder(cust
         defaultUsers.map { id -> DiscordSelectDefaultValue(id, type = User) } +
             defaultRoles.map { id -> DiscordSelectDefaultValue(id, type = Role) }
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        if (!super.equals(other)) return false
+
+        other as MentionableSelectBuilder
+
+        if (type != other.type) return false
+        if (defaultUsers != other.defaultUsers) return false
+        if (defaultRoles != other.defaultRoles) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + type.hashCode()
+        result = 31 * result + defaultUsers.hashCode()
+        result = 31 * result + defaultRoles.hashCode()
+        return result
+    }
+
 }
 
 @KordDsl
@@ -150,6 +261,29 @@ public class ChannelSelectBuilder(customId: String) : SelectMenuBuilder(customId
     override fun buildChannelTypes(): Optional<List<ChannelType>> = _channelTypes.mapCopy()
     override fun buildDefaultValues(): Optional<List<DiscordSelectDefaultValue>> =
         Optional.missingOnEmpty(defaultChannels.map { id -> DiscordSelectDefaultValue(id, type = Channel) })
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        if (!super.equals(other)) return false
+
+        other as ChannelSelectBuilder
+
+        if (type != other.type) return false
+        if (channelTypes != other.channelTypes) return false
+        if (defaultChannels != other.defaultChannels) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + type.hashCode()
+        result = 31 * result + (channelTypes?.hashCode() ?: 0)
+        result = 31 * result + defaultChannels.hashCode()
+        return result
+    }
+
 }
 
 public fun ChannelSelectBuilder.channelType(type: ChannelType) {

--- a/rest/src/commonMain/kotlin/builder/component/SelectOptionBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/component/SelectOptionBuilder.kt
@@ -50,4 +50,28 @@ public class SelectOptionBuilder(
         default = _default
     )
 
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as SelectOptionBuilder
+
+        if (label != other.label) return false
+        if (value != other.value) return false
+        if (description != other.description) return false
+        if (emoji != other.emoji) return false
+        if (default != other.default) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = label.hashCode()
+        result = 31 * result + value.hashCode()
+        result = 31 * result + (description?.hashCode() ?: 0)
+        result = 31 * result + (emoji?.hashCode() ?: 0)
+        result = 31 * result + (default?.hashCode() ?: 0)
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/component/TextInputBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/component/TextInputBuilder.kt
@@ -61,4 +61,35 @@ public class TextInputBuilder(
             required = _required,
         )
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        if (!super.equals(other)) return false
+
+        other as TextInputBuilder
+
+        if (style != other.style) return false
+        if (customId != other.customId) return false
+        if (label != other.label) return false
+        if (allowedLength != other.allowedLength) return false
+        if (placeholder != other.placeholder) return false
+        if (value != other.value) return false
+        if (required != other.required) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + style.hashCode()
+        result = 31 * result + customId.hashCode()
+        result = 31 * result + label.hashCode()
+        result = 31 * result + (allowedLength?.hashCode() ?: 0)
+        result = 31 * result + (placeholder?.hashCode() ?: 0)
+        result = 31 * result + (value?.hashCode() ?: 0)
+        result = 31 * result + (required?.hashCode() ?: 0)
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/guild/EmojiCreateBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/guild/EmojiCreateBuilder.kt
@@ -20,4 +20,27 @@ public class EmojiCreateBuilder(
         image = image.dataUri,
         roles = roles
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as EmojiCreateBuilder
+
+        if (name != other.name) return false
+        if (image != other.image) return false
+        if (reason != other.reason) return false
+        if (roles != other.roles) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = name.hashCode()
+        result = 31 * result + image.hashCode()
+        result = 31 * result + (reason?.hashCode() ?: 0)
+        result = 31 * result + roles.hashCode()
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/guild/EmojiModifyBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/guild/EmojiModifyBuilder.kt
@@ -21,4 +21,25 @@ public class EmojiModifyBuilder : AuditRequestBuilder<EmojiModifyRequest> {
         name = _name,
         roles = _roles
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as EmojiModifyBuilder
+
+        if (reason != other.reason) return false
+        if (name != other.name) return false
+        if (roles != other.roles) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = reason?.hashCode() ?: 0
+        result = 31 * result + (name?.hashCode() ?: 0)
+        result = 31 * result + (roles?.hashCode() ?: 0)
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/guild/GuildCreateBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/guild/GuildCreateBuilder.kt
@@ -176,4 +176,45 @@ public class GuildCreateBuilder(public var name: String) : RequestBuilder<GuildC
         _afkTimeout,
         _systemChannelId,
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as GuildCreateBuilder
+
+        if (name != other.name) return false
+        if (snowflakeGenerator != other.snowflakeGenerator) return false
+        if (region != other.region) return false
+        if (icon != other.icon) return false
+        if (verificationLevel != other.verificationLevel) return false
+        if (defaultMessageNotificationLevel != other.defaultMessageNotificationLevel) return false
+        if (explicitContentFilter != other.explicitContentFilter) return false
+        if (everyoneRole != other.everyoneRole) return false
+        if (roles != other.roles) return false
+        if (channels != other.channels) return false
+        if (afkChannelId != other.afkChannelId) return false
+        if (afkTimeout != other.afkTimeout) return false
+        if (systemChannelId != other.systemChannelId) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = name.hashCode()
+        result = 31 * result + snowflakeGenerator.hashCode()
+        result = 31 * result + (region?.hashCode() ?: 0)
+        result = 31 * result + (icon?.hashCode() ?: 0)
+        result = 31 * result + (verificationLevel?.hashCode() ?: 0)
+        result = 31 * result + (defaultMessageNotificationLevel?.hashCode() ?: 0)
+        result = 31 * result + (explicitContentFilter?.hashCode() ?: 0)
+        result = 31 * result + (everyoneRole?.hashCode() ?: 0)
+        result = 31 * result + roles.hashCode()
+        result = 31 * result + channels.hashCode()
+        result = 31 * result + (afkChannelId?.hashCode() ?: 0)
+        result = 31 * result + (afkTimeout?.hashCode() ?: 0)
+        result = 31 * result + (systemChannelId?.hashCode() ?: 0)
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/guild/GuildModifyBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/guild/GuildModifyBuilder.kt
@@ -103,4 +103,55 @@ public class GuildModifyBuilder : AuditRequestBuilder<GuildModifyRequest> {
         features = _features,
         safetyAlertsChannelId = _safetyAlertsChannelId,
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as GuildModifyBuilder
+
+        if (reason != other.reason) return false
+        if (name != other.name) return false
+        if (region != other.region) return false
+        if (verificationLevel != other.verificationLevel) return false
+        if (notificationLevel != other.notificationLevel) return false
+        if (explicitContentFilter != other.explicitContentFilter) return false
+        if (afkChannelId != other.afkChannelId) return false
+        if (afkTimeout != other.afkTimeout) return false
+        if (icon != other.icon) return false
+        if (ownerId != other.ownerId) return false
+        if (splash != other.splash) return false
+        if (banner != other.banner) return false
+        if (systemChannelId != other.systemChannelId) return false
+        if (rulesChannelId != other.rulesChannelId) return false
+        if (publicUpdatesChannelId != other.publicUpdatesChannelId) return false
+        if (preferredLocale != other.preferredLocale) return false
+        if (features != other.features) return false
+        if (safetyAlertsChannelId != other.safetyAlertsChannelId) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = reason?.hashCode() ?: 0
+        result = 31 * result + (name?.hashCode() ?: 0)
+        result = 31 * result + (region?.hashCode() ?: 0)
+        result = 31 * result + (verificationLevel?.hashCode() ?: 0)
+        result = 31 * result + (notificationLevel?.hashCode() ?: 0)
+        result = 31 * result + (explicitContentFilter?.hashCode() ?: 0)
+        result = 31 * result + (afkChannelId?.hashCode() ?: 0)
+        result = 31 * result + (afkTimeout?.hashCode() ?: 0)
+        result = 31 * result + (icon?.hashCode() ?: 0)
+        result = 31 * result + (ownerId?.hashCode() ?: 0)
+        result = 31 * result + (splash?.hashCode() ?: 0)
+        result = 31 * result + (banner?.hashCode() ?: 0)
+        result = 31 * result + (systemChannelId?.hashCode() ?: 0)
+        result = 31 * result + (rulesChannelId?.hashCode() ?: 0)
+        result = 31 * result + (publicUpdatesChannelId?.hashCode() ?: 0)
+        result = 31 * result + (preferredLocale?.hashCode() ?: 0)
+        result = 31 * result + (features?.hashCode() ?: 0)
+        result = 31 * result + (safetyAlertsChannelId?.hashCode() ?: 0)
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/guild/GuildOnboardingModifyBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/guild/GuildOnboardingModifyBuilder.kt
@@ -47,6 +47,31 @@ public class GuildOnboardingModifyBuilder : AuditRequestBuilder<GuildOnboardingM
         enabled = _enabled,
         mode = _mode,
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as GuildOnboardingModifyBuilder
+
+        if (reason != other.reason) return false
+        if (prompts != other.prompts) return false
+        if (defaultChannelIds != other.defaultChannelIds) return false
+        if (enabled != other.enabled) return false
+        if (mode != other.mode) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = reason?.hashCode() ?: 0
+        result = 31 * result + (prompts?.hashCode() ?: 0)
+        result = 31 * result + (defaultChannelIds?.hashCode() ?: 0)
+        result = 31 * result + (enabled?.hashCode() ?: 0)
+        result = 31 * result + (mode?.hashCode() ?: 0)
+        return result
+    }
+
 }
 
 /** Add a [channelId] to [defaultChannelIds][GuildOnboardingModifyBuilder.defaultChannelIds]. */
@@ -110,6 +135,35 @@ public class OnboardingPromptBuilder(
         required = required,
         inOnboarding = inOnboarding,
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as OnboardingPromptBuilder
+
+        if (type != other.type) return false
+        if (title != other.title) return false
+        if (singleSelect != other.singleSelect) return false
+        if (required != other.required) return false
+        if (inOnboarding != other.inOnboarding) return false
+        if (id != other.id) return false
+        if (options != other.options) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = type.hashCode()
+        result = 31 * result + title.hashCode()
+        result = 31 * result + singleSelect.hashCode()
+        result = 31 * result + required.hashCode()
+        result = 31 * result + inOnboarding.hashCode()
+        result = 31 * result + (id?.hashCode() ?: 0)
+        result = 31 * result + options.hashCode()
+        return result
+    }
+
 }
 
 /**
@@ -147,4 +201,27 @@ public class OnboardingPromptOptionBuilder(
         title = title,
         description = description,
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as OnboardingPromptOptionBuilder
+
+        if (title != other.title) return false
+        if (channelIds != other.channelIds) return false
+        if (roleIds != other.roleIds) return false
+        if (description != other.description) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = title.hashCode()
+        result = 31 * result + channelIds.hashCode()
+        result = 31 * result + roleIds.hashCode()
+        result = 31 * result + (description?.hashCode() ?: 0)
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/guild/ScheduledEventCreateBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/guild/ScheduledEventCreateBuilder.kt
@@ -63,4 +63,39 @@ public class ScheduledEventCreateBuilder(
         entityType = entityType,
         image = _image.map { it.dataUri },
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as ScheduledEventCreateBuilder
+
+        if (name != other.name) return false
+        if (privacyLevel != other.privacyLevel) return false
+        if (scheduledStartTime != other.scheduledStartTime) return false
+        if (entityType != other.entityType) return false
+        if (reason != other.reason) return false
+        if (channelId != other.channelId) return false
+        if (description != other.description) return false
+        if (entityMetadata != other.entityMetadata) return false
+        if (scheduledEndTime != other.scheduledEndTime) return false
+        if (image != other.image) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = name.hashCode()
+        result = 31 * result + privacyLevel.hashCode()
+        result = 31 * result + scheduledStartTime.hashCode()
+        result = 31 * result + entityType.hashCode()
+        result = 31 * result + (reason?.hashCode() ?: 0)
+        result = 31 * result + (channelId?.hashCode() ?: 0)
+        result = 31 * result + (description?.hashCode() ?: 0)
+        result = 31 * result + (entityMetadata?.hashCode() ?: 0)
+        result = 31 * result + (scheduledEndTime?.hashCode() ?: 0)
+        result = 31 * result + (image?.hashCode() ?: 0)
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/guild/StickerModifyBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/guild/StickerModifyBuilder.kt
@@ -19,4 +19,25 @@ public class StickerModifyBuilder : RequestBuilder<GuildStickerModifyRequest> {
     override fun toRequest(): GuildStickerModifyRequest {
         return GuildStickerModifyRequest(_name, _description, _tags)
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as StickerModifyBuilder
+
+        if (name != other.name) return false
+        if (description != other.description) return false
+        if (tags != other.tags) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = name?.hashCode() ?: 0
+        result = 31 * result + (description?.hashCode() ?: 0)
+        result = 31 * result + (tags?.hashCode() ?: 0)
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/guild/VoiceStateModifyBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/guild/VoiceStateModifyBuilder.kt
@@ -43,6 +43,27 @@ public class CurrentVoiceStateModifyBuilder : RequestBuilder<CurrentVoiceStateMo
         suppress = _suppress,
         requestToSpeakTimestamp = _requestToSpeakTimestamp,
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as CurrentVoiceStateModifyBuilder
+
+        if (channelId != other.channelId) return false
+        if (suppress != other.suppress) return false
+        if (requestToSpeakTimestamp != other.requestToSpeakTimestamp) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = channelId?.hashCode() ?: 0
+        result = 31 * result + (suppress?.hashCode() ?: 0)
+        result = 31 * result + (requestToSpeakTimestamp?.hashCode() ?: 0)
+        return result
+    }
+
 }
 
 
@@ -61,4 +82,23 @@ public class VoiceStateModifyBuilder(
         channelId = channelId,
         suppress = _suppress,
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as VoiceStateModifyBuilder
+
+        if (channelId != other.channelId) return false
+        if (suppress != other.suppress) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = channelId.hashCode()
+        result = 31 * result + (suppress?.hashCode() ?: 0)
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/guild/WelcomeScreenModifyBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/guild/WelcomeScreenModifyBuilder.kt
@@ -46,6 +46,28 @@ public class WelcomeScreenModifyBuilder : AuditRequestBuilder<GuildWelcomeScreen
         )
     }
 
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as WelcomeScreenModifyBuilder
+
+        if (reason != other.reason) return false
+        if (enabled != other.enabled) return false
+        if (description != other.description) return false
+        if (welcomeScreenChannels != other.welcomeScreenChannels) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = reason?.hashCode() ?: 0
+        result = 31 * result + (enabled?.hashCode() ?: 0)
+        result = 31 * result + (description?.hashCode() ?: 0)
+        result = 31 * result + (welcomeScreenChannels?.hashCode() ?: 0)
+        return result
+    }
+
 }
 
 @KordDsl
@@ -57,6 +79,28 @@ public class WelcomeScreenChannelBuilder(
 ) : RequestBuilder<DiscordWelcomeScreenChannel> {
     override fun toRequest(): DiscordWelcomeScreenChannel {
         return DiscordWelcomeScreenChannel(channelId, description, emojiId, emojiName)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as WelcomeScreenChannelBuilder
+
+        if (channelId != other.channelId) return false
+        if (description != other.description) return false
+        if (emojiId != other.emojiId) return false
+        if (emojiName != other.emojiName) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = channelId.hashCode()
+        result = 31 * result + description.hashCode()
+        result = 31 * result + (emojiId?.hashCode() ?: 0)
+        result = 31 * result + (emojiName?.hashCode() ?: 0)
+        return result
     }
 
 }

--- a/rest/src/commonMain/kotlin/builder/guild/WidgetModifyBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/guild/WidgetModifyBuilder.kt
@@ -21,4 +21,25 @@ public class GuildWidgetModifyBuilder : AuditRequestBuilder<GuildWidgetModifyReq
 
     override fun toRequest(): GuildWidgetModifyRequest =
         GuildWidgetModifyRequest(_enabled, _channelId)
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as GuildWidgetModifyBuilder
+
+        if (reason != other.reason) return false
+        if (enabled != other.enabled) return false
+        if (channelId != other.channelId) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = reason?.hashCode() ?: 0
+        result = 31 * result + (enabled?.hashCode() ?: 0)
+        result = 31 * result + (channelId?.hashCode() ?: 0)
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/integration/IntegrationModifyBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/integration/IntegrationModifyBuilder.kt
@@ -42,4 +42,26 @@ public class IntegrationModifyBuilder : AuditRequestBuilder<GuildIntegrationModi
         _expireBehavior, _expirePeriodInDays, _enableEmoticons
     )
 
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as IntegrationModifyBuilder
+
+        if (reason != other.reason) return false
+        if (expireBehavior != other.expireBehavior) return false
+        if (expirePeriodInDays != other.expirePeriodInDays) return false
+        if (enableEmoticons != other.enableEmoticons) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = reason?.hashCode() ?: 0
+        result = 31 * result + (expireBehavior?.hashCode() ?: 0)
+        result = 31 * result + (expirePeriodInDays ?: 0)
+        result = 31 * result + (enableEmoticons?.hashCode() ?: 0)
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/interaction/ApplicationCommandStateHolder.kt
+++ b/rest/src/commonMain/kotlin/builder/interaction/ApplicationCommandStateHolder.kt
@@ -30,4 +30,37 @@ internal class ApplicationCommandModifyStateHolder {
     var defaultPermission: OptionalBoolean = OptionalBoolean.Missing
 
     var nsfw: OptionalBoolean = OptionalBoolean.Missing
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as ApplicationCommandModifyStateHolder
+
+        if (name != other.name) return false
+        if (nameLocalizations != other.nameLocalizations) return false
+        if (description != other.description) return false
+        if (descriptionLocalizations != other.descriptionLocalizations) return false
+        if (options != other.options) return false
+        if (defaultMemberPermissions != other.defaultMemberPermissions) return false
+        if (dmPermission != other.dmPermission) return false
+        if (defaultPermission != other.defaultPermission) return false
+        if (nsfw != other.nsfw) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = name.hashCode()
+        result = 31 * result + nameLocalizations.hashCode()
+        result = 31 * result + description.hashCode()
+        result = 31 * result + descriptionLocalizations.hashCode()
+        result = 31 * result + options.hashCode()
+        result = 31 * result + defaultMemberPermissions.hashCode()
+        result = 31 * result + (dmPermission?.hashCode() ?: 0)
+        result = 31 * result + defaultPermission.hashCode()
+        result = 31 * result + nsfw.hashCode()
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/interaction/InputChatBuilders.kt
+++ b/rest/src/commonMain/kotlin/builder/interaction/InputChatBuilders.kt
@@ -170,6 +170,42 @@ internal class ChatInputCreateBuilderImpl(
 
     }
 
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as ChatInputCreateBuilderImpl
+
+        if (name != other.name) return false
+        if (description != other.description) return false
+        if (state != other.state) return false
+        if (nameLocalizations != other.nameLocalizations) return false
+        if (descriptionLocalizations != other.descriptionLocalizations) return false
+        if (type != other.type) return false
+        if (options != other.options) return false
+        if (defaultMemberPermissions != other.defaultMemberPermissions) return false
+        if (dmPermission != other.dmPermission) return false
+        if (defaultPermission != other.defaultPermission) return false
+        if (nsfw != other.nsfw) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = name.hashCode()
+        result = 31 * result + description.hashCode()
+        result = 31 * result + state.hashCode()
+        result = 31 * result + (nameLocalizations?.hashCode() ?: 0)
+        result = 31 * result + (descriptionLocalizations?.hashCode() ?: 0)
+        result = 31 * result + type.hashCode()
+        result = 31 * result + (options?.hashCode() ?: 0)
+        result = 31 * result + (defaultMemberPermissions?.hashCode() ?: 0)
+        result = 31 * result + (dmPermission?.hashCode() ?: 0)
+        result = 31 * result + (defaultPermission?.hashCode() ?: 0)
+        result = 31 * result + (nsfw?.hashCode() ?: 0)
+        return result
+    }
+
 }
 
 @KordDsl
@@ -212,6 +248,40 @@ internal class ChatInputModifyBuilderImpl : GlobalChatInputModifyBuilder {
             nsfw = state.nsfw,
         )
 
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as ChatInputModifyBuilderImpl
+
+        if (state != other.state) return false
+        if (name != other.name) return false
+        if (nameLocalizations != other.nameLocalizations) return false
+        if (description != other.description) return false
+        if (descriptionLocalizations != other.descriptionLocalizations) return false
+        if (options != other.options) return false
+        if (defaultMemberPermissions != other.defaultMemberPermissions) return false
+        if (dmPermission != other.dmPermission) return false
+        if (defaultPermission != other.defaultPermission) return false
+        if (nsfw != other.nsfw) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = state.hashCode()
+        result = 31 * result + (name?.hashCode() ?: 0)
+        result = 31 * result + (nameLocalizations?.hashCode() ?: 0)
+        result = 31 * result + (description?.hashCode() ?: 0)
+        result = 31 * result + (descriptionLocalizations?.hashCode() ?: 0)
+        result = 31 * result + (options?.hashCode() ?: 0)
+        result = 31 * result + (defaultMemberPermissions?.hashCode() ?: 0)
+        result = 31 * result + (dmPermission?.hashCode() ?: 0)
+        result = 31 * result + (defaultPermission?.hashCode() ?: 0)
+        result = 31 * result + (nsfw?.hashCode() ?: 0)
+        return result
     }
 
 }

--- a/rest/src/commonMain/kotlin/builder/interaction/MessageCommandBuilders.kt
+++ b/rest/src/commonMain/kotlin/builder/interaction/MessageCommandBuilders.kt
@@ -43,6 +43,34 @@ internal class MessageCommandModifyBuilderImpl : GlobalMessageCommandModifyBuild
 
     }
 
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as MessageCommandModifyBuilderImpl
+
+        if (state != other.state) return false
+        if (name != other.name) return false
+        if (nameLocalizations != other.nameLocalizations) return false
+        if (defaultMemberPermissions != other.defaultMemberPermissions) return false
+        if (dmPermission != other.dmPermission) return false
+        if (defaultPermission != other.defaultPermission) return false
+        if (nsfw != other.nsfw) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = state.hashCode()
+        result = 31 * result + (name?.hashCode() ?: 0)
+        result = 31 * result + (nameLocalizations?.hashCode() ?: 0)
+        result = 31 * result + (defaultMemberPermissions?.hashCode() ?: 0)
+        result = 31 * result + (dmPermission?.hashCode() ?: 0)
+        result = 31 * result + (defaultPermission?.hashCode() ?: 0)
+        result = 31 * result + (nsfw?.hashCode() ?: 0)
+        return result
+    }
+
 }
 
 @KordDsl
@@ -80,4 +108,35 @@ internal class MessageCommandCreateBuilderImpl(override var name: String) : Glob
             nsfw = state.nsfw,
         )
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as MessageCommandCreateBuilderImpl
+
+        if (name != other.name) return false
+        if (type != other.type) return false
+        if (state != other.state) return false
+        if (nameLocalizations != other.nameLocalizations) return false
+        if (defaultMemberPermissions != other.defaultMemberPermissions) return false
+        if (dmPermission != other.dmPermission) return false
+        if (defaultPermission != other.defaultPermission) return false
+        if (nsfw != other.nsfw) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = name.hashCode()
+        result = 31 * result + type.hashCode()
+        result = 31 * result + state.hashCode()
+        result = 31 * result + (nameLocalizations?.hashCode() ?: 0)
+        result = 31 * result + (defaultMemberPermissions?.hashCode() ?: 0)
+        result = 31 * result + (dmPermission?.hashCode() ?: 0)
+        result = 31 * result + (defaultPermission?.hashCode() ?: 0)
+        result = 31 * result + (nsfw?.hashCode() ?: 0)
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/interaction/ModalBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/interaction/ModalBuilder.kt
@@ -30,4 +30,25 @@ public class ModalBuilder(
         customId,
         components.map { it.build() }
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as ModalBuilder
+
+        if (title != other.title) return false
+        if (customId != other.customId) return false
+        if (components != other.components) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = title.hashCode()
+        result = 31 * result + customId.hashCode()
+        result = 31 * result + components.hashCode()
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/interaction/MultiApplicationCommandBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/interaction/MultiApplicationCommandBuilder.kt
@@ -12,6 +12,21 @@ public sealed class MultiApplicationCommandBuilder {
     public fun build(): List<ApplicationCommandCreateRequest> {
         return commands.map { it.toRequest() }
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as MultiApplicationCommandBuilder
+
+        return commands == other.commands
+    }
+
+    override fun hashCode(): Int {
+        return commands.hashCode()
+    }
+
+
 }
 public inline fun MultiApplicationCommandBuilder.input(
     name: String,
@@ -53,6 +68,14 @@ public class GlobalMultiApplicationCommandBuilder : MultiApplicationCommandBuild
         contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
         commands += UserCommandCreateBuilderImpl(name).apply(builder)
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        if (!super.equals(other)) return false
+        return true
+    }
+
 }
 
 @KordDsl
@@ -72,4 +95,12 @@ public class GuildMultiApplicationCommandBuilder : MultiApplicationCommandBuilde
         contract { callsInPlace(builder, InvocationKind.EXACTLY_ONCE) }
         commands += UserCommandCreateBuilderImpl(name).apply(builder)
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        if (!super.equals(other)) return false
+        return true
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/interaction/OptionsBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/interaction/OptionsBuilder.kt
@@ -51,6 +51,37 @@ public sealed class OptionsBuilder(
         _required,
         autocomplete = _autocomplete
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as OptionsBuilder
+
+        if (name != other.name) return false
+        if (description != other.description) return false
+        if (type != other.type) return false
+        if (default != other.default) return false
+        if (nameLocalizations != other.nameLocalizations) return false
+        if (descriptionLocalizations != other.descriptionLocalizations) return false
+        if (required != other.required) return false
+        if (autocomplete != other.autocomplete) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = name.hashCode()
+        result = 31 * result + description.hashCode()
+        result = 31 * result + type.hashCode()
+        result = 31 * result + (default?.hashCode() ?: 0)
+        result = 31 * result + (nameLocalizations?.hashCode() ?: 0)
+        result = 31 * result + (descriptionLocalizations?.hashCode() ?: 0)
+        result = 31 * result + (required?.hashCode() ?: 0)
+        result = 31 * result + (autocomplete?.hashCode() ?: 0)
+        return result
+    }
+
 }
 
 @KordDsl
@@ -86,6 +117,23 @@ public sealed class BaseChoiceBuilder<T, C : Choice>(
         default = _default,
         autocomplete = _autocomplete,
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        if (!super.equals(other)) return false
+
+        other as BaseChoiceBuilder<*, *>
+
+        return choices == other.choices
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + (choices?.hashCode() ?: 0)
+        return result
+    }
+
 }
 
 /**
@@ -99,6 +147,25 @@ public class ChoiceLocalizationsBuilder(override var name: String) : LocalizedNa
     @PublishedApi
     internal var _nameLocalizations: Optional<MutableMap<Locale, String>?> = Optional.Missing()
     override var nameLocalizations: MutableMap<Locale, String>? by ::_nameLocalizations.delegate()
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as ChoiceLocalizationsBuilder
+
+        if (name != other.name) return false
+        if (nameLocalizations != other.nameLocalizations) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = name.hashCode()
+        result = 31 * result + (nameLocalizations?.hashCode() ?: 0)
+        return result
+    }
+
 }
 
 /**
@@ -138,6 +205,27 @@ public sealed class NumericOptionBuilder<T : Number, C : Choice>(
         minValue = _minValue.map { JsonPrimitive(it) },
         maxValue = _maxValue.map { JsonPrimitive(it) },
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        if (!super.equals(other)) return false
+
+        other as NumericOptionBuilder<*, *>
+
+        if (minValue != other.minValue) return false
+        if (maxValue != other.maxValue) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + (minValue?.hashCode() ?: 0)
+        result = 31 * result + (maxValue?.hashCode() ?: 0)
+        return result
+    }
+
 }
 
 @KordDsl
@@ -148,6 +236,14 @@ public class IntegerOptionBuilder(name: String, description: String) :
         if (choices == null) choices = mutableListOf()
         choices!!.add(Choice.IntegerChoice(name, nameLocalizations, value))
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        if (!super.equals(other)) return false
+        return true
+    }
+
 }
 
 @KordDsl
@@ -157,6 +253,13 @@ public class NumberOptionBuilder(name: String, description: String) :
     override fun choice(name: String, value: Double, nameLocalizations: Optional<Map<Locale, String>?>) {
         if (choices == null) choices = mutableListOf()
         choices!!.add(Choice.NumberChoice(name, nameLocalizations, value))
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        if (!super.equals(other)) return false
+        return true
     }
 
 }
@@ -197,6 +300,27 @@ public class StringChoiceBuilder(name: String, description: String) :
         minLength = _minLength,
         maxLength = _maxLength
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        if (!super.equals(other)) return false
+
+        other as StringChoiceBuilder
+
+        if (minLength != other.minLength) return false
+        if (maxLength != other.maxLength) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + (minLength ?: 0)
+        result = 31 * result + (maxLength ?: 0)
+        return result
+    }
+
 }
 
 @KordDsl
@@ -227,6 +351,23 @@ public class ChannelBuilder(name: String, description: String) :
         autocomplete = _autocomplete,
         channelTypes = _channelTypes
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        if (!super.equals(other)) return false
+
+        other as ChannelBuilder
+
+        return channelTypes == other.channelTypes
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + (channelTypes?.hashCode() ?: 0)
+        return result
+    }
+
 }
 
 @KordDsl
@@ -255,6 +396,23 @@ public sealed class BaseCommandOptionBuilder(
         _descriptionLocalizations,
         options = _options.mapList { it.toRequest() }
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        if (!super.equals(other)) return false
+
+        other as BaseCommandOptionBuilder
+
+        return options == other.options
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + (options?.hashCode() ?: 0)
+        return result
+    }
+
 }
 
 @KordDsl

--- a/rest/src/commonMain/kotlin/builder/interaction/UserCommandBuilders.kt
+++ b/rest/src/commonMain/kotlin/builder/interaction/UserCommandBuilders.kt
@@ -40,6 +40,35 @@ internal class UserCommandModifyBuilderImpl : GlobalUserCommandModifyBuilder {
             nsfw = state.nsfw,
         )
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as UserCommandModifyBuilderImpl
+
+        if (state != other.state) return false
+        if (name != other.name) return false
+        if (nameLocalizations != other.nameLocalizations) return false
+        if (defaultMemberPermissions != other.defaultMemberPermissions) return false
+        if (dmPermission != other.dmPermission) return false
+        if (defaultPermission != other.defaultPermission) return false
+        if (nsfw != other.nsfw) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = state.hashCode()
+        result = 31 * result + (name?.hashCode() ?: 0)
+        result = 31 * result + (nameLocalizations?.hashCode() ?: 0)
+        result = 31 * result + (defaultMemberPermissions?.hashCode() ?: 0)
+        result = 31 * result + (dmPermission?.hashCode() ?: 0)
+        result = 31 * result + (defaultPermission?.hashCode() ?: 0)
+        result = 31 * result + (nsfw?.hashCode() ?: 0)
+        return result
+    }
+
 }
 
 @KordDsl
@@ -75,4 +104,35 @@ internal class UserCommandCreateBuilderImpl(override var name: String) : GlobalU
             nsfw = state.nsfw,
         )
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as UserCommandCreateBuilderImpl
+
+        if (name != other.name) return false
+        if (type != other.type) return false
+        if (state != other.state) return false
+        if (nameLocalizations != other.nameLocalizations) return false
+        if (defaultMemberPermissions != other.defaultMemberPermissions) return false
+        if (dmPermission != other.dmPermission) return false
+        if (defaultPermission != other.defaultPermission) return false
+        if (nsfw != other.nsfw) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = name.hashCode()
+        result = 31 * result + type.hashCode()
+        result = 31 * result + state.hashCode()
+        result = 31 * result + (nameLocalizations?.hashCode() ?: 0)
+        result = 31 * result + (defaultMemberPermissions?.hashCode() ?: 0)
+        result = 31 * result + (dmPermission?.hashCode() ?: 0)
+        result = 31 * result + (defaultPermission?.hashCode() ?: 0)
+        result = 31 * result + (nsfw?.hashCode() ?: 0)
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/member/MemberAddBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/member/MemberAddBuilder.kt
@@ -26,4 +26,28 @@ public class MemberAddBuilder(public var token: String) : RequestBuilder<GuildMe
         token, _nickname, Optional.missingOnEmpty(roles), mute = _muted, deaf = _deafened
     )
 
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as MemberAddBuilder
+
+        if (token != other.token) return false
+        if (nickname != other.nickname) return false
+        if (roles != other.roles) return false
+        if (muted != other.muted) return false
+        if (deafened != other.deafened) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = token.hashCode()
+        result = 31 * result + (nickname?.hashCode() ?: 0)
+        result = 31 * result + roles.hashCode()
+        result = 31 * result + (muted?.hashCode() ?: 0)
+        result = 31 * result + (deafened?.hashCode() ?: 0)
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/member/MemberModifyBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/member/MemberModifyBuilder.kt
@@ -45,4 +45,35 @@ public class MemberModifyBuilder : AuditRequestBuilder<GuildMemberModifyRequest>
         communicationDisabledUntil = _communicationDisabledUntil,
         flags = _flags,
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as MemberModifyBuilder
+
+        if (reason != other.reason) return false
+        if (voiceChannelId != other.voiceChannelId) return false
+        if (muted != other.muted) return false
+        if (deafened != other.deafened) return false
+        if (nickname != other.nickname) return false
+        if (communicationDisabledUntil != other.communicationDisabledUntil) return false
+        if (roles != other.roles) return false
+        if (flags != other.flags) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = reason?.hashCode() ?: 0
+        result = 31 * result + (voiceChannelId?.hashCode() ?: 0)
+        result = 31 * result + (muted?.hashCode() ?: 0)
+        result = 31 * result + (deafened?.hashCode() ?: 0)
+        result = 31 * result + (nickname?.hashCode() ?: 0)
+        result = 31 * result + (communicationDisabledUntil?.hashCode() ?: 0)
+        result = 31 * result + (roles?.hashCode() ?: 0)
+        result = 31 * result + (flags?.hashCode() ?: 0)
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/message/AllowedMentionsBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/message/AllowedMentionsBuilder.kt
@@ -62,4 +62,27 @@ public class AllowedMentionsBuilder {
         repliedUser = _repliedUser
     )
 
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as AllowedMentionsBuilder
+
+        if (roles != other.roles) return false
+        if (users != other.users) return false
+        if (types != other.types) return false
+        if (repliedUser != other.repliedUser) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = roles.hashCode()
+        result = 31 * result + users.hashCode()
+        result = 31 * result + types.hashCode()
+        result = 31 * result + (repliedUser?.hashCode() ?: 0)
+        return result
+    }
+
+
 }

--- a/rest/src/commonMain/kotlin/builder/message/AttachmentBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/message/AttachmentBuilder.kt
@@ -25,4 +25,25 @@ public class AttachmentBuilder(private val id: Snowflake) : RequestBuilder<Attac
         filename = _filename,
         description = _description,
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as AttachmentBuilder
+
+        if (id != other.id) return false
+        if (filename != other.filename) return false
+        if (description != other.description) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = id.hashCode()
+        result = 31 * result + (filename?.hashCode() ?: 0)
+        result = 31 * result + (description?.hashCode() ?: 0)
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/message/EmbedBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/message/EmbedBuilder.kt
@@ -159,6 +159,41 @@ public class EmbedBuilder : RequestBuilder<EmbedRequest> {
         Optional.missingOnEmpty(fields).mapList { it.toRequest() }
     )
 
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as EmbedBuilder
+
+        if (title != other.title) return false
+        if (description != other.description) return false
+        if (url != other.url) return false
+        if (timestamp != other.timestamp) return false
+        if (color != other.color) return false
+        if (image != other.image) return false
+        if (footer != other.footer) return false
+        if (thumbnail != other.thumbnail) return false
+        if (author != other.author) return false
+        if (fields != other.fields) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = title?.hashCode() ?: 0
+        result = 31 * result + (description?.hashCode() ?: 0)
+        result = 31 * result + (url?.hashCode() ?: 0)
+        result = 31 * result + (timestamp?.hashCode() ?: 0)
+        result = 31 * result + (color?.hashCode() ?: 0)
+        result = 31 * result + (image?.hashCode() ?: 0)
+        result = 31 * result + (footer?.hashCode() ?: 0)
+        result = 31 * result + (thumbnail?.hashCode() ?: 0)
+        result = 31 * result + (author?.hashCode() ?: 0)
+        result = 31 * result + fields.hashCode()
+        return result
+    }
+
+
     @KordDsl
     public class Thumbnail : RequestBuilder<EmbedThumbnailRequest> {
 
@@ -168,6 +203,21 @@ public class EmbedBuilder : RequestBuilder<EmbedRequest> {
         public lateinit var url: String
 
         override fun toRequest(): EmbedThumbnailRequest = EmbedThumbnailRequest(url)
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other == null || this::class != other::class) return false
+
+            other as Thumbnail
+
+            if(!this::url.isInitialized && !other::url.isInitialized) return true
+            return url == other.url
+        }
+
+        override fun hashCode(): Int {
+            return url.hashCode()
+        }
+
     }
 
     @KordDsl
@@ -184,6 +234,26 @@ public class EmbedBuilder : RequestBuilder<EmbedRequest> {
         public var icon: String? = null
 
         override fun toRequest(): EmbedFooterRequest = EmbedFooterRequest(text, icon)
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other == null || this::class != other::class) return false
+
+            other as Footer
+
+            if (icon != other.icon) return false
+            if (!this::text.isInitialized && !other::text.isInitialized) return true
+            if (text != other.text) return false
+
+            return true
+        }
+
+        override fun hashCode(): Int {
+            var result = text.hashCode()
+            result = 31 * result + (icon?.hashCode() ?: 0)
+            return result
+        }
+
 
         public object Limits {
             public const val text: Int = 2048
@@ -216,6 +286,26 @@ public class EmbedBuilder : RequestBuilder<EmbedRequest> {
         public var icon: String? by ::_icon.delegate()
 
         override fun toRequest(): EmbedAuthorRequest = EmbedAuthorRequest(_name, _url, _icon)
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other == null || this::class != other::class) return false
+
+            other as Author
+
+            if (name != other.name) return false
+            if (url != other.url) return false
+            if (icon != other.icon) return false
+
+            return true
+        }
+
+        override fun hashCode(): Int {
+            var result = name?.hashCode() ?: 0
+            result = 31 * result + (url?.hashCode() ?: 0)
+            result = 31 * result + (icon?.hashCode() ?: 0)
+            return result
+        }
 
         public object Limits {
             /**
@@ -255,6 +345,27 @@ public class EmbedBuilder : RequestBuilder<EmbedRequest> {
         public var inline: Boolean? by ::_inline.delegate()
 
         override fun toRequest(): EmbedFieldRequest = EmbedFieldRequest(name, value, _inline)
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other == null || this::class != other::class) return false
+
+            other as Field
+
+            if (value != other.value) return false
+            if (name != other.name) return false
+            if (inline != other.inline) return false
+
+            return true
+        }
+
+        override fun hashCode(): Int {
+            var result = value.hashCode()
+            result = 31 * result + name.hashCode()
+            result = 31 * result + (inline?.hashCode() ?: 0)
+            return result
+        }
+
 
         public object Limits {
             /**

--- a/rest/src/commonMain/kotlin/builder/message/create/FollowupMessageCreateBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/message/create/FollowupMessageCreateBuilder.kt
@@ -28,4 +28,21 @@ public class FollowupMessageCreateBuilder(public val ephemeral: Boolean) :
         ),
         files = files.toList(),
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        if (!super.equals(other)) return false
+
+        other as FollowupMessageCreateBuilder
+
+        return ephemeral == other.ephemeral
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + ephemeral.hashCode()
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/message/create/ForumMessageCreateBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/message/create/ForumMessageCreateBuilder.kt
@@ -36,6 +36,23 @@ public class ForumMessageCreateBuilder :
         ),
         files = files.toList(),
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        if (!super.equals(other)) return false
+
+        other as ForumMessageCreateBuilder
+
+        return stickerIds == other.stickerIds
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + (stickerIds?.hashCode() ?: 0)
+        return result
+    }
+
 }
 
 /** Add a [stickerId] to [stickerIds][ForumMessageCreateBuilder.stickerIds]. */

--- a/rest/src/commonMain/kotlin/builder/message/create/InteractionResponseCreateBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/message/create/InteractionResponseCreateBuilder.kt
@@ -34,4 +34,21 @@ public class InteractionResponseCreateBuilder(public val ephemeral: Boolean = fa
         ),
         files = files.toList(),
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        if (!super.equals(other)) return false
+
+        other as InteractionResponseCreateBuilder
+
+        return ephemeral == other.ephemeral
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + ephemeral.hashCode()
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/message/create/MessageCreateBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/message/create/MessageCreateBuilder.kt
@@ -63,4 +63,39 @@ public sealed class AbstractMessageCreateBuilder : MessageCreateBuilder {
     final override var flags: MessageFlags? = null
     final override var suppressEmbeds: Boolean? = null
     final override var suppressNotifications: Boolean? = null
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as AbstractMessageCreateBuilder
+
+        if (content != other.content) return false
+        if (tts != other.tts) return false
+        if (embeds != other.embeds) return false
+        if (allowedMentions != other.allowedMentions) return false
+        if (components != other.components) return false
+        if (files != other.files) return false
+        if (attachments != other.attachments) return false
+        if (flags != other.flags) return false
+        if (suppressEmbeds != other.suppressEmbeds) return false
+        if (suppressNotifications != other.suppressNotifications) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = content?.hashCode() ?: 0
+        result = 31 * result + (tts?.hashCode() ?: 0)
+        result = 31 * result + (embeds?.hashCode() ?: 0)
+        result = 31 * result + (allowedMentions?.hashCode() ?: 0)
+        result = 31 * result + (components?.hashCode() ?: 0)
+        result = 31 * result + files.hashCode()
+        result = 31 * result + (attachments?.hashCode() ?: 0)
+        result = 31 * result + (flags?.hashCode() ?: 0)
+        result = 31 * result + (suppressEmbeds?.hashCode() ?: 0)
+        result = 31 * result + (suppressNotifications?.hashCode() ?: 0)
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/message/create/UserMessageCreateBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/message/create/UserMessageCreateBuilder.kt
@@ -71,6 +71,31 @@ public class UserMessageCreateBuilder : AbstractMessageCreateBuilder(), RequestB
         ),
         files = files.toList(),
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        if (!super.equals(other)) return false
+
+        other as UserMessageCreateBuilder
+
+        if (nonce != other.nonce) return false
+        if (messageReference != other.messageReference) return false
+        if (failIfNotExists != other.failIfNotExists) return false
+        if (stickerIds != other.stickerIds) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + (nonce?.hashCode() ?: 0)
+        result = 31 * result + (messageReference?.hashCode() ?: 0)
+        result = 31 * result + (failIfNotExists?.hashCode() ?: 0)
+        result = 31 * result + (stickerIds?.hashCode() ?: 0)
+        return result
+    }
+
 }
 
 /** Add a [stickerId] to [stickerIds][UserMessageCreateBuilder.stickerIds]. */

--- a/rest/src/commonMain/kotlin/builder/message/create/WebhookMessageCreateBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/message/create/WebhookMessageCreateBuilder.kt
@@ -62,6 +62,31 @@ public class WebhookMessageCreateBuilder :
         ),
         files = files.toList(),
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        if (!super.equals(other)) return false
+
+        other as WebhookMessageCreateBuilder
+
+        if (username != other.username) return false
+        if (avatarUrl != other.avatarUrl) return false
+        if (threadName != other.threadName) return false
+        if (appliedTags != other.appliedTags) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + (username?.hashCode() ?: 0)
+        result = 31 * result + (avatarUrl?.hashCode() ?: 0)
+        result = 31 * result + (threadName?.hashCode() ?: 0)
+        result = 31 * result + (appliedTags?.hashCode() ?: 0)
+        return result
+    }
+
 }
 
 /** Add a [tagId] to [appliedTags][WebhookMessageCreateBuilder.appliedTags]. */

--- a/rest/src/commonMain/kotlin/builder/message/modify/MessageModifyBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/message/modify/MessageModifyBuilder.kt
@@ -54,4 +54,35 @@ public sealed class AbstractMessageModifyBuilder : MessageModifyBuilder {
 
     internal var _attachments: Optional<MutableList<AttachmentBuilder>?> = Optional.Missing()
     final override var attachments: MutableList<AttachmentBuilder>? by ::_attachments.delegate()
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as AbstractMessageModifyBuilder
+
+        if (content != other.content) return false
+        if (embeds != other.embeds) return false
+        if (flags != other.flags) return false
+        if (suppressEmbeds != other.suppressEmbeds) return false
+        if (allowedMentions != other.allowedMentions) return false
+        if (components != other.components) return false
+        if (files != other.files) return false
+        if (attachments != other.attachments) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = content?.hashCode() ?: 0
+        result = 31 * result + (embeds?.hashCode() ?: 0)
+        result = 31 * result + (flags?.hashCode() ?: 0)
+        result = 31 * result + (suppressEmbeds?.hashCode() ?: 0)
+        result = 31 * result + (allowedMentions?.hashCode() ?: 0)
+        result = 31 * result + (components?.hashCode() ?: 0)
+        result = 31 * result + files.hashCode()
+        result = 31 * result + (attachments?.hashCode() ?: 0)
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/role/RoleCreateBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/role/RoleCreateBuilder.kt
@@ -63,4 +63,35 @@ public class RoleCreateBuilder : AuditRequestBuilder<GuildRoleCreateRequest> {
         mentionable = _mentionable,
         permissions = _permissions
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as RoleCreateBuilder
+
+        if (reason != other.reason) return false
+        if (color != other.color) return false
+        if (hoist != other.hoist) return false
+        if (icon != other.icon) return false
+        if (unicodeEmoji != other.unicodeEmoji) return false
+        if (name != other.name) return false
+        if (mentionable != other.mentionable) return false
+        if (permissions != other.permissions) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = reason?.hashCode() ?: 0
+        result = 31 * result + (color?.hashCode() ?: 0)
+        result = 31 * result + (hoist?.hashCode() ?: 0)
+        result = 31 * result + (icon?.hashCode() ?: 0)
+        result = 31 * result + (unicodeEmoji?.hashCode() ?: 0)
+        result = 31 * result + (name?.hashCode() ?: 0)
+        result = 31 * result + (mentionable?.hashCode() ?: 0)
+        result = 31 * result + (permissions?.hashCode() ?: 0)
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/role/RoleModifyBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/role/RoleModifyBuilder.kt
@@ -63,4 +63,35 @@ public class RoleModifyBuilder : AuditRequestBuilder<GuildRoleModifyRequest> {
         mentionable = _mentionable,
         permissions = _permissions
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as RoleModifyBuilder
+
+        if (reason != other.reason) return false
+        if (color != other.color) return false
+        if (hoist != other.hoist) return false
+        if (icon != other.icon) return false
+        if (unicodeEmoji != other.unicodeEmoji) return false
+        if (name != other.name) return false
+        if (mentionable != other.mentionable) return false
+        if (permissions != other.permissions) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = reason?.hashCode() ?: 0
+        result = 31 * result + (color?.hashCode() ?: 0)
+        result = 31 * result + (hoist?.hashCode() ?: 0)
+        result = 31 * result + (icon?.hashCode() ?: 0)
+        result = 31 * result + (unicodeEmoji?.hashCode() ?: 0)
+        result = 31 * result + (name?.hashCode() ?: 0)
+        result = 31 * result + (mentionable?.hashCode() ?: 0)
+        result = 31 * result + (permissions?.hashCode() ?: 0)
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/role/RolePositionsModifyBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/role/RolePositionsModifyBuilder.kt
@@ -20,4 +20,23 @@ public class RolePositionsModifyBuilder : AuditRequestBuilder<GuildRolePositionM
 
     override fun toRequest(): GuildRolePositionModifyRequest =
         GuildRolePositionModifyRequest(swaps)
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as RolePositionsModifyBuilder
+
+        if (reason != other.reason) return false
+        if (swaps != other.swaps) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = reason?.hashCode() ?: 0
+        result = 31 * result + swaps.hashCode()
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/scheduled_events/ScheduledEventModifyBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/scheduled_events/ScheduledEventModifyBuilder.kt
@@ -80,4 +80,41 @@ public class ScheduledEventModifyBuilder : AuditRequestBuilder<ScheduledEventMod
         status = _status,
         image = _image.map { it.dataUri },
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as ScheduledEventModifyBuilder
+
+        if (reason != other.reason) return false
+        if (channelId != other.channelId) return false
+        if (name != other.name) return false
+        if (privacyLevel != other.privacyLevel) return false
+        if (scheduledStartTime != other.scheduledStartTime) return false
+        if (description != other.description) return false
+        if (entityType != other.entityType) return false
+        if (entityMetadata != other.entityMetadata) return false
+        if (scheduledEndTime != other.scheduledEndTime) return false
+        if (status != other.status) return false
+        if (image != other.image) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = reason?.hashCode() ?: 0
+        result = 31 * result + (channelId?.hashCode() ?: 0)
+        result = 31 * result + (name?.hashCode() ?: 0)
+        result = 31 * result + (privacyLevel?.hashCode() ?: 0)
+        result = 31 * result + (scheduledStartTime?.hashCode() ?: 0)
+        result = 31 * result + (description?.hashCode() ?: 0)
+        result = 31 * result + (entityType?.hashCode() ?: 0)
+        result = 31 * result + (entityMetadata?.hashCode() ?: 0)
+        result = 31 * result + (scheduledEndTime?.hashCode() ?: 0)
+        result = 31 * result + (status?.hashCode() ?: 0)
+        result = 31 * result + (image?.hashCode() ?: 0)
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/stage/StageInstanceCreateBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/stage/StageInstanceCreateBuilder.kt
@@ -43,4 +43,31 @@ public class StageInstanceCreateBuilder(
         _sendStartNotification,
         _guildScheduledEventId,
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as StageInstanceCreateBuilder
+
+        if (channelId != other.channelId) return false
+        if (topic != other.topic) return false
+        if (reason != other.reason) return false
+        if (privacyLevel != other.privacyLevel) return false
+        if (sendStartNotification != other.sendStartNotification) return false
+        if (guildScheduledEventId != other.guildScheduledEventId) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = channelId.hashCode()
+        result = 31 * result + topic.hashCode()
+        result = 31 * result + (reason?.hashCode() ?: 0)
+        result = 31 * result + (privacyLevel?.hashCode() ?: 0)
+        result = 31 * result + (sendStartNotification?.hashCode() ?: 0)
+        result = 31 * result + (guildScheduledEventId?.hashCode() ?: 0)
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/stage/StageInstanceModifyBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/stage/StageInstanceModifyBuilder.kt
@@ -26,4 +26,25 @@ public class StageInstanceModifyBuilder : AuditRequestBuilder<StageInstanceModif
         _topic,
         _privacyLevel,
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as StageInstanceModifyBuilder
+
+        if (reason != other.reason) return false
+        if (topic != other.topic) return false
+        if (privacyLevel != other.privacyLevel) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = reason?.hashCode() ?: 0
+        result = 31 * result + (topic?.hashCode() ?: 0)
+        result = 31 * result + (privacyLevel?.hashCode() ?: 0)
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/template/TemplateBuilders.kt
+++ b/rest/src/commonMain/kotlin/builder/template/TemplateBuilders.kt
@@ -20,6 +20,25 @@ public class GuildFromTemplateCreateBuilder(public var name: String) : RequestBu
     override fun toRequest(): GuildFromTemplateCreateRequest = GuildFromTemplateCreateRequest(
         name, _image.map { it.dataUri }
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as GuildFromTemplateCreateBuilder
+
+        if (name != other.name) return false
+        if (image != other.image) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = name.hashCode()
+        result = 31 * result + (image?.hashCode() ?: 0)
+        return result
+    }
+
 }
 
 @KordDsl
@@ -28,6 +47,25 @@ public class GuildTemplateCreateBuilder(public var name: String) : RequestBuilde
     public var description: String? by ::_description.delegate()
 
     override fun toRequest(): GuildTemplateCreateRequest = GuildTemplateCreateRequest(name, _description)
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as GuildTemplateCreateBuilder
+
+        if (name != other.name) return false
+        if (description != other.description) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = name.hashCode()
+        result = 31 * result + (description?.hashCode() ?: 0)
+        return result
+    }
+
 }
 
 @KordDsl
@@ -40,4 +78,23 @@ public class GuildTemplateModifyBuilder : RequestBuilder<GuildTemplateModifyRequ
     public var description: String? by ::_description.delegate()
 
     override fun toRequest(): GuildTemplateModifyRequest = GuildTemplateModifyRequest(_name, _description)
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as GuildTemplateModifyBuilder
+
+        if (name != other.name) return false
+        if (description != other.description) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = name?.hashCode() ?: 0
+        result = 31 * result + (description?.hashCode() ?: 0)
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/user/CurrentUserModifyBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/user/CurrentUserModifyBuilder.kt
@@ -21,4 +21,22 @@ public class CurrentUserModifyBuilder : RequestBuilder<CurrentUserModifyRequest>
         _username, _avatar.map { it.dataUri }
     )
 
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as CurrentUserModifyBuilder
+
+        if (username != other.username) return false
+        if (avatar != other.avatar) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = username?.hashCode() ?: 0
+        result = 31 * result + (avatar?.hashCode() ?: 0)
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/user/GroupDMCreateBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/user/GroupDMCreateBuilder.kt
@@ -15,4 +15,23 @@ public class GroupDMCreateBuilder : RequestBuilder<GroupDMCreateRequest> {
         tokens.toList(),
         nicknames.mapKeys { it.value }
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as GroupDMCreateBuilder
+
+        if (tokens != other.tokens) return false
+        if (nicknames != other.nicknames) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = tokens.hashCode()
+        result = 31 * result + nicknames.hashCode()
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/webhook/WebhookCreateBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/webhook/WebhookCreateBuilder.kt
@@ -16,4 +16,25 @@ public class WebhookCreateBuilder(public var name: String) : AuditRequestBuilder
     public var avatar: Image? by ::_avatar.delegate()
 
     override fun toRequest(): WebhookCreateRequest = WebhookCreateRequest(name, _avatar.map { it.dataUri })
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as WebhookCreateBuilder
+
+        if (name != other.name) return false
+        if (reason != other.reason) return false
+        if (avatar != other.avatar) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = name.hashCode()
+        result = 31 * result + (reason?.hashCode() ?: 0)
+        result = 31 * result + (avatar?.hashCode() ?: 0)
+        return result
+    }
+
 }

--- a/rest/src/commonMain/kotlin/builder/webhook/WebhookModifyBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/webhook/WebhookModifyBuilder.kt
@@ -28,4 +28,27 @@ public class WebhookModifyBuilder : AuditRequestBuilder<WebhookModifyRequest> {
         avatar = _avatar.map { it.dataUri },
         channelId = _channelId
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as WebhookModifyBuilder
+
+        if (reason != other.reason) return false
+        if (name != other.name) return false
+        if (avatar != other.avatar) return false
+        if (channelId != other.channelId) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = reason?.hashCode() ?: 0
+        result = 31 * result + (name?.hashCode() ?: 0)
+        result = 31 * result + (avatar?.hashCode() ?: 0)
+        result = 31 * result + (channelId?.hashCode() ?: 0)
+        return result
+    }
+
 }


### PR DESCRIPTION
# Context

When we compare the builder, like `EmbedBuilder`, the comparison between two instances will always return false no matter the field set. For example:

```kt
println(EmbedBuilder() == EmbedBuilder()) // false
println(EmbedBuilder().apply { title = "title" } == EmbedBuilder().apply { title = "title" }) // false

println(EmbedBuilder().hashCode()) // 2096057945
println(EmbedBuilder().hashCode()) // 1689843956
```

This behavior seems to be a bug and needs to be fixed because according to the result, equals & hashcode methods don't work.

# Usage

In my bot, when I render my components, I would like to compare the last `InteractionResponseModifyBuilder` and the new from the rendering to send only the changed components (embed / actionRow / text) to the discord API and consequently reduce the network load of the bot