### PR TITLE
Replace Gradle toolchain with `-Xjdk-release`

### DIFF
--- a/buildSrc/src/main/kotlin/Compiler.kt
+++ b/buildSrc/src/main/kotlin/Compiler.kt
@@ -1,6 +1,8 @@
 import org.gradle.api.NamedDomainObjectSet
 import org.gradle.kotlin.dsl.assign
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
 import org.jetbrains.kotlin.gradle.dsl.KotlinCommonCompilerOptions
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompilerOptions
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
 
 val kordOptIns = listOf(
@@ -12,14 +14,18 @@ val kordOptIns = listOf(
     "dev.kord.common.annotation.KordVoice",
 )
 
-object Jvm {
-    const val target = 8
-}
-
-fun KotlinCommonCompilerOptions.applyKordCompilerOptions() {
+internal fun KotlinCommonCompilerOptions.applyKordCommonCompilerOptions() {
     allWarningsAsErrors = true
     progressiveMode = true
     freeCompilerArgs.add("-Xexpect-actual-classes")
+}
+
+internal const val KORD_JVM_TARGET = 8
+
+internal fun KotlinJvmCompilerOptions.applyKordJvmCompilerOptions() {
+    applyKordCommonCompilerOptions()
+    jvmTarget = JVM_1_8
+    freeCompilerArgs.add("-Xjdk-release=1.8")
 }
 
 internal fun NamedDomainObjectSet<KotlinSourceSet>.applyKordTestOptIns() {

--- a/buildSrc/src/main/kotlin/kord-internal-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/kord-internal-module.gradle.kts
@@ -7,8 +7,13 @@ repositories {
 }
 
 kotlin {
-    jvmToolchain(Jvm.target)
     compilerOptions {
-        applyKordCompilerOptions()
+        applyKordJvmCompilerOptions()
+    }
+}
+
+tasks {
+    withType<JavaCompile>().configureEach {
+        options.release = KORD_JVM_TARGET
     }
 }

--- a/buildSrc/src/main/kotlin/kord-internal-multiplatform-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/kord-internal-multiplatform-module.gradle.kts
@@ -8,17 +8,20 @@ repositories {
     mavenCentral()
 }
 
+@OptIn(ExperimentalKotlinGradlePluginApi::class)
 kotlin {
-    jvm()
+    compilerOptions {
+        applyKordCommonCompilerOptions()
+    }
+
+    jvm {
+        compilerOptions {
+            applyKordJvmCompilerOptions()
+        }
+    }
     js {
         nodejs()
         useCommonJs()
-    }
-    jvmToolchain(Jvm.target)
-
-    @OptIn(ExperimentalKotlinGradlePluginApi::class)
-    compilerOptions {
-        applyKordCompilerOptions()
     }
 }
 

--- a/buildSrc/src/main/kotlin/kord-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/kord-module.gradle.kts
@@ -24,11 +24,8 @@ apiValidation {
 
 kotlin {
     explicitApi()
-
-    jvmToolchain(Jvm.target)
-
     compilerOptions {
-        applyKordCompilerOptions()
+        applyKordJvmCompilerOptions()
         optIn.addAll(kordOptIns)
     }
 
@@ -44,6 +41,10 @@ tasks {
 
     withType<AbstractDokkaLeafTask>().configureEach {
         applyKordDokkaOptions()
+    }
+
+    withType<JavaCompile>().configureEach {
+        options.release = KORD_JVM_TARGET
     }
 }
 

--- a/buildSrc/src/main/kotlin/kord-multiplatform-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/kord-multiplatform-module.gradle.kts
@@ -23,10 +23,19 @@ apiValidation {
     applyKordBCVOptions()
 }
 
+@OptIn(ExperimentalKotlinGradlePluginApi::class)
 kotlin {
     explicitApi()
+    compilerOptions {
+        applyKordCommonCompilerOptions()
+        optIn.addAll(kordOptIns)
+    }
 
-    jvm()
+    jvm {
+        compilerOptions {
+            applyKordJvmCompilerOptions()
+        }
+    }
     js {
         nodejs {
             testTask {
@@ -38,13 +47,6 @@ kotlin {
             }
         }
         useCommonJs()
-    }
-    jvmToolchain(Jvm.target)
-
-    @OptIn(ExperimentalKotlinGradlePluginApi::class)
-    compilerOptions {
-        applyKordCompilerOptions()
-        optIn.addAll(kordOptIns)
     }
 
     applyDefaultHierarchyTemplate()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,8 +1,3 @@
-plugins {
-    // https://github.com/gradle/foojay-toolchains
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
-}
-
 rootProject.name = "kord"
 
 include(


### PR DESCRIPTION
See https://jakewharton.com/gradle-toolchains-are-rarely-a-good-idea/, https://github.com/kordlib/gradle-tools/pull/3 and https://kotlinlang.org/docs/compiler-reference.html#xjdk-release-version