### PR TITLE
Exclude interaction endpoints from global rate-limit

### DIFF
--- a/rest/api/rest.api
+++ b/rest/api/rest.api
@@ -6492,10 +6492,11 @@ public abstract interface class dev/kord/rest/route/ResponseMapper {
 
 public abstract class dev/kord/rest/route/Route {
 	public static final field Companion Ldev/kord/rest/route/Route$Companion;
-	public synthetic fun <init> (Lio/ktor/http/HttpMethod;Ljava/lang/String;Ldev/kord/rest/route/ResponseMapper;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Lio/ktor/http/HttpMethod;Ljava/lang/String;Ldev/kord/rest/route/ResponseMapper;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Lio/ktor/http/HttpMethod;Ljava/lang/String;Lkotlinx/serialization/DeserializationStrategy;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Lio/ktor/http/HttpMethod;Ljava/lang/String;Lkotlinx/serialization/DeserializationStrategy;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lio/ktor/http/HttpMethod;Ljava/lang/String;Ldev/kord/rest/route/ResponseMapper;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lio/ktor/http/HttpMethod;Ljava/lang/String;Ldev/kord/rest/route/ResponseMapper;ZZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lio/ktor/http/HttpMethod;Ljava/lang/String;Lkotlinx/serialization/DeserializationStrategy;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lio/ktor/http/HttpMethod;Ljava/lang/String;Lkotlinx/serialization/DeserializationStrategy;ZZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getAffectedByGlobalRateLimit ()Z
 	public final fun getMapper ()Ldev/kord/rest/route/ResponseMapper;
 	public final fun getMethod ()Lio/ktor/http/HttpMethod;
 	public final fun getPath ()Ljava/lang/String;

--- a/rest/api/rest.klib.api
+++ b/rest/api/rest.klib.api
@@ -7211,6 +7211,8 @@ sealed class <#A: kotlin/Any?, #B: dev.kord.common.entity/Choice> dev.kord.rest.
 }
 
 sealed class <#A: kotlin/Any?> dev.kord.rest.route/Route { // dev.kord.rest.route/Route|null[0]
+    final val affectedByGlobalRateLimit // dev.kord.rest.route/Route.affectedByGlobalRateLimit|{}affectedByGlobalRateLimit[0]
+        final fun <get-affectedByGlobalRateLimit>(): kotlin/Boolean // dev.kord.rest.route/Route.affectedByGlobalRateLimit.<get-affectedByGlobalRateLimit>|<get-affectedByGlobalRateLimit>(){}[0]
     final val mapper // dev.kord.rest.route/Route.mapper|{}mapper[0]
         final fun <get-mapper>(): dev.kord.rest.route/ResponseMapper<#A> // dev.kord.rest.route/Route.mapper.<get-mapper>|<get-mapper>(){}[0]
     final val method // dev.kord.rest.route/Route.method|{}method[0]

--- a/rest/src/commonMain/kotlin/ratelimit/AbstractRateLimiter.kt
+++ b/rest/src/commonMain/kotlin/ratelimit/AbstractRateLimiter.kt
@@ -33,7 +33,9 @@ public abstract class AbstractRateLimiter internal constructor(public val clock:
     }
 
     override suspend fun await(request: Request<*, *>): RequestToken {
-        globalSuspensionPoint.value.await()
+        if (request.route.affectedByGlobalRateLimit) {
+            globalSuspensionPoint.value.await()
+        }
         val buckets = request.buckets
         buckets.forEach { it.awaitAndLock() }
 

--- a/rest/src/commonMain/kotlin/route/Route.kt
+++ b/rest/src/commonMain/kotlin/route/Route.kt
@@ -50,6 +50,7 @@ public sealed class Route<T>(
     public val path: String,
     public val mapper: ResponseMapper<T>,
     public val requiresAuthorizationHeader: Boolean = true,
+    public val affectedByGlobalRateLimit: Boolean = true
 ) {
 
     public companion object {
@@ -91,7 +92,8 @@ public sealed class Route<T>(
         path: String,
         strategy: DeserializationStrategy<T>,
         requiresAuthorizationHeader: Boolean = true,
-    ) : this(method, path, ValueJsonMapper(strategy), requiresAuthorizationHeader)
+        affectedByGlobalRateLimit: Boolean = true
+    ) : this(method, path, ValueJsonMapper(strategy), requiresAuthorizationHeader, affectedByGlobalRateLimit)
 
     override fun toString(): String = "Route(method:${method.value},path:$path,mapper:$mapper)"
 
@@ -990,6 +992,7 @@ public sealed class Route<T>(
             "/interactions/$InteractionId/$InteractionToken/callback",
             NoStrategy,
             requiresAuthorizationHeader = false,
+            affectedByGlobalRateLimit = false
         )
 
     public object OriginalInteractionResponseGet :
@@ -998,6 +1001,7 @@ public sealed class Route<T>(
             "/webhooks/$ApplicationId/$InteractionToken/messages/@original",
             DiscordMessage.serializer(),
             requiresAuthorizationHeader = false,
+            affectedByGlobalRateLimit = false
         )
 
     public object OriginalInteractionResponseModify :
@@ -1006,6 +1010,7 @@ public sealed class Route<T>(
             "/webhooks/$ApplicationId/$InteractionToken/messages/@original",
             DiscordMessage.serializer(),
             requiresAuthorizationHeader = false,
+            affectedByGlobalRateLimit = false
         )
 
     public object OriginalInteractionResponseDelete :
@@ -1014,6 +1019,7 @@ public sealed class Route<T>(
             "/webhooks/$ApplicationId/$InteractionToken/messages/@original",
             NoStrategy,
             requiresAuthorizationHeader = false,
+            affectedByGlobalRateLimit = false
         )
 
     public object FollowupMessageCreate :
@@ -1022,6 +1028,7 @@ public sealed class Route<T>(
             "/webhooks/$ApplicationId/$InteractionToken",
             DiscordMessage.serializer(),
             requiresAuthorizationHeader = false,
+            affectedByGlobalRateLimit = false
         )
 
     public object FollowupMessageGet :
@@ -1030,6 +1037,7 @@ public sealed class Route<T>(
             "/webhooks/$ApplicationId/$InteractionToken/messages/$MessageId",
             DiscordMessage.serializer(),
             requiresAuthorizationHeader = false,
+            affectedByGlobalRateLimit = false
         )
 
     public object FollowupMessageModify :
@@ -1038,6 +1046,7 @@ public sealed class Route<T>(
             "/webhooks/$ApplicationId/$InteractionToken/messages/$MessageId",
             DiscordMessage.serializer(),
             requiresAuthorizationHeader = false,
+            affectedByGlobalRateLimit = false
         )
 
     public object FollowupMessageDelete :
@@ -1046,6 +1055,7 @@ public sealed class Route<T>(
             "/webhooks/$ApplicationId/$InteractionToken/messages/$MessageId",
             NoStrategy,
             requiresAuthorizationHeader = false,
+            affectedByGlobalRateLimit = false
         )
 
 


### PR DESCRIPTION
> [Interaction endpoints](https://discord.com/developers/docs/interactions/receiving-and-responding#endpoints) are not bound to the bot's Global Rate Limit.

https://discord.com/developers/docs/topics/rate-limits#global-rate-limit

This actually causes issues with Kord no longer responding to commands because it exceeded some other rate-limit