### PR TITLE
Link to JDK 22 in Dokka output

### DIFF
--- a/buildSrc/src/main/kotlin/Documentation.kt
+++ b/buildSrc/src/main/kotlin/Documentation.kt
@@ -10,7 +10,7 @@ fun AbstractDokkaLeafTask.applyKordDokkaOptions() {
 
     dokkaSourceSets.configureEach {
 
-        jdkVersion = Jvm.target
+        jdkVersion = 22
 
         suppressGeneratedFiles = false
 

--- a/common/src/commonMain/kotlin/entity/Snowflake.kt
+++ b/common/src/commonMain/kotlin/entity/Snowflake.kt
@@ -138,7 +138,7 @@ public class Snowflake : Comparable<Snowflake> {
      *
      * The comparison is based first on the value of the [timestamp], then on the value of the [workerId], then on the
      * value of the [processId] and finally on the value of the [increment]. It is *consistent with equals*, as defined
-     * by [Comparable](https://docs.oracle.com/javase/8/docs/api/java/lang/Comparable.html).
+     * by [Comparable](https://docs.oracle.com/en/java/javase/22/docs/api/java.base/java/lang/Comparable.html).
      */
     override fun compareTo(other: Snowflake): Int {
         // the layout of Snowflake values from MSB to LSB is timestamp, workerId, processId, increment,
@@ -175,12 +175,13 @@ public class Snowflake : Comparable<Snowflake> {
          * [processId] and [increment] are not taken into account.
          *
          * Note: this comparator imposes an ordering that is *inconsistent with equals*, as defined by
-         * [Comparator](https://docs.oracle.com/javase/8/docs/api/java/util/Comparator.html). It therefore shouldn't be
-         * used to order a [SortedSet](https://docs.oracle.com/javase/8/docs/api/java/util/SortedSet.html) or
-         * [SortedMap](https://docs.oracle.com/javase/8/docs/api/java/util/SortedMap.html). This is because
-         * `TimestampComparator` only compares the first 42 bits of the ULong [value] (comparing the timestamp), whereas
-         * [equals][Snowflake.equals] compares all the bits of the [value]. `TimestampComparator` can return `0` even if
-         * [equals][Snowflake.equals] returns `false`, but [equals][Snowflake.equals] only returns `true` if
+         * [Comparator](https://docs.oracle.com/en/java/javase/22/docs/api/java.base/java/util/Comparator.html). It
+         * therefore shouldn't be used to order a
+         * [SortedSet](https://docs.oracle.com/en/java/javase/22/docs/api/java.base/java/util/SortedSet.html) or
+         * [SortedMap](https://docs.oracle.com/en/java/javase/22/docs/api/java.base/java/util/SortedMap.html). This is
+         * because `TimestampComparator` only compares the first 42 bits of the ULong [value] (comparing the timestamp),
+         * whereas [equals][Snowflake.equals] compares all the bits of the [value]. `TimestampComparator` can return `0`
+         * even if [equals][Snowflake.equals] returns `false`, but [equals][Snowflake.equals] only returns `true` if
          * `TimestampComparator` returns `0`.
          */
         public val TimestampComparator: Comparator<Snowflake> = Comparator { s1, s2 ->


### PR DESCRIPTION
Javadoc of recent JDK versions is nicer to use (mobile-friendly, searchable, etc.).