### PR TITLE
Clarify error message when initial gateway requests results in error

### DIFF
--- a/core/src/commonMain/kotlin/builder/kord/KordBuilder.kt
+++ b/core/src/commonMain/kotlin/builder/kord/KordBuilder.kt
@@ -190,7 +190,7 @@ public abstract class BaseKordBuilder internal constructor(public val token: Str
                 if (response.status == HttpStatusCode.Unauthorized) {
                     append(", make sure the bot token you entered is valid.")
                 } else {
-                    append('.')
+                    append(". ")
                 }
 
                 appendLine("Discord response: $responseBody (${response.status})")

--- a/core/src/commonMain/kotlin/builder/kord/KordBuilder.kt
+++ b/core/src/commonMain/kotlin/builder/kord/KordBuilder.kt
@@ -193,7 +193,7 @@ public abstract class BaseKordBuilder internal constructor(public val token: Str
                     append('.')
                 }
 
-                appendLine(responseBody)
+                appendLine("Discord response: $responseBody (${response.status})")
             }
 
             throw KordInitializationException(message)


### PR DESCRIPTION
Yesterday DIscord had a short outage resulting in this error message

`Something went wrong while initializing Kord.no healthy upstreams`


This message can be quite confusing as it doesn't indicate that the Discord servers are down, this PR changes the message to

`Something went wrong while initializing Kord. Discord response: no healthy upstreams (502)`