### PR TITLE
Update Auto Moderation builders

### DIFF
--- a/rest/api/rest.api
+++ b/rest/api/rest.api
@@ -247,7 +247,6 @@ public final class dev/kord/rest/builder/automoderation/KeywordAutoModerationRul
 
 public final class dev/kord/rest/builder/automoderation/KeywordAutoModerationRuleCreateBuilder : dev/kord/rest/builder/automoderation/AutoModerationRuleCreateBuilder, dev/kord/rest/builder/automoderation/KeywordAutoModerationRuleBuilder {
 	public fun <init> (Ljava/lang/String;Ldev/kord/common/entity/AutoModerationRuleEventType;)V
-	public synthetic fun buildTriggerMetadata ()Ldev/kord/common/entity/optional/Optional;
 	public fun getAllowedKeywords ()Ljava/util/List;
 	public fun getKeywords ()Ljava/util/List;
 	public fun getRegexPatterns ()Ljava/util/List;
@@ -274,6 +273,7 @@ public abstract interface class dev/kord/rest/builder/automoderation/KeywordPres
 	public abstract fun assignPresets (Ljava/util/List;)V
 	public abstract fun getPresets ()Ljava/util/List;
 	public abstract fun getTriggerType ()Ldev/kord/common/entity/AutoModerationRuleTriggerType$KeywordPreset;
+	public abstract fun setPresets (Ljava/util/List;)V
 }
 
 public final class dev/kord/rest/builder/automoderation/KeywordPresetAutoModerationRuleBuilder$DefaultImpls {
@@ -283,7 +283,6 @@ public final class dev/kord/rest/builder/automoderation/KeywordPresetAutoModerat
 public final class dev/kord/rest/builder/automoderation/KeywordPresetAutoModerationRuleCreateBuilder : dev/kord/rest/builder/automoderation/AutoModerationRuleCreateBuilder, dev/kord/rest/builder/automoderation/KeywordPresetAutoModerationRuleBuilder {
 	public fun <init> (Ljava/lang/String;Ldev/kord/common/entity/AutoModerationRuleEventType;)V
 	public fun assignPresets (Ljava/util/List;)V
-	public synthetic fun buildTriggerMetadata ()Ldev/kord/common/entity/optional/Optional;
 	public fun getAllowedKeywords ()Ljava/util/List;
 	public fun getPresets ()Ljava/util/List;
 	public fun getTriggerType ()Ldev/kord/common/entity/AutoModerationRuleTriggerType$KeywordPreset;
@@ -317,7 +316,6 @@ public final class dev/kord/rest/builder/automoderation/MentionSpamAutoModeratio
 
 public final class dev/kord/rest/builder/automoderation/MentionSpamAutoModerationRuleCreateBuilder : dev/kord/rest/builder/automoderation/AutoModerationRuleCreateBuilder, dev/kord/rest/builder/automoderation/MentionSpamAutoModerationRuleBuilder {
 	public fun <init> (Ljava/lang/String;Ldev/kord/common/entity/AutoModerationRuleEventType;)V
-	public synthetic fun buildTriggerMetadata ()Ldev/kord/common/entity/optional/Optional;
 	public fun getMentionLimit ()Ljava/lang/Integer;
 	public fun getMentionRaidProtectionEnabled ()Ljava/lang/Boolean;
 	public fun getTriggerType ()Ldev/kord/common/entity/AutoModerationRuleTriggerType$MentionSpam;

--- a/rest/api/rest.klib.api
+++ b/rest/api/rest.klib.api
@@ -460,10 +460,12 @@ sealed interface dev.kord.rest.builder.automoderation/KeywordAutoModerationRuleB
 }
 
 sealed interface dev.kord.rest.builder.automoderation/KeywordPresetAutoModerationRuleBuilder : dev.kord.rest.builder.automoderation/AllowedKeywordsAutoModerationRuleBuilder { // dev.kord.rest.builder.automoderation/KeywordPresetAutoModerationRuleBuilder|null[0]
-    abstract val presets // dev.kord.rest.builder.automoderation/KeywordPresetAutoModerationRuleBuilder.presets|{}presets[0]
-        abstract fun <get-presets>(): kotlin.collections/MutableList<dev.kord.common.entity/AutoModerationRuleKeywordPresetType>? // dev.kord.rest.builder.automoderation/KeywordPresetAutoModerationRuleBuilder.presets.<get-presets>|<get-presets>(){}[0]
     open val triggerType // dev.kord.rest.builder.automoderation/KeywordPresetAutoModerationRuleBuilder.triggerType|{}triggerType[0]
         open fun <get-triggerType>(): dev.kord.common.entity/AutoModerationRuleTriggerType.KeywordPreset // dev.kord.rest.builder.automoderation/KeywordPresetAutoModerationRuleBuilder.triggerType.<get-triggerType>|<get-triggerType>(){}[0]
+
+    abstract var presets // dev.kord.rest.builder.automoderation/KeywordPresetAutoModerationRuleBuilder.presets|{}presets[0]
+        abstract fun <get-presets>(): kotlin.collections/MutableList<dev.kord.common.entity/AutoModerationRuleKeywordPresetType>? // dev.kord.rest.builder.automoderation/KeywordPresetAutoModerationRuleBuilder.presets.<get-presets>|<get-presets>(){}[0]
+        abstract fun <set-presets>(kotlin.collections/MutableList<dev.kord.common.entity/AutoModerationRuleKeywordPresetType>?) // dev.kord.rest.builder.automoderation/KeywordPresetAutoModerationRuleBuilder.presets.<set-presets>|<set-presets>(kotlin.collections.MutableList<dev.kord.common.entity.AutoModerationRuleKeywordPresetType>?){}[0]
 
     abstract fun assignPresets(kotlin.collections/MutableList<dev.kord.common.entity/AutoModerationRuleKeywordPresetType>) // dev.kord.rest.builder.automoderation/KeywordPresetAutoModerationRuleBuilder.assignPresets|assignPresets(kotlin.collections.MutableList<dev.kord.common.entity.AutoModerationRuleKeywordPresetType>){}[0]
 }
@@ -765,8 +767,8 @@ final class dev.kord.rest.builder.automoderation/KeywordPresetAutoModerationRule
         final fun <get-allowedKeywords>(): kotlin.collections/MutableList<kotlin/String>? // dev.kord.rest.builder.automoderation/KeywordPresetAutoModerationRuleCreateBuilder.allowedKeywords.<get-allowedKeywords>|<get-allowedKeywords>(){}[0]
         final fun <set-allowedKeywords>(kotlin.collections/MutableList<kotlin/String>?) // dev.kord.rest.builder.automoderation/KeywordPresetAutoModerationRuleCreateBuilder.allowedKeywords.<set-allowedKeywords>|<set-allowedKeywords>(kotlin.collections.MutableList<kotlin.String>?){}[0]
     final var presets // dev.kord.rest.builder.automoderation/KeywordPresetAutoModerationRuleCreateBuilder.presets|{}presets[0]
-        final fun <get-presets>(): kotlin.collections/MutableList<dev.kord.common.entity/AutoModerationRuleKeywordPresetType> // dev.kord.rest.builder.automoderation/KeywordPresetAutoModerationRuleCreateBuilder.presets.<get-presets>|<get-presets>(){}[0]
-        final fun <set-presets>(kotlin.collections/MutableList<dev.kord.common.entity/AutoModerationRuleKeywordPresetType>) // dev.kord.rest.builder.automoderation/KeywordPresetAutoModerationRuleCreateBuilder.presets.<set-presets>|<set-presets>(kotlin.collections.MutableList<dev.kord.common.entity.AutoModerationRuleKeywordPresetType>){}[0]
+        final fun <get-presets>(): kotlin.collections/MutableList<dev.kord.common.entity/AutoModerationRuleKeywordPresetType>? // dev.kord.rest.builder.automoderation/KeywordPresetAutoModerationRuleCreateBuilder.presets.<get-presets>|<get-presets>(){}[0]
+        final fun <set-presets>(kotlin.collections/MutableList<dev.kord.common.entity/AutoModerationRuleKeywordPresetType>?) // dev.kord.rest.builder.automoderation/KeywordPresetAutoModerationRuleCreateBuilder.presets.<set-presets>|<set-presets>(kotlin.collections.MutableList<dev.kord.common.entity.AutoModerationRuleKeywordPresetType>?){}[0]
 
     final fun assignPresets(kotlin.collections/MutableList<dev.kord.common.entity/AutoModerationRuleKeywordPresetType>) // dev.kord.rest.builder.automoderation/KeywordPresetAutoModerationRuleCreateBuilder.assignPresets|assignPresets(kotlin.collections.MutableList<dev.kord.common.entity.AutoModerationRuleKeywordPresetType>){}[0]
 }

--- a/rest/src/commonMain/kotlin/builder/automoderation/AutoModerationRuleBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/automoderation/AutoModerationRuleBuilder.kt
@@ -282,18 +282,24 @@ public sealed interface KeywordPresetAutoModerationRuleBuilder : AllowedKeywords
     override val triggerType: KeywordPreset get() = KeywordPreset
 
     /** The internally pre-defined wordsets which will be searched for in content. */
-    public val presets: MutableList<AutoModerationRuleKeywordPresetType>?
+    public var presets: MutableList<AutoModerationRuleKeywordPresetType>?
 
     /**
      * Use this to set [presets][KeywordPresetAutoModerationRuleBuilder.presets] for
      * [KeywordPresetAutoModerationRuleBuilder].
      */
+    @Deprecated(
+        "This can be replaced with 'presets', it is now a 'var'. The deprecation level will be raised to ERROR in " +
+            "0.16.0, to HIDDEN in 0.17.0, and this declaration will be removed in 0.18.0.",
+        ReplaceWith("this.run { this@run.presets = presets }", imports = ["kotlin.run"]),
+        DeprecationLevel.WARNING,
+    )
     public fun assignPresets(presets: MutableList<AutoModerationRuleKeywordPresetType>)
 }
 
 /** Add a [preset] to [presets][KeywordPresetAutoModerationRuleBuilder.presets]. */
 public fun KeywordPresetAutoModerationRuleBuilder.preset(preset: AutoModerationRuleKeywordPresetType) {
-    presets?.add(preset) ?: assignPresets(mutableListOf(preset))
+    presets?.add(preset) ?: run { presets = mutableListOf(preset) }
 }
 
 

