### PR TITLE
Use declaration-site variance for `EntitySupplyStrategy`

### DIFF
--- a/core/api/core.klib.api
+++ b/core/api/core.klib.api
@@ -6,7 +6,7 @@
 // - Show declarations: true
 
 // Library unique name: <kord:core>
-abstract interface <#A: dev.kord.core.supplier/EntitySupplier> dev.kord.core.supplier/EntitySupplyStrategy { // dev.kord.core.supplier/EntitySupplyStrategy|null[0]
+abstract interface <#A: out dev.kord.core.supplier/EntitySupplier> dev.kord.core.supplier/EntitySupplyStrategy { // dev.kord.core.supplier/EntitySupplyStrategy|null[0]
     abstract fun supply(dev.kord.core/Kord): #A // dev.kord.core.supplier/EntitySupplyStrategy.supply|supply(dev.kord.core.Kord){}[0]
 
     final object Companion { // dev.kord.core.supplier/EntitySupplyStrategy.Companion|null[0]

--- a/core/src/commonMain/kotlin/supplier/EntitySupplyStrategy.kt
+++ b/core/src/commonMain/kotlin/supplier/EntitySupplyStrategy.kt
@@ -6,7 +6,7 @@ import dev.kord.core.supplier.EntitySupplyStrategy.Companion.cache
 /**
  *  A supplier that accepts a [Kord] instance and returns an [EntitySupplier] of type [T].
  */
-public interface EntitySupplyStrategy<T : EntitySupplier> {
+public interface EntitySupplyStrategy<out T : EntitySupplier> {
 
     /**
      * Returns an [EntitySupplier] of type [T] that operates on the [kord] instance.


### PR DESCRIPTION
This should fix an [issue with Kord Extensions](https://discord.com/channels/1121419906995458098/1323320267031838791/1325461220412751883), and there is generally no reason not to add `out` in this case.