--- a/rest/src/commonMain/kotlin/builder/automoderation/AutoModerationRuleCreateBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/automoderation/AutoModerationRuleCreateBuilder.kt
@@ -74,8 +74,8 @@ public class KeywordAutoModerationRuleCreateBuilder(
     private var _allowedKeywords: Optional<MutableList<String>> = Optional.Missing()
     override var allowedKeywords: MutableList<String>? by ::_allowedKeywords.delegate()
 
-    // one of keywords or regexPatterns is required, don't bother to send missing trigger metadata if both are missing
-    override fun buildTriggerMetadata(): Optional.Value<DiscordAutoModerationRuleTriggerMetadata> =
+    // triggerMetadata is required for Keyword rules
+    override fun buildTriggerMetadata(): Optional<DiscordAutoModerationRuleTriggerMetadata> =
         DiscordAutoModerationRuleTriggerMetadata(
             keywordFilter = _keywords.mapCopy(),
             regexPatterns = _regexPatterns.mapCopy(),
@@ -97,9 +97,16 @@ public class KeywordPresetAutoModerationRuleCreateBuilder(
     eventType: AutoModerationRuleEventType,
 ) : AutoModerationRuleCreateBuilder(name, eventType), KeywordPresetAutoModerationRuleBuilder {
 
-    override var presets: MutableList<AutoModerationRuleKeywordPresetType> = mutableListOf()
+    private var _presets: Optional<MutableList<AutoModerationRuleKeywordPresetType>> = Optional.Missing()
+    override var presets: MutableList<AutoModerationRuleKeywordPresetType>? by ::_presets.delegate()
 
     /** @suppress Use `this.presets = presets` instead. */
+    @Deprecated(
+        "Use 'this.presets = presets' instead. The deprecation level will be raised to ERROR in 0.16.0, to HIDDEN in " +
+            "0.17.0, and this declaration will be removed in 0.18.0.",
+        ReplaceWith("this.run { this@run.presets = presets }", imports = ["kotlin.run"]),
+        DeprecationLevel.WARNING,
+    )
     override fun assignPresets(presets: MutableList<AutoModerationRuleKeywordPresetType>) {
         this.presets = presets
     }
@@ -107,9 +114,10 @@ public class KeywordPresetAutoModerationRuleCreateBuilder(
     private var _allowedKeywords: Optional<MutableList<String>> = Optional.Missing()
     override var allowedKeywords: MutableList<String>? by ::_allowedKeywords.delegate()
 
-    override fun buildTriggerMetadata(): Optional.Value<DiscordAutoModerationRuleTriggerMetadata> =
+    // triggerMetadata is required for KeywordPreset rules
+    override fun buildTriggerMetadata(): Optional<DiscordAutoModerationRuleTriggerMetadata> =
         DiscordAutoModerationRuleTriggerMetadata(
-            presets = presets.toList().optional(),
+            presets = _presets.mapCopy(),
             allowList = _allowedKeywords.mapCopy(),
         ).optional()
 }
@@ -127,9 +135,8 @@ public class MentionSpamAutoModerationRuleCreateBuilder(
     private var _mentionRaidProtectionEnabled: OptionalBoolean = OptionalBoolean.Missing
     override var mentionRaidProtectionEnabled: Boolean? by ::_mentionRaidProtectionEnabled.delegate()
 
-    // one of mentionTotalLimit or mentionRaidProtectionEnabled is required, don't bother to send missing trigger
-    // metadata if both are missing
-    override fun buildTriggerMetadata(): Optional.Value<DiscordAutoModerationRuleTriggerMetadata> =
+    // triggerMetadata is required for MentionSpam rules
+    override fun buildTriggerMetadata(): Optional<DiscordAutoModerationRuleTriggerMetadata> =
         DiscordAutoModerationRuleTriggerMetadata(
             mentionTotalLimit = _mentionLimit,
             mentionRaidProtectionEnabled = _mentionRaidProtectionEnabled,

--- a/rest/src/commonMain/kotlin/builder/automoderation/AutoModerationRuleModifyBuilder.kt
+++ b/rest/src/commonMain/kotlin/builder/automoderation/AutoModerationRuleModifyBuilder.kt
@@ -103,7 +103,7 @@ public class KeywordAutoModerationRuleModifyBuilder :
 }
 
 /** A [SpamAutoModerationRuleBuilder] for building [AutoModerationRuleModifyRequest]s. */
-@Suppress("CanSealedSubClassBeObject") // has state in super class
+@Suppress("CanSealedSubClassBeObject") // superclass is mutable
 @KordDsl
 public class SpamAutoModerationRuleModifyBuilder :
     AutoModerationRuleModifyBuilder(),
@@ -119,6 +119,12 @@ public class KeywordPresetAutoModerationRuleModifyBuilder :
     override var presets: MutableList<AutoModerationRuleKeywordPresetType>? by ::_presets.delegate()
 
     /** @suppress Use `this.presets = presets` instead. */
+    @Deprecated(
+        "Use 'this.presets = presets' instead. The deprecation level will be raised to ERROR in 0.16.0, to HIDDEN in " +
+            "0.17.0, and this declaration will be removed in 0.18.0.",
+        ReplaceWith("this.run { this@run.presets = presets }", imports = ["kotlin.run"]),
+        DeprecationLevel.WARNING,
+    )
     override fun assignPresets(presets: MutableList<AutoModerationRuleKeywordPresetType>) {
         this.presets = presets
     }


### PR DESCRIPTION
* `KeywordPresetAutoModerationRuleCreateBuilder.presets` can be omitted

* `AutoModerationRuleCreateBuilder.buildTriggerMetadata` doesn't need covariant overrides